### PR TITLE
fix: block context, fetch class, simulate flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- fix: creation of the block context
+- fix: is_missing_class
 - feat(db): backups
 - fix: state root for nonce
 - fix: store the first history in storage ket

--- a/crates/client/rpc/src/methods/read/call.rs
+++ b/crates/client/rpc/src/methods/read/call.rs
@@ -12,7 +12,6 @@ use starknet_core::types::{BlockId, FunctionCall};
 
 use crate::errors::StarknetRpcApiError;
 use crate::utils::execution::block_context;
-use crate::utils::helpers::previous_substrate_block_hash;
 use crate::{utils, Arc, Starknet};
 
 /// Call a Function in a Contract Without Creating a Transaction
@@ -48,8 +47,7 @@ where
         StarknetRpcApiError::BlockNotFound
     })?;
 
-    let previous_substrate_block_hash = previous_substrate_block_hash(starknet, substrate_block_hash)?;
-    let block_context = block_context(starknet.client.as_ref(), previous_substrate_block_hash)?;
+    let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 
     let calldata = Calldata(Arc::new(request.calldata.iter().map(|x| Felt252Wrapper::from(*x).into()).collect()));
 

--- a/crates/client/rpc/src/methods/read/estimate_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_fee.rs
@@ -15,7 +15,6 @@ use starknet_core::types::{
 
 use crate::errors::StarknetRpcApiError;
 use crate::utils::execution::block_context;
-use crate::utils::helpers::previous_substrate_block_hash;
 use crate::{utils, Starknet};
 
 /// Estimate the fee associated with transaction
@@ -46,8 +45,7 @@ where
         StarknetRpcApiError::BlockNotFound
     })?;
 
-    let previous_substrate_block_hash = previous_substrate_block_hash(starknet, substrate_block_hash)?;
-    let block_context = block_context(starknet.client.as_ref(), previous_substrate_block_hash)?;
+    let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 
     let transactions = request
         .into_iter()

--- a/crates/client/rpc/src/methods/read/estimate_message_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_message_fee.rs
@@ -19,7 +19,6 @@ use starknet_core::types::{BlockId, FeeEstimate, MsgFromL1};
 
 use crate::errors::StarknetRpcApiError;
 use crate::utils::execution::block_context;
-use crate::utils::helpers::previous_substrate_block_hash;
 use crate::{utils, Starknet, StarknetReadRpcApiServer};
 
 /// Estimate the L2 fee of a message sent on L1
@@ -54,8 +53,7 @@ where
         log::error!("'{e}'");
         StarknetRpcApiError::BlockNotFound
     })?;
