### PR TITLE
fix: :bug: fix StateReader for get_storage_at()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix: fix implementation `get_storage_at()` for `BlockifierStateAdapter`
 - fix(sync): Fix end condition of the l2 sync
 - fix(rpc): fix chain id method for mainnet
 - fix(class): Fix Sierra classes conversion (missing abis)


### PR DESCRIPTION
# Retrieve the value of a key from a given block in the bonsai lib


# Pull Request type

- Bugfix


## What is the current behavior?

- `get_storage_at` does not use cache of 'BlockifierStateAdapter' to retrieve keys
- `get_storage_at` retrieve the value of the keys on the last block


## What is the new behavior?


## Does this introduce a breaking change?


## Other information
