### PR TITLE
feat: :bug: fix a minor bug when computing l1HandlerTx hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix: l1HandlerTx computed for commit
 - refactor: optimise get_events RPC
 - fix(root): fixed state commitments broken due to genesis loader
 - feat(docker): add dockerfile and docker-compose

--- a/crates/client/rpc/src/methods/trace/simulate_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/simulate_transactions.rs
@@ -17,7 +17,6 @@ use sp_runtime::traits::Block as BlockT;
 use starknet_core::types::{
     BlockId, BroadcastedTransaction, FeeEstimate, PriceUnit, SimulatedTransaction, SimulationFlag,
 };
-use starknet_ff::FieldElement;
 
 use super::lib::ConvertCallInfoToExecuteInvocationError;
 use super::utils::tx_execution_infos_to_tx_trace;
@@ -103,8 +102,8 @@ fn tx_execution_infos_to_simulated_transactions<B: BlockT>(
                 let overall_fee = fee.into();
 
                 let unit: PriceUnit = PriceUnit::Wei; //TODO(Tbelleng) : Get Price Unit from Tx
-                let data_gas_consumed = FieldElement::default();
-                let data_gas_price = FieldElement::default();
+                let data_gas_consumed = tx_exec_info.da_gas.l1_data_gas.into();
+                let data_gas_price = tx_exec_info.da_gas.l1_gas.into();
 
                 results.push(SimulatedTransaction {
                     transaction_trace,

--- a/crates/client/sync/src/commitments/transactions.rs
+++ b/crates/client/sync/src/commitments/transactions.rs
@@ -70,6 +70,7 @@ where
                 H::compute_hash_on_elements(&[])
             }
         }
+        Transaction::L1Handler(_) => H::compute_hash_on_elements(&[]),
         _ => H::compute_hash_on_elements(&[]),
     };
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix 🐛

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

Fix computationalTx hash for L1HandlerTransaction (first tx occur at block 192) because this type of tx wasnt computed at all .
Also remove 2 default on fee computation

## Does this introduce a breaking change?

No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