-    let previous_substrate_block_hash = previous_substrate_block_hash(starknet, substrate_block_hash)?;
-    let block_context = block_context(starknet.client.as_ref(), previous_substrate_block_hash)?;
+    let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 
     let block_number = starknet.block_number().map_err(|e| {
         log::error!("'{e}'");

--- a/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
@@ -26,7 +26,7 @@ use crate::utils::call_info::{
     blockifier_call_info_to_starknet_resources, extract_events_from_call_info, extract_messages_from_call_info,
 };
 use crate::utils::execution::{block_context, re_execute_transactions};
-use crate::utils::helpers::{previous_substrate_block_hash, tx_hash_compute, tx_hash_retrieve};
+use crate::utils::helpers::{tx_hash_compute, tx_hash_retrieve};
 use crate::utils::transaction::blockifier_transactions;
 use crate::{Felt, Starknet};
 
@@ -95,9 +95,7 @@ where
     let block_number = block_header.block_number;
     let block_hash: Felt252Wrapper = block_header.hash::<H>();
 
-    // computes the previous SUBSTRATE block hash and creates a block context
-    let previous_substrate_block_hash = previous_substrate_block_hash(client, substrate_block_hash)?;
-    let block_context = block_context(client.client.as_ref(), previous_substrate_block_hash)?;
+    let block_context = block_context(client.client.as_ref(), substrate_block_hash)?;
 
     // retrieve all transaction hashes from the block in the cache or compute them
     let block_txs_hashes = if let Some(tx_hashes) = client.get_cached_transaction_hashes(block_hash.into()) {

--- a/crates/client/rpc/src/methods/trace/simulate_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/simulate_transactions.rs
@@ -51,7 +51,10 @@ where
             },
         )?;
 
-    let simulation_flags = SimulationFlags::from(simulation_flags);
+    let simulation_flags = SimulationFlags {
+        validate: !simulation_flags.contains(&SimulationFlag::SkipValidate),
+        charge_fee: !simulation_flags.contains(&SimulationFlag::SkipFeeCharge),
+    };
 
     let fee_types = user_transactions.iter().map(|tx| tx.fee_type()).collect::<Vec<_>>();
     let charge_fee = block_context.block_info().gas_prices.eth_l1_gas_price.get() != 1;

--- a/crates/client/rpc/src/methods/trace/simulate_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/simulate_transactions.rs
@@ -17,7 +17,6 @@ use super::lib::ConvertCallInfoToExecuteInvocationError;
 use super::utils::{block_number_by_id, tx_execution_infos_to_tx_trace};
 use crate::errors::StarknetRpcApiError;
 use crate::utils::execution::block_context;
-use crate::utils::helpers::previous_substrate_block_hash;
 use crate::{utils, Starknet};
 
 pub async fn simulate_transactions<BE, C, H>(
@@ -36,8 +35,7 @@ where
     let substrate_block_hash =
         starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|_e| StarknetRpcApiError::BlockNotFound)?;
 
-    let previous_substrate_block_hash = previous_substrate_block_hash(starknet, substrate_block_hash)?;
-    let block_context = block_context(starknet.client.as_ref(), previous_substrate_block_hash)?;
+    let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
     let block_number = block_number_by_id(block_id);
 
     let tx_type_and_tx_iterator = transactions.into_iter().map(|tx| match tx {

--- a/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
@@ -14,7 +14,7 @@ use super::utils::tx_execution_infos_to_tx_trace;
 use crate::deoxys_backend_client::get_block_by_block_hash;
 use crate::errors::StarknetRpcApiError;
 use crate::utils::execution::{block_context, re_execute_transactions};
-use crate::utils::helpers::{previous_substrate_block_hash, tx_hash_compute, tx_hash_retrieve};
+use crate::utils::helpers::{tx_hash_compute, tx_hash_retrieve};
 use crate::utils::transaction::blockifier_transactions;
 use crate::Starknet;
 
@@ -42,8 +42,7 @@ where
     let block_number = block_header.block_number;
     let block_hash: Felt252Wrapper = block_header.hash::<H>();
     let chain_id = starknet.chain_id()?;
-    let previous_substrate_block_hash = previous_substrate_block_hash(starknet, substrate_block_hash)?;
-    let block_context = block_context(starknet.client.as_ref(), previous_substrate_block_hash)?;
+    let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 
     let block_txs_hashes = if let Some(tx_hashes) = starknet.get_cached_transaction_hashes(block_hash.into()) {
         tx_hash_retrieve(tx_hashes)

--- a/crates/client/rpc/src/methods/trace/trace_transaction.rs
+++ b/crates/client/rpc/src/methods/trace/trace_transaction.rs
@@ -18,7 +18,7 @@ use super::utils::tx_execution_infos_to_tx_trace;
 use crate::deoxys_backend_client::get_block_by_block_hash;
 use crate::errors::StarknetRpcApiError;
 use crate::utils::execution::block_context;
-use crate::utils::helpers::{previous_substrate_block_hash, tx_hash_compute, tx_hash_retrieve};
+use crate::utils::helpers::{tx_hash_compute, tx_hash_retrieve};
 use crate::utils::transaction::blockifier_transactions;
 use crate::Starknet;
 
@@ -46,8 +46,7 @@ where
     let block_hash: Felt252Wrapper = block_header.hash::<H>();
     let block_number = block_header.block_number;
     let chain_id = starknet.chain_id()?;
-    let previous_substrate_block_hash = previous_substrate_block_hash(starknet, substrate_block_hash)?;
-    let block_context = block_context(starknet.client.as_ref(), previous_substrate_block_hash)?;
+    let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 
     // retrieve all transaction hashes from the block in the cache or compute them
     // here we can optimize by computing only tx before the one that we want to trace (optimized if we

--- a/crates/client/rpc/src/utils/execution.rs
+++ b/crates/client/rpc/src/utils/execution.rs
@@ -78,13 +78,12 @@ pub fn simulate_transactions(
     transactions: Vec<AccountTransaction>,
     simulation_flags: &SimulationFlags,
     block_context: &BlockContext,
-    charge_fee: bool,
 ) -> Result<Vec<TransactionExecutionInfo>, TransactionExecutionError> {
     let mut cached_state = init_cached_state(block_context);
 
     let tx_execution_results = transactions
         .into_iter()
-        .map(|tx| tx.execute(&mut cached_state, block_context, charge_fee, simulation_flags.validate))
+        .map(|tx| tx.execute(&mut cached_state, block_context, simulation_flags.charge_fee, simulation_flags.validate))
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(tx_execution_results)

--- a/crates/client/rpc/src/utils/execution.rs
+++ b/crates/client/rpc/src/utils/execution.rs
@@ -265,5 +265,5 @@ pub fn from_tx_info_and_gas_price(
 
 fn init_cached_state(block_context: &BlockContext) -> CachedState<BlockifierStateAdapter> {
     let block_number = block_context.block_info().block_number.0;
-    CachedState::new(BlockifierStateAdapter::new(block_number - 1), GlobalContractCache::new(10))
+    CachedState::new(BlockifierStateAdapter::new(block_number - 1), GlobalContractCache::new(16))
 }

--- a/crates/client/rpc/src/utils/helpers.rs
+++ b/crates/client/rpc/src/utils/helpers.rs
@@ -48,6 +48,7 @@ pub(crate) fn status(block_number: u64) -> BlockStatus {
     }
 }
 
+#[allow(dead_code)]
 pub fn previous_substrate_block_hash<BE, C, H>(
     starknet: &Starknet<BE, C, H>,
     substrate_block_hash: DHashT,

--- a/crates/client/sync/src/fetch/fetchers.rs
+++ b/crates/client/sync/src/fetch/fetchers.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use mc_db::storage_handler::primitives::contract_class::{ContractClassData, ContractClassWrapper};
-use mc_db::storage_handler::{self, DeoxysStorageError, StorageView};
+use mc_db::storage_handler::{self, StorageView};
 use mp_block::DeoxysBlock;
 use mp_convert::state_update::ToStateUpdateCore;
 use sp_core::H160;

--- a/crates/client/sync/src/fetch/fetchers.rs
+++ b/crates/client/sync/src/fetch/fetchers.rs
@@ -3,9 +3,8 @@ use core::time::Duration;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use mc_db::storage_handler;
 use mc_db::storage_handler::primitives::contract_class::{ContractClassData, ContractClassWrapper};
-use mc_db::storage_handler::StorageView;
+use mc_db::storage_handler::{self, DeoxysStorageError, StorageView};
 use mp_block::DeoxysBlock;
 use mp_convert::state_update::ToStateUpdateCore;
 use sp_core::H160;
@@ -212,5 +211,6 @@ async fn fetch_class(
 /// this means we only need to check for class hashes in the db.
 fn is_missing_class(class_hash: &FieldElement) -> bool {
     let class_hash = ClassHash(StarkFelt(class_hash.to_bytes_be()));
-    storage_handler::contract_class_data().contains(&class_hash).is_ok()
+    // TODO: return the db error instead of unwrapping
+    storage_handler::contract_class_data().contains(&class_hash).map(|x| !x).unwrap_or(true)
 }

--- a/crates/primitives/block/src/header.rs
+++ b/crates/primitives/block/src/header.rs
@@ -133,24 +133,23 @@ impl Header {
             VersionedConstants::latest_constants()
         };
 
-        BlockContext::new_unchecked(
-            &BlockInfo {
-                block_number: BlockNumber(self.block_number),
-                block_timestamp: BlockTimestamp(self.block_timestamp),
-                sequencer_address: self.sequencer_address,
-                gas_prices: self.l1_gas_price.clone().unwrap_or(GasPrices {
-                    eth_l1_gas_price: NonZeroU128::new(1).unwrap(),
-                    strk_l1_gas_price: NonZeroU128::new(1).unwrap(),
-                    eth_l1_data_gas_price: NonZeroU128::new(1).unwrap(),
-                    strk_l1_data_gas_price: NonZeroU128::new(1).unwrap(),
-                }),
-                // TODO
-                // I have no idea what this is, let's say we did not use any for now
-                use_kzg_da: false,
-            },
-            &ChainInfo { chain_id, fee_token_addresses },
-            versioned_constants,
-        )
+        let chain_info = ChainInfo { chain_id, fee_token_addresses };
+
+        let block_info = BlockInfo {
+            block_number: BlockNumber(self.block_number),
+            block_timestamp: BlockTimestamp(self.block_timestamp),
+            sequencer_address: self.sequencer_address,
+            gas_prices: self.l1_gas_price.clone().unwrap_or(GasPrices {
+                eth_l1_gas_price: NonZeroU128::new(1).unwrap(),
+                strk_l1_gas_price: NonZeroU128::new(1).unwrap(),
+                eth_l1_data_gas_price: NonZeroU128::new(1).unwrap(),
+                strk_l1_data_gas_price: NonZeroU128::new(1).unwrap(),
+            }),
+            // TODO: Verify if this is correct
+            use_kzg_da: self.l1_da_mode == L1DataAvailabilityMode::Blob,
+        };
+
+        BlockContext::new_unchecked(&block_info, &chain_info, versioned_constants)
     }
 
     /// Compute the hash of the header.


### PR DESCRIPTION
# Fix: RPC

## Pull Request type

- Bugfix

## What is the current behavior?
 
- we recover classes already stored in db if it is deployed on a contract

## What is the new behavior?

- consistent creation of simulation flags
- creation of the block context from the corresponding block header
- fix is_missing_class: only classes not in DB are fetch

## Does this introduce a breaking change?


## Other information
