### PR TITLE
Allow compiling without libm + Fix state corruption during sync when doing CTRL+c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix: class and store updates and block desync after ctrl+c
 - fix: compile without libm
 - refactor: optimize get_class_at
 - fix: crash build genesis on restart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix: compile without libm
 - refactor: optimize get_class_at
 - fix: crash build genesis on restart
 - fix(classes): Fixed sierra exception on block 31625 and added --starting-block arg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,7 +236,7 @@ mc-db = { path = "crates/client/db" }
 mc-genesis-data-provider = { path = "crates/client/genesis-data-provider" }
 mc-mapping-sync = { path = "crates/client/mapping-sync" }
 mc-rpc = { path = "crates/client/rpc" }
-mc-sync = { path = "crates/client/sync" }
+mc-sync = { path = "crates/client/sync", default-features = false }
 
 # Deoxys runtime
 deoxys-runtime = { path = "crates/runtime" }

--- a/crates/client/sync/src/lib.rs
+++ b/crates/client/sync/src/lib.rs
@@ -15,7 +15,9 @@ pub mod utils;
 
 pub use l2::SenderConfig;
 pub use mp_types::block::{DBlockT, DHashT};
-pub use utils::{convert, m, utility};
+#[cfg(feature = "m")]
+pub use utils::m;
+pub use utils::{convert, utility};
 
 type CommandSink = futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<sp_core::H256>>;
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -100,7 +100,8 @@ url = { workspace = true }
 substrate-build-script-utils = { workspace = true }
 
 [features]
-default = []
+default = ["sound"]
+sound = ["mc-sync/m"]
 # Dependencies that are only required if runtime benchmarking should be build.
 runtime-benchmarks = [
   "frame-benchmarking-cli/runtime-benchmarks",


### PR DESCRIPTION

# Pull Request type


- Bugfix

## What is the current behavior?

Resolves: #NA

## What is the new behavior?
- Allow compiling without libm
- Fix state corruption during sync when doing CTRL+c
## Does this introduce a breaking change?
No

## Other information
Also, made the create_block do stuff in parallel wrt. state/class updates