### PR TITLE
fix(sync): Fix end condition of the l2 sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix(sync): Fix end condition of the l2 sync
 - fix(rpc): fix chain id method for mainnet
 - fix(class): Fix Sierra classes conversion (missing abis)
 - fix(compute): Fixed prepare_data_availability_modes computation

--- a/crates/client/sync/src/lib.rs
+++ b/crates/client/sync/src/lib.rs
@@ -41,7 +41,7 @@ pub mod starknet_sync_worker {
 
         let _ = tokio::join!(
             l1::sync(l1_url.clone()),
-            l2::sync(sender_config, fetch_config.clone(), starting_block.into(), client)
+            l2::sync(sender_config, fetch_config.clone(), starting_block.into(), None, client)
         );
     }
 }


### PR DESCRIPTION

# Pull Request type

- Bugfix

## What is the current behavior?

The end blocks don't get synced, as the fetch task stops the whole sync process

## What is the new behavior?

This does not do any polling to get new blocks, but it should sync the last few blocks correctly.
Please tell me if it doesnt :)

## Does this introduce a breaking change?
No


## Other information

