### PR TITLE
Refactor(storage): Removed reliance on Substrate for contract storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- feat(storage): finished migrating contract storage to our backend bonsai trie dbs
 - feat(storage): set up type-safe bonsai storage abstractions for usage in RPC
 - fix(root): fix state root computation
 - refactor: refactor mc-db crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "zeroize",
 ]
 
@@ -305,7 +305,7 @@ dependencies = [
  "digest 0.10.7",
  "itertools 0.10.5",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "paste",
  "rustc_version",
  "zeroize",
@@ -328,7 +328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -416,7 +416,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rand 0.8.5",
 ]
 
@@ -482,7 +482,7 @@ dependencies = [
  "asn1-rs-impl",
  "displaydoc",
  "nom",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rusticata-macros",
  "thiserror",
  "time",
@@ -720,7 +720,7 @@ checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "serde",
 ]
 
@@ -939,7 +939,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "phf",
  "scale-info",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "bonsai-trie"
 version = "0.1.0"
-source = "git+https://github.com/trantorian1/bonsai-trie.git?branch=oss#5101abbdd650bb566f22def4abe6c4c47288e3f6"
+source = "git+https://github.com/trantorian1/bonsai-trie.git?branch=oss#058d74485f92b75eba7f7a5849c1c6edae958a5e"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -1099,7 +1099,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "serde",
 ]
@@ -1113,7 +1113,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "indoc",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "serde",
@@ -1236,7 +1236,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "once_cell",
  "salsa",
  "smol_str",
@@ -1256,7 +1256,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "salsa",
  "smol_str",
  "unescaper",
@@ -1322,7 +1322,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "once_cell",
  "salsa",
  "smol_str",
@@ -1341,7 +1341,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "regex",
  "salsa",
  "serde",
@@ -1419,7 +1419,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "thiserror",
 ]
 
@@ -1464,7 +1464,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "once_cell",
  "serde",
  "serde_json",
@@ -1482,7 +1482,7 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "salsa",
  "smol_str",
  "thiserror",
@@ -1509,7 +1509,7 @@ dependencies = [
  "itertools 0.10.5",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "serde",
 ]
@@ -1528,7 +1528,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -1562,7 +1562,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-prime",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "rand 0.8.5",
  "serde",
@@ -1709,7 +1709,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
@@ -2619,7 +2619,7 @@ dependencies = [
  "displaydoc",
  "nom",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rusticata-macros",
 ]
 
@@ -3487,7 +3487,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "log",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "scale-info",
@@ -3528,7 +3528,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -4678,7 +4678,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -5874,6 +5874,7 @@ dependencies = [
  "sp-core",
  "sp-database",
  "sp-runtime",
+ "starknet-core 0.8.0",
  "starknet-ff 0.3.5 (git+https://github.com/jbcaron/starknet-rs.git?branch=classes)",
  "starknet-types-core",
  "starknet_api",
@@ -6544,7 +6545,7 @@ dependencies = [
  "nalgebra-macros",
  "num-complex 0.4.4",
  "num-rational",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "simba",
  "typenum",
 ]
@@ -6578,7 +6579,7 @@ dependencies = [
  "matrixmultiply 0.2.4",
  "num-complex 0.2.4",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rawpointer",
 ]
 
@@ -6743,7 +6744,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rand 0.8.5",
  "serde",
 ]
@@ -6755,7 +6756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -6764,7 +6765,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -6795,7 +6796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -6806,7 +6807,7 @@ checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -6821,7 +6822,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-modular",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rand 0.8.5",
 ]
 
@@ -6834,7 +6835,7 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
@@ -6843,14 +6844,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -6902,7 +6903,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -6945,7 +6946,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "num-derive",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "oboe-sys",
 ]
 
@@ -7822,7 +7823,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bitflags 2.4.1",
  "lazy_static",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
@@ -8033,7 +8034,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rand 0.8.5",
 ]
 
@@ -8903,7 +8904,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-rational",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-client-api",
@@ -9846,18 +9847,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10068,7 +10069,7 @@ checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex 0.4.4",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "paste",
  "wide",
 ]
