### PR TITLE
chore: Padded devnet addresses display to 64 characters

### DIFF
--- a/.github/workflows/starknet-js-test.yml
+++ b/.github/workflows/starknet-js-test.yml
@@ -23,7 +23,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Setup dev chain and run tests
         run: |
-          ./target/release/madara --name madara --base-path ../madara_db --telemetry-disabled --rpc-port 9944 --rpc-cors all --devnet --preset devnet &
+          ./target/release/madara --name madara --base-path ../madara_db --rpc-port 9944 --rpc-cors all --devnet --preset devnet &
           MADARA_PID=$!
           while ! echo exit | nc localhost 9944; do sleep 1; done
           cd tests/js_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- chore: padded devnet address display with 64 chars
 - feat(script): added more capabilities to the launcher script
 - fix(fgw): sync from other nodes and block signature
 - fix: added more launcher capabilities

--- a/crates/client/devnet/src/predeployed_contracts.rs
+++ b/crates/client/devnet/src/predeployed_contracts.rs
@@ -27,7 +27,7 @@ impl fmt::Display for DevnetKeys {
         writeln!(f, "==== DEVNET PREDEPLOYED CONTRACTS ====")?;
         writeln!(f)?;
         for (i, contract) in self.0.iter().enumerate() {
-            writeln!(f, "(#{}) Address: {:#x}", i + 1, contract.address,)?;
+            writeln!(f, "(#{}) Address: 0x{:0>64}", i + 1, format!("{:x}", contract.address),)?;
             writeln!(f, "  Private key: {:#x}", contract.secret.secret_scalar())?;
             match contract.balance.as_u128_fri_wei() {
                 Ok((fri, wei)) => {

--- a/crates/client/devnet/src/predeployed_contracts.rs
+++ b/crates/client/devnet/src/predeployed_contracts.rs
@@ -27,8 +27,8 @@ impl fmt::Display for DevnetKeys {
         writeln!(f, "==== DEVNET PREDEPLOYED CONTRACTS ====")?;
         writeln!(f)?;
         for (i, contract) in self.0.iter().enumerate() {
-            writeln!(f, "(#{}) Address: 0x{:0>64}", i + 1, format!("{:x}", contract.address),)?;
-            writeln!(f, "  Private key: {:#x}", contract.secret.secret_scalar())?;
+            writeln!(f, "(#{}) Address: {}", i + 1, contract.address.to_fixed_hex_string())?;
+            writeln!(f, "  Private key: {}", contract.secret.secret_scalar().to_fixed_hex_string())?;
             match contract.balance.as_u128_fri_wei() {
                 Ok((fri, wei)) => {
                     let (strk, eth) = (fri / STRK_FRI_DECIMALS, wei / ETH_WEI_DECIMALS);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Other (please describe): QoL

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

Some dev tools check that the provided account addresses are 64 characters long (instead of padding it with zeros). This PR is a smol QoL change allowing us to copy addresses without worrying about any missing leading zeros.

## Does this introduce a breaking change?

No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
