### PR TITLE
feat: store key/value in `--disble-root` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- feat: store key/value in `--disble-root` mode
 - fix: storage nonce and key/value
 - fix: class and store updates and block desync after ctrl+c
 - fix: compile without libm

--- a/crates/client/db/src/storage_updates.rs
+++ b/crates/client/db/src/storage_updates.rs
@@ -112,8 +112,6 @@ pub async fn store_class_update(block_number: u64, class_update: ClassUpdateWrap
     handler_contract_class_data_mut.commit(block_number)
 }
 
-// this function used only in `--disable-root` mode
-// in `--disable-root` mode, keys are stored in `contract_trie_root` function
 pub async fn store_key_update(
     block_number: u64,
     storage_diffs: &Vec<ContractStorageDiffItem>,

--- a/crates/client/db/src/storage_updates.rs
+++ b/crates/client/db/src/storage_updates.rs
@@ -114,7 +114,7 @@ pub async fn store_class_update(block_number: u64, class_update: ClassUpdateWrap
 
 // this function used only in `--disable-root` mode
 // in `--disable-root` mode, keys are stored in `contract_trie_root` function
-pub fn store_key_update(
+pub async fn store_key_update(
     block_number: u64,
     storage_diffs: &Vec<ContractStorageDiffItem>,
 ) -> Result<(), DeoxysStorageError> {

--- a/crates/client/sync/src/l2.rs
+++ b/crates/client/sync/src/l2.rs
@@ -243,15 +243,11 @@ pub async fn sync<C>(
                         log::debug!("end store_class {}: {:?}", block_n, std::time::Instant::now() - start);
                     },
                     async {
-                        // store key update only if not verifying
-                        // because we already stored the key update in verify_l2
-                        if !verify {
                             let start = std::time::Instant::now();
                             if store_key_update(block_n, &storage_diffs).await.is_err() {
                                 log::info!("❗ Failed to store key update for block {block_n}");
                             };
                             log::debug!("end store_key {}: {:?}", block_n, std::time::Instant::now() - start);
-                        }
                     },
                     async {
                         let start = std::time::Instant::now();


### PR DESCRIPTION
# feat: store key/value in `--disble-root` mode

## Pull Request type

- Feature

## What is the current behavior?

- key/value are not stored in `--disable-root` mode (#96)

## What is the new behavior?

- key/value are stored in `--disable-root` mode 


## Does this introduce a breaking change?


## Other information


