### PR TITLE
fix: l1_sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: #225
 - feat: experimental block production and mempool
 - refactor: L1BlockMetric is intialized inside the EthereumClient new function
 - refactor: BlockMetrics divided in L1BlockMetrics and BlockMetrics

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ default-members = [
   "crates/client/metrics",
   "crates/node",
   "crates/primitives/block",
+  "crates/primitives/convert",
   "crates/primitives/transactions",
   "crates/primitives/class",
   "crates/primitives/receipt",

--- a/crates/client/eth/src/client.rs
+++ b/crates/client/eth/src/client.rs
@@ -63,10 +63,9 @@ impl Clone for EthereumClient {
 
 impl EthereumClient {
     /// Create a new EthereumClient instance with the given RPC URL
-    pub async fn new(url: Url, l1_core_address: Address, metrics_handle: MetricsRegistry) -> anyhow::Result<Self> {
+    pub async fn new(url: Url, l1_core_address: Address, l1_block_metrics: L1BlockMetrics) -> anyhow::Result<Self> {
         let provider = ProviderBuilder::new().on_http(url);
         let core_contract = StarknetCoreContract::new(l1_core_address, provider.clone());
-        let l1_block_metrics = L1BlockMetrics::register(&metrics_handle)?;
 
         Ok(Self { provider: Arc::new(provider), l1_core_contract: core_contract, l1_block_metrics })
     }

--- a/crates/client/sync/src/lib.rs
+++ b/crates/client/sync/src/lib.rs
@@ -28,7 +28,7 @@ pub mod starknet_sync_worker {
     pub async fn sync(
         backend: &Arc<DeoxysBackend>,
         fetch_config: FetchConfig,
-        eth_client: EthereumClient,
+        eth_client: Option<EthereumClient>,
         starting_block: Option<u64>,
         backup_every_n_blocks: Option<u64>,
         block_metrics: BlockMetrics,
@@ -56,7 +56,13 @@ pub mod starknet_sync_worker {
             None => provider,
         };
 
-        let l1_fut = async { dc_eth::state_update::sync(backend, &eth_client, chain_id).await };
+        let l1_fut = async {
+            if let Some(eth_client) = eth_client {
+                dc_eth::state_update::sync(backend, &eth_client, chain_id).await
+            } else {
+                Ok(())
+            }
+        };
 
         tokio::try_join!(
             l1_fut,

--- a/crates/client/sync/src/metrics/block_metrics.rs
+++ b/crates/client/sync/src/metrics/block_metrics.rs
@@ -31,9 +31,10 @@ impl BlockMetrics {
             transaction_count: registry
                 .register(Gauge::new("deoxys_transaction_count", "Gauge for deoxys transaction count")?)?,
             event_count: registry.register(Gauge::new("deoxys_event_count", "Gauge for deoxys event count")?)?,
-            l1_gas_price_wei: registry.register(Gauge::new("deoxys_l1_gas_price", "Gauge for deoxys L1 gas price")?)?,
+            l1_gas_price_wei: registry
+                .register(Gauge::new("deoxys_l1_block_gas_price", "Gauge for deoxys L1 gas price")?)?,
             l1_gas_price_strk: registry
-                .register(Gauge::new("deoxys_l1_gas_price_strk", "Gauge for deoxys L1 gas price in strk")?)?,
+                .register(Gauge::new("deoxys_l1_block_gas_price_strk", "Gauge for deoxys L1 gas price in strk")?)?,
         })
     }
 }


### PR DESCRIPTION
## Pull Request type


- Bugfix

## What is the current behavior?

- the node crash with ***--sync-l1-disabled*** option
- double **l1_gas_price** metrics

Resolves: #225
Introduced by: #223

## What is the new behavior?

- eth client is not created with option ***--sync-l1-disabled*** 

## Does this introduce a breaking change?

No

## Other information

The metrics server must be updated accordingly