@@ -10080,7 +10081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "thiserror",
  "time",
 ]
@@ -10249,7 +10250,7 @@ version = "16.0.0"
 source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
 dependencies = [
  "integer-sqrt",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -11049,7 +11050,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -11068,7 +11069,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (git+https://github.com/jbcaron/starknet-rs.git?branch=classes)",
@@ -11086,7 +11087,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (git+https://github.com/xJonathanLEI/starknet-rs.git?rev=64ebc36)",
@@ -11105,7 +11106,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (git+https://github.com/xJonathanLEI/starknet-rs.git?rev=a35ce22)",
@@ -11305,16 +11306,15 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.0.11"
-source = "git+https://github.com/starknet-io/types-rs.git?branch=main#bcb3fc518620635dbb172ce5f80e63177aa913ef"
+version = "0.1.0"
+source = "git+https://github.com/starknet-io/types-rs.git?branch=main#ab055382b23c9cc907985e1d19dce4c9c316d3ae"
 dependencies = [
  "bitvec",
  "lambdaworks-crypto",
  "lambdaworks-math",
- "lazy_static",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits 0.2.18",
  "parity-scale-codec",
  "serde",
 ]
@@ -12342,7 +12342,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "zeroize",
 ]
 
@@ -305,7 +305,7 @@ dependencies = [
  "digest 0.10.7",
  "itertools 0.10.5",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "paste",
  "rustc_version",
  "zeroize",
@@ -328,7 +328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -416,7 +416,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rand 0.8.5",
 ]
 
@@ -482,7 +482,7 @@ dependencies = [
  "asn1-rs-impl",
  "displaydoc",
  "nom",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rusticata-macros",
  "thiserror",
  "time",
@@ -720,7 +720,7 @@ checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "serde",
 ]
 
@@ -939,7 +939,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "phf",
  "scale-info",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "bonsai-trie"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/bonsai-trie.git?branch=oss#83b2cab7f25cf6aad907e2d49c39ab9303a723c0"
+source = "git+https://github.com/trantorian1/bonsai-trie.git?branch=oss#5101abbdd650bb566f22def4abe6c4c47288e3f6"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -1099,7 +1099,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "serde",
 ]
@@ -1113,7 +1113,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "indoc",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "serde",
@@ -1236,7 +1236,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "once_cell",
  "salsa",
  "smol_str",
@@ -1256,7 +1256,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "salsa",
  "smol_str",
  "unescaper",
@@ -1322,7 +1322,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "once_cell",
  "salsa",
  "smol_str",
@@ -1341,7 +1341,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "regex",
  "salsa",
  "serde",
@@ -1419,7 +1419,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "thiserror",
 ]
 
@@ -1464,7 +1464,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "once_cell",
  "serde",
  "serde_json",
@@ -1482,7 +1482,7 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "salsa",
  "smol_str",
  "thiserror",
@@ -1509,7 +1509,7 @@ dependencies = [
  "itertools 0.10.5",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "serde",
 ]
@@ -1528,7 +1528,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -1562,7 +1562,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-prime",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "rand 0.8.5",
  "serde",
@@ -1709,7 +1709,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
@@ -2619,7 +2619,7 @@ dependencies = [
  "displaydoc",
  "nom",
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rusticata-macros",
 ]
 
@@ -3487,7 +3487,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "log",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "scale-info",
@@ -3528,7 +3528,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -4678,7 +4678,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -6544,7 +6544,7 @@ dependencies = [
  "nalgebra-macros",
  "num-complex 0.4.4",
  "num-rational",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "simba",
  "typenum",
 ]
@@ -6578,7 +6578,7 @@ dependencies = [
  "matrixmultiply 0.2.4",
  "num-complex 0.2.4",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rawpointer",
 ]
 
@@ -6743,7 +6743,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rand 0.8.5",
  "serde",
 ]
