### PR TITLE
fix(cleanup): Updated EditorConfig to 4-space indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,10 +9,9 @@ tab_width=2
 end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
-insert_final_newline = true
+insert_final_newline=true
 
 [*.{rs,toml}]
-indent_style=tab
-indent_size=tab
+indent_size=4
 tab_width=4
 max_line_length=100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(cleanup): Updated EditorConfig to 4-space indents
 - fix: override chain config
 - fix: estimate_fee should through an error if any txn fails
 - fix: rejected transaction block production panic


### PR DESCRIPTION
This matches what is the current coding practice of the repo.

