### PR TITLE
fix(namespace): versioning now works for methods without `starknet` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(namespace): versioning now works for methods without `starknet` namesapce
 - fix: contract 0 state diff fixed
 - refactor(rpc): re-worked rpc tower server and added proper websocket support
 - fix(network): added the FGW and gateway url to the chain config

--- a/crates/node/src/service/rpc/middleware.rs
+++ b/crates/node/src/service/rpc/middleware.rs
@@ -211,7 +211,7 @@ where
                 return inner.call(req).await;
             }
 
-            let Ok(version) = RpcVersion::from_request_path(&path) else {
+            let Ok(version) = RpcVersion::from_request_path(&path).map(|v| v.name()) else {
                 return jsonrpsee::MethodResponse::error(
                     req.id,
                     jsonrpsee::types::ErrorObject::owned(
@@ -222,7 +222,7 @@ where
                 );
             };
 
-            let Some(method_without_namespace) = req.method.strip_prefix("starknet_") else {
+            let Some((namespace, method)) = req.method.split_once('_') else {
                 return jsonrpsee::MethodResponse::error(
                     req.id(),
                     jsonrpsee::types::ErrorObject::owned(
@@ -233,7 +233,7 @@ where
                 );
             };
 
-            let method_new = format!("starknet_{}_{}", version.name(), method_without_namespace);
+            let method_new = format!("{namespace}_{version}_{method}");
             req.method = jsonrpsee::core::Cow::from(method_new);
 
             inner.call(req).await


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Following #350, change were made to the rpc method versioning middleware that did not take into account methods with a unique namespace such as `madara_addDeclareV0Transaction`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Methods with arbitrary namespaces can be versioned.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No
