### PR TITLE
performance improvement for data storage key/value history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- perf: storage key with encode
 - feat: up blockifier to v0.6.0-rc.2
 - fix: change bonsai-trie fork location
 - refactor: remove L1HandlerTxFee

--- a/crates/client/db/src/storage_handler/codec.rs
+++ b/crates/client/db/src/storage_handler/codec.rs
@@ -76,15 +76,6 @@ impl Decode for History<StarkFelt> {
     }
 }
 
-impl Encode for &(ContractAddress, StorageKey) {
-    fn encode(&self) -> Result<Vec<u8>, Error> {
-        let mut buffer = Vec::new();
-        self.0.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
-        self.1.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
-        Ok(buffer)
-    }
-}
-
 impl Encode for (ContractAddress, StorageKey) {
     fn encode(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::new();

--- a/crates/client/db/src/storage_handler/codec.rs
+++ b/crates/client/db/src/storage_handler/codec.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Cursor, Read, Write};
 
+use starknet_api::core::ContractAddress;
 use starknet_api::hash::StarkFelt;
+use starknet_api::state::StorageKey;
 
 use super::history::History;
 
@@ -37,10 +39,19 @@ impl Decode for StarkFelt {
     }
 }
 
+impl Encode for u64 {
+    fn encode(&self) -> Result<Vec<u8>, Error> {
+        let mut buffer = Vec::new();
+        serialize_vlq(*self, &mut buffer).map_err(|_| Error::EncodeError)?;
+        Ok(buffer)
+    }
+}
+
 impl Encode for History<StarkFelt> {
     fn encode(&self) -> Result<Vec<u8>, Error> {
         let mut buffer = Vec::new();
-        for &(index, value) in &self.0 {
+        serialize_vlq(self.last_index, &mut buffer).map_err(|_| Error::EncodeError)?;
+        for &(index, value) in &self.values {
             serialize_vlq(index, &mut buffer).map_err(|_| Error::EncodeError)?;
             value.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
         }
@@ -54,14 +65,55 @@ impl Decode for History<StarkFelt> {
         Self: Sized,
     {
         let mut cursor = Cursor::new(bytes);
-        let mut history = Vec::new();
+        let mut values = Vec::new();
+        let last_index = deserialize_vlq(&mut cursor).map_err(|_| Error::DecodeError)?;
         while (cursor.position() as usize) < bytes.len() {
             let index = deserialize_vlq(&mut cursor).map_err(|_| Error::DecodeError)?;
             let value = StarkFelt::deserialize(&mut cursor).ok_or(Error::DecodeError)?;
-            history.push((index, value));
+            values.push((index, value));
         }
-        Ok(History(history))
+        Ok(History { last_index, values })
     }
+}
+
+impl Encode for &(ContractAddress, StorageKey) {
+    fn encode(&self) -> Result<Vec<u8>, Error> {
+        let mut buffer = Vec::new();
+        self.0.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
+        self.1.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
+        Ok(buffer)
+    }
+}
+
+impl Encode for (ContractAddress, StorageKey) {
+    fn encode(&self) -> Result<Vec<u8>, Error> {
+        let mut buffer = Vec::new();
+        self.0.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
+        self.1.serialize(&mut buffer).map_err(|_| Error::EncodeError)?;
+        Ok(buffer)
+    }
+}
+
+/// Add a new value to an encoded history without decoding it.
+pub fn add_to_history_encoded(history_encoded: &mut Vec<u8>, index: u64, value: StarkFelt) -> Result<(), Error> {
+    // If the history is empty, we can add the new last_index
+    if history_encoded.is_empty() {
+        history_encoded.extend(index.encode()?);
+        return Ok(());
+    }
+    // If the history is not empty, we need to check if we insert in the right order
+    else {
+        let mut cursor = Cursor::new(&history_encoded);
+        let last_index = deserialize_vlq(&mut cursor).map_err(|_| Error::DecodeError)?;
+        if index <= last_index {
+            return Err(Error::EncodeError);
+        }
+    }
+
+    history_encoded.extend(index.encode()?);
+    history_encoded.extend(value.encode()?);
+
+    Ok(())
 }
 
 /// Write a variable-length quantity to the writer from an u64.
@@ -151,7 +203,7 @@ mod tests {
     #[test]
     fn test_encode_decode_history() {
         let mut history = History::default();
-        history.push(0, StarkFelt::from(42_u64)).unwrap();
+        history.push(1, StarkFelt::from(42_u64)).unwrap();
         history
             .push(
                 42,
@@ -166,6 +218,6 @@ mod tests {
             .unwrap();
         let bytes = history.encode().unwrap();
         let decoded = History::decode(&bytes).unwrap();
-        assert_eq!(history.0, decoded.0);
+        assert_eq!(history.values, decoded.values);
     }
 }

--- a/crates/client/db/src/storage_handler/history.rs
+++ b/crates/client/db/src/storage_handler/history.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 /// A simple history implementation that stores values at a given index.
 #[derive(Serialize, Deserialize, Default)]
 #[serde(bound = "T: Serialize + DeserializeOwned")]
-pub struct History<T>(pub Vec<(u64, T)>);
+pub struct History<T> {
+    pub last_index: u64,
+    pub values: Vec<(u64, T)>,
+}
 
 #[derive(Debug)]
 pub enum HistoryError {
@@ -20,47 +23,55 @@ impl<T> History<T>
 where
     T: Serialize + for<'de> Deserialize<'de>,
 {
+    pub fn new(index: u64, value: T) -> Self {
+        Self { last_index: index, values: vec![(index, value)] }
+    }
+
     /// Push a new value with an index.
     /// If the index is smaller or equal to the last index, it will return an error.
     pub fn push(&mut self, index: u64, value: T) -> Result<(), HistoryError> {
-        match self.0.last() {
-            Some((last_index, _)) if index <= *last_index => Err(HistoryError::ValueNotOrdered),
-            _ => {
-                self.0.push((index, value));
-                Ok(())
-            }
+        if self.last_index != 0 && self.last_index >= index {
+            return Err(HistoryError::ValueNotOrdered);
         }
+        self.last_index = index;
+        self.values.push((index, value));
+        Ok(())
     }
 
     /// Get the value at a given index.
     /// If the index is not found, it will return the value at the previous index.
     /// If the index is smaller than the first index, it will return None.
     pub fn get_at(&self, index: u64) -> Option<&T> {
-        match self.0.binary_search_by_key(&index, |&(i, _)| i) {
-            Ok(i) => Some(&self.0[i].1),
+        match self.values.binary_search_by_key(&index, |&(i, _)| i) {
+            Ok(i) => Some(&self.values[i].1),
             Err(0) => None,
-            Err(i) => Some(&self.0[i - 1].1),
+            Err(i) => Some(&self.values[i - 1].1),
         }
     }
 
     /// Get the last value.
     pub fn get(&self) -> Option<&T> {
-        self.0.last().map(|(_, value)| value)
+        self.values.last().map(|(_, value)| value)
     }
 
     /// Revert the history to a given index.
     /// If the index is not found, it will revert to the previous index.
     /// If the index is smaller than the first index, it will clear the history.
     pub fn revert_to(&mut self, index: u64) {
-        match self.0.binary_search_by_key(&index, |&(i, _)| i) {
-            Ok(i) => self.0.truncate(i + 1),
-            Err(0) => self.0.clear(),
-            Err(i) => self.0.truncate(i),
+        match self.values.binary_search_by_key(&index, |&(i, _)| i) {
+            Ok(i) => self.values.truncate(i + 1),
+            Err(0) => self.values.clear(),
+            Err(i) => self.values.truncate(i),
         }
+        self.last_index = self.values.last().map(|(i, _)| *i).unwrap_or_default();
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.values.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
     }
 }
 
@@ -70,7 +81,7 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "History {{ ")?;
-        for (index, value) in &self.0 {
+        for (index, value) in &self.values {
             write!(f, "{:?} => {:?}, ", index, value)?;
         }
         write!(f, "}}")

--- a/crates/client/db/src/storage_handler/mod.rs
+++ b/crates/client/db/src/storage_handler/mod.rs
@@ -88,6 +88,12 @@ impl From<history::HistoryError> for DeoxysStorageError {
     }
 }
 
+impl From<codec::Error> for DeoxysStorageError {
+    fn from(_: codec::Error) -> Self {
+        DeoxysStorageError::StorageSerdeError
+    }
+}
+
 #[derive(Debug)]
 pub enum TrieType {
     Contract,

--- a/crates/client/rpc/src/utils/blockifier_state_adapter.rs
+++ b/crates/client/rpc/src/utils/blockifier_state_adapter.rs
@@ -69,15 +69,14 @@ impl StateReader for BlockifierStateAdapter {
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         match self.class_hash_update.get(&contract_address).cloned() {
             Some(class_hash) => Ok(class_hash),
-            None => {
-                match storage_handler::contract_data().get_class_hash_at(&contract_address, self.block_number + 1) {
-                    Ok(Some(class_hash)) => Ok(class_hash),
-                    _ => Err(StateError::StateReadError(format!(
-                        "failed to retrive class hash for contract address {}",
-                        contract_address.0.0
-                    ))),
-                }
-            }
+            None => match storage_handler::contract_data().get_class_hash_at(&contract_address, self.block_number) {
+                Ok(Some(class_hash)) => Ok(class_hash),
+                Ok(None) => Ok(ClassHash::default()),
+                Err(_) => Err(StateError::StateReadError(format!(
+                    "Failed to retrieve class hash for contract {}",
+                    contract_address.0.0
+                ))),
+            },
         }
     }
 


### PR DESCRIPTION

# performance improvement for data storage key/value history

## Pull Request type

- Refactoring (no functional changes, no API changes)

## What is the current behavior?


## What is the new behavior?

- use encode on `Starkfelt`
- `add_to_history_encoded` enhances performance by allowing new values to be added to the encoded history without requiring the decoding of the entire dataset, thereby reducing processing operations and associated costs.

## Does this introduce a breaking change?

DB

## Other information