@@ -6755,7 +6755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -6764,7 +6764,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -6790,11 +6790,12 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "num-traits 0.2.18",
+ "autocfg",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -6805,7 +6806,7 @@ checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -6820,7 +6821,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-modular",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rand 0.8.5",
 ]
 
@@ -6833,7 +6834,7 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -6842,14 +6843,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -6901,7 +6902,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -6944,7 +6945,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "num-derive",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "oboe-sys",
 ]
 
@@ -7821,7 +7822,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bitflags 2.4.1",
  "lazy_static",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
@@ -8032,7 +8033,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rand 0.8.5",
 ]
 
@@ -8902,7 +8903,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-rational",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-client-api",
@@ -9845,18 +9846,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10067,7 +10068,7 @@ checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex 0.4.4",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "paste",
  "wide",
 ]
@@ -10079,7 +10080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "thiserror",
  "time",
 ]
@@ -10248,7 +10249,7 @@ version = "16.0.0"
 source = "git+https://github.com/massalabs/polkadot-sdk?branch=release-polkadot-v1.3.0-std#a41673f8aa3f24d7ed8fb1f246a97551eca58837"
 dependencies = [
  "integer-sqrt",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -11048,7 +11049,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -11067,7 +11068,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (git+https://github.com/jbcaron/starknet-rs.git?branch=classes)",
@@ -11085,7 +11086,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (git+https://github.com/xJonathanLEI/starknet-rs.git?rev=64ebc36)",
@@ -11104,7 +11105,7 @@ dependencies = [
  "hmac 0.12.1",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "rfc6979",
  "sha2 0.10.8",
  "starknet-crypto-codegen 0.3.2 (git+https://github.com/xJonathanLEI/starknet-rs.git?rev=a35ce22)",
@@ -11305,7 +11306,7 @@ dependencies = [
 [[package]]
 name = "starknet-types-core"
 version = "0.0.11"
-source = "git+https://github.com/starknet-io/types-rs.git?branch=main#948fbb22ca59166d3e39666f7387c6f7976650f9"
+source = "git+https://github.com/starknet-io/types-rs.git?branch=main#bcb3fc518620635dbb172ce5f80e63177aa913ef"
 dependencies = [
  "bitvec",
  "lambdaworks-crypto",
@@ -11313,7 +11314,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.18",
+ "num-traits 0.2.17",
  "parity-scale-codec",
  "serde",
 ]
@@ -12341,7 +12342,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ pallet-grandpa = { default-features = true, git = "https://github.com/massalabs/
 pallet-timestamp = { default-features = true, git = "https://github.com/massalabs/polkadot-sdk", branch = "release-polkadot-v1.3.0-std" }
 
 # Bonsai trie dependencies
-bonsai-trie = { default-features = false, git = "https://github.com/keep-starknet-strange/bonsai-trie.git", branch = "oss", features = [
+bonsai-trie = { default-features = false, git = "https://github.com/trantorian1/bonsai-trie.git", branch = "oss", features = [
   "std",
 ] }
 

--- a/crates/client/db/Cargo.toml
+++ b/crates/client/db/Cargo.toml
@@ -38,6 +38,7 @@ starknet-ff = { workspace = true, default-features = false, features = [
   "alloc",
   "serde",
 ] }
+starknet-core = { workspace = true }
 starknet-types-core = { workspace = true, default-features = false, features = [
   "hash",
   "parity-scale-codec",

--- a/crates/client/db/Cargo.toml
+++ b/crates/client/db/Cargo.toml
@@ -34,11 +34,11 @@ blockifier = { workspace = true, default-features = false, features = [
   "testing",
 ] }
 bonsai-trie = { workspace = true }
+starknet-core = { workspace = true }
 starknet-ff = { workspace = true, default-features = false, features = [
   "alloc",
   "serde",
 ] }
-starknet-core = { workspace = true }
 starknet-types-core = { workspace = true, default-features = false, features = [
   "hash",
   "parity-scale-codec",

--- a/crates/client/db/src/storage.rs
+++ b/crates/client/db/src/storage.rs
@@ -310,6 +310,16 @@ impl ContractStorageTrieMut {
             .get(conv_contract_identifier(identifier), &conv_contract_storage_key(key))
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractStorage))
     }
+
+    pub fn get_storage(&self, identifier: &ContractAddress) -> Result<Vec<(Felt, Felt)>, DeoxysStorageError> {
+        Ok(self
+            .0
+            .get_key_value_pairs(conv_contract_identifier(identifier))
+            .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractStorage))?
+            .into_iter()
+            .map(|(k, v)| (Felt::from_bytes_be_slice(&k), Felt::from_bytes_be_slice(&v)))
+            .collect())
+    }
 }
 
 impl ContractStorageTrieView<'_> {

--- a/crates/client/rpc/src/methods/read/get_storage_at.rs
+++ b/crates/client/rpc/src/methods/read/get_storage_at.rs
@@ -72,7 +72,7 @@ where
 
     log::info!("block number: {block_number}");
 
-    let value = StorageHandler::contract_storage_mut(block_number)
+    let value = StorageHandler::contract_storage_mut(BlockId::Number(block_number))
         .map_err(|_| StarknetRpcApiError::ContractNotFound)?
         .get(&contract_address, &key)
         .unwrap_or(None)

--- a/crates/client/storage/src/overrides/mod.rs
+++ b/crates/client/storage/src/overrides/mod.rs
@@ -12,8 +12,6 @@ use sp_api::ProvideRuntimeApi;
 use sp_io::hashing::twox_128;
 use sp_runtime::traits::Block as BlockT;
 use starknet_api::api_core::{ClassHash, ContractAddress, Nonce};
-use starknet_api::hash::StarkFelt;
-use starknet_api::state::StorageKey;
 
 mod schema_v1_override;
 
@@ -56,9 +54,6 @@ impl<B: BlockT> OverrideHandle<B> {
 /// State Backend with some assumptions about pallet-starknet's storage schema. Using such an
 /// optimized implementation avoids spawning a runtime and the overhead associated with it.
 pub trait StorageOverride<B: BlockT>: Send + Sync {
-    /// get storage keys and values from a specific contract address
-    fn get_storage_from(&self, block_hash: B::Hash, address: ContractAddress) -> Option<Vec<(StorageKey, StarkFelt)>>;
-
     /// Return the class hash at the provided address for the provided block.
     fn contract_class_hash_by_address(&self, block_hash: B::Hash, address: ContractAddress) -> Option<ClassHash>;
     /// Return the contract class at the provided address for the provided block.
@@ -107,27 +102,6 @@ where
     C: ProvideRuntimeApi<B> + Send + Sync,
     C::Api: StarknetRuntimeApi<B>,
 {
-    /// Get the storage keys and values from a specific contract address
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - The contract address to fetch the storage from
-    ///
-    /// # Returns
-    /// * `Vec<(storage_key, storage_value)>` - The storage from the provided contract address
-    fn get_storage_from(
-        &self,
-        block_hash: <B as BlockT>::Hash,
-        address: ContractAddress,
-    ) -> Option<Vec<(StorageKey, StarkFelt)>> {
-        let api = self.client.runtime_api();
-        match api.get_storage_from(block_hash, address) {
-            Ok(Ok(storage)) => Some(storage),
-            Ok(Err(_)) => None,
-            Err(_) => None,
-        }
-    }
-
     /// Return the class hash at the provided address for the provided block.
     ///
     /// # Arguments

--- a/crates/client/storage/src/overrides/schema_v1_override.rs
+++ b/crates/client/storage/src/overrides/schema_v1_override.rs
@@ -5,7 +5,6 @@ use blockifier::execution::contract_class::ContractClass;
 use mp_contract::ContractAbi;
 use mp_storage::{
     PALLET_STARKNET, STARKNET_CONTRACT_ABI, STARKNET_CONTRACT_CLASS, STARKNET_CONTRACT_CLASS_HASH, STARKNET_NONCE,
-    STARKNET_STORAGE,
 };
 use parity_scale_codec::{Decode, Encode};
 // Substrate
@@ -14,8 +13,6 @@ use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
 use sp_storage::StorageKey;
 use starknet_api::api_core::{ClassHash, ContractAddress, Nonce};
-use starknet_api::hash::StarkFelt;
-use starknet_api::state::StorageKey as StarknetStorageKey;
 
 use super::{storage_key_build, storage_prefix_build, StorageOverride};
 
@@ -56,23 +53,6 @@ where
     C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,
     BE: Backend<B> + 'static,
 {
-    fn get_storage_from(
-        &self,
-        block_hash: <B as BlockT>::Hash,
-        address: ContractAddress,
-    ) -> Option<Vec<(StarknetStorageKey, StarkFelt)>> {
-        let storage_storage_prefix = storage_prefix_build(PALLET_STARKNET, STARKNET_STORAGE);
-        let storage = self.query_storage::<Vec<(StarknetStorageKey, StarkFelt)>>(
-            block_hash,
-            &StorageKey(storage_key_build(storage_storage_prefix, &self.encode_storage_key(&address))),
-        );
-
-        match storage {
-            Some(storage) => Some(storage),
-            None => Some(Default::default()),
-        }
-    }
-
     fn contract_class_by_address(
         &self,
         block_hash: <B as BlockT>::Hash,

--- a/crates/client/sync/src/commitments/lib.rs
+++ b/crates/client/sync/src/commitments/lib.rs
@@ -21,6 +21,7 @@ use starknet_api::api_core::{ClassHash, CompiledClassHash, ContractAddress, Nonc
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::Event;
+use starknet_core::types::BlockId;
 use starknet_ff::FieldElement;
 use starknet_types_core::felt::Felt;
 
@@ -194,8 +195,8 @@ fn contract_trie_root(
 ) -> Result<Felt252Wrapper, DeoxysStorageError> {
     // NOTE: handlers implicitely acquire a lock on their respective tries
     // for the duration of their livetimes
-    let mut contract_write = StorageHandler::contract_mut(block_number)?;
-    let mut storage_write = StorageHandler::contract_storage_mut(block_number)?;
+    let mut contract_write = StorageHandler::contract_mut(BlockId::Number(block_number))?;
+    let mut storage_write = StorageHandler::contract_storage_mut(BlockId::Number(block_number))?;
 
     // Tries need to be initialised before values are inserted
     contract_write.init()?;
@@ -309,7 +310,7 @@ lazy_static! {
 ///
 /// The class root.
 fn class_trie_root(csd: &CommitmentStateDiff, block_number: u64) -> Result<Felt252Wrapper, DeoxysStorageError> {
-    let mut class_write = StorageHandler::class_mut(block_number)?;
+    let mut class_write = StorageHandler::class_mut(BlockId::Number(block_number))?;
 
     let updates = csd
         .class_hash_to_compiled_class_hash

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -21,8 +21,7 @@ use mp_simulations::{PlaceHolderErrorTypeForFailedStarknetExecution, SimulationF
 use sp_runtime::DispatchError;
 use starknet_api::api_core::{ChainId, ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::block::{BlockNumber, BlockTimestamp};
-use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::StorageKey;
+use starknet_api::hash::StarkHash;
 use starknet_api::transaction::{Calldata, Event as StarknetEvent, Fee, MessageToL1, TransactionHash};
 
 #[derive(parity_scale_codec::Encode, parity_scale_codec::Decode, scale_info::TypeInfo)]
@@ -38,8 +37,6 @@ sp_api::decl_runtime_apis! {
     pub trait StarknetRuntimeApi {
         /// Returns the nonce associated with the given address in the given block
         fn nonce(contract_address: ContractAddress) -> Nonce;
-        /// Returns a storage keys and values of a given contract
-        fn get_storage_from(address: ContractAddress) -> Result<Vec<(StorageKey, StarkFelt)>, DispatchError>;
         /// Returns a `Call` response.
         fn call(address: ContractAddress, function_selector: EntryPointSelector, calldata: Calldata) -> Result<Vec<Felt252Wrapper>, DispatchError>;
         /// Returns the contract class hash at the given address.

--- a/crates/pallets/starknet/src/blockifier_state_adapter.rs
+++ b/crates/pallets/starknet/src/blockifier_state_adapter.rs
@@ -6,11 +6,13 @@ use blockifier::state::cached_state::{CommitmentStateDiff, StateChangesCount};
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{State, StateReader, StateResult};
 use indexmap::IndexMap;
+use mc_db::storage::StorageHandler;
 use mp_felt::Felt252Wrapper;
 use mp_state::StateChanges;
 use starknet_api::api_core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
+use starknet_core::types::{BlockId, BlockTag};
 use starknet_crypto::FieldElement;
 
 use crate::{Config, Pallet};
@@ -56,11 +58,11 @@ impl<T: Config> Default for BlockifierStateAdapter<T> {
 
 impl<T: Config> StateReader for BlockifierStateAdapter<T> {
     fn get_storage_at(&mut self, contract_address: ContractAddress, key: StorageKey) -> StateResult<StarkFelt> {
-        let search = Pallet::<T>::storage(contract_address).into_iter().find(|(storage_key, _)| key == *storage_key);
+        let search = StorageHandler::contract_storage().unwrap().get(&contract_address, &key);
 
         match search {
-            Some((_, value)) => Ok(value),
-            None => Err(StateError::StateReadError(format!(
+            Ok(Some(value)) => Ok(StarkFelt(value.to_bytes_be())),
+            _ => Err(StateError::StateReadError(format!(
                 "Failed to retrieve storage value for contract {} at key {}",
                 contract_address.0.0, key.0.0
             ))),
@@ -87,7 +89,11 @@ impl<T: Config> StateReader for BlockifierStateAdapter<T> {
 impl<T: Config> State for BlockifierStateAdapter<T> {
     fn set_storage_at(&mut self, contract_address: ContractAddress, key: StorageKey, value: StarkFelt) {
         self.storage_update.insert(contract_address, vec![(key, value)]);
-        crate::StorageView::<T>::insert(contract_address, vec![(key, value)]);
+        let _ = StorageHandler::contract_storage_mut(BlockId::Tag(BlockTag::Latest)).unwrap().insert(
+            &contract_address,
+            &key,
+            value,
+        );
     }
 
     fn increment_nonce(&mut self, contract_address: ContractAddress) -> StateResult<()> {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -56,8 +56,7 @@ pub use sp_runtime::{Perbill, Permill};
 use sp_std::prelude::*;
 use sp_version::RuntimeVersion;
 use starknet_api::api_core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
-use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::StorageKey;
+use starknet_api::hash::StarkHash;
 use starknet_api::transaction::{Calldata, Event as StarknetEvent, Fee, MessageToL1, TransactionHash};
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -232,11 +231,6 @@ impl_runtime_apis! {
     }
 
     impl pallet_starknet_runtime_api::StarknetRuntimeApi<Block> for Runtime {
-
-        fn get_storage_from(address: ContractAddress) -> Result<Vec<(StorageKey, StarkFelt)>, DispatchError> {
-            Starknet::get_storage_from(address)
-        }
-
         fn call(address: ContractAddress, function_selector: EntryPointSelector, calldata: Calldata) -> Result<Vec<Felt252Wrapper>, DispatchError> {
             Starknet::call_contract(address, function_selector, calldata)
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Contract storage is duplicated across the backend bonsai storage in `DeoxysBackend` and the Substrate storage.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Removed contract storage entirely from the Substrate runtime: it is now only accessed and updated via `StorageHandler` and the backend contract storage bonsai db.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No. Relevant functions have been updated to use the new storage capabilities.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

Any feedback on the impact this would have on execution with blockifier is welcome.

> :information_source:  Also note that some of the change were made in [this](https://github.com/Trantorian1/deoxys/blob/feat/storage/crates/client/db/src/storage.rs) pr on the bonsai-lib repo. Please refer to that version of the lib until that PR is approved.