### PR TITLE
perf: convert blocks in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- perf: convert blocks in parallel
 - feat(commitments): Joined hash computation in event and tx commitments
 - feat(l2 sync): polling to get new blocks once sync has caught up with the chain
 - perf: store key

--- a/crates/client/sync/src/fetch/fetchers.rs
+++ b/crates/client/sync/src/fetch/fetchers.rs
@@ -110,7 +110,7 @@ pub async fn fetch_apply_genesis_block(config: FetchConfig) -> Result<DeoxysBloc
     };
     let block = client.get_block(BlockId::Number(0)).await.map_err(|e| format!("failed to get block: {e}"))?;
 
-    Ok(crate::convert::block(block).await)
+    Ok(crate::convert::convert_block(block).expect("invalid genesis block"))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/client/sync/src/utils/convert.rs
+++ b/crates/client/sync/src/utils/convert.rs
@@ -23,13 +23,11 @@ use starknet_providers::sequencer::models::state_update::{
 use starknet_providers::sequencer::models::{self as p, StateUpdate as StateUpdateProvider};
 
 use crate::commitments::lib::calculate_commitments;
+use crate::l2::L2SyncError;
 use crate::utility::get_config;
 
-pub async fn block(block: p::Block) -> DeoxysBlock {
-    tokio::task::spawn_blocking(|| convert_block_sync(block)).await.expect("join error")
-}
-
-pub fn convert_block_sync(block: p::Block) -> DeoxysBlock {
+/// Compute heavy, this should only be called in a rayon ctx
+pub fn convert_block(block: p::Block) -> Result<DeoxysBlock, L2SyncError> {
     // converts starknet_provider transactions and events to mp_transactions and starknet_api events
     let transactions = transactions(block.transactions);
     let events = events(&block.transaction_receipts);
@@ -72,7 +70,7 @@ pub fn convert_block_sync(block: p::Block) -> DeoxysBlock {
         .map(|(i, r)| mp_block::OrderedEvents::new(i as u128, r.events.iter().map(event).collect()))
         .collect();
 
-    DeoxysBlock::new(header, transactions, ordered_events)
+    Ok(DeoxysBlock::new(header, transactions, ordered_events))
 }
 
 fn transactions(txs: Vec<p::TransactionType>) -> Vec<Transaction> {

--- a/crates/client/sync/src/utils/mod.rs
+++ b/crates/client/sync/src/utils/mod.rs
@@ -1,5 +1,24 @@
+#![macro_use]
+#![allow(clippy::new_without_default)]
+use std::time::Instant;
+
 pub mod constant;
 pub mod convert;
 #[cfg(feature = "m")]
 pub mod m;
 pub mod utility;
+
+pub struct PerfStopwatch(pub Instant);
+
+impl PerfStopwatch {
+    pub fn new() -> PerfStopwatch {
+        PerfStopwatch(Instant::now())
+    }
+}
+
+#[macro_export]
+macro_rules! stopwatch_end {
+    ($stopwatch:expr, $($arg:tt)+) => {
+        log::debug!($($arg)+, $stopwatch.0.elapsed())
+    }
+}


### PR DESCRIPTION
# Pull Request type

- Perf

## What is the current behavior?

sequencial

## What is the new behavior?

blocks are converted and commitments computed in parallel, up to 10 blocks in the future

## Does this introduce a breaking change?

No

## Other information
