### PR TITLE
fix: db, add test, add codec traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix(db): with new implementation ContractStorage
 - feat(rocksdb): replaced most async database operations iwth multigets and batched inserts
 - fix: get_state_update with new storage
 - up: starknet-rs

--- a/crates/client/db/src/lib.rs
+++ b/crates/client/db/src/lib.rs
@@ -400,6 +400,10 @@ impl DeoxysBackend {
         DB_SINGLETON.get().expect("Databsae not initialized")
     }
 
+    pub fn compact() {
+        Self::expose_db().compact_range(None::<&[u8]>, None::<&[u8]>);
+    }
+
     /// Return l1 handler tx paid fee database manager
     pub fn l1_handler_paid_fee() -> &'static Arc<L1HandlerTxFeeDb> {
         BACKEND_SINGLETON.get().map(|backend| &backend.l1_handler_paid_fee).expect("Backend not initialized")

--- a/crates/client/db/src/storage_handler/codec.rs
+++ b/crates/client/db/src/storage_handler/codec.rs
@@ -1,0 +1,171 @@
+use std::io::{self, Cursor, Read, Write};
+
+use starknet_api::hash::StarkFelt;
+
+use super::history::History;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Decode error")]
+    DecodeError,
+    #[error("Encode error")]
+    EncodeError,
+}
+
+pub trait Encode {
+    fn encode(&self) -> Result<Vec<u8>, Error>;
+}
+
+pub trait Decode {
+    fn decode(bytes: &[u8]) -> Result<Self, Error>
+    where
+        Self: Sized;
+}
+
+impl Encode for StarkFelt {
+    fn encode(&self) -> Result<Vec<u8>, Error> {
+        let mut buffer = Vec::new();
+        self.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
+        Ok(buffer)
+    }
+}
+
+impl Decode for StarkFelt {
+    fn decode(bytes: &[u8]) -> Result<Self, Error> {
+        let mut cursor = std::io::Cursor::new(bytes);
+        StarkFelt::deserialize(&mut cursor).ok_or(Error::DecodeError)
+    }
+}
+
+impl Encode for History<StarkFelt> {
+    fn encode(&self) -> Result<Vec<u8>, Error> {
+        let mut buffer = Vec::new();
+        for &(index, value) in &self.0 {
+            serialize_vlq(index, &mut buffer).map_err(|_| Error::EncodeError)?;
+            value.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
+        }
+        Ok(buffer)
+    }
+}
+
+impl Decode for History<StarkFelt> {
+    fn decode(bytes: &[u8]) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let mut cursor = Cursor::new(bytes);
+        let mut history = Vec::new();
+        while (cursor.position() as usize) < bytes.len() {
+            let index = deserialize_vlq(&mut cursor).map_err(|_| Error::DecodeError)?;
+            let value = StarkFelt::deserialize(&mut cursor).ok_or(Error::DecodeError)?;
+            history.push((index, value));
+        }
+        Ok(History(history))
+    }
+}
+
+/// Write a variable-length quantity to the writer from an u64.
+/// The value is written as a sequence of 7-bit bytes, with the most significant bits first.
+/// The most significant bit of each byte is set if there are more bytes to read.
+fn serialize_vlq(mut value: u64, writer: &mut impl Write) -> io::Result<()> {
+    loop {
+        let mut byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        writer.write_all(&[byte])?;
+        if value == 0 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Read a variable-length quantity from the reader into an u64.
+/// The value is read as a sequence of 7-bit bytes, with the most significant bits first.
+/// The most significant bit of each byte is set if there are more bytes to read.
+fn deserialize_vlq(reader: &mut impl Read) -> io::Result<u64> {
+    let mut value: u64 = 0;
+    let mut shift = 0;
+    loop {
+        let mut byte = [0];
+        reader.read_exact(&mut byte)?;
+        value |= ((byte[0] & 0x7F) as u64) << shift;
+        if byte[0] & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vlq() {
+        let mut buffer = Vec::new();
+        serialize_vlq(0, &mut buffer).unwrap();
+        assert_eq!(buffer, [0]);
+        buffer.clear();
+
+        serialize_vlq(127, &mut buffer).unwrap();
+        assert_eq!(buffer, [127]);
+        buffer.clear();
+
+        serialize_vlq(128, &mut buffer).unwrap();
+        assert_eq!(buffer, [0x80, 1]);
+        buffer.clear();
+
+        serialize_vlq(300, &mut buffer).unwrap();
+        assert_eq!(buffer, [0xAC, 2]);
+        buffer.clear();
+
+        serialize_vlq(16384, &mut buffer).unwrap();
+        assert_eq!(buffer, [0x80, 0x80, 1]);
+        buffer.clear();
+
+        serialize_vlq(2097152, &mut buffer).unwrap();
+        assert_eq!(buffer, [0x80, 0x80, 0x80, 1]);
+        buffer.clear();
+
+        let mut cursor = Cursor::new(&[0x80, 0x80, 0x80, 1]);
+        assert_eq!(deserialize_vlq(&mut cursor).unwrap(), 2097152);
+        assert_eq!(cursor.position(), 4);
+        cursor.set_position(0);
+
+        assert_eq!(deserialize_vlq(&mut cursor).unwrap(), 2097152);
+        assert_eq!(cursor.position(), 4);
+    }
+
+    #[test]
+    fn test_encode_decode_starkfelt() {
+        let value = StarkFelt::from(42 as u64);
+        let bytes = value.encode().unwrap();
+        let decoded = StarkFelt::decode(&bytes).unwrap();
+        assert_eq!(value, decoded);
+    }
+
+    #[test]
+    fn test_encode_decode_history() {
+        let mut history = History::default();
+        history.push(0, StarkFelt::from(42 as u64)).unwrap();
+        history
+            .push(
+                42,
+                StarkFelt::try_from("0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7").unwrap(),
+            )
+            .unwrap();
+        history
+            .push(
+                u64::MAX,
+                StarkFelt::try_from("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d").unwrap(),
+            )
+            .unwrap();
+        let bytes = history.encode().unwrap();
+        let decoded = History::decode(&bytes).unwrap();
+        assert_eq!(history.0, decoded.0);
+    }
+}

--- a/crates/client/db/src/storage_handler/codec.rs
+++ b/crates/client/db/src/storage_handler/codec.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_starkfelt() {
-        let value = StarkFelt::from(42 as u64);
+        let value = StarkFelt::from(42_u64);
         let bytes = value.encode().unwrap();
         let decoded = StarkFelt::decode(&bytes).unwrap();
         assert_eq!(value, decoded);
@@ -151,7 +151,7 @@ mod tests {
     #[test]
     fn test_encode_decode_history() {
         let mut history = History::default();
-        history.push(0, StarkFelt::from(42 as u64)).unwrap();
+        history.push(0, StarkFelt::from(42_u64)).unwrap();
         history
             .push(
                 42,

--- a/crates/client/db/src/storage_handler/contract_data.rs
+++ b/crates/client/db/src/storage_handler/contract_data.rs
@@ -44,18 +44,18 @@ impl StorageView for ContractDataView {
 }
 
 impl ContractDataView {
-    pub fn get_nonce(self, contract_address: &ContractAddress) -> Result<Option<Nonce>, DeoxysStorageError> {
+    pub fn get_nonce(&self, contract_address: &ContractAddress) -> Result<Option<Nonce>, DeoxysStorageError> {
         self.get(contract_address)
             .map(|option| option.map(|contract_data| contract_data.nonce.get().cloned().unwrap_or_default()))
     }
 
-    pub fn get_class_hash(self, contract_address: &ContractAddress) -> Result<Option<ClassHash>, DeoxysStorageError> {
+    pub fn get_class_hash(&self, contract_address: &ContractAddress) -> Result<Option<ClassHash>, DeoxysStorageError> {
         self.get(contract_address)
             .map(|option| option.and_then(|contract_data| contract_data.class_hash.get().cloned()))
     }
 
     pub fn get_nonce_at(
-        self,
+        &self,
         contract_address: &ContractAddress,
         block_number: u64,
     ) -> Result<Option<Nonce>, DeoxysStorageError> {
@@ -75,7 +75,7 @@ impl ContractDataView {
     }
 
     pub fn get_class_hash_at(
-        self,
+        &self,
         contract_address: &ContractAddress,
         block_number: u64,
     ) -> Result<Option<ClassHash>, DeoxysStorageError> {

--- a/crates/client/db/src/storage_handler/contract_storage.rs
+++ b/crates/client/db/src/storage_handler/contract_storage.rs
@@ -199,7 +199,7 @@ impl StorageViewRevetible for ContractStorageViewMut {
     }
 }
 
-impl ContractStorageViewMut {
+impl ContractStorageView {
     pub fn get_at(
         &self,
         key: &(ContractAddress, StorageKey),

--- a/crates/client/db/src/storage_handler/history.rs
+++ b/crates/client/db/src/storage_handler/history.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// A simple history implementation that stores values at a given index.
 #[derive(Serialize, Deserialize, Default)]
 #[serde(bound = "T: Serialize + DeserializeOwned")]
-pub struct History<T>(Vec<(u64, T)>);
+pub struct History<T>(pub Vec<(u64, T)>);
 
 /// A simple history implementation that stores values at a given index.
 /// It allows to get the value at a given index, push a new value with an index,
@@ -69,5 +69,49 @@ where
             write!(f, "{:?} => {:?}, ", index, value)?;
         }
         write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_history() {
+        let mut history = History::<u64>::default();
+
+        assert_eq!(history.get(), None);
+        assert_eq!(history.get_at(0), None);
+
+        history.push(0, 0).unwrap();
+        assert_eq!(history.get(), Some(&0));
+        assert_eq!(history.get_at(0), Some(&0));
+        assert_eq!(history.get_at(1), Some(&0));
+
+        history.push(1, 1).unwrap();
+        assert_eq!(history.get(), Some(&1));
+        assert_eq!(history.get_at(0), Some(&0));
+        assert_eq!(history.get_at(1), Some(&1));
+        assert_eq!(history.get_at(2), Some(&1));
+
+        history.push(2, 2).unwrap();
+        assert_eq!(history.get(), Some(&2));
+        assert_eq!(history.get_at(0), Some(&0));
+        assert_eq!(history.get_at(1), Some(&1));
+        assert_eq!(history.get_at(2), Some(&2));
+        assert_eq!(history.get_at(3), Some(&2));
+
+        history.push(1, 3).unwrap_err();
+        assert_eq!(history.get(), Some(&2));
+        assert_eq!(history.get_at(0), Some(&0));
+        assert_eq!(history.get_at(1), Some(&1));
+        assert_eq!(history.get_at(2), Some(&2));
+        assert_eq!(history.get_at(3), Some(&2));
+
+        history.revert_to(1);
+        assert_eq!(history.get(), Some(&1));
+        assert_eq!(history.get_at(0), Some(&0));
+        assert_eq!(history.get_at(1), Some(&1));
+        assert_eq!(history.get_at(2), Some(&1));
     }
 }

--- a/crates/client/db/src/storage_handler/mod.rs
+++ b/crates/client/db/src/storage_handler/mod.rs
@@ -28,6 +28,7 @@ pub mod block_hash;
 pub mod block_number;
 pub mod block_state_diff;
 mod class_trie;
+mod codec;
 mod contract_class_data;
 mod contract_class_hashes;
 mod contract_data;
@@ -63,6 +64,8 @@ pub enum DeoxysStorageError {
     StorageRetrievalError(StorageType),
     #[error("failed to commit to {0}")]
     StorageCommitError(StorageType),
+    #[error("failed to encode {0}")]
+    StorageEncodeError(StorageType),
     #[error("failed to decode {0}")]
     StorageDecodeError(StorageType),
     #[error("failed to revert {0} to block {1}")]

--- a/crates/client/rpc/src/utils/execution.rs
+++ b/crates/client/rpc/src/utils/execution.rs
@@ -64,12 +64,12 @@ pub fn re_execute_transactions(
 
     transactions_before
         .into_iter()
-        .map(|tx| tx.execute(&mut cached_state, block_context, charge_fee, false))
+        .map(|tx| tx.execute(&mut cached_state, block_context, charge_fee, true))
         .collect::<Result<Vec<_>, _>>()?;
 
     let transactions_exec_infos = transactions_to_trace
         .into_iter()
-        .map(|tx| tx.execute(&mut cached_state, block_context, charge_fee, false))
+        .map(|tx| tx.execute(&mut cached_state, block_context, charge_fee, true))
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(transactions_exec_infos)

--- a/crates/client/sync/src/l2.rs
+++ b/crates/client/sync/src/l2.rs
@@ -7,6 +7,7 @@ use futures::prelude::*;
 use lazy_static::lazy_static;
 use mc_db::storage_handler::primitives::contract_class::ClassUpdateWrapper;
 use mc_db::storage_updates::{store_class_update, store_state_update};
+use mc_db::DeoxysBackend;
 use mp_block::DeoxysBlock;
 use mp_felt::Felt252Wrapper;
 use mp_types::block::{DBlockT, DHashT};
@@ -248,6 +249,11 @@ pub async fn sync<C>(
                 create_block(&mut command_sink, &mut last_block_hash).await.expect("creating block");
                 log::debug!("end create_block: {:?}", std::time::Instant::now() - start);
                 block_n += 1;
+
+                // compact DB every 1k blocks
+                if block_n % 1000 == 0 {
+                    DeoxysBackend::compact();
+                }
             }
         } => {},
         // store state updates


### PR DESCRIPTION
# fix: db, add test, add codec traits

## Pull Request type

- Bugfix
- Feature


## What is the current behavior?


## What is the new behavior?

- add codec traits on Starkfelt and History<T>
- use `get_storage_at` instead of using bonsai
- add unit tests

## Does this introduce a breaking change?

No

## Other information


