### PR TITLE
fix(network): added FGW url to chain config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(network): added the FGW and gateway url to the chain config
 - feat: strk gas price cli param added
 - fix(snos): added special address while closing block for SNOS
 - fix(mempool): validator errors were ignored in `mempool/rsc/lib.rs`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5830,6 +5830,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -9021,6 +9022,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde_yaml = { version = "0.9.34" }
 thiserror = "1.0"
 tokio = { version = "1.34", features = ["signal", "rt"] }
-url = "2.4"
+url = { version = "2.4", features = ["serde"] }
 rayon = "1.10"
 bincode = "1.3"
 prometheus = "0.13.4"

--- a/configs/presets/devnet.yaml
+++ b/configs/presets/devnet.yaml
@@ -1,5 +1,7 @@
 chain_name: "Madara"
 chain_id: "MADARA_DEVNET"
+feeder_gateway_url: "http://localhost:8080/feeder_gateway/"
+gateway_url: "http://localhost:8080/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 parent_fee_token_address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
 latest_protocol_version: "0.13.2"

--- a/configs/presets/integration.yaml
+++ b/configs/presets/integration.yaml
@@ -1,5 +1,7 @@
 chain_name: "Starknet Sepolia"
 chain_id: "SN_INTEGRATION_SEPOLIA"
+feeder_gateway_url: "https://integration-sepolia.starknet.io/feeder_gateway/"
+gateway_url: "https://integration-sepolia.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 parent_fee_token_address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
 latest_protocol_version: "0.13.2"

--- a/configs/presets/mainnet.yaml
+++ b/configs/presets/mainnet.yaml
@@ -1,5 +1,7 @@
 chain_name: "Starknet Mainnet"
 chain_id: "SN_MAIN"
+feeder_gateway_url: "https://alpha-mainnet.starknet.io/feeder_gateway/"
+gateway_url: "https://alpha-mainnet.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 parent_fee_token_address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
 latest_protocol_version: "0.13.2"

--- a/configs/presets/sepolia.yaml
+++ b/configs/presets/sepolia.yaml
@@ -1,5 +1,7 @@
 chain_name: "Starknet Sepolia"
 chain_id: "SN_SEPOLIA"
+feeder_gateway_url: "https://alpha-sepolia.starknet.io/feeder_gateway/"
+gateway_url: "https://alpha-sepolia.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 parent_fee_token_address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
 latest_protocol_version: "0.13.2"

