### PR TITLE
fix: remove `unwrap` in storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Deoxys Changelog
 
 ## Next release
 
+- fix: sync, remove `unwrap` in storage
 - fix(classes): Fixed classes on the RPC level by adding ordering and complete deserialisation
 - fix: class update
 - feat: store key/value in `--disble-root` mode

--- a/crates/client/db/src/storage_handler/block_number.rs
+++ b/crates/client/db/src/storage_handler/block_number.rs
@@ -10,14 +10,14 @@ impl BlockNumberView {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::BlockHashToNumber);
 
-        db.put_cf(&column, bincode::serialize(&block_hash).unwrap(), bincode::serialize(&block_number).unwrap())
+        db.put_cf(&column, bincode::serialize(&block_hash)?, bincode::serialize(&block_number)?)
             .map_err(|_| DeoxysStorageError::StorageInsertionError(StorageType::BlockNumber))
     }
     pub fn get(&self, block_hash: &Felt252Wrapper) -> Result<Option<u64>, DeoxysStorageError> {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::BlockHashToNumber);
         let block_number = db
-            .get_cf(&column, bincode::serialize(&block_hash).unwrap())
+            .get_cf(&column, bincode::serialize(&block_hash)?)
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::BlockNumber))?
             .map(|bytes| bincode::deserialize::<u64>(&bytes[..]));
 
@@ -32,7 +32,7 @@ impl BlockNumberView {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::BlockHashToNumber);
 
-        match db.key_may_exist_cf(&column, bincode::serialize(&block_hash).unwrap()) {
+        match db.key_may_exist_cf(&column, bincode::serialize(&block_hash)?) {
             true => Ok(self.get(block_hash)?.is_some()),
             false => Ok(false),
         }

--- a/crates/client/db/src/storage_handler/block_state_diff.rs
+++ b/crates/client/db/src/storage_handler/block_state_diff.rs
@@ -10,7 +10,7 @@ impl BlockStateDiffView {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::BlockStateDiff);
 
-        db.put_cf(&column, bincode::serialize(&block_number).unwrap(), bincode::serialize(&state_diff).unwrap())
+        db.put_cf(&column, bincode::serialize(&block_number)?, bincode::serialize(&state_diff)?)
             .map_err(|_| DeoxysStorageError::StorageInsertionError(StorageType::BlockStateDiff))
     }
 
@@ -19,7 +19,7 @@ impl BlockStateDiffView {
         let column = db.get_column(Column::BlockStateDiff);
 
         let state_diff = db
-            .get_cf(&column, bincode::serialize(&block_number).unwrap())
+            .get_cf(&column, bincode::serialize(&block_number)?)
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::BlockStateDiff))?
             .map(|bytes| bincode::deserialize::<StateDiff>(&bytes[..]));
 
@@ -34,7 +34,7 @@ impl BlockStateDiffView {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::BlockStateDiff);
 
-        match db.key_may_exist_cf(&column, bincode::serialize(&block_number).unwrap()) {
+        match db.key_may_exist_cf(&column, bincode::serialize(&block_number)?) {
             true => Ok(self.get(block_number)?.is_some()),
             false => Ok(false),
         }

--- a/crates/client/db/src/storage_handler/contract_class_hashes.rs
+++ b/crates/client/db/src/storage_handler/contract_class_hashes.rs
@@ -18,7 +18,7 @@ impl StorageView for ContractClassHashesView {
         let column = db.get_column(Column::ContractClassHashes);
 
         let compiled_class_hash = db
-            .get_cf(&column, bincode::serialize(&class_hash).unwrap())
+            .get_cf(&column, bincode::serialize(&class_hash)?)
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractClassHashes))?
             .map(|bytes| bincode::deserialize::<CompiledClassHash>(&bytes[..]));
 
@@ -33,7 +33,7 @@ impl StorageView for ContractClassHashesView {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::ContractClassHashes);
 
