### PR TITLE
fix: pending storage & sequencer_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: pending storage & sequencer_provider
 - refactor: support pending blocks & db crate
 - refactor: new crate exec
 - fix(issue): Removed unrelated link from issue template

--- a/crates/client/db/src/block_db.rs
+++ b/crates/client/db/src/block_db.rs
@@ -142,6 +142,9 @@ impl DeoxysBackend {
         tx.put_cf(&col, ROW_PENDING_INFO, bincode::serialize(&block.info)?);
         tx.put_cf(&col, ROW_PENDING_INNER, bincode::serialize(&block.inner)?);
         tx.put_cf(&col, ROW_PENDING_STATE_UPDATE, bincode::serialize(&state_update)?);
+        let mut writeopts = WriteOptions::new();
+        writeopts.disable_wal(true);
+        self.db.write_opt(tx, &writeopts)?;
         Ok(())
     }
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -201,8 +201,8 @@ impl Starknet {
             backend,
             starting_block,
             sequencer_provider: Arc::new(SequencerGatewayProvider::new(
-                chain_config.feeder_gateway.clone(),
                 chain_config.gateway.clone(),
+                chain_config.feeder_gateway.clone(),
                 chain_config.chain_id,
             )),
             chain_config,


### PR DESCRIPTION
# Fix pending storage & sequencer_provider

## Pull Request type

- Bugfix

## What is the current behavior?

- `block not found` error on pending request

## What is the new behavior?

- fix estimate_fee for l1_handler
- fix sequencer_provider mismatch between gateway & feeder_gateway
- store pending block

## Does this introduce a breaking change?

No

## Other information

