### PR TITLE
l2 commitments: fix rayon collect iter order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix(root): fix state root computation
 - refactor: refactor mc-db crate
 - feat(api_key): api key passed to FetchConfig correctly
 - feat(api_key): Added support for --gateway-api to avoid rate limit from the gateway

--- a/crates/primitives/felt/src/lib.rs
+++ b/crates/primitives/felt/src/lib.rs
@@ -18,6 +18,7 @@ mod starkware_types_conversions;
 pub mod with_serde;
 
 use alloc::string::{String, ToString};
+use core::fmt;
 
 use cairo_vm::felt::Felt252;
 #[cfg(feature = "parity-scale-codec")]
@@ -33,10 +34,22 @@ use thiserror_no_std::Error;
 #[cfg(feature = "serde")]
 pub use crate::with_serde::*;
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Hash, Eq, Copy)]
+#[derive(Clone, PartialEq, PartialOrd, Ord, Hash, Eq, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct Felt252Wrapper(pub FieldElement);
+
+impl fmt::Debug for Felt252Wrapper {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#x}", &self.0)
+    }
+}
+
+impl fmt::Display for Felt252Wrapper {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#x}", &self.0)
+    }
+}
 
 impl Felt252Wrapper {
     /// Field252 constant that's equal to 0


### PR DESCRIPTION
Fix state root computation!

i thought I understood rayon but, the problem here was that, under the hood
- par_bridge wraps the underlying iter in a lock and is not indexedparalleliterator. workers take new items as soon as they can in an unspecified way
- collect is specialized(ish) when collecting to a vec: it will return all the elements in order in the final vec, and every worker has its dedicated range of the destination vector it writes to -- this is what I thought was happening
- instead, unindexed parallel iterators don't benefit from this specialized collect
- unindexed parallel iterators always collect to a LinkedList<Vec<>> behind the scene, every worker write to its own Vec it pushes results to, and they are merged at the end into the final Vec that `collect` returns
This means that, when using par_bridge + collect to a vec, the order of the items in the final vec in unspecified - and the final hash of the state root is never the same :(

This is easy to fix though: we just keep track of the keys along with the values when using par_bridge

# Pull Request type

- Bugfix

## What is the current behavior?

State root dono work

Resolves: #NA

## What is the new behavior?

State root work

## Does this introduce a breaking change?

N/A

## Other information

To be honest, after this PR i'll test deoxys with make my parallelized bonsai-trie; there is a good chance that makes these parallel iterators kinda redundant as a single bonsai-trie commit would be already parallel enough

Also, the `Debug` impl for Felt was driving me insane so I changed it to make reading lots of logs easier