### PR TITLE
fix: nonce & key/value storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix: storage nonce
 - fix: class and store updates and block desync after ctrl+c
 - fix: compile without libm
 - fix: genesis state_update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
-- fix: storage nonce
+- fix: storage nonce and key/value
 - fix: class and store updates and block desync after ctrl+c
 - fix: compile without libm
 - fix: genesis state_update

--- a/crates/client/db/src/storage_handler/contract_data.rs
+++ b/crates/client/db/src/storage_handler/contract_data.rs
@@ -93,6 +93,17 @@ impl ContractDataView {
 
         Ok(contract_data.class_hash.get_at(block_number).cloned())
     }
+
+    pub fn is_contract_deployed_at(
+        &self,
+        contract_address: &ContractAddress,
+        block_number: u64,
+    ) -> Result<bool, DeoxysStorageError> {
+        match self.get(contract_address)? {
+            Some(contract_data) => Ok(contract_data.class_hash.get_at(block_number).is_some()),
+            None => Ok(false),
+        }
+    }
 }
 
 impl StorageViewMut for ContractDataViewMut {

--- a/crates/client/db/src/storage_updates.rs
+++ b/crates/client/db/src/storage_updates.rs
@@ -26,7 +26,7 @@ pub async fn store_state_update(block_number: u64, state_update: StateUpdate) ->
 
     log::debug!("💾 update state: block_number: {}", block_number);
 
-    let (result1, result2, result3, result4) = tokio::join!(
+    let (result1, result2, result3) = tokio::join!(
         // Contract address to class hash and nonce update
         async move {
             let handler_contract_data = storage_handler::contract_data_mut();
@@ -81,15 +81,12 @@ pub async fn store_state_update(block_number: u64, state_update: StateUpdate) ->
         },
         // Block number to state diff update
         async move { storage_handler::block_state_diff().insert(block_number, state_diff) },
-        // Contract address to contract storage update
-        async move { storage_handler::contract_storage_mut().commit(block_number) }
     );
 
-    match (result1, result2, result3, result4) {
-        (Err(err), _, _, _) => Err(err),
-        (_, Err(err), _, _) => Err(err),
-        (_, _, Err(err), _) => Err(err),
-        (_, _, _, Err(err)) => Err(err),
+    match (result1, result2, result3) {
+        (Err(err), _, _) => Err(err),
+        (_, Err(err), _) => Err(err),
+        (_, _, Err(err)) => Err(err),
         _ => Ok(()),
     }
 }

--- a/crates/client/sync/src/commitments/lib.rs
+++ b/crates/client/sync/src/commitments/lib.rs
@@ -183,6 +183,7 @@ fn contract_trie_root(csd: &CommitmentStateDiff, block_number: u64) -> Result<Fe
 
     // Then we commit them
     handler_storage_trie.commit(block_number)?;
+    handler_storage.commit(block_number)?;
 
     // Then we compute the leaf hashes retrieving the corresponding storage root
     let updates = csd


### PR DESCRIPTION
# fix: nonce & key/value storage

## Pull Request type

- Bugfix

## What is the current behavior?

- the nonce is stored only if the contract is deployed in the same block
- key/value are not stored

## What is the new behavior?

- the nonce is updated normally in the history
- key/value are updated normally in the history
- key/value **are not stored** in `--disable-root` mode

## Does this introduce a breaking change?


## Other information
