### PR TITLE
fix: block production nonce error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(db): storing a block needs to clear the current pending block
 - feat(script): added more capabilities to the launcher script
 - fix(fgw): sync from other nodes and block signature
 - fix: added more launcher capabilities

--- a/crates/client/db/src/storage_updates.rs
+++ b/crates/client/db/src/storage_updates.rs
@@ -19,6 +19,9 @@ impl MadaraBackend {
         let block_n = block.info.block_n();
         let state_diff_cpy = state_diff.clone();
 
+        // Clear in every case, even when storing a pending block
+        self.clear_pending_block()?;
+
         let task_block_db = || match block.info {
             MadaraMaybePendingBlockInfo::Pending(info) => {
                 self.block_db_store_pending(&MadaraPendingBlock { info, inner: block.inner }, &state_diff_cpy)

--- a/crates/client/mempool/src/block_production.rs
+++ b/crates/client/mempool/src/block_production.rs
@@ -463,6 +463,13 @@ impl<Mempool: MempoolProvider> BlockProductionTask<Mempool> {
                 instant = interval_block_time.tick() => {
                     if let Err(err) = self.on_block_time().await {
                         log::error!("Block production task has errored: {err:#}");
+                        // Clear pending block. The reason we do this is because if the error happened because the closed
+                        // block is invalid or has not been saved properly, we want to avoid redoing the same error in the next
+                        // block. So we drop all the transactions in the pending block just in case.
+                        // If the problem happened after the block was closed and saved to the db, this will do nothing.
+                        if let Err(err) = self.backend.clear_pending_block() {
+                            log::error!("Error while clearing the pending block in recovery of block production error: {err:#}");
+                        }
                     }
                     // ensure the pending block tick and block time match up
                     interval_pending_block_update.reset_at(instant + interval_pending_block_update.period());

--- a/crates/client/mempool/src/lib.rs
+++ b/crates/client/mempool/src/lib.rs
@@ -14,6 +14,7 @@ use mp_block::BlockId;
 use mp_block::BlockTag;
 use mp_block::MadaraPendingBlockInfo;
 use mp_class::ConvertedClass;
+use mp_convert::ToFelt;
 use mp_transactions::broadcasted_to_blockifier;
 use mp_transactions::BroadcastedToBlockifierError;
 use starknet_api::core::{ContractAddress, Nonce};
@@ -125,12 +126,15 @@ impl Mempool {
             None
         };
 
+        log::debug!("Mempool verify tx_hash={:#x}", tx_hash(&tx).to_felt());
+
         // Perform validations
         let exec_context = ExecutionContext::new_in_block(Arc::clone(&self.backend), &pending_block_info)?;
         let mut validator = exec_context.tx_validator();
-        let _ = validator.perform_validations(clone_account_tx(&tx), deploy_account_tx_hash.is_some());
+        validator.perform_validations(clone_account_tx(&tx), deploy_account_tx_hash.is_some())?;
 
         if !is_only_query(&tx) {
+            log::debug!("Adding to mempool tx_hash={:#x}", tx_hash(&tx).to_felt());
             // Finally, add it to the nonce chain for the account nonce
             let force = false;
             self.inner


### PR DESCRIPTION
# Pull Request type

Bugfix
- Solves #323
- Added a clear_pending_block when block production on_block_time errors, just in case (unreleated to 323)
- Re-added mempool prevalidation, which was broken by #263 - this pr is a duplicate with #324, sorry didnt see it

closes #323 

## Does this introduce a breaking change?

No
