### PR TITLE
fix: behavior when pending block is not present in db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix: pending block must always be returned in rpc even if none is in db
 - docs: fixed Docker Compose instructions
 - fix: removed unused dependencies with udeps and machete
 - feat: add devnet via `--devnet` cli argument

--- a/crates/client/db/tests/test_block.rs
+++ b/crates/client/db/tests/test_block.rs
@@ -81,7 +81,7 @@ async fn test_store_pending_block() {
     let db = temp_db().await;
     let backend = db.backend();
 
-    assert!(backend.get_block(&BLOCK_ID_PENDING).unwrap().is_none());
+    assert!(backend.get_block(&BLOCK_ID_PENDING).unwrap().is_some()); // Pending block should always be there
 
     let block = pending_block_one();
     let state_diff = pending_state_diff_one();
@@ -106,7 +106,12 @@ async fn test_erase_pending_block() {
     backend.store_block(pending_block_one(), pending_state_diff_one(), vec![]).unwrap();
     backend.clear_pending_block().unwrap();
 
-    assert!(backend.get_block(&BLOCK_ID_PENDING).unwrap().is_none());
+    assert!(backend.get_block(&BLOCK_ID_PENDING).unwrap().unwrap().inner.transactions.is_empty());
+    assert!(
+        backend.get_block(&BLOCK_ID_PENDING).unwrap().unwrap().info.as_pending().unwrap().header.parent_block_hash
+            == finalized_block_zero().info.as_nonpending().unwrap().block_hash,
+        "fake pending block parent hash must match with latest block in db"
+    );
 
     backend.store_block(finalized_block_one(), finalized_state_diff_one(), vec![]).unwrap();
 

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script is the same as `e2e-coverage` but does not run with llvm-cov. Use this for faster testing, because
+# `e2e-coverage` will likely rebuild everything.
+set -e
+
+# will also launch anvil and automatically close it down on error or success
+
+anvil --fork-url https://eth.merkle.io --fork-block-number 20395662 &
+
+subshell() {
+    set -e
+    cargo build --bin madara --profile dev
+    cargo test --profile dev
+}
+
+(subshell && r=$?) || r=$?
+pkill -P $$
+exit $r


### PR DESCRIPTION
# Pull Request type

- Bugfix

## What is the current behavior?

RPC endpoints return BlockNotFound when doing any call on Pending, when the block is in db

## What is the new behavior?

Match the pathfinder and juno behavior: behave as if there is a pending block in db in that case. The new behavior makes sense to me for call, estimate, simulate etc - but I was surprised to see that they also return a fake pending block for get_block rpcs too - all the endpoints, really. We need to match their behavior even if it's questionable because that's what the clients expect.

## Does this introduce a breaking change?

No
