### PR TITLE
add StarknetVersion in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- refactor: new type StarknetVersion
 - refactor: update starknet-rs with Felt
 - fix(rpc): fixed block not found error on get_class method
 - fix (rpc): get_transaction_status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,6 +2119,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "dp-convert",
+ "dp-transactions",
  "lazy_static",
  "primitive-types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "starknet-core",
  "starknet-types-core",
  "starknet_api",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/client/db/src/storage_handler/primitives/contract_class.rs
+++ b/crates/client/db/src/storage_handler/primitives/contract_class.rs
@@ -8,6 +8,7 @@ use blockifier::execution::contract_class::{
 };
 use cairo_vm::types::program::Program;
 use dp_convert::to_felt::ToFelt;
+use dp_convert::to_stark_felt::ToStarkFelt;
 use dp_transactions::from_broadcasted_transactions::flattened_sierra_to_casm_contract_class;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
@@ -15,7 +16,6 @@ use indexmap::IndexMap;
 use parity_scale_codec::{Decode, Encode};
 use starknet_api::core::{ClassHash, EntryPointSelector, Nonce};
 use starknet_api::deprecated_contract_class::{EntryPoint, EntryPointOffset, EntryPointType};
-use starknet_api::hash::StarkFelt;
 use starknet_core::types::{
     CompressedLegacyContractClass, ContractClass as ContractClassCore, EntryPointsByType, FlattenedSierraClass,
     LegacyContractAbiEntry, LegacyContractEntryPoint, LegacyEntryPointsByType, SierraEntryPoint,
@@ -320,7 +320,7 @@ fn to_entry_point(entry_point: EntryPointV1, index: u64) -> SierraEntryPoint {
 /// Returns a [EntryPoint] (starknet-api) from a [LegacyContractEntryPoint]
 /// (starknet-rs)
 fn from_legacy_entry_point(entry_point: &LegacyContractEntryPoint) -> EntryPoint {
-    let selector = EntryPointSelector(StarkFelt::new_unchecked(entry_point.selector.to_bytes_be()));
+    let selector = EntryPointSelector(entry_point.selector.to_stark_felt());
     let offset = EntryPointOffset(entry_point.offset);
     EntryPoint { selector, offset }
 }

--- a/crates/client/db/src/storage_updates.rs
+++ b/crates/client/db/src/storage_updates.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use dp_convert::to_stark_felt::ToStarkFelt;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
-use starknet_api::hash::StarkFelt;
 use starknet_core::types::{
     ContractStorageDiffItem, DeclaredClassItem, DeployedContractItem, NonceUpdate, ReplacedClassItem, StateUpdate,
     StorageEntry,
@@ -86,10 +85,7 @@ pub fn store_state_update(
             .declared_classes
             .into_iter()
             .map(|DeclaredClassItem { class_hash, compiled_class_hash }| {
-                (
-                    ClassHash(StarkFelt::new_unchecked(class_hash.to_bytes_be())),
-                    CompiledClassHash(StarkFelt::new_unchecked(compiled_class_hash.to_bytes_be())),
-                )
+                (ClassHash(class_hash.to_stark_felt()), CompiledClassHash(compiled_class_hash.to_stark_felt()))
             })
             .for_each(|(class_hash, compiled_class_hash)| {
                 handler_contract_class_hashes.insert(class_hash, compiled_class_hash).unwrap();

--- a/crates/client/rpc/src/utils/block.rs
+++ b/crates/client/rpc/src/utils/block.rs
@@ -44,5 +44,5 @@ pub(crate) fn l1_da_mode(block: &DeoxysBlock) -> L1DataAvailabilityMode {
 }
 
 pub(crate) fn starknet_version(block: &DeoxysBlock) -> String {
-    block.header().protocol_version.clone()
+    block.header().protocol_version.to_string()
 }

--- a/crates/client/rpc/src/utils/execution.rs
+++ b/crates/client/rpc/src/utils/execution.rs
@@ -48,7 +48,9 @@ pub fn block_context(_client: &Starknet, block_info: &DeoxysBlockInfo) -> Result
     };
     let chain_id = starknet_api::core::ChainId("SN_MAIN".to_string());
 
-    Ok(block_header.into_block_context(fee_token_address, chain_id))
+    block_header
+        .into_block_context(fee_token_address, chain_id)
+        .map_err(|e| StarknetRpcApiError::ErrUnexpectedError { data: e.to_string() })
 }
 
 pub fn re_execute_transactions(

--- a/crates/client/rpc/src/utils/transaction.rs
+++ b/crates/client/rpc/src/utils/transaction.rs
@@ -2,8 +2,8 @@ use blockifier::execution::contract_class::ClassInfo;
 use blockifier::transaction::transaction_execution as btx;
 use dc_db::storage_handler::primitives::contract_class::StorageContractClassData;
 use dc_db::storage_handler::StorageView;
+use dp_convert::to_stark_felt::ToStarkFelt;
 use jsonrpsee::core::RpcResult;
-use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{Transaction, TransactionHash};
 use starknet_core::types::Felt;
 
@@ -17,7 +17,7 @@ pub(crate) fn blockifier_transactions(
     let transactions = transaction_with_hash
             .iter()
             .filter(|(tx, _)| !matches!(tx, Transaction::Deploy(_))) // deploy transaction was not supported by blockifier
-            .map(|(tx, hash)| to_blockifier_transactions(starknet, tx, &TransactionHash(StarkFelt::new_unchecked(hash.to_bytes_be()))))
+            .map(|(tx, hash)| to_blockifier_transactions(starknet, tx, &TransactionHash(hash.to_stark_felt())))
             .collect::<Result<Vec<_>, _>>()?;
 
     Ok(transactions)

--- a/crates/client/sync/src/commitments/transactions.rs
+++ b/crates/client/sync/src/commitments/transactions.rs
@@ -5,6 +5,7 @@ use bonsai_trie::{BonsaiStorage, BonsaiStorageConfig};
 use dc_db::storage_handler::bonsai_identifier;
 use dp_convert::to_felt::ToFelt;
 use dp_transactions::compute_hash::ComputeTransactionHash;
+use dp_transactions::MAIN_CHAIN_ID;
 use rayon::prelude::*;
 use starknet_api::transaction::Transaction;
 use starknet_types_core::felt::Felt;
@@ -28,7 +29,7 @@ pub fn calculate_transaction_hash_with_signature(
     chain_id: Felt,
     block_number: u64,
 ) -> (Felt, Felt) {
-    let include_signature = block_number >= 61394;
+    let include_signature = !(block_number < 61394 && chain_id == MAIN_CHAIN_ID);
 
     let (signature_hash, tx_hash) = rayon::join(
         || match transaction {

--- a/crates/client/sync/src/utils/convert.rs
+++ b/crates/client/sync/src/utils/convert.rs
@@ -11,7 +11,6 @@ use dp_convert::to_stark_felt::ToStarkFelt;
 use dp_transactions::from_broadcasted_transactions::fee_from_felt;
 use dp_transactions::MAIN_CHAIN_ID;
 use starknet_api::block::BlockHash;
-use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{
     DeclareTransaction, DeployAccountTransaction, DeployAccountTransactionV1, DeployTransaction, Event,
     InvokeTransaction, L1HandlerTransaction, Transaction, TransactionHash,
@@ -37,10 +36,9 @@ pub struct ConvertedBlock {
 /// Compute heavy, this should only be called in a rayon ctx
 pub fn convert_block(block: p::Block, chain_id: Felt) -> Result<ConvertedBlock, L2SyncError> {
     // converts starknet_provider transactions and events to dp_transactions and starknet_api events
-    let transactions = transactions(block.transactions);
+    let transactions = transactions(&block.transactions);
     let reverted_transactions = reverted_transactions(&block.transaction_receipts);
     let events = events(&block.transaction_receipts);
-    let parent_block_hash = block.parent_block_hash.to_stark_felt();
     let block_hash = block.block_hash.expect("no block hash provided");
     let block_number = block.block_number.expect("no block number provided");
     let block_timestamp = block.timestamp;
@@ -52,26 +50,21 @@ pub fn convert_block(block: p::Block, chain_id: Felt) -> Result<ConvertedBlock, 
     let ((transaction_commitment, txs_hashes), event_commitment) =
         calculate_tx_and_event_commitments(&transactions, &events, chain_id, block_number);
 
-    // Provisory conversion while Starknet-api doesn't support the universal `Felt` type
-    let transaction_commitment = transaction_commitment.to_stark_felt();
-    let event_commitment = event_commitment.to_stark_felt();
-    let txs_hashes: Vec<StarkFelt> = txs_hashes.iter().map(|felt| (*felt).to_stark_felt()).collect();
-
     let protocol_version = protocol_version(block.starknet_version);
     let l1_gas_price = resource_price(block.l1_gas_price, block.l1_data_gas_price);
     let l1_da_mode = l1_da_mode(block.l1_da_mode);
     let extra_data = Some(dp_block::U256::from_big_endian(&block_hash.to_bytes_be()));
 
     let header = dp_block::Header {
-        parent_block_hash,
+        parent_block_hash: block.parent_block_hash.to_stark_felt(),
         block_number,
         block_timestamp,
         global_state_root,
         sequencer_address,
         transaction_count,
-        transaction_commitment,
+        transaction_commitment: transaction_commitment.to_stark_felt(),
         event_count,
-        event_commitment,
+        event_commitment: event_commitment.to_stark_felt(),
         protocol_version,
         l1_gas_price,
         l1_da_mode,
@@ -81,6 +74,22 @@ pub fn convert_block(block: p::Block, chain_id: Felt) -> Result<ConvertedBlock, 
     let computed_block_hash = header.hash(chain_id);
     // mismatched block hash is allowed for blocks 1466..=2242 on mainnet
     if computed_block_hash != block_hash && !((1466..=2242).contains(&block_number) && chain_id == MAIN_CHAIN_ID) {
+        if event_commitment != block.event_commitment.unwrap() {
+            log::warn!(
+                "Mismatched event commitment({}): expected 0x{:x}, got 0x{:x}",
+                block_number,
+                event_commitment,
+                block.event_commitment.unwrap()
+            );
+        }
+        if transaction_commitment != block.transaction_commitment.unwrap() {
+            log::warn!(
+                "Mismatched transaction commitment({}): expected 0x{:x}, got 0x{:x}",
+                block_number,
+                transaction_commitment,
+                block.transaction_commitment.unwrap()
+            );
+        }
         return Err(L2SyncError::MismatchedBlockHash(block_number));
     }
     let ordered_events: Vec<dp_block::OrderedEvents> = block
@@ -94,7 +103,7 @@ pub fn convert_block(block: p::Block, chain_id: Felt) -> Result<ConvertedBlock, 
     let block = DeoxysBlock::new(
         DeoxysBlockInfo::new(
             header,
-            txs_hashes.into_iter().map(TransactionHash).collect(),
+            txs_hashes.into_iter().map(ToStarkFelt::to_stark_felt).map(TransactionHash).collect(),
             BlockHash(block_hash.to_stark_felt()),
         ),
         DeoxysBlockInner::new(transactions, ordered_events),
@@ -107,11 +116,11 @@ fn protocol_version(version: Option<String>) -> StarknetVersion {
     version.map(|version| StarknetVersion::from_str(&version).unwrap_or_default()).unwrap_or_default()
 }
 
-fn transactions(txs: Vec<p::TransactionType>) -> Vec<Transaction> {
-    txs.into_iter().map(transaction).collect()
+fn transactions(txs: &[p::TransactionType]) -> Vec<Transaction> {
+    txs.iter().map(transaction).collect()
 }
 
-fn transaction(transaction: p::TransactionType) -> Transaction {
+fn transaction(transaction: &p::TransactionType) -> Transaction {
     match transaction {
         p::TransactionType::Declare(tx) => Transaction::Declare(declare_transaction(tx)),
         p::TransactionType::Deploy(tx) => Transaction::Deploy(deploy_transaction(tx)),
@@ -121,11 +130,11 @@ fn transaction(transaction: p::TransactionType) -> Transaction {
     }
 }
 
-fn declare_transaction(tx: p::DeclareTransaction) -> DeclareTransaction {
+fn declare_transaction(tx: &p::DeclareTransaction) -> DeclareTransaction {
     if tx.version == Felt::ZERO {
         DeclareTransaction::V0(starknet_api::transaction::DeclareTransactionV0V1 {
             max_fee: fee(tx.max_fee.expect("no max fee provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce),
             class_hash: class_hash(tx.class_hash),
             sender_address: contract_address(tx.sender_address),
@@ -133,7 +142,7 @@ fn declare_transaction(tx: p::DeclareTransaction) -> DeclareTransaction {
     } else if tx.version == Felt::ONE {
         DeclareTransaction::V1(starknet_api::transaction::DeclareTransactionV0V1 {
             max_fee: fee(tx.max_fee.expect("no max fee provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce),
             class_hash: class_hash(tx.class_hash),
             sender_address: contract_address(tx.sender_address),
@@ -141,7 +150,7 @@ fn declare_transaction(tx: p::DeclareTransaction) -> DeclareTransaction {
     } else if tx.version == Felt::TWO {
         DeclareTransaction::V2(starknet_api::transaction::DeclareTransactionV2 {
             max_fee: fee(tx.max_fee.expect("no max fee provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce),
             class_hash: class_hash(tx.class_hash),
             compiled_class_hash: compiled_class_hash(tx.compiled_class_hash.expect("no compiled class hash provided")),
@@ -149,9 +158,9 @@ fn declare_transaction(tx: p::DeclareTransaction) -> DeclareTransaction {
         })
     } else if tx.version == Felt::THREE {
         DeclareTransaction::V3(starknet_api::transaction::DeclareTransactionV3 {
-            resource_bounds: resource_bounds(tx.resource_bounds.expect("no resource bounds provided")),
+            resource_bounds: resource_bounds(tx.resource_bounds.as_ref().expect("no resource bounds provided")),
             tip: tip(tx.tip.expect("no tip provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce),
             class_hash: class_hash(tx.class_hash),
             compiled_class_hash: compiled_class_hash(tx.compiled_class_hash.expect("no compiled class hash provided")),
@@ -162,9 +171,9 @@ fn declare_transaction(tx: p::DeclareTransaction) -> DeclareTransaction {
             fee_data_availability_mode: data_availability_mode(
                 tx.fee_data_availability_mode.expect("no fee_data_availability_mode provided"),
             ),
-            paymaster_data: paymaster_data(tx.paymaster_data.expect("no paymaster_data provided")),
+            paymaster_data: paymaster_data(tx.paymaster_data.as_ref().expect("no paymaster_data provided")),
             account_deployment_data: account_deployment_data(
-                tx.account_deployment_data.expect("no account_deployment_data provided"),
+                tx.account_deployment_data.as_ref().expect("no account_deployment_data provided"),
             ),
         })
     } else {
@@ -172,41 +181,41 @@ fn declare_transaction(tx: p::DeclareTransaction) -> DeclareTransaction {
     }
 }
 
-fn deploy_transaction(tx: p::DeployTransaction) -> DeployTransaction {
+fn deploy_transaction(tx: &p::DeployTransaction) -> DeployTransaction {
     DeployTransaction {
         version: transaction_version(tx.version),
         class_hash: class_hash(tx.class_hash),
         contract_address_salt: contract_address_salt(tx.contract_address_salt),
-        constructor_calldata: call_data(tx.constructor_calldata),
+        constructor_calldata: call_data(&tx.constructor_calldata),
     }
 }
 
-fn deploy_account_transaction(tx: p::DeployAccountTransaction) -> DeployAccountTransaction {
-    match deploy_account_transaction_version(&tx) {
+fn deploy_account_transaction(tx: &p::DeployAccountTransaction) -> DeployAccountTransaction {
+    match deploy_account_transaction_version(tx) {
         1 => DeployAccountTransaction::V1(DeployAccountTransactionV1 {
             max_fee: fee(tx.max_fee.expect("no max fee provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce),
             class_hash: class_hash(tx.class_hash),
             contract_address_salt: contract_address_salt(tx.contract_address_salt),
-            constructor_calldata: call_data(tx.constructor_calldata),
+            constructor_calldata: call_data(&tx.constructor_calldata),
         }),
 
         3 => DeployAccountTransaction::V3(starknet_api::transaction::DeployAccountTransactionV3 {
-            resource_bounds: resource_bounds(tx.resource_bounds.expect("no resource bounds provided")),
+            resource_bounds: resource_bounds(tx.resource_bounds.as_ref().expect("no resource bounds provided")),
             tip: tip(tx.tip.expect("no tip provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce),
             class_hash: class_hash(tx.class_hash),
             contract_address_salt: contract_address_salt(tx.contract_address_salt),
-            constructor_calldata: call_data(tx.constructor_calldata),
+            constructor_calldata: call_data(&tx.constructor_calldata),
             nonce_data_availability_mode: data_availability_mode(
                 tx.nonce_data_availability_mode.expect("no nonce_data_availability_mode provided"),
             ),
             fee_data_availability_mode: data_availability_mode(
                 tx.fee_data_availability_mode.expect("no fee_data_availability_mode provided"),
             ),
-            paymaster_data: paymaster_data(tx.paymaster_data.expect("no paymaster_data provided")),
+            paymaster_data: paymaster_data(tx.paymaster_data.as_ref().expect("no paymaster_data provided")),
         }),
 
         _ => panic!("deploy account transaction version not supported"),
@@ -222,40 +231,40 @@ fn deploy_account_transaction_version(tx: &p::DeployAccountTransaction) -> u8 {
     }
 }
 
-fn invoke_transaction(tx: p::InvokeFunctionTransaction) -> InvokeTransaction {
+fn invoke_transaction(tx: &p::InvokeFunctionTransaction) -> InvokeTransaction {
     if tx.version == Felt::ZERO {
         InvokeTransaction::V0(starknet_api::transaction::InvokeTransactionV0 {
             max_fee: fee(tx.max_fee.expect("no max fee provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             contract_address: contract_address(tx.sender_address),
             entry_point_selector: entry_point(tx.entry_point_selector.expect("no entry_point_selector provided")),
-            calldata: call_data(tx.calldata),
+            calldata: call_data(&tx.calldata),
         })
     } else if tx.version == Felt::ONE {
         InvokeTransaction::V1(starknet_api::transaction::InvokeTransactionV1 {
             max_fee: fee(tx.max_fee.expect("no max fee provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce.expect("no nonce provided")),
             sender_address: contract_address(tx.sender_address),
-            calldata: call_data(tx.calldata),
+            calldata: call_data(&tx.calldata),
         })
     } else if tx.version == Felt::THREE {
         InvokeTransaction::V3(starknet_api::transaction::InvokeTransactionV3 {
-            resource_bounds: resource_bounds(tx.resource_bounds.expect("no resource bounds provided")),
+            resource_bounds: resource_bounds(tx.resource_bounds.as_ref().expect("no resource bounds provided")),
             tip: tip(tx.tip.expect("no tip provided")),
-            signature: signature(tx.signature),
+            signature: signature(&tx.signature),
             nonce: nonce(tx.nonce.expect("no nonce provided")),
             sender_address: contract_address(tx.sender_address),
-            calldata: call_data(tx.calldata),
+            calldata: call_data(&tx.calldata),
             nonce_data_availability_mode: data_availability_mode(
                 tx.nonce_data_availability_mode.expect("no nonce_data_availability_mode provided"),
             ),
             fee_data_availability_mode: data_availability_mode(
                 tx.fee_data_availability_mode.expect("no fee_data_availability_mode provided"),
             ),
-            paymaster_data: paymaster_data(tx.paymaster_data.expect("no paymaster_data provided")),
+            paymaster_data: paymaster_data(tx.paymaster_data.as_ref().expect("no paymaster_data provided")),
             account_deployment_data: account_deployment_data(
-                tx.account_deployment_data.expect("no account_deployment_data provided"),
+                tx.account_deployment_data.as_ref().expect("no account_deployment_data provided"),
             ),
         })
     } else {
@@ -263,13 +272,13 @@ fn invoke_transaction(tx: p::InvokeFunctionTransaction) -> InvokeTransaction {
     }
 }
 
-fn l1_handler_transaction(tx: p::L1HandlerTransaction) -> L1HandlerTransaction {
+fn l1_handler_transaction(tx: &p::L1HandlerTransaction) -> L1HandlerTransaction {
     L1HandlerTransaction {
         version: transaction_version(tx.version),
-        nonce: nonce(tx.nonce.unwrap_or_default()), // TODO check when a L1Ha
+        nonce: nonce(tx.nonce.unwrap_or_default()),
         contract_address: contract_address(tx.contract_address),
         entry_point_selector: entry_point(tx.entry_point_selector),
-        calldata: call_data(tx.calldata),
+        calldata: call_data(&tx.calldata),
     }
 }
 
@@ -285,8 +294,8 @@ fn fee(fee: Felt) -> starknet_api::transaction::Fee {
     fee_from_felt(fee)
 }
 
-fn signature(signature: Vec<Felt>) -> starknet_api::transaction::TransactionSignature {
-    starknet_api::transaction::TransactionSignature(signature.into_iter().map(ToStarkFelt::to_stark_felt).collect())
+fn signature(signature: &[Felt]) -> starknet_api::transaction::TransactionSignature {
+    starknet_api::transaction::TransactionSignature(signature.iter().map(ToStarkFelt::to_stark_felt).collect())
 }
 
 fn contract_address(address: Felt) -> starknet_api::core::ContractAddress {
@@ -297,8 +306,8 @@ fn entry_point(entry_point: Felt) -> starknet_api::core::EntryPointSelector {
     starknet_api::core::EntryPointSelector(entry_point.to_stark_felt())
 }
 
-fn call_data(call_data: Vec<Felt>) -> starknet_api::transaction::Calldata {
-    starknet_api::transaction::Calldata(Arc::new(call_data.into_iter().map(ToStarkFelt::to_stark_felt).collect()))
+fn call_data(call_data: &[Felt]) -> starknet_api::transaction::Calldata {
+    starknet_api::transaction::Calldata(Arc::new(call_data.iter().map(ToStarkFelt::to_stark_felt).collect()))
 }
 
 fn nonce(nonce: Felt) -> starknet_api::core::Nonce {
@@ -322,7 +331,7 @@ fn transaction_version(version: Felt) -> starknet_api::transaction::TransactionV
 }
 
 fn resource_bounds(
-    ressource_bounds: starknet_providers::sequencer::models::ResourceBoundsMapping,
+    ressource_bounds: &starknet_providers::sequencer::models::ResourceBoundsMapping,
 ) -> starknet_api::transaction::ResourceBoundsMapping {
     starknet_api::transaction::ResourceBoundsMapping::try_from(vec![
         (
@@ -360,13 +369,13 @@ fn data_availability_mode(
     }
 }
 
-fn paymaster_data(paymaster_data: Vec<Felt>) -> starknet_api::transaction::PaymasterData {
-    starknet_api::transaction::PaymasterData(paymaster_data.into_iter().map(ToStarkFelt::to_stark_felt).collect())
+fn paymaster_data(paymaster_data: &[Felt]) -> starknet_api::transaction::PaymasterData {
+    starknet_api::transaction::PaymasterData(paymaster_data.iter().map(ToStarkFelt::to_stark_felt).collect())
 }
 
-fn account_deployment_data(account_deployment_data: Vec<Felt>) -> starknet_api::transaction::AccountDeploymentData {
+fn account_deployment_data(account_deployment_data: &[Felt]) -> starknet_api::transaction::AccountDeploymentData {
     starknet_api::transaction::AccountDeploymentData(
-        account_deployment_data.into_iter().map(ToStarkFelt::to_stark_felt).collect(),
+        account_deployment_data.iter().map(ToStarkFelt::to_stark_felt).collect(),
     )
 }
 

--- a/crates/client/sync/src/utils/convert.rs
+++ b/crates/client/sync/src/utils/convert.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::num::NonZeroU128;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use blockifier::block::GasPrices;
@@ -102,7 +103,7 @@ pub fn convert_block(block: p::Block, chain_id: Felt) -> Result<ConvertedBlock, 
 }
 
 fn protocol_version(version: Option<String>) -> StarknetVersion {
-    version.map(|version| StarknetVersion::try_from_str(&version).unwrap_or_default()).unwrap_or_default()
+    version.map(|version| StarknetVersion::from_str(&version).unwrap_or_default()).unwrap_or_default()
 }
 
 fn transactions(txs: Vec<p::TransactionType>) -> Vec<Transaction> {

--- a/crates/client/sync/src/utils/convert.rs
+++ b/crates/client/sync/src/utils/convert.rs
@@ -9,6 +9,7 @@ use blockifier::block::GasPrices;
 use dp_block::{DeoxysBlock, DeoxysBlockInfo, DeoxysBlockInner, StarknetVersion};
 use dp_convert::to_stark_felt::ToStarkFelt;
 use dp_transactions::from_broadcasted_transactions::fee_from_felt;
+use dp_transactions::MAIN_CHAIN_ID;
 use starknet_api::block::BlockHash;
 use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{
@@ -78,8 +79,8 @@ pub fn convert_block(block: p::Block, chain_id: Felt) -> Result<ConvertedBlock, 
     };
 
     let computed_block_hash = header.hash(chain_id);
-    // mismatched block hash is allowed for blocks 1466..=2242
-    if computed_block_hash != block_hash && !(1466..=2242).contains(&block_number) {
+    // mismatched block hash is allowed for blocks 1466..=2242 on mainnet
+    if computed_block_hash != block_hash && !((1466..=2242).contains(&block_number) && chain_id == MAIN_CHAIN_ID) {
         return Err(L2SyncError::MismatchedBlockHash(block_number));
     }
     let ordered_events: Vec<dp_block::OrderedEvents> = block

--- a/crates/client/sync/src/utils/convert.rs
+++ b/crates/client/sync/src/utils/convert.rs
@@ -77,7 +77,7 @@ pub fn convert_block(block: p::Block, chain_id: Felt) -> Result<ConvertedBlock, 
         extra_data,
     };
 
-    let computed_block_hash = header.hash();
+    let computed_block_hash = header.hash(chain_id);
     // mismatched block hash is allowed for blocks 1466..=2242
     if computed_block_hash != block_hash && !(1466..=2242).contains(&block_number) {
         return Err(L2SyncError::MismatchedBlockHash(block_number));

--- a/crates/primitives/block/Cargo.toml
+++ b/crates/primitives/block/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 # Deoxys
 dp-convert = { workspace = true }
+dp-transactions = { workspace = true }
 
 # Starknet
 blockifier = { workspace = true }

--- a/crates/primitives/block/Cargo.toml
+++ b/crates/primitives/block/Cargo.toml
@@ -28,3 +28,4 @@ lazy_static = { workspace = true }
 primitive-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/primitives/block/src/lib.rs
+++ b/crates/primitives/block/src/lib.rs
@@ -2,10 +2,12 @@
 
 mod header;
 mod ordered_events;
+mod starknet_version;
 pub use header::Header;
 pub use ordered_events::*;
 use starknet_api::block::BlockHash;
 use starknet_api::transaction::{Transaction, TransactionHash};
+pub use starknet_version::StarknetVersion;
 
 pub use primitive_types::{H160, U256};
 use starknet_types_core::felt::Felt;

--- a/crates/primitives/block/src/starknet_version.rs
+++ b/crates/primitives/block/src/starknet_version.rs
@@ -1,26 +1,10 @@
+use std::str::FromStr;
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct StarknetVersion([u8; 4]);
 
 impl StarknetVersion {
-    pub fn new(major: u8, minor: u8, patch: u8, build: u8) -> Self {
+    pub const fn new(major: u8, minor: u8, patch: u8, build: u8) -> Self {
         StarknetVersion([major, minor, patch, build])
-    }
-
-    pub fn try_from_str(version_str: &str) -> Result<Self, &'static str> {
-        let parts: Vec<&str> = version_str.split('.').collect();
-        if parts.len() > 4 {
-            return Err("Too many components in version string");
-        }
-
-        let mut version = [0u8; 4];
-        for (i, part) in parts.iter().enumerate() {
-            match part.parse::<u8>() {
-                Ok(num) => version[i] = num,
-                Err(_) => return Err("Invalid number in version string"),
-            }
-        }
-
-        Ok(StarknetVersion(version))
     }
 
     pub const STARKNET_VERSION_0_13_0: StarknetVersion = StarknetVersion([0, 13, 0, 0]);
@@ -40,29 +24,50 @@ impl std::fmt::Display for StarknetVersion {
     }
 }
 
+impl FromStr for StarknetVersion {
+    type Err = &'static str;
+
+    fn from_str(version_str: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = version_str.split('.').collect();
+        if parts.len() > 4 {
+            return Err("Too many components in version string");
+        }
+
+        let mut version = [0u8; 4];
+        for (i, part) in parts.iter().enumerate() {
+            match part.parse::<u8>() {
+                Ok(num) => version[i] = num,
+                Err(_) => return Err("Invalid number in version string"),
+            }
+        }
+
+        Ok(StarknetVersion(version))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_starknet_version_string_3() {
-        let version = StarknetVersion::try_from_str("0.11.3").unwrap();
+        let version = StarknetVersion::from_str("0.11.3").unwrap();
         assert_eq!(version, StarknetVersion::new(0, 11, 3, 0));
         assert_eq!(version.to_string(), "0.11.3");
     }
 
     #[test]
     fn test_starknet_version_string_4() {
-        let version = StarknetVersion::try_from_str("1.2.3.4").unwrap();
+        let version = StarknetVersion::from_str("1.2.3.4").unwrap();
         assert_eq!(version, StarknetVersion::new(1, 2, 3, 4));
         assert_eq!(version.to_string(), "1.2.3.4");
     }
 
     #[test]
     fn test_starknet_version_string_invalid() {
-        assert_eq!(StarknetVersion::try_from_str("definitely not a version"), Err("Invalid number in version string"));
-        assert_eq!(StarknetVersion::try_from_str("0.256.0"), Err("Invalid number in version string"));
-        assert_eq!(StarknetVersion::try_from_str("1.1.1.1.1"), Err("Too many components in version string"));
+        assert_eq!(StarknetVersion::from_str("definitely not a version"), Err("Invalid number in version string"));
+        assert_eq!(StarknetVersion::from_str("0.256.0"), Err("Invalid number in version string"));
+        assert_eq!(StarknetVersion::from_str("1.1.1.1.1"), Err("Too many components in version string"));
     }
 
     #[test]

--- a/crates/primitives/block/src/starknet_version.rs
+++ b/crates/primitives/block/src/starknet_version.rs
@@ -1,0 +1,81 @@
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct StarknetVersion([u8; 4]);
+
+impl StarknetVersion {
+    pub fn new(major: u8, minor: u8, patch: u8, build: u8) -> Self {
+        StarknetVersion([major, minor, patch, build])
+    }
+
+    pub fn try_from_str(version_str: &str) -> Result<Self, &'static str> {
+        let parts: Vec<&str> = version_str.split('.').collect();
+        if parts.len() > 4 {
+            return Err("Too many components in version string");
+        }
+
+        let mut version = [0u8; 4];
+        for (i, part) in parts.iter().enumerate() {
+            match part.parse::<u8>() {
+                Ok(num) => version[i] = num,
+                Err(_) => return Err("Invalid number in version string"),
+            }
+        }
+
+        Ok(StarknetVersion(version))
+    }
+
+    pub const STARKNET_VERSION_0_13_0: StarknetVersion = StarknetVersion([0, 13, 0, 0]);
+    pub const STARKNET_VERSION_0_13_1: StarknetVersion = StarknetVersion([0, 13, 1, 0]);
+    pub const STARKNET_VERSION_0_13_1_1: StarknetVersion = StarknetVersion([0, 13, 1, 1]);
+}
+
+impl std::fmt::Display for StarknetVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut parts: Vec<String> = self.0[..3].iter().map(|&num| num.to_string()).collect();
+
+        if self.0[3] != 0 {
+            parts.push(self.0[3].to_string());
+        }
+
+        write!(f, "{}", parts.join("."))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_starknet_version_string_3() {
+        let version = StarknetVersion::try_from_str("0.11.3").unwrap();
+        assert_eq!(version, StarknetVersion::new(0, 11, 3, 0));
+        assert_eq!(version.to_string(), "0.11.3");
+    }
+
+    #[test]
+    fn test_starknet_version_string_4() {
+        let version = StarknetVersion::try_from_str("1.2.3.4").unwrap();
+        assert_eq!(version, StarknetVersion::new(1, 2, 3, 4));
+        assert_eq!(version.to_string(), "1.2.3.4");
+    }
+
+    #[test]
+    fn test_starknet_version_string_invalid() {
+        assert_eq!(StarknetVersion::try_from_str("definitely not a version"), Err("Invalid number in version string"));
+        assert_eq!(StarknetVersion::try_from_str("0.256.0"), Err("Invalid number in version string"));
+        assert_eq!(StarknetVersion::try_from_str("1.1.1.1.1"), Err("Too many components in version string"));
+    }
+
+    #[test]
+    fn test_starknet_version_comparison() {
+        let version_1 = StarknetVersion::new(1, 2, 3, 4);
+        let version_2 = StarknetVersion::new(1, 2, 3, 5);
+        let version_3 = StarknetVersion::new(1, 2, 4, 0);
+        let version_4 = StarknetVersion::new(1, 3, 0, 0);
+        let version_5 = StarknetVersion::new(2, 0, 0, 0);
+
+        assert!(version_1 < version_2);
+        assert!(version_2 < version_3);
+        assert!(version_3 < version_4);
+        assert!(version_4 < version_5);
+    }
+}

--- a/crates/primitives/block/src/tests.rs
+++ b/crates/primitives/block/src/tests.rs
@@ -7,7 +7,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Pedersen, StarkHash};
 
-use crate::Header;
+use crate::{Header, StarknetVersion};
 
 fn generate_dummy_header() -> Vec<Felt> {
     vec![
@@ -76,7 +76,13 @@ fn test_real_header_hash() {
 fn test_to_block_context() {
     let sequencer_address = StarkFelt::try_from("0xFF").unwrap().try_into().unwrap();
     // Create a block header.
-    let block_header = Header { block_number: 1, block_timestamp: 1, sequencer_address, ..Default::default() };
+    let block_header = Header {
+        block_number: 1,
+        block_timestamp: 1,
+        sequencer_address,
+        protocol_version: StarknetVersion::STARKNET_VERSION_0_13_0,
+        ..Default::default()
+    };
     // Create a fee token address.
     let fee_token_addresses = FeeTokenAddresses {
         eth_fee_token_address: StarkFelt::try_from("0xAA").unwrap().try_into().unwrap(),
@@ -85,7 +91,7 @@ fn test_to_block_context() {
     // Create a chain id.
     let chain_id = ChainId("0x1".to_string());
     // Try to serialize the block header.
-    let block_context = block_header.into_block_context(fee_token_addresses.clone(), chain_id);
+    let block_context = block_header.into_block_context(fee_token_addresses.clone(), chain_id).unwrap();
     // Check that the block context was serialized correctly.
     assert_eq!(block_context.block_info().block_number, BlockNumber(1));
     assert_eq!(block_context.block_info().block_timestamp, BlockTimestamp(1));

--- a/crates/primitives/transactions/src/compute_hash.rs
+++ b/crates/primitives/transactions/src/compute_hash.rs
@@ -1,6 +1,6 @@
+use dp_convert::to_stark_felt::ToStarkFelt;
 use starknet_api::core::calculate_contract_address;
 use starknet_api::data_availability::DataAvailabilityMode;
-use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{
     AccountDeploymentData, Calldata, DeclareTransaction, DeclareTransactionV0V1, DeclareTransactionV2,
     DeclareTransactionV3, DeployAccountTransaction, DeployAccountTransactionV1, DeployAccountTransactionV3,
@@ -125,7 +125,7 @@ impl ComputeTransactionHash for InvokeTransactionV0 {
 
         // Check for deprecated environment
         if block_number > Some(LEGACY_BLOCK_NUMBER) && chain_id == LEGACY_CHAIN_ID {
-            TransactionHash(StarkFelt::new_unchecked(
+            TransactionHash(
                 Pedersen::hash_array(&[
                     INVOKE_PREFIX,
                     version,
@@ -135,13 +135,13 @@ impl ComputeTransactionHash for InvokeTransactionV0 {
                     max_fee,
                     chain_id,
                 ])
-                .to_bytes_be(),
-            ))
+                .to_stark_felt(),
+            )
         } else {
-            TransactionHash(StarkFelt::new_unchecked(
+            TransactionHash(
                 Pedersen::hash_array(&[INVOKE_PREFIX, sender_address, entrypoint_selector, calldata_hash, chain_id])
-                    .to_bytes_be(),
-            ))
+                    .to_stark_felt(),
+            )
         }
     }
 }
@@ -157,7 +157,7 @@ impl ComputeTransactionHash for InvokeTransactionV1 {
         let max_fee = Felt::from(self.max_fee.0);
         let nonce = self.nonce.to_felt();
 
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Pedersen::hash_array(&[
                 INVOKE_PREFIX,
                 version,
@@ -168,8 +168,8 @@ impl ComputeTransactionHash for InvokeTransactionV1 {
                 chain_id,
                 nonce,
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     }
 }
 
@@ -188,7 +188,7 @@ impl ComputeTransactionHash for InvokeTransactionV3 {
         let account_deployment_data_hash = compute_account_deployment_hash(&self.account_deployment_data);
         let calldata_hash = compute_calldata_hash_poseidon(self.calldata.clone());
 
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Poseidon::hash_array(&[
                 INVOKE_PREFIX,
                 version,
@@ -201,8 +201,8 @@ impl ComputeTransactionHash for InvokeTransactionV3 {
                 account_deployment_data_hash,
                 calldata_hash,
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     }
 }
 
@@ -238,7 +238,7 @@ impl ComputeTransactionHash for DeclareTransactionV0V1 {
         let class_or_nothing_hash =
             if version == Felt::ZERO { Pedersen::hash_array(&[]) } else { Pedersen::hash_array(&[class_hash_as_felt]) };
 
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Pedersen::hash_array(&[
                 DECLARE_PREFIX,
                 version,
@@ -249,8 +249,8 @@ impl ComputeTransactionHash for DeclareTransactionV0V1 {
                 chain_id,
                 nonce_or_class_hash,
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     }
 }
 
@@ -266,7 +266,7 @@ impl ComputeTransactionHash for DeclareTransactionV2 {
         let nonce = self.nonce.to_felt();
         let compiled_class_hash = self.compiled_class_hash.to_felt();
 
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Pedersen::hash_array(&[
                 DECLARE_PREFIX,
                 version,
@@ -278,8 +278,8 @@ impl ComputeTransactionHash for DeclareTransactionV2 {
                 nonce,
                 compiled_class_hash,
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     }
 }
 
@@ -297,7 +297,7 @@ impl ComputeTransactionHash for DeclareTransactionV3 {
 
         let account_deployment_data_hash = compute_account_deployment_hash(&self.account_deployment_data);
 
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Poseidon::hash_array(&[
                 DECLARE_PREFIX,
                 version,
@@ -311,8 +311,8 @@ impl ComputeTransactionHash for DeclareTransactionV3 {
                 self.class_hash.to_felt(),
                 self.compiled_class_hash.to_felt(),
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     }
 }
 
@@ -362,7 +362,7 @@ impl ComputeTransactionHash for DeployAccountTransactionV1 {
         let max_fee = Felt::from(self.max_fee.0);
         let nonce = self.nonce.to_felt();
 
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Pedersen::hash_array(&[
                 DEPLOY_ACCOUNT_PREFIX,
                 version,
@@ -373,8 +373,8 @@ impl ComputeTransactionHash for DeployAccountTransactionV1 {
                 chain_id,
                 nonce,
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     }
 }
 
@@ -425,7 +425,7 @@ impl ComputeTransactionHash for DeployAccountTransactionV3 {
 
         let constructor_calldata_hash = Poseidon::hash_array(constructor_calldata.as_slice());
 
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Poseidon::hash_array(&[
                 DEPLOY_ACCOUNT_PREFIX,
                 version,
@@ -439,8 +439,8 @@ impl ComputeTransactionHash for DeployAccountTransactionV3 {
                 self.class_hash.to_felt(),
                 self.contract_address_salt.to_felt(),
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     }
 }
 
@@ -457,12 +457,12 @@ impl ComputeTransactionHash for L1HandlerTransaction {
         let nonce = self.nonce.to_felt();
 
         if block_number < Some(LEGACY_L1_HANDLER_BLOCK) && chain_id == LEGACY_CHAIN_ID {
-            TransactionHash(StarkFelt::new_unchecked(
+            TransactionHash(
                 Pedersen::hash_array(&[INVOKE_PREFIX, contract_address, entrypoint_selector, calldata_hash, chain_id])
-                    .to_bytes_be(),
-            ))
+                    .to_stark_felt(),
+            )
         } else if block_number < Some(LEGACY_BLOCK_NUMBER) && chain_id == LEGACY_CHAIN_ID {
-            TransactionHash(StarkFelt::new_unchecked(
+            TransactionHash(
                 Pedersen::hash_array(&[
                     L1_HANDLER_PREFIX,
                     contract_address,
@@ -471,10 +471,10 @@ impl ComputeTransactionHash for L1HandlerTransaction {
                     chain_id,
                     nonce,
                 ])
-                .to_bytes_be(),
-            ))
+                .to_stark_felt(),
+            )
         } else {
-            TransactionHash(StarkFelt::new_unchecked(
+            TransactionHash(
                 Pedersen::hash_array(&[
                     L1_HANDLER_PREFIX,
                     version,
@@ -485,8 +485,8 @@ impl ComputeTransactionHash for L1HandlerTransaction {
                     chain_id,
                     nonce,
                 ])
-                .to_bytes_be(),
-            ))
+                .to_stark_felt(),
+            )
         }
     }
 }
@@ -506,7 +506,7 @@ pub fn compute_hash_given_contract_address(
     let constructor = Felt::from_bytes_be(&starknet_keccak(b"constructor").to_bytes_be());
 
     if block_number > Some(LEGACY_BLOCK_NUMBER) && chain_id == LEGACY_CHAIN_ID {
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Pedersen::hash_array(&[
                 DEPLOY_PREFIX,
                 version,
@@ -516,13 +516,13 @@ pub fn compute_hash_given_contract_address(
                 Felt::ZERO,
                 chain_id,
             ])
-            .to_bytes_be(),
-        ))
+            .to_stark_felt(),
+        )
     } else {
-        TransactionHash(StarkFelt::new_unchecked(
+        TransactionHash(
             Pedersen::hash_array(&[DEPLOY_PREFIX, contract_address, constructor, constructor_calldata, chain_id])
-                .to_bytes_be(),
-        ))
+                .to_stark_felt(),
+        )
     }
 }
 

--- a/crates/primitives/transactions/src/lib.rs
+++ b/crates/primitives/transactions/src/lib.rs
@@ -19,6 +19,9 @@ const SIMULATE_TX_VERSION_OFFSET: Felt =
 pub const LEGACY_BLOCK_NUMBER: u64 = 1470;
 pub const LEGACY_L1_HANDLER_BLOCK: u64 = 854;
 
+//  b"SN_MAIN" == 0x534e5f4d41494e
+pub const MAIN_CHAIN_ID: Felt = Felt::from_hex_unchecked("0x534e5f4d41494e");
+
 /// Wrapper type for transaction execution error.
 /// Different tx types.
 /// See `https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/` for more details.


### PR DESCRIPTION
# New primitive StarknetVersion
## Pull Request type

- Refactoring (no functional changes, no API changes)

## What is the current behavior?



## What is the new behavior?

- new primitive `StarknetVersion([u8; 4])`
- implement comparison
- refacto compute_hash:
  - simplification of constants
  - use of `chain_id` for legacy blocks
  
close #18 

## Does this introduce a breaking change?

DB

## Other information

- useful for testnet support
