### PR TITLE
fix(tests): Add testing feature to mc-db dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix:(tests): Add testing feature to mc-db dev dependency (#294)
 - feat: new crate gateway client & server
 - test: Starknet-js basic tests added
 - test: add block conversion task test

--- a/crates/client/block_import/Cargo.toml
+++ b/crates/client/block_import/Cargo.toml
@@ -41,3 +41,4 @@ starknet_api.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 rstest.workspace = true
+mc-db = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
This PR adds the `testing` `mc-db` feature to `mc-block-import` `dev-dependencies`. This fixes compilation errors when running tests in that crate.

Solves #293. 

# Pull Request type

Fix
