### PR TITLE
bump starknet-types-core to 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-git # Deoxys Changelog
+# Deoxys Changelog
 
 ## Next release
 
+- chore: bump starknet-types-core to 0.0.11
 - feat(api_key): api key passed to FetchConfig correctly
 - feat(api_key): Added support for --gateway-api to avoid rate limit from the gateway
 - fix(latest): Retrieve latest synced block via internal client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "bonsai-trie"
 version = "0.1.0"
-source = "git+https://github.com/antiyro/bonsai-trie.git?branch=oss#d1641a844b418a7e399a061f9d1cf38b52bbdfc2"
+source = "git+https://github.com/cchudant/bonsai-trie.git?branch=deoxys#144c0ee8f40a870682283896aa4ec8dfab2b9357"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -11275,7 +11275,8 @@ dependencies = [
 [[package]]
 name = "starknet-types-core"
 version = "0.0.11"
-source = "git+https://github.com/starknet-io/types-rs.git?branch=main#bcb3fc518620635dbb172ce5f80e63177aa913ef"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e16522c1c9aa7fc149a46816cd18aa12a5fc2b2b75a018089022db473a9237"
 dependencies = [
  "bitvec",
  "lambdaworks-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ pallet-grandpa = { default-features = true, git = "https://github.com/massalabs/
 pallet-timestamp = { default-features = true, git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 
 # Bonsai trie dependencies
-bonsai-trie = { default-features = false, git = "https://github.com/antiyro/bonsai-trie.git", branch = "oss", features = [
+bonsai-trie = { default-features = false, git = "https://github.com/cchudant/bonsai-trie.git", branch = "deoxys", features = [
   "std",
 ] }
 
@@ -274,7 +274,7 @@ starknet-ff = { git = "https://github.com/jbcaron/starknet-rs.git", branch = "cl
 starknet-providers = { git = "https://github.com/jbcaron/starknet-rs.git", branch = "classes", default-features = false }
 starknet-signers = { git = "https://github.com/jbcaron/starknet-rs.git", branch = "classes", default-features = false }
 
-starknet-types-core = { git = "https://github.com/starknet-io/types-rs.git", branch = "main", default-features = false }
+starknet-types-core = { version = "0.0.11", default-features = false }
 
 blockifier = { git = "https://github.com/massalabs/blockifier", branch = "no_std-support-7578442-std", default-features = false, features = [
   "parity-scale-codec",


### PR DESCRIPTION

# Pull Request type

- Chore

## What is the current behavior?

N/A

## What is the new behavior?

## Does this introduce a breaking change?

No

## Other information

Take advantage of the fact that types-rs 0.0.11 updated lambdaworks-crypto to 0.0.6 which landed a speedup to pedersen hash computations