### PR TITLE
Add log message when no pending block to improve debugging

### DIFF
--- a/crates/client/sync/src/l2.rs
+++ b/crates/client/sync/src/l2.rs
@@ -181,6 +181,7 @@ async fn l2_pending_block_task(
 
         let Some(block) = block else {
             // No pending block.
+            log::trace!("No pending block available, continuing to next iteration");
             continue;
         };
 


### PR DESCRIPTION
I suggest adding a log message when there is no pending block to improve debugging.