### PR TITLE
bug(tests): Fix local test scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(tests): Fixed local testing scripts
 - fix: override chain config
 - fix: estimate_fee should through an error if any txn fails
 - fix: rejected transaction block production panic

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -172,26 +172,14 @@ impl MadaraCmdBuilder {
     }
 
     pub fn run(self) -> MadaraCmd {
-        let output = std::process::Command::new("cargo")
-            .arg("locate-project")
-            .arg("--workspace")
-            .arg("--message-format=plain")
-            .output()
-            .expect("Failed to execute command");
-
-        let cargo_toml_path = String::from_utf8(output.stdout).expect("Invalid UTF-8");
-        let project_root = PathBuf::from(cargo_toml_path.trim()).parent().unwrap().to_path_buf();
-
-        env::set_current_dir(&project_root).expect("Failed to set working directory");
-        let target_bin = option_env!("COVERAGE_BIN").unwrap_or("./target/debug/madara");
-        let target_bin = PathBuf::from_str(target_bin).expect("target bin is not a path");
+        let target_bin = env::var("COVERAGE_BIN").expect("env COVERAGE_BIN to be set by script");
+        let target_bin = PathBuf::from_str(&target_bin).expect("COVERAGE_BIN to be a path");
         if !target_bin.exists() {
             panic!("No binary to run: {:?}", target_bin)
         }
 
         // This is an optional argument to sync faster from the FGW if gateway_key is set
-        let gateway_key_arg =
-            std::env::var("GATEWAY_KEY").ok().map(|gateway_key| ["--gateway-key".into(), gateway_key]);
+        let gateway_key_arg = env::var("GATEWAY_KEY").ok().map(|gateway_key| ["--gateway-key".into(), gateway_key]);
 
         let process = Command::new(target_bin)
             .envs(self.env)

--- a/crates/tests/src/rpc/read.rs
+++ b/crates/tests/src/rpc/read.rs
@@ -25,8 +25,6 @@ mod test_rpc_read_calls {
     use starknet_providers::{JsonRpcClient, Provider};
     use std::any::Any;
     use std::fmt::Write;
-    use std::fs::File;
-    use std::io::BufReader;
     use std::io::Read;
     use std::ops::Deref;
     use std::sync::{Arc, Mutex};
@@ -1196,15 +1194,9 @@ mod test_rpc_read_calls {
 
         let decompressed_program = decompress_to_string(contract_program.unwrap());
 
-        let mut class_program_file = File::open("crates/tests/src/rpc/test_utils/class_program.txt").unwrap();
-
-        let mut original_program = String::new();
-        class_program_file.read_to_string(&mut original_program).expect("issue while reading the file");
-
-        let contract_class_file = File::open("crates/tests/src/rpc/test_utils/contract_class.json").unwrap();
-        let reader = BufReader::new(contract_class_file);
-
-        let expected_contract_class: ContractClass = serde_json::from_reader(reader).unwrap();
+        let expected_program = include_str!("test_utils/class_program.txt");
+        let expected_contract_class: ContractClass =
+            serde_json::from_slice(include_bytes!("test_utils/contract_class.json")).unwrap();
 
         let expected_contract_entry_points = match expected_contract_class.clone() {
             ContractClass::Legacy(compressed) => Some(compressed.entry_points_by_type),
@@ -1216,7 +1208,7 @@ mod test_rpc_read_calls {
             _ => None,
         };
 
-        assert_eq!(decompressed_program, original_program);
+        assert_eq!(decompressed_program, expected_program);
         assert_eq!(contract_entry_points, expected_contract_entry_points);
         assert_eq!(contract_abi, expected_contract_abi);
     }

--- a/scripts/e2e-coverage.sh
+++ b/scripts/e2e-coverage.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+anvil --fork-url https://eth.merkle.io --fork-block-number 20395662 &
+
 subshell() {
     set -e
     rm -f target/madara-* lcov.info
@@ -10,6 +12,13 @@ subshell() {
     cargo build --bin madara --profile dev
 
     export COVERAGE_BIN=$(realpath target/debug/madara)
+    export ETH_FORK_URL=https://eth.merkle.io
+
+    # wait for anvil
+    while ! nc -z localhost 8545; do
+        sleep 1
+    done
+
     cargo test --profile dev
 
     cargo llvm-cov report --lcov --output-path lcov.info
@@ -17,4 +26,5 @@ subshell() {
 }
 
 (subshell && r=$?) || r=$?
+pkill -P $$
 exit $r

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -11,10 +11,15 @@ anvil --fork-url https://eth.merkle.io --fork-block-number 20395662 &
 subshell() {
     set -e
     cargo build --bin madara --profile dev
+
+    export COVERAGE_BIN=$(realpath target/debug/madara)
+    export ETH_FORK_URL=https://eth.merkle.io
+
     # wait for anvil
     while ! nc -z localhost 8545; do
         sleep 1
     done
+
     cargo test --profile dev $@
 }
 


### PR DESCRIPTION
The test scripts in `scripts` didn't work due to missing environment variables needed by the tests.

The tests also relied on the working directory being set such that test artifacts in source could be read. This has been fixed with `include_bytes!` and `include_str!` isntead, and the the working directory for the test is no longer modified.