### PR TITLE
feat: fetch block and state update in only one request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- feat: fetch block and state update in only one request
 - fix: creation of the block context
 - fix: is_missing_class
 - fix: state root - replaced_classes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7061,7 +7061,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -11128,7 +11128,7 @@ dependencies = [
 [[package]]
 name = "starknet-core"
 version = "0.10.0"
-source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#5fc0e80815e30abf63ee452bf3caf4f007eebab2"
+source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#13fb5e5b6af35bc32e760c05716782a983c0cc40"
 dependencies = [
  "base64 0.21.5",
  "flate2",
@@ -11185,7 +11185,7 @@ dependencies = [
 [[package]]
 name = "starknet-crypto"
 version = "0.6.2"
-source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#5fc0e80815e30abf63ee452bf3caf4f007eebab2"
+source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#13fb5e5b6af35bc32e760c05716782a983c0cc40"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -11215,7 +11215,7 @@ dependencies = [
 [[package]]
 name = "starknet-crypto-codegen"
 version = "0.3.3"
-source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#5fc0e80815e30abf63ee452bf3caf4f007eebab2"
+source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#13fb5e5b6af35bc32e760c05716782a983c0cc40"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff 0.3.7",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "starknet-curve"
 version = "0.4.2"
-source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#5fc0e80815e30abf63ee452bf3caf4f007eebab2"
+source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#13fb5e5b6af35bc32e760c05716782a983c0cc40"
 dependencies = [
  "starknet-ff 0.3.7",
 ]
@@ -11266,7 +11266,7 @@ dependencies = [
 [[package]]
 name = "starknet-ff"
 version = "0.3.7"
-source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#5fc0e80815e30abf63ee452bf3caf4f007eebab2"
+source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#13fb5e5b6af35bc32e760c05716782a983c0cc40"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "starknet-providers"
 version = "0.10.0"
-source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#5fc0e80815e30abf63ee452bf3caf4f007eebab2"
+source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#13fb5e5b6af35bc32e760c05716782a983c0cc40"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/crates/client/sync/src/fetch/fetchers.rs
+++ b/crates/client/sync/src/fetch/fetchers.rs
@@ -4,13 +4,15 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use mc_db::storage_handler::primitives::contract_class::{ContractClassData, ContractClassWrapper};
-use mc_db::storage_handler::{self, StorageView};
+use mc_db::storage_handler::{self, DeoxysStorageError, StorageView};
 use mp_block::DeoxysBlock;
 use mp_convert::state_update::ToStateUpdateCore;
 use sp_core::H160;
 use starknet_api::core::ClassHash;
 use starknet_api::hash::StarkFelt;
-use starknet_core::types::{BlockId as BlockIdCore, DeclaredClassItem, DeployedContractItem, StateUpdate};
+use starknet_core::types::{
+    BlockId as BlockIdCore, DeclaredClassItem, DeployedContractItem, StarknetError, StateUpdate,
+};
 use starknet_ff::FieldElement;
 use starknet_providers::sequencer::models::{self as p, BlockId};
 use starknet_providers::{Provider, ProviderError, SequencerGatewayProvider};
@@ -47,12 +49,6 @@ pub struct FetchConfig {
     pub n_blocks_to_sync: Option<u64>,
 }
 
-pub async fn fetch_block(client: &SequencerGatewayProvider, block_number: u64) -> Result<p::Block, L2SyncError> {
-    let block = client.get_block(BlockId::Number(block_number)).await?;
-
-    Ok(block)
-}
-
 pub struct L2BlockAndUpdates {
     pub block_n: u64,
     pub block: p::Block,
@@ -76,24 +72,23 @@ pub async fn fetch_block_and_updates(
     Ok(L2BlockAndUpdates { block_n, block, state_update, class_update })
 }
 
-async fn retry<F, Fut, T>(mut f: F, max_retries: u32, base_delay: Duration) -> Result<T, L2SyncError>
+async fn retry<F, Fut, T>(mut f: F, max_retries: u32, base_delay: Duration) -> Result<T, ProviderError>
 where
     F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<T, L2SyncError>>,
+    Fut: std::future::Future<Output = Result<T, ProviderError>>,
 {
     let mut attempt = 0;
     loop {
         match f().await {
             Ok(res) => return Ok(res),
-            Err(L2SyncError::Provider(err)) => {
+            Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => {
+                break Err(ProviderError::StarknetError(StarknetError::BlockNotFound));
+            }
+            Err(err) => {
                 let delay = base_delay * 2_u32.pow(attempt).min(6); // Cap to prevent overly long delays
                 attempt += 1;
                 if attempt > max_retries {
-                    break Err(if matches!(err, ProviderError::RateLimited) {
-                        L2SyncError::FetchRetryLimit
-                    } else {
-                        L2SyncError::Provider(err)
-                    });
+                    break Err(err);
                 }
                 match err {
                     ProviderError::RateLimited => {
@@ -103,7 +98,6 @@ where
                 }
                 tokio::time::sleep(delay).await;
             }
-            Err(err) => break Err(err),
         }
     }
 }
@@ -123,7 +117,7 @@ pub async fn fetch_apply_genesis_block(config: FetchConfig) -> Result<DeoxysBloc
 async fn fetch_state_update_with_block(
     provider: &SequencerGatewayProvider,
     block_number: u64,
-) -> Result<(StateUpdate, p::Block), L2SyncError> {
+) -> Result<(StateUpdate, p::Block), ProviderError> {
     let state_update_with_block = provider.get_state_update_with_block(BlockId::Number(block_number)).await?;
 
     Ok((state_update_with_block.state_update.to_state_update_core(), state_update_with_block.block))
@@ -152,8 +146,15 @@ async fn fetch_class_update(
         )
         .chain(state_update.state_diff.deprecated_declared_classes.iter())
         .unique()
-        .filter(|class_hash| is_missing_class(class_hash))
-        .collect();
+        //.filter(|class_hash| is_missing_class(class_hash)?)
+        .filter_map(|class_hash| {
+            match is_missing_class(class_hash) {
+                Ok(true) => Some(Ok(class_hash)),
+                Ok(false) => None,
+                Err(e) => Some(Err(e)),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     let arc_provider = Arc::new(provider.clone());
 
@@ -187,7 +188,7 @@ async fn fetch_class(
     class_hash: FieldElement,
     block_number: u64,
     provider: &SequencerGatewayProvider,
-) -> Result<ContractClassData, L2SyncError> {
+) -> Result<ContractClassData, ProviderError> {
     let core_class = provider.get_class(BlockIdCore::Number(block_number), class_hash).await?;
     Ok(ContractClassData {
         hash: ClassHash(StarkFelt(class_hash.to_bytes_be())),
@@ -199,8 +200,8 @@ async fn fetch_class(
 ///
 /// Since a change in class definition will result in a change in class hash,
 /// this means we only need to check for class hashes in the db.
-fn is_missing_class(class_hash: &FieldElement) -> bool {
+fn is_missing_class(class_hash: &FieldElement) -> Result<bool, DeoxysStorageError> {
     let class_hash = ClassHash(StarkFelt(class_hash.to_bytes_be()));
     // TODO: return the db error instead of unwrapping
-    storage_handler::contract_class_data().contains(&class_hash).map(|x| !x).unwrap_or(true)
+    storage_handler::contract_class_data().contains(&class_hash).map(|x| !x)
 }

--- a/crates/client/sync/src/fetch/fetchers.rs
+++ b/crates/client/sync/src/fetch/fetchers.rs
@@ -94,7 +94,7 @@ where
                     ProviderError::RateLimited => {
                         log::info!("The fetching process has been rate limited, retrying in {:?}", delay)
                     }
-                    _ => log::info!("The provider has returned an error, retrying in {:?}", delay),
+                    _ => log::info!("The provider has returned an error: {}, retrying in {:?}", err, delay),
                 }
                 tokio::time::sleep(delay).await;
             }
@@ -146,13 +146,10 @@ async fn fetch_class_update(
         )
         .chain(state_update.state_diff.deprecated_declared_classes.iter())
         .unique()
-        //.filter(|class_hash| is_missing_class(class_hash)?)
-        .filter_map(|class_hash| {
-            match is_missing_class(class_hash) {
-                Ok(true) => Some(Ok(class_hash)),
-                Ok(false) => None,
-                Err(e) => Some(Err(e)),
-            }
+        .filter_map(|class_hash| match is_missing_class(class_hash) {
+            Ok(true) => Some(Ok(class_hash)),
+            Ok(false) => None,
+            Err(e) => Some(Err(e)),
         })
         .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/client/sync/src/fetch/fetchers.rs
+++ b/crates/client/sync/src/fetch/fetchers.rs
@@ -199,6 +199,5 @@ async fn fetch_class(
 /// this means we only need to check for class hashes in the db.
 fn is_missing_class(class_hash: &FieldElement) -> Result<bool, DeoxysStorageError> {
     let class_hash = ClassHash(StarkFelt(class_hash.to_bytes_be()));
-    // TODO: return the db error instead of unwrapping
     storage_handler::contract_class_data().contains(&class_hash).map(|x| !x)
 }

--- a/crates/client/sync/src/l2.rs
+++ b/crates/client/sync/src/l2.rs
@@ -398,15 +398,12 @@ async fn update_starknet_data<C>(provider: &SequencerGatewayProvider, client: &C
 where
     C: HeaderBackend<DBlockT>,
 {
-    let StateUpdateWithBlock { state_update, block } = provider
-        .get_state_update_with_block(BlockId::Pending)
-        .await.context("Failed to get pending block")?;
+    let StateUpdateWithBlock { state_update, block } =
+        provider.get_state_update_with_block(BlockId::Pending).await.context("Failed to get pending block")?;
 
     let hash_best = client.info().best_hash;
     let hash_current = block.parent_block_hash;
-    let number = provider
-        .get_block_id_by_hash(hash_current)
-        .await.context("Failed to get block id by hash")?;
+    let number = provider.get_block_id_by_hash(hash_current).await.context("Failed to get block id by hash")?;
     let tmp = DHashT::from_str(&hash_current.to_string()).unwrap_or(Default::default());
 
     if hash_best == tmp {

--- a/crates/client/sync/src/l2.rs
+++ b/crates/client/sync/src/l2.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context};
 use futures::{stream, StreamExt, TryStreamExt};
 use lazy_static::lazy_static;
 use mc_db::storage_handler::primitives::contract_class::{ClassUpdateWrapper, ContractClassData};
+use mc_db::storage_handler::DeoxysStorageError;
 use mc_db::storage_updates::{store_class_update, store_key_update, store_state_update};
 use mc_db::DeoxysBackend;
 use mp_block::DeoxysBlock;
@@ -54,8 +55,8 @@ where
 pub enum L2SyncError {
     #[error("provider error")]
     Provider(#[from] ProviderError),
-    #[error("fetch retry limit exceeded")]
-    FetchRetryLimit,
+    #[error("db error")]
+    Db(#[from] DeoxysStorageError),
 }
 
 /// Contains the latest Starknet verified state on L2


### PR DESCRIPTION
# feat: fetch block and state update in only one request

# Pull Request type

- Feature

## What is the current behavior?

- if the fetch of a single class fails in a block, the entire fetch of the classes is retry

## What is the new behavior?

- fetch block and state update in only one request
- retry fetch for each class independently

## Does this introduce a breaking change?

No

## Other information


