### PR TITLE
fix: 0.13.2 had wrong version constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(version constants): 0.13.2 was mapped to wrong constants
 - fix(compilation): devnet contract artifacts are not compiled by `cargo build` anymore
 - feat: add fgw get_block_traces
 - refactor: use `hyper` & `tower` instead of `reqwest` for feeder client

--- a/crates/primitives/chain_config/src/chain_config.rs
+++ b/crates/primitives/chain_config/src/chain_config.rs
@@ -361,7 +361,7 @@ impl Default for ChainVersionedConstants {
             (StarknetVersion::V0_13_0, BLOCKIFIER_VERSIONED_CONSTANTS_0_13_0.deref().clone()),
             (StarknetVersion::V0_13_1, BLOCKIFIER_VERSIONED_CONSTANTS_0_13_1.deref().clone()),
             (StarknetVersion::V0_13_1_1, BLOCKIFIER_VERSIONED_CONSTANTS_0_13_1_1.deref().clone()),
-            (StarknetVersion::V0_13_2, VersionedConstants::latest_constants().clone()),
+            (StarknetVersion::V0_13_2, BLOCKIFIER_VERSIONED_CONSTANTS_0_13_2.deref().clone()),
         ]
         .into()
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

0.13.2 was mapped with latest version constants which was resulting in incorrect max gas value, screenshot attached which shows the only difference between the both

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- it will be calculating the right gas price value

## Does this introduce a breaking change?
No
<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
<img width="1226" alt="Screenshot 2024-10-25 at 11 34 01 PM" src="https://github.com/user-attachments/assets/64965c3f-6da0-4ed2-83e2-d324d62af13a">

