### PR TITLE
Fix/rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(rpc): error handling
 - feat: fetch block and state update in only one request
 - feat: added deoxys launcher script
 - fix: creation of the block context

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7292,6 +7292,7 @@ dependencies = [
  "log",
  "mc-db",
  "mp-block",
+ "mp-chain-id",
  "mp-digest-log",
  "mp-felt",
  "mp-genesis-config",

--- a/crates/client/db/src/error.rs
+++ b/crates/client/db/src/error.rs
@@ -1,5 +1,4 @@
 use bonsai_trie::DBError;
-use thiserror::Error;
 
 use crate::Column;
 
@@ -17,7 +16,7 @@ pub enum DbError {
     Format(String),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum BonsaiDbError {
     #[error("IO error: `{0}`")]
     Io(#[from] std::io::Error),

--- a/crates/client/db/src/lib.rs
+++ b/crates/client/db/src/lib.rs
@@ -29,7 +29,6 @@ mod mapping_db;
 use rocksdb::{
     BoundColumnFamily, ColumnFamilyDescriptor, DBCompressionType, Env, MultiThreaded, OptimisticTransactionDB, Options,
 };
-use starknet_api::hash::StarkHash;
 use starknet_types_core::hash::{Pedersen, Poseidon};
 pub mod bonsai_db;
 mod meta_db;
@@ -498,12 +497,5 @@ impl DeoxysBackend {
 
     pub fn compact() {
         Self::expose_db().compact_range(None::<&[u8]>, None::<&[u8]>);
-    }
-
-    /// In the future, we will compute the block global state root asynchronously in the client,
-    /// using the Starknet-Bonzai-trie.
-    /// That what replaces it for now :)
-    pub fn temporary_global_state_root_getter() -> StarkHash {
-        Default::default()
     }
 }

--- a/crates/client/db/src/storage_handler/contract_data.rs
+++ b/crates/client/db/src/storage_handler/contract_data.rs
@@ -67,7 +67,7 @@ impl ContractDataView {
             .map_err(|_| DeoxysStorageError::StorageRetrievalError(StorageType::ContractData))?
         {
             Some(bytes) => bincode::deserialize::<StorageContractData>(&bytes[..])?,
-            None => StorageContractData::default(),
+            None => return Ok(None),
         };
 
         Ok(contract_data.nonce.get_at(block_number).cloned())
@@ -141,6 +141,11 @@ impl StorageViewMut for ContractDataViewMut {
 
             if let Some(nonce) = nonce {
                 contract_data.nonce.push(block_number, nonce)?;
+            }
+
+            // If the contract is just being deployed, we need to initialize the nonce
+            if contract_data.nonce.is_empty() && contract_data.class_hash.is_empty() {
+                contract_data.nonce.push(block_number, Nonce::default())?;
             }
 
             batch.put_cf(&column, bincode::serialize(&key)?, bincode::serialize(&contract_data)?);

--- a/crates/client/db/src/storage_handler/contract_data.rs
+++ b/crates/client/db/src/storage_handler/contract_data.rs
@@ -144,7 +144,7 @@ impl StorageViewMut for ContractDataViewMut {
             }
 
             // If the contract is just being deployed, we need to initialize the nonce
-            if contract_data.nonce.is_empty() && contract_data.class_hash.is_empty() {
+            if contract_data.nonce.is_empty() {
                 contract_data.nonce.push(block_number, Nonce::default())?;
             }
 

--- a/crates/client/db/src/storage_handler/mod.rs
+++ b/crates/client/db/src/storage_handler/mod.rs
@@ -9,7 +9,6 @@ use starknet_api::core::{ClassHash, ContractAddress};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_types_core::felt::Felt;
-use thiserror::Error;
 
 use self::block_hash::BlockHashView;
 use self::block_number::BlockNumberView;
@@ -46,7 +45,7 @@ pub mod bonsai_identifier {
     pub const EVENT: &[u8] = "0xevent".as_bytes();
 }
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum DeoxysStorageError {
     #[error("failed to initialize trie for {0}")]
     TrieInitError(TrieType),

--- a/crates/client/db/src/storage_updates.rs
+++ b/crates/client/db/src/storage_updates.rs
@@ -115,7 +115,7 @@ pub async fn store_class_update(block_number: u64, class_update: ClassUpdateWrap
 
 pub async fn store_key_update(
     block_number: u64,
-    storage_diffs: &Vec<ContractStorageDiffItem>,
+    storage_diffs: &[ContractStorageDiffItem],
 ) -> Result<(), DeoxysStorageError> {
     let handler_storage = storage_handler::contract_storage_mut();
 

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -3,7 +3,7 @@ use mp_block::DeoxysBlock;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -19,7 +19,7 @@ impl<BE, C, H> Starknet<BE, C, H>
 where
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     BE: Backend<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {

--- a/crates/client/rpc/src/events/mod.rs
+++ b/crates/client/rpc/src/events/mod.rs
@@ -19,7 +19,7 @@ impl<BE, C, H> Starknet<BE, C, H>
 where
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     BE: Backend<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {

--- a/crates/client/rpc/src/methods/get_block.rs
+++ b/crates/client/rpc/src/methods/get_block.rs
@@ -3,7 +3,7 @@ use jsonrpsee::core::RpcResult;
 use mc_sync::l2::get_pending_block;
 use mp_hashers::HasherT;
 use mp_types::block::{DBlockT, DHashT};
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -29,7 +29,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let starknet_block = get_block_by_block_hash(server.client.as_ref(), substrate_block_hash)?;
@@ -109,7 +109,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let starknet_block = get_block_by_block_hash(server.client.as_ref(), substrate_block_hash)?;

--- a/crates/client/rpc/src/methods/get_block.rs
+++ b/crates/client/rpc/src/methods/get_block.rs
@@ -29,7 +29,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let starknet_block = get_block_by_block_hash(server.client.as_ref(), substrate_block_hash)?;

--- a/crates/client/rpc/src/methods/read/block_hash_and_number.rs
+++ b/crates/client/rpc/src/methods/read/block_hash_and_number.rs
@@ -26,7 +26,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let block_number = starknet.current_block_number()?;

--- a/crates/client/rpc/src/methods/read/block_hash_and_number.rs
+++ b/crates/client/rpc/src/methods/read/block_hash_and_number.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -26,7 +26,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let block_number = starknet.current_block_number()?;

--- a/crates/client/rpc/src/methods/read/call.rs
+++ b/crates/client/rpc/src/methods/read/call.rs
@@ -42,10 +42,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 

--- a/crates/client/rpc/src/methods/read/call.rs
+++ b/crates/client/rpc/src/methods/read/call.rs
@@ -39,7 +39,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/call.rs
+++ b/crates/client/rpc/src/methods/read/call.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -39,7 +39,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
@@ -58,8 +58,6 @@ where
         log::error!("Request parameters error");
         StarknetRpcApiError::InternalServerError
     })?;
-
-    // let result = convert_error(starknet.client.clone(), substrate_block_hash, result)?;
 
     Ok(result.iter().map(|x| format!("{:#x}", x.0)).collect())
 }

--- a/crates/client/rpc/src/methods/read/estimate_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_fee.rs
@@ -40,10 +40,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 

--- a/crates/client/rpc/src/methods/read/estimate_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_fee.rs
@@ -34,7 +34,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/estimate_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_fee.rs
@@ -3,7 +3,7 @@ use jsonrpsee::core::RpcResult;
 use mp_hashers::HasherT;
 use mp_transactions::from_broadcasted_transactions::ToAccountTransaction;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -34,7 +34,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/estimate_message_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_message_fee.rs
@@ -49,10 +49,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
     let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
 
     let block_number = starknet.block_number().map_err(|e| {

--- a/crates/client/rpc/src/methods/read/estimate_message_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_message_fee.rs
@@ -47,7 +47,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/estimate_message_fee.rs
+++ b/crates/client/rpc/src/methods/read/estimate_message_fee.rs
@@ -7,7 +7,7 @@ use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_transactions::compute_hash::ComputeTransactionHash;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -47,7 +47,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_block_transaction_count.rs
+++ b/crates/client/rpc/src/methods/read/get_block_transaction_count.rs
@@ -31,7 +31,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_block_transaction_count.rs
+++ b/crates/client/rpc/src/methods/read/get_block_transaction_count.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -31,7 +31,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_block_transaction_count.rs
+++ b/crates/client/rpc/src/methods/read/get_block_transaction_count.rs
@@ -9,7 +9,6 @@ use sp_blockchain::HeaderBackend;
 use starknet_core::types::BlockId;
 
 use crate::deoxys_backend_client::get_block_by_block_hash;
-use crate::errors::StarknetRpcApiError;
 use crate::Starknet;
 
 /// Get the Number of Transactions in a Given Block
@@ -35,10 +34,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash)?;
 

--- a/crates/client/rpc/src/methods/read/get_block_with_receipts.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_receipts.rs
@@ -36,10 +36,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
     let block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash)?;
     let block_header = block.header();
     let block_number = block_header.block_number;

--- a/crates/client/rpc/src/methods/read/get_block_with_receipts.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_receipts.rs
@@ -3,7 +3,7 @@ use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_transactions::to_starknet_core_transaction::to_starknet_core_tx;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -33,7 +33,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_block_with_receipts.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_receipts.rs
@@ -33,7 +33,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_block_with_tx_hashes.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_tx_hashes.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let chain_id = starknet.chain_id()?;

--- a/crates/client/rpc/src/methods/read/get_block_with_tx_hashes.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_tx_hashes.rs
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let chain_id = starknet.chain_id()?;

--- a/crates/client/rpc/src/methods/read/get_block_with_tx_hashes.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_tx_hashes.rs
@@ -8,7 +8,6 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use starknet_core::types::{BlockId, BlockTag, MaybePendingBlockWithTxHashes};
 
-use crate::errors::StarknetRpcApiError;
 use crate::{get_block_with_tx_hashes_finalized, get_block_with_tx_hashes_pending, Starknet};
 
 /// Get block information with transaction hashes given the block id.
@@ -35,10 +34,7 @@ where
     H: HasherT + Send + Sync + 'static,
 {
     let chain_id = starknet.chain_id()?;
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     match block_id {
         BlockId::Tag(BlockTag::Pending) => get_block_with_tx_hashes_pending::<H>(chain_id),

--- a/crates/client/rpc/src/methods/read/get_block_with_txs.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_txs.rs
@@ -36,7 +36,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let chain_id = starknet.chain_id()?;

--- a/crates/client/rpc/src/methods/read/get_block_with_txs.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_txs.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -36,7 +36,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let chain_id = starknet.chain_id()?;

--- a/crates/client/rpc/src/methods/read/get_block_with_txs.rs
+++ b/crates/client/rpc/src/methods/read/get_block_with_txs.rs
@@ -8,7 +8,6 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use starknet_core::types::{BlockId, BlockTag, MaybePendingBlockWithTxs};
 
-use crate::errors::StarknetRpcApiError;
 use crate::{get_block_with_txs_finalized, get_block_with_txs_pending, Starknet};
 
 /// Get block information with full transactions given the block id.
@@ -41,10 +40,7 @@ where
     H: HasherT + Send + Sync + 'static,
 {
     let chain_id = starknet.chain_id()?;
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("Block not found: '{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     match block_id {
         BlockId::Tag(BlockTag::Pending) => get_block_with_txs_pending::<H>(chain_id),

--- a/crates/client/rpc/src/methods/read/get_class_hash_at.rs
+++ b/crates/client/rpc/src/methods/read/get_class_hash_at.rs
@@ -25,10 +25,12 @@ pub fn get_class_hash_at(block_id: BlockId, contract_address: FieldElement) -> R
     let block_number = block_number_by_id(block_id);
     let key = ContractAddress(PatriciaKey(StarkFelt(contract_address.to_bytes_be())));
 
-    let Ok(Some(class_hash)) = storage_handler::contract_data().get_class_hash_at(&key, block_number) else {
-        log::error!("Failed to retrieve contract class hash at '{contract_address:?}'");
-        return Err(StarknetRpcApiError::ContractNotFound.into());
-    };
-
-    Ok(Felt(Felt252Wrapper::from(class_hash).into()))
+    match storage_handler::contract_data().get_class_hash_at(&key, block_number) {
+        Err(e) => {
+            log::error!("Failed to retrieve contract class hash: {e}");
+            Err(StarknetRpcApiError::InternalServerError.into())
+        }
+        Ok(None) => Err(StarknetRpcApiError::ContractNotFound.into()),
+        Ok(Some(class_hash)) => Ok(Felt(Felt252Wrapper::from(class_hash).into())),
+    }
 }

--- a/crates/client/rpc/src/methods/read/get_events.rs
+++ b/crates/client/rpc/src/methods/read/get_events.rs
@@ -40,7 +40,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let from_address = filter.event_filter.address.map(Felt252Wrapper::from);
@@ -129,7 +129,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let latest = starknet.substrate_block_number_from_starknet_block(BlockId::Tag(BlockTag::Latest)).map_err(|e| {

--- a/crates/client/rpc/src/methods/read/get_events.rs
+++ b/crates/client/rpc/src/methods/read/get_events.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -40,7 +40,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let from_address = filter.event_filter.address.map(Felt252Wrapper::from);
@@ -129,7 +129,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let latest = starknet.substrate_block_number_from_starknet_block(BlockId::Tag(BlockTag::Latest)).map_err(|e| {

--- a/crates/client/rpc/src/methods/read/get_nonce.rs
+++ b/crates/client/rpc/src/methods/read/get_nonce.rs
@@ -29,10 +29,12 @@ pub fn get_nonce(block_id: BlockId, contract_address: FieldElement) -> RpcResult
     let key = ContractAddress(PatriciaKey(StarkFelt(contract_address.to_bytes_be())));
 
     let block_number = block_number_by_id(block_id);
-    let Ok(Some(nonce)) = storage_handler::contract_data().get_nonce_at(&key, block_number) else {
-        log::error!("Failed to get nonce at '{contract_address:?}'");
-        return Err(StarknetRpcApiError::ContractNotFound.into());
-    };
-
-    Ok(Felt(Felt252Wrapper::from(nonce).into()))
+    match storage_handler::contract_data().get_nonce_at(&key, block_number) {
+        Err(e) => {
+            log::error!("Failed to get nonce: {e}");
+            Err(StarknetRpcApiError::InternalServerError.into())
+        }
+        Ok(None) => Err(StarknetRpcApiError::ContractNotFound.into()),
+        Ok(Some(nonce)) => Ok(Felt(Felt252Wrapper::from(nonce).into())),
+    }
 }

--- a/crates/client/rpc/src/methods/read/get_state_update.rs
+++ b/crates/client/rpc/src/methods/read/get_state_update.rs
@@ -5,7 +5,7 @@ use mc_sync::l2::get_pending_state_update;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -42,7 +42,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     match block_id {
@@ -59,7 +59,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_state_update.rs
+++ b/crates/client/rpc/src/methods/read/get_state_update.rs
@@ -1,10 +1,10 @@
 use jsonrpsee::core::error::Error;
 use jsonrpsee::core::RpcResult;
-use mc_db::{storage_handler, DeoxysBackend};
+use mc_db::storage_handler;
 use mc_sync::l2::get_pending_state_update;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
-use mp_types::block::{DBlockT, DHashT};
+use mp_types::block::DBlockT;
 use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
@@ -15,52 +15,6 @@ use starknet_core::types::{BlockId, BlockTag, FieldElement, MaybePendingStateUpd
 use crate::deoxys_backend_client::get_block_by_block_hash;
 use crate::errors::StarknetRpcApiError;
 use crate::Starknet;
-
-fn get_state_update_finalized<BE, C, H>(
-    server: &Starknet<BE, C, H>,
-    substrate_block_hash: DHashT,
-) -> RpcResult<MaybePendingStateUpdate>
-where
-    BE: Backend<DBlockT> + 'static,
-    C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
-    C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
-    H: HasherT + Send + Sync + 'static,
-{
-    let starknet_block = get_block_by_block_hash(server.client.as_ref(), substrate_block_hash)?;
-
-    let block_hash = starknet_block.header().hash::<H>().into();
-
-    let block_number = starknet_block.header().block_number;
-
-    let new_root = Felt252Wrapper::from(starknet_block.header().global_state_root).into();
-
-    let old_root = if starknet_block.header().block_number > 0 {
-        Felt252Wrapper::from(DeoxysBackend::temporary_global_state_root_getter()).into()
-    } else {
-        FieldElement::default()
-    };
-
-    let state_diff = storage_handler::block_state_diff()
-        .get(block_number)
-        .map_err(|e| {
-            log::error!("Failed to get state diff: {e}");
-            StarknetRpcApiError::InternalServerError
-        })?
-        .ok_or({
-            log::error!("State diff not found for block number: {block_number}");
-            StarknetRpcApiError::InternalServerError
-        })?;
-
-    Ok(MaybePendingStateUpdate::Update(StateUpdate { block_hash, old_root, new_root, state_diff }))
-}
-
-fn get_state_update_pending() -> RpcResult<MaybePendingStateUpdate> {
-    match get_pending_state_update() {
-        Some(state_update) => Ok(MaybePendingStateUpdate::PendingUpdate(state_update)),
-        None => Err(Error::Custom("Failed to retrieve pending state update, node not yet synchronized".to_string())),
-    }
-}
 
 /// Get the information about the result of executing the requested block.
 ///
@@ -91,13 +45,57 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
-
     match block_id {
         BlockId::Tag(BlockTag::Pending) => get_state_update_pending(),
-        _ => get_state_update_finalized(starknet, substrate_block_hash),
+        _ => get_state_update_finalized(starknet, block_id),
+    }
+}
+
+fn get_state_update_finalized<BE, C, H>(
+    starknet: &Starknet<BE, C, H>,
+    block_id: BlockId,
+) -> RpcResult<MaybePendingStateUpdate>
+where
+    BE: Backend<DBlockT> + 'static,
+    C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
+    C: ProvideRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    H: HasherT + Send + Sync + 'static,
+{
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
+
+    let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash)?;
+
+    let block_hash = starknet_block.header().hash::<H>().into();
+
+    let block_number = starknet_block.header().block_number;
+
+    let new_root = Felt252Wrapper::from(starknet_block.header().global_state_root).into();
+
+    // Get the old root from the previous block if it exists, otherwise default to zero.
+    let old_root = if starknet_block.header().block_number > 0 {
+        let previous_substrate_block_hash =
+            starknet.substrate_block_hash_from_starknet_block(BlockId::Number(block_number - 1))?;
+        let previous_starknet_block = get_block_by_block_hash(starknet.client.as_ref(), previous_substrate_block_hash)?;
+        Felt252Wrapper::from(previous_starknet_block.header().global_state_root).into()
+    } else {
+        FieldElement::default()
+    };
+
+    let state_diff = storage_handler::block_state_diff()
+        .get(block_number)
+        .map_err(|e| {
+            log::error!("Failed to get state diff: {e}");
+            StarknetRpcApiError::InternalServerError
+        })?
+        .ok_or(StarknetRpcApiError::BlockNotFound)?;
+
+    Ok(MaybePendingStateUpdate::Update(StateUpdate { block_hash, old_root, new_root, state_diff }))
+}
+
+fn get_state_update_pending() -> RpcResult<MaybePendingStateUpdate> {
+    match get_pending_state_update() {
+        Some(state_update) => Ok(MaybePendingStateUpdate::PendingUpdate(state_update)),
+        None => Err(Error::Custom("Failed to retrieve pending state update, node not yet synchronized".to_string())),
     }
 }

--- a/crates/client/rpc/src/methods/read/get_state_update.rs
+++ b/crates/client/rpc/src/methods/read/get_state_update.rs
@@ -42,7 +42,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     match block_id {
@@ -59,7 +59,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_storage_at.rs
+++ b/crates/client/rpc/src/methods/read/get_storage_at.rs
@@ -3,7 +3,7 @@ use mc_db::storage_handler::{self};
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -55,7 +55,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let block_number = starknet.substrate_block_number_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_storage_at.rs
+++ b/crates/client/rpc/src/methods/read/get_storage_at.rs
@@ -1,5 +1,4 @@
 use jsonrpsee::core::RpcResult;
-use log::error;
 use mc_db::storage_handler::{self};
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
@@ -59,10 +58,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let block_number = starknet.substrate_block_number_from_starknet_block(block_id).map_err(|e| {
-        error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let block_number = starknet.substrate_block_number_from_starknet_block(block_id)?;
 
     let contract_address = ContractAddress(PatriciaKey(StarkFelt(contract_address.to_bytes_be())));
     let key = StorageKey(PatriciaKey(StarkFelt(key.to_bytes_be())));
@@ -70,7 +66,7 @@ where
     // Check if the contract exists at the given address in the specified block.
     match storage_handler::contract_data().is_contract_deployed_at(&contract_address, block_number) {
         Err(e) => {
-            error!("Failed to check if contract exists at '{contract_address:?}': {e}");
+            log::error!("Failed to check if contract is deployed: {e}");
             return Err(StarknetRpcApiError::InternalServerError.into());
         }
         Ok(false) => {
@@ -83,7 +79,7 @@ where
         Ok(Some(value)) => Ok(Felt(Felt252Wrapper::from(value).into())),
         Ok(None) => Ok(Felt(FieldElement::default())), // all keys are initialized to 0
         Err(e) => {
-            error!("Failed to retrieve storage at '{contract_address:?}' and '{key:?}': {e}");
+            log::error!("Failed to retrieve contract storage: {e}");
             Err(StarknetRpcApiError::InternalServerError.into())
         }
     }

--- a/crates/client/rpc/src/methods/read/get_storage_at.rs
+++ b/crates/client/rpc/src/methods/read/get_storage_at.rs
@@ -55,7 +55,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let block_number = starknet.substrate_block_number_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
@@ -48,10 +48,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("'{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash)?;
 

--- a/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
@@ -4,7 +4,7 @@ use mp_hashers::HasherT;
 use mp_transactions::compute_hash::ComputeTransactionHash;
 use mp_transactions::to_starknet_core_transaction::to_starknet_core_tx;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -44,7 +44,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let index = index as usize;

--- a/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
@@ -52,12 +52,12 @@ where
 
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash)?;
     let block_number = starknet_block.header().block_number;
+    let starknet_block_hash = starknet_block.header().hash::<H>();
 
     let transaction = starknet_block.transactions().get(index).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
     let chain_id = starknet.chain_id()?;
 
-    let opt_cached_transaction_hashes =
-        starknet.get_cached_transaction_hashes(starknet_block.header().hash::<H>().into());
+    let opt_cached_transaction_hashes = starknet.get_cached_transaction_hashes(starknet_block_hash.into());
 
     // Get the transaction hash from the cache if it exists, otherwise compute it.
     let transaction_hash = match opt_cached_transaction_hashes {

--- a/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
@@ -44,7 +44,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let index = index as usize;

--- a/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_block_id_and_index.rs
@@ -1,5 +1,4 @@
 use jsonrpsee::core::RpcResult;
-use jsonrpsee::types::error::CallError;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_transactions::compute_hash::ComputeTransactionHash;
@@ -48,28 +47,29 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
+    let index = index as usize;
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash)?;
+    let block_number = starknet_block.header().block_number;
 
-    let transaction = starknet_block.transactions().get(index as usize).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
+    let transaction = starknet_block.transactions().get(index).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
     let chain_id = starknet.chain_id()?;
 
     let opt_cached_transaction_hashes =
         starknet.get_cached_transaction_hashes(starknet_block.header().hash::<H>().into());
 
-    let transaction_hash = if let Some(cached_tx_hashes) = opt_cached_transaction_hashes {
-        cached_tx_hashes.get(index as usize).map(|&fe| FieldElement::from(Felt252Wrapper::from(fe))).ok_or(
-            CallError::Failed(anyhow::anyhow!(
-                "Number of cached tx hashes does not match the number of transactions in block with id {:?}",
-                block_id
-            )),
-        )?
-    } else {
-        Felt252Wrapper::from(
-            transaction.compute_hash::<H>(chain_id.0.into(), false, Some(starknet_block.header().block_number)).0,
-        )
-        .into()
+    // Get the transaction hash from the cache if it exists, otherwise compute it.
+    let transaction_hash = match opt_cached_transaction_hashes {
+        Some(cached_tx_hashes) => {
+            cached_tx_hashes.get(index).map(|&fe| FieldElement::from(Felt252Wrapper::from(fe))).ok_or(
+                // This should never happen, because the index is checked above when getting the transaction.
+                StarknetRpcApiError::InternalServerError,
+            )?
+        }
+        None => {
+            Felt252Wrapper::from(transaction.compute_hash::<H>(chain_id.0.into(), false, Some(block_number)).0).into()
+        }
     };
 
     Ok(to_starknet_core_tx(transaction.clone(), transaction_hash))

--- a/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
@@ -54,39 +54,41 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash_from_db = DeoxysBackend::mapping()
+    let substrate_block_hash = DeoxysBackend::mapping()
         .block_hash_from_transaction_hash(Felt252Wrapper::from(transaction_hash).into())
         .map_err(|e| {
-            log::error!("Failed to get transaction's substrate block hash from mapping_db: {e}");
-            StarknetRpcApiError::TxnHashNotFound
-        })?;
-
-    let substrate_block_hash = match substrate_block_hash_from_db {
-        Some(block_hash) => block_hash,
-        None => return Err(StarknetRpcApiError::TxnHashNotFound.into()),
-    };
+            log::error!("Failed to get block hash from transaction hash: {:?}", e);
+            StarknetRpcApiError::InternalServerError
+        })?
+        .ok_or(StarknetRpcApiError::TxnHashNotFound)?;
 
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash)?;
+    let block_number = starknet_block.header().block_number;
+    let starknet_block_hash = starknet_block.header().hash::<H>();
 
     let chain_id = starknet.chain_id()?.0.into();
 
-    let find_tx =
-        if let Some(tx_hashes) = starknet.get_cached_transaction_hashes(starknet_block.header().hash::<H>().into()) {
-            tx_hashes
-                .into_iter()
-                .zip(starknet_block.transactions())
-                .find(|(tx_hash, _)| *tx_hash == Felt252Wrapper(transaction_hash).into())
-                .map(|(_, tx)| to_starknet_core_tx(tx.clone(), transaction_hash))
-        } else {
-            starknet_block
-                .transactions()
-                .iter()
-                .find(|tx| {
-                    tx.compute_hash::<H>(chain_id, false, Some(starknet_block.header().block_number)).0
-                        == Felt252Wrapper::from(transaction_hash).into()
-                })
-                .map(|tx| to_starknet_core_tx(tx.clone(), transaction_hash))
-        };
+    let opt_cached_transaction_hashes = starknet.get_cached_transaction_hashes(starknet_block_hash.into());
 
-    find_tx.ok_or(StarknetRpcApiError::TxnHashNotFound.into())
+    let transaction_hash = Felt252Wrapper::from(transaction_hash);
+
+    let transaction = match opt_cached_transaction_hashes {
+        Some(cached_tx_hashes) => cached_tx_hashes
+            .into_iter()
+            .zip(starknet_block.transactions())
+            .find(|(tx_hash, _)| *tx_hash == transaction_hash.into())
+            .map(|(_, tx)| tx.clone()),
+        None => starknet_block
+            .transactions()
+            .iter()
+            .find(|tx| tx.compute_hash::<H>(chain_id, false, Some(block_number)).0 == transaction_hash.into())
+            .cloned(),
+    };
+
+    match transaction {
+        Some(tx) => Ok(to_starknet_core_tx(tx, transaction_hash.into())),
+        // This should never happen, because the transaction hash is checked above when getting block hash from
+        // transaction hash.
+        None => Err(StarknetRpcApiError::InternalServerError.into()),
+    }
 }

--- a/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
@@ -5,7 +5,7 @@ use mp_hashers::HasherT;
 use mp_transactions::compute_hash::ComputeTransactionHash;
 use mp_transactions::to_starknet_core_transaction::to_starknet_core_tx;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -51,7 +51,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = DeoxysBackend::mapping()

--- a/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
@@ -51,7 +51,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = DeoxysBackend::mapping()

--- a/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_by_hash.rs
@@ -57,7 +57,7 @@ where
     let substrate_block_hash = DeoxysBackend::mapping()
         .block_hash_from_transaction_hash(Felt252Wrapper::from(transaction_hash).into())
         .map_err(|e| {
-            log::error!("Failed to get block hash from transaction hash: {:?}", e);
+            log::error!("Failed to get substrate block hash from transaction hash: {}", e);
             StarknetRpcApiError::InternalServerError
         })?
         .ok_or(StarknetRpcApiError::TxnHashNotFound)?;

--- a/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
@@ -67,7 +67,7 @@ where
     let substrate_block_hash = DeoxysBackend::mapping()
         .block_hash_from_transaction_hash(Felt252Wrapper::from(transaction_hash).into())
         .map_err(|e| {
-            log::error!("Failed to get transaction's substrate block hash from mapping_db: {e}");
+            log::error!("Failed to get substrate block hash from transaction hash: {}", e);
             StarknetRpcApiError::InternalServerError
         })?
         .ok_or(StarknetRpcApiError::TxnHashNotFound)?;

--- a/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
@@ -98,10 +98,9 @@ where
     let block_context = block_context(client.client.as_ref(), substrate_block_hash)?;
 
     // retrieve all transaction hashes from the block in the cache or compute them
-    let block_txs_hashes = if let Some(tx_hashes) = client.get_cached_transaction_hashes(block_hash.into()) {
-        tx_hash_retrieve(tx_hashes)
-    } else {
-        tx_hash_compute::<H>(&block, chain_id)
+    let block_txs_hashes = match client.get_cached_transaction_hashes(block_hash.into()) {
+        Some(tx_hashes) => tx_hash_retrieve(tx_hashes),
+        None => tx_hash_compute::<H>(&block, chain_id),
     };
 
     // retrieve the transaction index in the block with the transaction hash

--- a/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
@@ -60,7 +60,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     // get the substrate block hash from the transaction hash
@@ -87,7 +87,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let block = get_block_by_block_hash(client.client.as_ref(), substrate_block_hash)?;

--- a/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_receipt.rs
@@ -6,7 +6,7 @@ use mc_db::DeoxysBackend;
 use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_types::block::{DBlockT, DHashT};
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -60,7 +60,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     // get the substrate block hash from the transaction hash
@@ -87,7 +87,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let block = get_block_by_block_hash(client.client.as_ref(), substrate_block_hash)?;

--- a/crates/client/rpc/src/methods/read/get_transaction_status.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_status.rs
@@ -42,7 +42,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = DeoxysBackend::mapping()

--- a/crates/client/rpc/src/methods/read/get_transaction_status.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_status.rs
@@ -5,7 +5,7 @@ use mp_hashers::HasherT;
 use mp_transactions::compute_hash::ComputeTransactionHash;
 use mp_transactions::to_starknet_core_transaction::to_starknet_core_tx;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -42,14 +42,14 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = DeoxysBackend::mapping()
         .block_hash_from_transaction_hash(Felt252Wrapper(transaction_hash).into())
         .map_err(|e| {
             log::error!("Failed to get substrate block hash from transaction hash: {}", e);
-            StarknetRpcApiError::TxnHashNotFound
+            StarknetRpcApiError::InternalServerError
         })?
         .ok_or(StarknetRpcApiError::TxnHashNotFound)?;
 

--- a/crates/client/rpc/src/methods/read/get_transaction_status.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_status.rs
@@ -10,7 +10,7 @@ use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
-use starknet_core::types::{FieldElement, TransactionExecutionStatus, TransactionStatus};
+use starknet_core::types::{FieldElement, TransactionStatus};
 
 use crate::deoxys_backend_client::get_block_by_block_hash;
 use crate::errors::StarknetRpcApiError;
@@ -75,25 +75,28 @@ where
                 .map(|tx| to_starknet_core_tx(tx.clone(), transaction_hash))
         };
 
-    let execution_status = {
-        let revert_error = starknet
-            .client
-            .runtime_api()
-            .get_tx_execution_outcome(substrate_block_hash, Felt252Wrapper(transaction_hash).into())
-            .map_err(|e| {
-                log::error!(
-                    "Failed to get transaction execution outcome. Substrate block hash: {substrate_block_hash}, \
-                     transaction hash: {transaction_hash}, error: {e}"
-                );
-                StarknetRpcApiError::InternalServerError
-            })?;
+    // TODO: Implement this method
+    Err(StarknetRpcApiError::UnimplementedMethod.into())
 
-        if revert_error.is_none() {
-            TransactionExecutionStatus::Succeeded
-        } else {
-            TransactionExecutionStatus::Reverted
-        }
-    };
+    // let execution_status = {
+    //     let revert_error = starknet
+    //         .client
+    //         .runtime_api()
+    //         .get_tx_execution_outcome(substrate_block_hash,
+    // Felt252Wrapper(transaction_hash).into())         .map_err(|e| {
+    //             log::error!(
+    //                 "Failed to get transaction execution outcome. Substrate block hash:
+    // {substrate_block_hash}, \                  transaction hash: {transaction_hash}, error:
+    // {e}"             );
+    //             StarknetRpcApiError::InternalServerError
+    //         })?;
 
-    Ok(TransactionStatus::AcceptedOnL2(execution_status))
+    //     if revert_error.is_none() {
+    //         TransactionExecutionStatus::Succeeded
+    //     } else {
+    //         TransactionExecutionStatus::Reverted
+    //     }
+    // };
+
+    // Ok(TransactionStatus::AcceptedOnL2(execution_status))
 }

--- a/crates/client/rpc/src/methods/read/get_transaction_status.rs
+++ b/crates/client/rpc/src/methods/read/get_transaction_status.rs
@@ -48,7 +48,7 @@ where
     let substrate_block_hash = DeoxysBackend::mapping()
         .block_hash_from_transaction_hash(Felt252Wrapper(transaction_hash).into())
         .map_err(|e| {
-            log::error!("Failed to get transaction's substrate block hash from mapping_db: {e}");
+            log::error!("Failed to get substrate block hash from transaction hash: {}", e);
             StarknetRpcApiError::TxnHashNotFound
         })?
         .ok_or(StarknetRpcApiError::TxnHashNotFound)?;

--- a/crates/client/rpc/src/methods/read/lib.rs
+++ b/crates/client/rpc/src/methods/read/lib.rs
@@ -41,7 +41,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     fn block_number(&self) -> RpcResult<u64> {

--- a/crates/client/rpc/src/methods/read/lib.rs
+++ b/crates/client/rpc/src/methods/read/lib.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -41,7 +41,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     fn block_number(&self) -> RpcResult<u64> {

--- a/crates/client/rpc/src/methods/read/syncing.rs
+++ b/crates/client/rpc/src/methods/read/syncing.rs
@@ -31,7 +31,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     // obtain best seen (highest) block number

--- a/crates/client/rpc/src/methods/read/syncing.rs
+++ b/crates/client/rpc/src/methods/read/syncing.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use mc_sync::l2::get_highest_block_hash_and_number;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -31,7 +31,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     // obtain best seen (highest) block number

--- a/crates/client/rpc/src/methods/trace/lib.rs
+++ b/crates/client/rpc/src/methods/trace/lib.rs
@@ -10,7 +10,6 @@ use starknet_core::types::{
     BlockId, BroadcastedTransaction, SimulatedTransaction, SimulationFlag, TransactionTraceWithHash,
 };
 use starknet_ff::FieldElement;
-use thiserror::Error;
 
 use super::simulate_transactions::simulate_transactions;
 use super::trace_block_transactions::trace_block_transactions;
@@ -45,7 +44,7 @@ where
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum ConvertCallInfoToExecuteInvocationError {
     #[error("One of the simulated transaction failed")]
     TransactionExecutionFailed,
@@ -64,7 +63,7 @@ impl From<ConvertCallInfoToExecuteInvocationError> for StarknetRpcApiError {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum TryFuntionInvocationFromCallInfoError {
     #[error(transparent)]
     TransactionExecution(#[from] TransactionExecutionError),

--- a/crates/client/rpc/src/methods/trace/lib.rs
+++ b/crates/client/rpc/src/methods/trace/lib.rs
@@ -2,7 +2,7 @@ use blockifier::transaction::errors::TransactionExecutionError;
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::{Backend, BlockBackend, StorageProvider};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -23,7 +23,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     async fn simulate_transactions(

--- a/crates/client/rpc/src/methods/trace/lib.rs
+++ b/crates/client/rpc/src/methods/trace/lib.rs
@@ -23,7 +23,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     async fn simulate_transactions(

--- a/crates/client/rpc/src/methods/trace/simulate_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/simulate_transactions.rs
@@ -32,8 +32,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash =
-        starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|_| StarknetRpcApiError::BlockNotFound)?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     let block_context = block_context(starknet.client.as_ref(), substrate_block_hash)?;
     let block_number = block_number_by_id(block_id);

--- a/crates/client/rpc/src/methods/trace/simulate_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/simulate_transactions.rs
@@ -29,7 +29,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/trace/simulate_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/simulate_transactions.rs
@@ -5,7 +5,7 @@ use mp_simulations::SimulationFlags;
 use mp_transactions::from_broadcasted_transactions::ToAccountTransaction;
 use mp_transactions::TxType;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::{Backend, BlockBackend, StorageProvider};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -29,7 +29,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
@@ -29,10 +29,7 @@ where
     C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
-    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id).map_err(|e| {
-        log::error!("Block not found: '{e}'");
-        StarknetRpcApiError::BlockNotFound
-    })?;
+    let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;
 
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash).map_err(|e| {
         log::error!("Failed to get block for block hash {substrate_block_hash}: '{e}'");

--- a/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
@@ -3,7 +3,7 @@ use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_transactions::TxType;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::{Backend, BlockBackend, StorageProvider};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -26,7 +26,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
+++ b/crates/client/rpc/src/methods/trace/trace_block_transactions.rs
@@ -26,7 +26,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = starknet.substrate_block_hash_from_starknet_block(block_id)?;

--- a/crates/client/rpc/src/methods/trace/trace_transaction.rs
+++ b/crates/client/rpc/src/methods/trace/trace_transaction.rs
@@ -5,7 +5,7 @@ use mp_felt::Felt252Wrapper;
 use mp_hashers::HasherT;
 use mp_transactions::TxType;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::{Backend, BlockBackend, StorageProvider};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = DeoxysBackend::mapping()

--- a/crates/client/rpc/src/methods/trace/trace_transaction.rs
+++ b/crates/client/rpc/src/methods/trace/trace_transaction.rs
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let substrate_block_hash = DeoxysBackend::mapping()

--- a/crates/client/rpc/src/methods/trace/trace_transaction.rs
+++ b/crates/client/rpc/src/methods/trace/trace_transaction.rs
@@ -36,7 +36,7 @@ where
     let substrate_block_hash = DeoxysBackend::mapping()
         .block_hash_from_transaction_hash(Felt252Wrapper(transaction_hash).into())
         .map_err(|e| {
-            log::error!("Failed to get transaction's substrate block hash from mapping_db: {e}");
+            log::error!("Failed to get substrate block hash from transaction hash: {}", e);
             StarknetRpcApiError::TxnHashNotFound
         })?
         .ok_or(StarknetRpcApiError::TxnHashNotFound)?;

--- a/crates/client/rpc/src/methods/write/add_declare_transaction.rs
+++ b/crates/client/rpc/src/methods/write/add_declare_transaction.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use mc_sync::utility::get_config;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let config = get_config().ok_or_else(|| {

--- a/crates/client/rpc/src/methods/write/add_declare_transaction.rs
+++ b/crates/client/rpc/src/methods/write/add_declare_transaction.rs
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let config = get_config().ok_or_else(|| {

--- a/crates/client/rpc/src/methods/write/add_deploy_account_transaction.rs
+++ b/crates/client/rpc/src/methods/write/add_deploy_account_transaction.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use mc_sync::utility::get_config;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -31,7 +31,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let config = get_config().ok_or_else(|| {

--- a/crates/client/rpc/src/methods/write/add_deploy_account_transaction.rs
+++ b/crates/client/rpc/src/methods/write/add_deploy_account_transaction.rs
@@ -31,7 +31,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let config = get_config().ok_or_else(|| {

--- a/crates/client/rpc/src/methods/write/add_invoke_transaction.rs
+++ b/crates/client/rpc/src/methods/write/add_invoke_transaction.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use mc_sync::utility::get_config;
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let config = get_config().ok_or_else(|| {

--- a/crates/client/rpc/src/methods/write/add_invoke_transaction.rs
+++ b/crates/client/rpc/src/methods/write/add_invoke_transaction.rs
@@ -30,7 +30,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let config = get_config().ok_or_else(|| {

--- a/crates/client/rpc/src/methods/write/lib.rs
+++ b/crates/client/rpc/src/methods/write/lib.rs
@@ -22,7 +22,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     async fn add_declare_transaction(

--- a/crates/client/rpc/src/methods/write/lib.rs
+++ b/crates/client/rpc/src/methods/write/lib.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_hashers::HasherT;
 use mp_types::block::DBlockT;
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -22,7 +22,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     async fn add_declare_transaction(

--- a/crates/client/rpc/src/utils/helpers.rs
+++ b/crates/client/rpc/src/utils/helpers.rs
@@ -57,7 +57,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> ,
+    C::Api: StarknetRuntimeApi<DBlockT>,
     H: HasherT + Send + Sync + 'static,
 {
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash).map_err(|e| {

--- a/crates/client/rpc/src/utils/helpers.rs
+++ b/crates/client/rpc/src/utils/helpers.rs
@@ -70,10 +70,7 @@ where
         _ => block_number - 1,
     };
     let substrate_block_hash =
-        starknet.substrate_block_hash_from_starknet_block(BlockId::Number(previous_block_number)).map_err(|e| {
-            log::error!("Failed to retrieve previous block substrate hash: {e}");
-            StarknetRpcApiError::InternalServerError
-        })?;
+        starknet.substrate_block_hash_from_starknet_block(BlockId::Number(previous_block_number))?;
 
     Ok(substrate_block_hash)
 }

--- a/crates/client/rpc/src/utils/helpers.rs
+++ b/crates/client/rpc/src/utils/helpers.rs
@@ -4,7 +4,7 @@ use mp_block::DeoxysBlock;
 use mp_hashers::HasherT;
 use mp_transactions::to_starknet_core_transaction::to_starknet_core_tx;
 use mp_types::block::{DBlockT, DHashT};
-use pallet_starknet_runtime_api::{ConvertTransactionRuntimeApi, StarknetRuntimeApi};
+use pallet_starknet_runtime_api::StarknetRuntimeApi;
 use sc_client_api::backend::{Backend, StorageProvider};
 use sc_client_api::BlockBackend;
 use sp_api::ProvideRuntimeApi;
@@ -57,7 +57,7 @@ where
     BE: Backend<DBlockT> + 'static,
     C: HeaderBackend<DBlockT> + BlockBackend<DBlockT> + StorageProvider<DBlockT, BE> + 'static,
     C: ProvideRuntimeApi<DBlockT>,
-    C::Api: StarknetRuntimeApi<DBlockT> + ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: StarknetRuntimeApi<DBlockT> ,
     H: HasherT + Send + Sync + 'static,
 {
     let starknet_block = get_block_by_block_hash(starknet.client.as_ref(), substrate_block_hash).map_err(|e| {

--- a/crates/client/sync/src/l2.rs
+++ b/crates/client/sync/src/l2.rs
@@ -328,7 +328,7 @@ where
             loop {
                 interval.tick().await;
                 if let Err(e) = update_starknet_data(&provider, client.as_ref()).await {
-                    log::error!("{}", e.chain().map(|e| e.to_string()).collect::<Vec<_>>().join(": "));
+                    log::error!("{:#}", e);
                 }
             }
         } => Ok(()),

--- a/crates/client/sync/src/l2.rs
+++ b/crates/client/sync/src/l2.rs
@@ -21,7 +21,6 @@ use starknet_core::types::{PendingStateUpdate, StateUpdate};
 use starknet_ff::FieldElement;
 use starknet_providers::sequencer::models::{BlockId, StateUpdateWithBlock};
 use starknet_providers::{ProviderError, SequencerGatewayProvider};
-use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::time::Duration;
@@ -51,7 +50,7 @@ where
 }
 
 // TODO: add more error variants, which are more explicit
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum L2SyncError {
     #[error("provider error")]
     Provider(#[from] ProviderError),

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -55,8 +55,7 @@ where
     C: Send + Sync + 'static,
     C::Api: substrate_frame_rpc_system::AccountNonceApi<DBlockT, DAccountIdT, DTxIndexT>,
     C::Api: BlockBuilder<DBlockT>,
-    C::Api: pallet_starknet_runtime_api::StarknetRuntimeApi<DBlockT>
-        + pallet_starknet_runtime_api::ConvertTransactionRuntimeApi<DBlockT>,
+    C::Api: pallet_starknet_runtime_api::StarknetRuntimeApi<DBlockT>,
     G: GenesisProvider + Send + Sync + 'static,
     P: TransactionPool<Block = DBlockT> + 'static,
     BE: Backend<DBlockT> + 'static,

--- a/crates/pallets/starknet/Cargo.toml
+++ b/crates/pallets/starknet/Cargo.toml
@@ -20,6 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 # Deoxys primitives
 mc-db = { workspace = true }
 mp-block = { workspace = true }
+mp-chain-id = { workspace = true }
 mp-digest-log = { workspace = true }
 mp-felt = { workspace = true, features = ["parity-scale-codec", "serde"] }
 mp-genesis-config = { workspace = true, default-features = false }

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -9,8 +9,7 @@ use mp_felt::Felt252Wrapper;
 pub extern crate alloc;
 use alloc::vec::Vec;
 
-use sp_runtime::DispatchError;
-use starknet_api::transaction::{Event as StarknetEvent, MessageToL1, TransactionHash};
+use starknet_api::transaction::TransactionHash;
 
 #[derive(parity_scale_codec::Encode, parity_scale_codec::Decode, scale_info::TypeInfo)]
 pub enum StarknetTransactionExecutionError {
@@ -25,21 +24,7 @@ sp_api::decl_runtime_apis! {
     pub trait StarknetRuntimeApi {
         /// Returns the chain id.
         fn chain_id() -> Felt252Wrapper;
-        /// Returns the Starknet OS Cairo program hash.
-        fn program_hash() -> Felt252Wrapper;
-
-        fn get_events_for_tx_by_hash(tx_hash: TransactionHash) -> Vec<StarknetEvent>;
-
         /// Return the outcome of the tx execution
         fn get_tx_execution_outcome(tx_hash: TransactionHash) -> Option<Vec<u8>>;
-        /// Return is fee disabled in state
-        fn is_transaction_fee_disabled() -> bool;
-        /// Return messages sent to L1 during tx execution
-        fn get_tx_messages_to_l1(tx_hash: TransactionHash) -> Vec<MessageToL1>;
-    }
-
-    pub trait ConvertTransactionRuntimeApi {
-        /// Converts the DispatchError to an understandable error for the client
-        fn convert_error(error: DispatchError) -> StarknetTransactionExecutionError;
     }
 }

--- a/crates/pallets/starknet/runtime_api/src/lib.rs
+++ b/crates/pallets/starknet/runtime_api/src/lib.rs
@@ -7,9 +7,6 @@
 
 use mp_felt::Felt252Wrapper;
 pub extern crate alloc;
-use alloc::vec::Vec;
-
-use starknet_api::transaction::TransactionHash;
 
 #[derive(parity_scale_codec::Encode, parity_scale_codec::Decode, scale_info::TypeInfo)]
 pub enum StarknetTransactionExecutionError {
@@ -24,7 +21,5 @@ sp_api::decl_runtime_apis! {
     pub trait StarknetRuntimeApi {
         /// Returns the chain id.
         fn chain_id() -> Felt252Wrapper;
-        /// Return the outcome of the tx execution
-        fn get_tx_execution_outcome(tx_hash: TransactionHash) -> Option<Vec<u8>>;
     }
 }

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -54,14 +54,12 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use frame_support::pallet_prelude::*;
-use frame_support::traits::Time;
 use frame_system::pallet_prelude::*;
 use mc_db::storage_handler;
 use mc_db::storage_handler::StorageViewMut;
 use mp_block::DeoxysBlock;
 use mp_digest_log::DEOXYS_ENGINE_ID;
 use mp_felt::{trim_hash, Felt252Wrapper};
-use mp_hashers::HasherT;
 use mp_sequencer_address::{InherentError, InherentType, DEFAULT_SEQUENCER_ADDRESS, INHERENT_IDENTIFIER};
 use mp_storage::{StarknetStorageSchemaVersion, PALLET_STARKNET_SCHEMA};
 use sp_runtime::traits::UniqueSaturatedInto;
@@ -105,10 +103,6 @@ pub mod pallet {
     pub trait Config: frame_system::Config {
         /// Because this pallet emits events, it depends on the runtime's definition of an event.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-        /// The hashing function to use.
-        type SystemHash: HasherT;
-        /// The block time
-        type TimestampProvider: Time;
     }
 
     /// The Starknet pallet hooks.
@@ -328,17 +322,6 @@ pub mod pallet {
 
 /// The Starknet pallet internal functions.
 impl<T: Config> Pallet<T> {
-    /// Get the current block timestamp in seconds.
-    ///
-    /// # Returns
-    ///
-    /// The current block timestamp in seconds.
-    #[inline(always)]
-    pub fn block_timestamp() -> u64 {
-        let timestamp_in_millisecond: u64 = T::TimestampProvider::now().unique_saturated_into();
-        timestamp_in_millisecond / 1000
-    }
-
     /// Store a Starknet block in the blockchain.
     ///
     /// # Arguments

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -67,7 +67,7 @@ use sp_runtime::DigestItem;
 use starknet_api::core::{CompiledClassHash, ContractAddress};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
-use starknet_api::transaction::{Event as StarknetEvent, TransactionHash};
+use starknet_api::transaction::TransactionHash;
 
 use crate::types::{CasmClassHash, SierraClassHash};
 
@@ -100,10 +100,7 @@ pub mod pallet {
     /// We're coupling the starknet pallet to the tx payment pallet to be able to override the fee
     /// mechanism and comply with starknet which uses an ER20 as fee token
     #[pallet::config]
-    pub trait Config: frame_system::Config {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-    }
+    pub trait Config: frame_system::Config {}
 
     /// The Starknet pallet hooks.
     /// HOOKS
@@ -220,23 +217,6 @@ pub mod pallet {
             LastKnownEthBlock::<T>::set(None);
             SeqAddrUpdate::<T>::put(true);
         }
-    }
-
-    /// The Starknet pallet events.
-    /// EVENTS
-    /// See: `<https://docs.substrate.io/main-docs/build/events-errors/>`
-    #[pallet::event]
-    pub enum Event<T: Config> {
-        KeepStarknetStrange,
-        /// Regular Starknet event
-        StarknetEvent(StarknetEvent),
-        /// Emitted when fee token address is changed.
-        /// This is emitted by the `set_fee_token_address` extrinsic.
-        /// [old_fee_token_address, new_fee_token_address]
-        FeeTokenAddressChanged {
-            old_fee_token_address: ContractAddress,
-            new_fee_token_address: ContractAddress,
-        },
     }
 
     /// The Starknet pallet custom errors.

--- a/crates/pallets/starknet/src/lib.rs
+++ b/crates/pallets/starknet/src/lib.rs
@@ -109,18 +109,6 @@ pub mod pallet {
         type SystemHash: HasherT;
         /// The block time
         type TimestampProvider: Time;
-        #[pallet::constant]
-        type InvokeTxMaxNSteps: Get<u32>;
-        #[pallet::constant]
-        type ValidateMaxNSteps: Get<u32>;
-        #[pallet::constant]
-        type ProtocolVersion: Get<Felt252Wrapper>;
-        #[pallet::constant]
-        type ChainId: Get<Felt252Wrapper>;
-        #[pallet::constant]
-        type MaxRecursionDepth: Get<u32>;
-        #[pallet::constant]
-        type ProgramHash: Get<Felt252Wrapper>;
     }
 
     /// The Starknet pallet hooks.
@@ -394,6 +382,6 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn chain_id() -> Felt252Wrapper {
-        T::ChainId::get()
+        mp_chain_id::SN_MAIN_CHAIN_ID
     }
 }

--- a/crates/primitives/block/src/ordered_events.rs
+++ b/crates/primitives/block/src/ordered_events.rs
@@ -27,7 +27,7 @@ impl OrderedEvents {
         self.index
     }
 
-    pub fn events(&self) -> &Vec<Event> {
+    pub fn events(&self) -> &[Event] {
         &self.events
     }
 }

--- a/crates/primitives/simulations/src/lib.rs
+++ b/crates/primitives/simulations/src/lib.rs
@@ -5,7 +5,7 @@ pub extern crate alloc;
 
 use alloc::vec::Vec;
 
-use starknet_core::types::{SimulationFlag, SimulationFlagForEstimateFee as EstimateFeeFlag};
+use starknet_core::types::SimulationFlag;
 
 // TODO: This is a placeholder
 // https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L3919
@@ -45,27 +45,5 @@ impl From<Vec<SimulationFlag>> for SimulationFlags {
 impl core::default::Default for SimulationFlags {
     fn default() -> Self {
         Self { validate: true, charge_fee: true }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "parity-scale-codec", derive(parity_scale_codec::Encode, parity_scale_codec::Decode))]
-#[cfg_attr(feature = "scale-info", derive(scale_info::TypeInfo))]
-pub struct SimulationFlagForEstimateFee {
-    pub skip_validate: bool,
-}
-
-pub fn convert_flags(flags: Vec<EstimateFeeFlag>) -> Vec<SimulationFlagForEstimateFee> {
-    flags
-        .iter()
-        .map(|flag| match flag {
-            EstimateFeeFlag::SkipValidate => SimulationFlagForEstimateFee { skip_validate: false },
-        })
-        .collect()
-}
-
-impl core::default::Default for SimulationFlagForEstimateFee {
-    fn default() -> Self {
-        Self { skip_validate: true }
     }
 }

--- a/crates/primitives/transactions/src/from_broadcasted_transactions.rs
+++ b/crates/primitives/transactions/src/from_broadcasted_transactions.rs
@@ -35,11 +35,10 @@ use starknet_core::types::{
     FlattenedSierraClass, LegacyContractEntryPoint, LegacyEntryPointsByType, SierraEntryPoint,
 };
 use starknet_crypto::FieldElement;
-use thiserror::Error;
 
 use crate::compute_hash::ComputeTransactionHash;
 
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum BroadcastedTransactionConversionError {
     #[error("Max fee should not be greater than u128::MAX")]
     MaxFeeTooBig,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -30,8 +30,6 @@ use mp_types::block::DHeaderT;
 use mp_types::transactions::{DTxIndexT, DTxSignatureT};
 /// Import the Starknet pallet.
 pub use pallet_starknet;
-use pallet_starknet::pallet::Error as PalletError;
-use pallet_starknet_runtime_api::StarknetTransactionExecutionError;
 pub use pallet_timestamp::Call as TimestampCall;
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
@@ -40,11 +38,11 @@ use sp_runtime::traits::Block as BlockT;
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-use sp_runtime::{generic, ApplyExtrinsicResult, DispatchError};
+use sp_runtime::{generic, ApplyExtrinsicResult};
 pub use sp_runtime::{Perbill, Permill};
 use sp_std::prelude::*;
 use sp_version::RuntimeVersion;
-use starknet_api::transaction::{Event as StarknetEvent, MessageToL1, TransactionHash};
+use starknet_api::transaction::TransactionHash;
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
@@ -183,44 +181,8 @@ impl_runtime_apis! {
             Starknet::chain_id()
         }
 
-        fn program_hash() -> Felt252Wrapper {
-            Starknet::program_hash()
-        }
-
-        fn is_transaction_fee_disabled() -> bool {
-            Starknet::is_transaction_fee_disabled()
-        }
-
-        fn get_tx_messages_to_l1(tx_hash: TransactionHash) -> Vec<MessageToL1> {
-            Starknet::tx_messages(tx_hash)
-        }
-
-        fn get_events_for_tx_by_hash(tx_hash: TransactionHash) -> Vec<StarknetEvent> {
-            Starknet::tx_events(tx_hash)
-        }
-
         fn get_tx_execution_outcome(tx_hash: TransactionHash) -> Option<Vec<u8>> {
             Starknet::tx_revert_error(tx_hash).map(|s| s.into_bytes())
-        }
-    }
-
-    impl pallet_starknet_runtime_api::ConvertTransactionRuntimeApi<Block> for Runtime {
-
-        fn convert_error(error: DispatchError) -> StarknetTransactionExecutionError {
-            if error == PalletError::<Runtime>::ContractNotFound.into() {
-                return StarknetTransactionExecutionError::ContractNotFound;
-            }
-            if error == PalletError::<Runtime>::ClassHashAlreadyDeclared.into() {
-                return StarknetTransactionExecutionError::ClassAlreadyDeclared;
-            }
-            if error == PalletError::<Runtime>::ContractClassHashUnknown.into() {
-                return StarknetTransactionExecutionError::ClassHashNotFound;
-            }
-            if error == PalletError::<Runtime>::InvalidContractClass.into() {
-                return StarknetTransactionExecutionError::InvalidContractClass;
-            }
-
-            StarknetTransactionExecutionError::ContractError
         }
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -42,7 +42,6 @@ use sp_runtime::{generic, ApplyExtrinsicResult};
 pub use sp_runtime::{Perbill, Permill};
 use sp_std::prelude::*;
 use sp_version::RuntimeVersion;
-use starknet_api::transaction::TransactionHash;
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
@@ -179,10 +178,6 @@ impl_runtime_apis! {
 
         fn chain_id() -> Felt252Wrapper {
             Starknet::chain_id()
-        }
-
-        fn get_tx_execution_outcome(tx_hash: TransactionHash) -> Option<Vec<u8>> {
-            Starknet::tx_revert_error(tx_hash).map(|s| s.into_bytes())
         }
     }
 

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -36,12 +36,6 @@ impl pallet_starknet::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SystemHash = DHasherT;
     type TimestampProvider = Timestamp;
-    type InvokeTxMaxNSteps = InvokeTxMaxNSteps;
-    type ValidateMaxNSteps = ValidateMaxNSteps;
-    type ProtocolVersion = ProtocolVersion;
-    type ChainId = ChainId;
-    type MaxRecursionDepth = MaxRecursionDepth;
-    type ProgramHash = ProgramHash;
 }
 
 /// --------------------------------------
@@ -145,18 +139,6 @@ impl pallet_timestamp::Config for Runtime {
     type OnTimestampSet = ConsensusOnTimestampSet<Self>;
     type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
     type WeightInfo = ();
-}
-
-// TODO: change the ChainId to the correct one which depends on the network
-parameter_types! {
-    pub const UnsignedPriority: u64 = 1 << 20;
-    pub const TransactionLongevity: u64 = u64::MAX;
-    pub const InvokeTxMaxNSteps: u32 = 1_000_000;
-    pub const ValidateMaxNSteps: u32 = 1_000_000;
-    pub const ProtocolVersion: u8 = 0;
-    pub const ChainId: Felt252Wrapper = mp_chain_id::SN_MAIN_CHAIN_ID;
-    pub const MaxRecursionDepth: u32 = 50;
-    pub const ProgramHash: Felt252Wrapper = SN_OS_PROGRAM_HASH;
 }
 
 /// Implement the OnTimestampSet trait to override the default Aura.

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -36,13 +36,6 @@ impl pallet_starknet::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SystemHash = DHasherT;
     type TimestampProvider = Timestamp;
-    type UnsignedPriority = UnsignedPriority;
-    type TransactionLongevity = TransactionLongevity;
-    #[cfg(not(feature = "disable-transaction-fee"))]
-    type DisableTransactionFee = ConstBool<false>;
-    #[cfg(feature = "disable-transaction-fee")]
-    type DisableTransactionFee = ConstBool<true>;
-    type DisableNonceValidation = ConstBool<false>;
     type InvokeTxMaxNSteps = InvokeTxMaxNSteps;
     type ValidateMaxNSteps = ValidateMaxNSteps;
     type ProtocolVersion = ProtocolVersion;

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -11,7 +11,7 @@ pub use frame_support::weights::{IdentityFee, Weight};
 pub use frame_support::{construct_runtime, parameter_types, StorageValue};
 pub use frame_system::Call as SystemCall;
 pub use mp_program_hash::SN_OS_PROGRAM_HASH;
-use mp_types::block::{DHashT, DHasherT};
+use mp_types::block::DHashT;
 use mp_types::transactions::DTxIndexT;
 /// Import the StarkNet pallet.
 pub use pallet_starknet;
@@ -34,8 +34,6 @@ use crate::*;
 /// Configure the Starknet pallet in pallets/starknet.
 impl pallet_starknet::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type SystemHash = DHasherT;
-    type TimestampProvider = Timestamp;
 }
 
 /// --------------------------------------

--- a/crates/runtime/src/pallets.rs
+++ b/crates/runtime/src/pallets.rs
@@ -32,9 +32,7 @@ use crate::*;
 // --------------------------------------
 
 /// Configure the Starknet pallet in pallets/starknet.
-impl pallet_starknet::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-}
+impl pallet_starknet::Config for Runtime {}
 
 /// --------------------------------------
 /// FRAME SYSTEM PALLET


### PR DESCRIPTION
## Pull Request type

- Bugfix

## What is the current behavior?


## What is the new behavior?

- fix error handling for:
  - `get_class_hash_at`
  - `get_nonce`
  - `get_storage_at`
  - `get_transction_by_block_id_and_index`
  - `get_transction_by_hash`
- simplifying error handling with `substrate_block_hash_from_starknet_block`
- explicit use of `thiserror::Error`
- clean: pallet/starknet

## Does this introduce a breaking change?


## Other information

## TODO

- fix: `get_transaction_status`