-        match db.key_may_exist_cf(&column, bincode::serialize(&class_hash).unwrap()) {
+        match db.key_may_exist_cf(&column, bincode::serialize(&class_hash)?) {
             true => Ok(self.get(class_hash)?.is_some()),
             false => Ok(false),
         }
@@ -55,7 +55,7 @@ impl StorageViewMut for ContractClassHashesViewMut {
 
         let mut batch = WriteBatchWithTransaction::<true>::default();
         for (key, value) in self.0.into_iter() {
-            batch.put_cf(&column, bincode::serialize(&key).unwrap(), bincode::serialize(&value).unwrap());
+            batch.put_cf(&column, bincode::serialize(&key)?, bincode::serialize(&value)?);
         }
         db.write(batch).map_err(|_| DeoxysStorageError::StorageCommitError(StorageType::ContractClassHashes))
     }

--- a/crates/client/db/src/storage_handler/contract_data.rs
+++ b/crates/client/db/src/storage_handler/contract_data.rs
@@ -21,7 +21,7 @@ impl StorageView for ContractDataView {
         let column = db.get_column(Column::ContractData);
 
         match db
-            .get_cf(&column, bincode::serialize(&contract_address).unwrap())
+            .get_cf(&column, bincode::serialize(&contract_address)?)
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractData))?
         {
             Some(bytes) => Ok(Some(
@@ -36,7 +36,7 @@ impl StorageView for ContractDataView {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::ContractData);
 
-        match db.key_may_exist_cf(&column, bincode::serialize(&contract_address).unwrap()) {
+        match db.key_may_exist_cf(&column, bincode::serialize(&contract_address)?) {
             true => Ok(self.get(contract_address)?.is_some()),
             false => Ok(false),
         }
@@ -63,11 +63,10 @@ impl ContractDataView {
         let column = db.get_column(Column::ContractData);
 
         let contract_data = match db
-            .get_cf(&column, bincode::serialize(&contract_address).unwrap())
+            .get_cf(&column, bincode::serialize(&contract_address)?)
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractData))?
         {
-            Some(bytes) => bincode::deserialize::<StorageContractData>(&bytes[..])
-                .map_err(|_| DeoxysStorageError::StorageDecodeError(StorageType::ContractData))?,
+            Some(bytes) => bincode::deserialize::<StorageContractData>(&bytes[..])?,
             None => StorageContractData::default(),
         };
 
@@ -83,7 +82,7 @@ impl ContractDataView {
         let column = db.get_column(Column::ContractData);
 
         let contract_data = match db
-            .get_cf(&column, bincode::serialize(&contract_address).unwrap())
+            .get_cf(&column, bincode::serialize(&contract_address)?)
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractData))?
         {
             Some(bytes) => bincode::deserialize::<StorageContractData>(&bytes[..])
@@ -137,14 +136,14 @@ impl StorageViewMut for ContractDataViewMut {
         let mut batch = WriteBatchWithTransaction::<true>::default();
         for (key, mut contract_data, (class_hash, nonce)) in izip!(keys, histories, values) {
             if let Some(class_hash) = class_hash {
-                contract_data.class_hash.push(block_number, class_hash).unwrap();
+                contract_data.class_hash.push(block_number, class_hash)?;
             }
 
             if let Some(nonce) = nonce {
-                contract_data.nonce.push(block_number, nonce).unwrap();
+                contract_data.nonce.push(block_number, nonce)?;
             }
 
-            batch.put_cf(&column, bincode::serialize(&key).unwrap(), bincode::serialize(&contract_data).unwrap());
+            batch.put_cf(&column, bincode::serialize(&key)?, bincode::serialize(&contract_data)?);
         }
         db.write(batch).map_err(|_| DeoxysStorageError::StorageCommitError(StorageType::ContractData))
     }
@@ -159,7 +158,7 @@ impl StorageView for ContractDataViewMut {
         let column = db.get_column(Column::ContractData);
 
         match db
-            .get_cf(&column, bincode::serialize(&contract_address).unwrap())
+            .get_cf(&column, bincode::serialize(&contract_address)?)
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractData))?
         {
             Some(bytes) => Ok(Some(
@@ -174,7 +173,7 @@ impl StorageView for ContractDataViewMut {
         let db = DeoxysBackend::expose_db();
         let column = db.get_column(Column::ContractData);
 
-        match db.key_may_exist_cf(&column, bincode::serialize(&contract_address).unwrap()) {
+        match db.key_may_exist_cf(&column, bincode::serialize(&contract_address)?) {
             true => Ok(self.get(contract_address)?.is_some()),
             false => Ok(false),
         }
@@ -203,7 +202,7 @@ impl StorageViewRevetible for ContractDataViewMut {
                     .delete(key)
                     .map_err(|_| DeoxysStorageError::StorageRevertError(StorageType::ContractData, block_number))?,
                 _ => db
-                    .put_cf(&column, key, bincode::serialize(&contract_data).unwrap())
+                    .put_cf(&column, key, bincode::serialize(&contract_data)?)
                     .map_err(|_| DeoxysStorageError::StorageRevertError(StorageType::ContractData, block_number))?,
             }
         }

--- a/crates/client/db/src/storage_handler/history.rs
+++ b/crates/client/db/src/storage_handler/history.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 #[serde(bound = "T: Serialize + DeserializeOwned")]
 pub struct History<T>(pub Vec<(u64, T)>);
 
+pub enum HistoryError {
+    ValueNotOrdered,
+}
+
 /// A simple history implementation that stores values at a given index.
 /// It allows to get the value at a given index, push a new value with an index,
 /// and revert the history to a given index.
@@ -17,9 +21,9 @@ where
 {
     /// Push a new value with an index.
     /// If the index is smaller or equal to the last index, it will return an error.
-    pub fn push(&mut self, index: u64, value: T) -> Result<(), ()> {
+    pub fn push(&mut self, index: u64, value: T) -> Result<(), HistoryError> {
         match self.0.last() {
-            Some((last_index, _)) if index <= *last_index => Err(()),
+            Some((last_index, _)) if index <= *last_index => Err(HistoryError::ValueNotOrdered),
             _ => {
                 self.0.push((index, value));
                 Ok(())

--- a/crates/client/db/src/storage_handler/history.rs
+++ b/crates/client/db/src/storage_handler/history.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[serde(bound = "T: Serialize + DeserializeOwned")]
 pub struct History<T>(pub Vec<(u64, T)>);
 
+#[derive(Debug)]
 pub enum HistoryError {
     ValueNotOrdered,
 }

--- a/crates/client/db/src/storage_handler/mod.rs
+++ b/crates/client/db/src/storage_handler/mod.rs
@@ -68,8 +68,24 @@ pub enum DeoxysStorageError {
     StorageEncodeError(StorageType),
     #[error("failed to decode {0}")]
     StorageDecodeError(StorageType),
+    #[error("failed to serialize/deserialize")]
+    StorageSerdeError,
     #[error("failed to revert {0} to block {1}")]
     StorageRevertError(StorageType, u64),
+    #[error("failed to push new value in history")]
+    StorageHistoryError
+}
+
+impl From<bincode::Error> for DeoxysStorageError {
+    fn from(_: bincode::Error) -> Self {
+        DeoxysStorageError::StorageSerdeError
+    }
+}
+
+impl From<history::HistoryError> for DeoxysStorageError {
+    fn from(_: history::HistoryError) -> Self {
+        DeoxysStorageError::StorageHistoryError
+    }
 }
 
 #[derive(Debug)]

--- a/crates/client/db/src/storage_handler/mod.rs
+++ b/crates/client/db/src/storage_handler/mod.rs
@@ -73,7 +73,7 @@ pub enum DeoxysStorageError {
     #[error("failed to revert {0} to block {1}")]
     StorageRevertError(StorageType, u64),
     #[error("failed to push new value in history")]
-    StorageHistoryError
+    StorageHistoryError,
 }
 
 impl From<bincode::Error> for DeoxysStorageError {


### PR DESCRIPTION
# fix: remove `unwrap` in storage

## Pull Request type

- Bugfix


## What is the current behavior?

- if the block sync stops with the storage updates already in db but not the block, when restarting the program crashes

## What is the new behavior?

- remove unwrap in the storage

## Does this introduce a breaking change?


## Other information