--- a/crates/client/gateway/src/server/router.rs
+++ b/crates/client/gateway/src/server/router.rs
@@ -22,9 +22,9 @@ pub(crate) async fn main_router(
     match (path.as_ref(), feeder_gateway_enable, gateway_enable) {
         ("health", _, _) => Ok(Response::new(Body::from("OK"))),
         (path, true, _) if path.starts_with("feeder_gateway/") => feeder_gateway_router(req, path, backend).await,
-        (path, _, true) if path.starts_with("feeder/") => gateway_router(req, path, add_transaction_provider).await,
+        (path, _, true) if path.starts_with("gateway/") => gateway_router(req, path, add_transaction_provider).await,
         (path, false, _) if path.starts_with("feeder_gateway/") => Ok(service_unavailable_response("Feeder Gateway")),
-        (path, _, false) if path.starts_with("feeder/") => Ok(service_unavailable_response("Feeder")),
+        (path, _, false) if path.starts_with("gateway/") => Ok(service_unavailable_response("Feeder")),
         _ => {
             log::debug!(target: "feeder_gateway", "Main router received invalid request: {path}");
             Ok(not_found_response())
@@ -74,7 +74,7 @@ async fn gateway_router(
     add_transaction_provider: Arc<dyn AddTransactionProvider>,
 ) -> Result<Response<Body>, Infallible> {
     match (req.method(), req.uri().path()) {
-        (&Method::POST, "feeder/add_transaction") => {
+        (&Method::POST, "gateway/add_transaction") => {
             Ok(handle_add_transaction(req, add_transaction_provider).await.unwrap_or_else(Into::into))
         }
         _ => {

--- a/crates/node/src/cli/chain_config_overrides.rs
+++ b/crates/node/src/cli/chain_config_overrides.rs
@@ -101,6 +101,8 @@ impl ChainConfigOverrideParams {
         Ok(ChainConfig {
             chain_name: chain_config_overrides.chain_name,
             chain_id: chain_config_overrides.chain_id,
+            feeder_gateway_url: chain_config.feeder_gateway_url,
+            gateway_url: chain_config.gateway_url,
             native_fee_token_address: chain_config_overrides.native_fee_token_address,
             parent_fee_token_address: chain_config_overrides.parent_fee_token_address,
             latest_protocol_version: chain_config_overrides.latest_protocol_version,

--- a/crates/node/src/cli/mod.rs
+++ b/crates/node/src/cli/mod.rs
@@ -24,7 +24,6 @@ use clap::ArgGroup;
 use mp_chain_config::ChainConfig;
 use std::path::PathBuf;
 use std::sync::Arc;
-use url::Url;
 
 /// Madara: High performance Starknet sequencer/full-node.
 #[derive(Clone, Debug, clap::Parser)]
@@ -202,23 +201,6 @@ pub enum NetworkType {
 }
 
 impl NetworkType {
-    pub fn uri(&self) -> &'static str {
-        match self {
-            NetworkType::Main => "https://alpha-mainnet.starknet.io",
-            NetworkType::Test => "https://alpha-sepolia.starknet.io",
-            NetworkType::Integration => "https://integration-sepolia.starknet.io",
-            NetworkType::Devnet => unreachable!("Gateway url isn't needed for a devnet sequencer"),
-        }
-    }
-
-    pub fn gateway(&self) -> Url {
-        Url::parse(&format!("{}/gateway/", self.uri())).expect("Invalid uri")
-    }
-
-    pub fn feeder_gateway(&self) -> Url {
-        Url::parse(&format!("{}/feeder_gateway/", self.uri())).expect("Invalid uri")
-    }
-
     pub fn chain_id(&self) -> ChainId {
         match self {
             NetworkType::Main => ChainId::Mainnet,

--- a/crates/node/src/cli/sync.rs
+++ b/crates/node/src/cli/sync.rs
@@ -1,12 +1,11 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
+use mp_chain_config::ChainConfig;
 use starknet_api::core::ChainId;
 
 use mc_sync::fetch::fetchers::FetchConfig;
 use mp_utils::parsers::{parse_duration, parse_url};
 use url::Url;
-
-use crate::cli::NetworkType;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct SyncParams {
@@ -69,13 +68,13 @@ pub struct SyncParams {
 }
 
 impl SyncParams {
-    pub fn block_fetch_config(&self, chain_id: ChainId, network: NetworkType) -> FetchConfig {
+    pub fn block_fetch_config(&self, chain_id: ChainId, chain_config: Arc<ChainConfig>) -> FetchConfig {
         let (gateway, feeder_gateway) = match &self.gateway_url {
             Some(url) => (
-                url.join("/gateway/").expect("Error parsing url (this should not panic)"),
-                url.join("/feeder_gateway/").expect("Error parsing url (this should not panic)"),
+                url.join("/gateway/").expect("Error parsing url"),
+                url.join("/feeder_gateway/").expect("Error parsing url"),
             ),
-            None => (network.gateway(), network.feeder_gateway()),
+            None => (chain_config.gateway_url.clone(), chain_config.feeder_gateway_url.clone()),
         };
 
         let polling = if self.no_sync_polling { None } else { Some(self.sync_polling_interval) };

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -149,9 +149,6 @@ async fn main() -> anyhow::Result<()> {
                 let sync_service = SyncService::new(
                     &run_cmd.sync_params,
                     Arc::clone(&chain_config),
-                    run_cmd.network.context(
-                        "You should provide a `--network` argument to ensure you're syncing from the right FGW",
-                    )?,
                     &db_service,
                     importer,
                     telemetry_service.new_handle(),
@@ -160,24 +157,13 @@ async fn main() -> anyhow::Result<()> {
                 .context("Initializing sync service")?;
 
                 (
-                ServiceGroup::default().with(sync_service),
-                // TODO(rate-limit): we may get rate limited with this unconfigured provider?
-                Arc::new(ForwardToProvider::new(SequencerGatewayProvider::new(
-                    run_cmd
-                        .network
-                        .context(
-                            "You should provide a `--network` argument to ensure you're syncing from the right gateway",
-                        )?
-                        .gateway(),
-                    run_cmd
-                        .network
-                        .context(
-                            "You should provide a `--network` argument to ensure you're syncing from the right FGW",
-                        )?
-                        .feeder_gateway(),
-                    chain_config.chain_id.to_felt(),
-                ))),
-            )
+                    ServiceGroup::default().with(sync_service),
+                    Arc::new(ForwardToProvider::new(SequencerGatewayProvider::new(
+                        chain_config.gateway_url.clone(),
+                        chain_config.feeder_gateway_url.clone(),
+                        chain_config.chain_id.to_felt(),
+                    ))),
+                )
             }
         };
 

--- a/crates/node/src/service/sync.rs
+++ b/crates/node/src/service/sync.rs
@@ -1,4 +1,4 @@
-use crate::cli::{NetworkType, SyncParams};
+use crate::cli::SyncParams;
 use anyhow::Context;
 use mc_block_import::BlockImporter;
 use mc_db::{DatabaseService, MadaraBackend};
@@ -26,14 +26,13 @@ impl SyncService {
     pub async fn new(
         config: &SyncParams,
         chain_config: Arc<ChainConfig>,
-        network: NetworkType,
         db: &DatabaseService,
         block_importer: Arc<BlockImporter>,
         telemetry: TelemetryHandle,
     ) -> anyhow::Result<Self> {
-        let fetch_config = config.block_fetch_config(chain_config.chain_id.clone(), network);
+        let fetch_config = config.block_fetch_config(chain_config.chain_id.clone(), chain_config.clone());
 
-        log::info!("🛰️ Using feeder url: {} ", fetch_config.gateway.as_str());
+        log::info!("🛰️ Using feeder gateway URL: {}", fetch_config.feeder_gateway.as_str());
 
         Ok(Self {
             db_backend: Arc::clone(db.backend()),

--- a/crates/primitives/chain_config/Cargo.toml
+++ b/crates/primitives/chain_config/Cargo.toml
@@ -31,6 +31,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/primitives/chain_config/src/chain_config.rs
+++ b/crates/primitives/chain_config/src/chain_config.rs
@@ -284,6 +284,8 @@ impl ChainConfig {
         Self {
             chain_name: "Test".into(),
             chain_id: ChainId::Other("MADARA_TEST".into()),
+            feeder_gateway_url: Url::parse("http://localhost:8080/feeder_gateway/").unwrap(),
+            gateway_url: Url::parse("http://localhost:8080/gateway/").unwrap(),
             // A random sequencer address for fee transfers to work in block production.
             sequencer_address: Felt::from_hex_unchecked(
                 "0x211b748338b39fe8fa353819d457681aa50ac598a3db84cacdd6ece0a17e1f3",

--- a/crates/primitives/chain_config/src/chain_config.rs
+++ b/crates/primitives/chain_config/src/chain_config.rs
@@ -243,6 +243,8 @@ impl ChainConfig {
         Self {
             chain_name: "Starknet Sepolia".into(),
             chain_id: ChainId::Sepolia,
+            feeder_gateway_url: Url::parse("https://alpha-sepolia.starknet.io/feeder_gateway/").unwrap(),
+            gateway_url: Url::parse("https://alpha-sepolia.starknet.io/gateway/").unwrap(),
             eth_core_contract_address: eth_core_contract_address::SEPOLIA_TESTNET.parse().expect("parsing a constant"),
             eth_gps_statement_verifier: eth_gps_statement_verifier::SEPOLIA_TESTNET
                 .parse()
@@ -255,6 +257,8 @@ impl ChainConfig {
         Self {
             chain_name: "Starknet Sepolia Integration".into(),
             chain_id: ChainId::IntegrationSepolia,
+            feeder_gateway_url: Url::parse("https://integration-sepolia.starknet.io/feeder_gateway/").unwrap(),
+            gateway_url: Url::parse("https://integration-sepolia.starknet.io/gateway/").unwrap(),
             eth_core_contract_address: eth_core_contract_address::SEPOLIA_INTEGRATION
                 .parse()
                 .expect("parsing a constant"),

--- a/crates/primitives/chain_config/src/chain_config.rs
+++ b/crates/primitives/chain_config/src/chain_config.rs
@@ -273,6 +273,8 @@ impl ChainConfig {
         Self {
             chain_name: "Madara".into(),
             chain_id: ChainId::Other("MADARA_DEVNET".into()),
+            feeder_gateway_url: Url::parse("http://localhost:8080/feeder_gateway/").unwrap(),
+            gateway_url: Url::parse("http://localhost:8080/gateway/").unwrap(),
             sequencer_address: Felt::from_hex_unchecked("0x123").try_into().unwrap(),
             ..ChainConfig::starknet_sepolia()
         }

--- a/crates/primitives/chain_config/src/chain_config.rs
+++ b/crates/primitives/chain_config/src/chain_config.rs
@@ -23,6 +23,7 @@ use serde::de::{MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use starknet_api::core::{ChainId, ContractAddress, PatriciaKey};
 use starknet_types_core::felt::Felt;
+use url::Url;
 
 use mp_utils::serde::{deserialize_duration, deserialize_private_key};
 
@@ -72,6 +73,10 @@ pub struct ChainConfig {
     /// Human readable chain name, for displaying to the console.
     pub chain_name: String,
     pub chain_id: ChainId,
+
+    // The Gateway URLs are the URLs of the endpoint that the node will use to sync blocks in full mode.
+    pub feeder_gateway_url: Url,
+    pub gateway_url: Url,
 
     /// For starknet, this is the STRK ERC-20 contract on starknet.
     pub native_fee_token_address: ContractAddress,
@@ -175,6 +180,8 @@ impl ChainConfig {
         Self {
             chain_name: "Starknet Mainnet".into(),
             chain_id: ChainId::Mainnet,
+            feeder_gateway_url: Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/").unwrap(),
+            gateway_url: Url::parse("https://alpha-mainnet.starknet.io/gateway/").unwrap(),
             native_fee_token_address: ContractAddress(
                 PatriciaKey::try_from(Felt::from_hex_unchecked(
                     "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",


### PR DESCRIPTION
Now both of this commands should work the same way:

`cargo run --release -- --full --preset mainnet`
`cargo run --release -- --full --network mainnet`

This ofc adds a bit of overhead but the idea is to keep it high level for the users and differenciate Starknet from app chains using Network.

We could in the future imagine that a sequencer will sync mainnet with` --network mainnet `