### PR TITLE
perf(get events)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ starknet-e2e-test/contracts/build
 # rpc output
 output*
 
+# test output
+test_output*
+
 tmp/
 
 *.info

--- a/crates/client/db/src/block_db.rs
+++ b/crates/client/db/src/block_db.rs
@@ -381,7 +381,7 @@ impl MadaraBackend {
         let iter_block_info = self.db.iterator_cf(&handle_block_info, iter_mode.clone());
         let iter_block_innr = self.db.iterator_cf(&handle_block_innr, iter_mode);
 
-        let iter = iter_block_info.zip(iter_block_innr).enumerate().map_while(move |(i, kvs)| {
+        let iter = iter_block_info.zip(iter_block_innr).map_while(move |kvs| {
             if let (Ok((_, bytes_info)), Ok((_, bytes_innr))) = kvs {
                 let block_info = bincode::deserialize::<MadaraBlockInfo>(&bytes_info).ok();
                 let block_innr = bincode::deserialize::<MadaraBlockInner>(&bytes_innr).ok();

--- a/crates/client/db/src/block_db.rs
+++ b/crates/client/db/src/block_db.rs
@@ -371,7 +371,7 @@ impl MadaraBackend {
     }
 
     #[tracing::instrument(skip(self), fields(module = "BlockDB"))]
-    pub fn get_block_stream(&self, block_n: usize) -> Result<impl Iterator<Item = MadaraBlock> + '_> {
+    pub fn get_block_stream(&self, block_n: u64) -> Result<impl Iterator<Item = MadaraBlock> + '_> {
         let handle_block_info = self.db.get_column(Column::BlockNToBlockInfo);
         let handle_block_innr = self.db.get_column(Column::BlockNToBlockInner);
 

--- a/crates/client/rpc/src/constants.rs
+++ b/crates/client/rpc/src/constants.rs
@@ -1,4 +1,4 @@
 /// Maximum number of filter keys that can be passed to the `get_events` RPC.
 pub const MAX_EVENTS_KEYS: usize = 100;
 /// Maximum number of events that can be fetched in a single chunk for the `get_events` RPC.
-pub const MAX_EVENTS_CHUNK_SIZE: usize = 1000;
+pub const MAX_EVENTS_CHUNK_SIZE: u64 = 1000;

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -71,7 +71,7 @@ impl Starknet {
             .ok_or(StarknetRpcApiError::BlockNotFound)
     }
 
-    pub fn get_block_stream(&self, block_n: usize) -> StarknetRpcResult<impl Iterator<Item = MadaraBlock> + '_> {
+    pub fn get_block_stream(&self, block_n: u64) -> StarknetRpcResult<impl Iterator<Item = MadaraBlock> + '_> {
         self.backend.get_block_stream(block_n).map_err(|_| StarknetRpcApiError::BlockNotFound)
     }
 

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! It uses the madara client and backend in order to answer queries.
 
+#![feature(iter_collect_into)]
+
 mod constants;
 mod errors;
 pub mod providers;

--- a/crates/client/rpc/src/lib.rs
+++ b/crates/client/rpc/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use mc_db::db_block_id::DbBlockIdResolvable;
 use mc_db::MadaraBackend;
-use mp_block::{MadaraMaybePendingBlock, MadaraMaybePendingBlockInfo};
+use mp_block::{MadaraBlock, MadaraMaybePendingBlock, MadaraMaybePendingBlockInfo};
 use mp_chain_config::{ChainConfig, RpcVersion};
 use mp_convert::ToFelt;
 
@@ -69,6 +69,10 @@ impl Starknet {
             .get_block(block_id)
             .or_internal_server_error("Error getting block from storage")?
             .ok_or(StarknetRpcApiError::BlockNotFound)
+    }
+
+    pub fn get_block_stream(&self, block_n: usize) -> StarknetRpcResult<impl Iterator<Item = MadaraBlock> + '_> {
+        self.backend.get_block_stream(block_n).map_err(|_| StarknetRpcApiError::BlockNotFound)
     }
 
     pub fn chain_id(&self) -> Felt {

--- a/crates/client/rpc/src/versions/v0_7_1/methods/read/get_events.rs
+++ b/crates/client/rpc/src/versions/v0_7_1/methods/read/get_events.rs
@@ -38,46 +38,46 @@ pub async fn get_events(starknet: &Starknet, filter: EventFilterWithPage) -> Sta
         return Err(StarknetRpcApiError::PageSizeTooBig);
     }
 
-    // TODO: this function doesn't do much, should be hoisted out
-    // Get the block numbers for the requested range
-    let (from_block, to_block, latest_block) =
-        block_range(starknet, filter.event_filter.from_block, filter.event_filter.to_block)?;
+    let latest_block = starknet.get_block_n(&BlockId::Tag(BlockTag::Latest))?;
+    let from_block = match filter.event_filter.from_block {
+        Some(BlockId::Tag(BlockTag::Pending)) => latest_block + 1,
+        Some(block_id) => starknet.get_block_n(&block_id)?,
+        None => 0,
+    };
+    let to_block = match filter.event_filter.to_block {
+        Some(BlockId::Tag(BlockTag::Pending)) => latest_block + 1,
+        Some(block_id) => starknet.get_block_n(&block_id)?,
+        None => latest_block,
+    };
+
+    if from_block > to_block {
+        return Ok(EventsPage { events: vec![], continuation_token: None });
+    }
 
     let continuation_token = match filter.result_page_request.continuation_token {
         Some(token) => ContinuationToken::parse(token).map_err(|_| StarknetRpcApiError::InvalidContinuationToken)?,
         None => ContinuationToken { block_n: from_block, event_n: 0 },
     };
-
-    // PERF: this is minor but this could happen earlier
-    // Verify that the requested range is valid
-    if from_block > to_block {
-        return Ok(EventsPage { events: vec![], continuation_token: None });
-    }
-
     let from_block = continuation_token.block_n;
-    // PERF: this should at least be pre-allocated to some sensible default
-    let mut filtered_events: Vec<EmittedEvent> = Vec::new();
 
     // PERF: we should truncate from_block to the creation block of the contract
     // if it is less than that
-    for current_block in from_block..=to_block {
+    let mut filtered_events: Vec<EmittedEvent> = Vec::with_capacity(16);
+    for block_n in from_block..=to_block {
         // PERF: this check can probably be hoisted out of this loop
-        let (_pending, block) = if current_block <= latest_block {
+        let block = if block_n <= latest_block {
             // PERF: This is probably the main bottleneck: we should be able to
             // mitigate this by implementing a db iterator
-            (false, starknet.get_block(&BlockId::Number(current_block))?)
+            starknet.get_block(&BlockId::Number(block_n))?
         } else {
-            (true, starknet.get_block(&BlockId::Tag(BlockTag::Pending))?)
+            starknet.get_block(&BlockId::Tag(BlockTag::Pending))?
         };
 
         // PERF: collection needs to be more efficient
-        let block_filtered_events: Vec<EmittedEvent> = get_block_events(starknet, &block)
-            .into_iter()
-            .filter(|event| event_match_filter(event, from_address, &keys))
-            .collect();
+        let block_filtered_events: Vec<EmittedEvent> = get_block_events(block, from_address, &keys);
 
         // PERF: this condition needs to be moved out the loop as it needs to happen only once
-        if current_block == from_block && (block_filtered_events.len() as u64) < continuation_token.event_n {
+        if block_n == from_block && (block_filtered_events.len() as u64) < continuation_token.event_n {
             return Err(StarknetRpcApiError::InvalidContinuationToken);
         }
 
@@ -85,7 +85,7 @@ pub async fn get_events(starknet: &Starknet, filter: EventFilterWithPage) -> Sta
         #[allow(clippy::iter_skip_zero)]
         let block_filtered_reduced_events: Vec<EmittedEvent> = block_filtered_events
             .into_iter()
-            .skip(if current_block == from_block { continuation_token.event_n as usize } else { 0 })
+            .skip(if block_n == from_block { continuation_token.event_n as usize } else { 0 })
             .take(chunk_size as usize - filtered_events.len())
             .collect();
 
@@ -97,8 +97,8 @@ pub async fn get_events(starknet: &Starknet, filter: EventFilterWithPage) -> Sta
 
         if filtered_events.len() == chunk_size as usize {
             let event_n =
-                if current_block == from_block { continuation_token.event_n + chunk_size } else { num_events as u64 };
-            let token = Some(ContinuationToken { block_n: current_block, event_n }.to_string());
+                if block_n == from_block { continuation_token.event_n + chunk_size } else { num_events as u64 };
+            let token = Some(ContinuationToken { block_n, event_n }.to_string());
 
             return Ok(EventsPage { events: filtered_events, continuation_token: token });
         }
@@ -106,40 +106,11 @@ pub async fn get_events(starknet: &Starknet, filter: EventFilterWithPage) -> Sta
     Ok(EventsPage { events: filtered_events, continuation_token: None })
 }
 
-#[inline]
-fn event_match_filter(event: &EmittedEvent, address: Option<Felt>, keys: &[Vec<Felt>]) -> bool {
-    let match_from_address = address.map_or(true, |addr| addr == event.from_address);
-    // PERF: HOLY FUCK WE CHECK ALL EVENTS EVEN IF THEY COME FROM THE WRONG
-    // ADDRESS
-    let match_keys = keys
-        .iter()
-        .enumerate()
-        .all(|(i, keys)| event.keys.len() > i && (keys.is_empty() || keys.contains(&event.keys[i])));
-    // PERF: this can be short-circuited
-    match_from_address && match_keys
-}
-
-// TODO: remove this function, this code can be dealt with manually
-fn block_range(
-    starknet: &Starknet,
-    from_block: Option<BlockId>,
-    to_block: Option<BlockId>,
-) -> StarknetRpcResult<(u64, u64, u64)> {
-    let latest_block_n = starknet.get_block_n(&BlockId::Tag(BlockTag::Latest))?;
-    let from_block_n = match from_block {
-        Some(BlockId::Tag(BlockTag::Pending)) => latest_block_n + 1,
-        Some(block_id) => starknet.get_block_n(&block_id)?,
-        None => 0,
-    };
-    let to_block_n = match to_block {
-        Some(BlockId::Tag(BlockTag::Pending)) => latest_block_n + 1,
-        Some(block_id) => starknet.get_block_n(&block_id)?,
-        None => latest_block_n,
-    };
-    Ok((from_block_n, to_block_n, latest_block_n))
-}
-
-fn get_block_events(_starknet: &Starknet, block: &MadaraMaybePendingBlock) -> Vec<EmittedEvent> {
+fn get_block_events(
+    block: MadaraMaybePendingBlock,
+    address: Option<Felt>,
+    keys: &[Vec<Felt>],
+) -> Vec<starknet_core::types::EmittedEvent> {
     // PERF:: this check can probably be removed by handling pending blocks
     // separatly
     let (block_hash, block_number) = match &block.info {
@@ -147,21 +118,41 @@ fn get_block_events(_starknet: &Starknet, block: &MadaraMaybePendingBlock) -> Ve
         MadaraMaybePendingBlockInfo::NotPending(block) => (Some(block.block_hash), Some(block.header.block_number)),
     };
 
-    let tx_hash_and_events = block.inner.receipts.iter().flat_map(|receipt| {
-        let tx_hash = receipt.transaction_hash();
-        receipt.events().iter().map(move |events| (tx_hash, events))
-    });
+    block
+        .inner
+        .receipts
+        .into_iter()
+        .flat_map(move |receipt| {
+            let transaction_hash = receipt.transaction_hash();
 
-    // PERF: clone here is brutal, there must be a way to take ownership of this
-    // data
-    tx_hash_and_events
-        .map(|(transaction_hash, event)| EmittedEvent {
-            from_address: event.from_address,
-            keys: event.keys.clone(),
-            data: event.data.clone(),
-            block_hash,
-            block_number,
-            transaction_hash,
+            receipt.events_owned().into_iter().filter_map(move |event| {
+                if address.is_some() && address.unwrap() != event.from_address {
+                    return None;
+                }
+
+                // Keys are matched as follows:
+                //
+                // - `keys` is an array of Felt
+                // - `keys[n]` represents allowed value for event key at index n
+                // - so `event.keys[n]` needs to match any value in `keys[n]`
+                let match_keys = keys
+                    .iter()
+                    .enumerate()
+                    .all(|(i, keys)| event.keys.len() >= i && (keys.is_empty() || keys.contains(&event.keys[i])));
+
+                if !match_keys {
+                    None
+                } else {
+                    Some(EmittedEvent {
+                        from_address: event.from_address,
+                        keys: event.keys,
+                        data: event.data,
+                        block_hash,
+                        block_number,
+                        transaction_hash,
+                    })
+                }
+            })
         })
         .collect()
 }

--- a/crates/client/rpc/src/versions/v0_7_1/methods/read/get_events.rs
+++ b/crates/client/rpc/src/versions/v0_7_1/methods/read/get_events.rs
@@ -42,19 +42,27 @@ pub async fn get_events(starknet: &Starknet, filter: EventFilterWithPage) -> Sta
 
     let from_block = match filter.event_filter.from_block {
         Some(BlockId::Tag(BlockTag::Pending)) => latest_block + 1,
-        Some(block_id) => starknet.get_block_n(&block_id)?,
+        Some(block_id) => {
+            let block_n = starknet.get_block_n(&block_id)?;
+            if block_n > latest_block {
+                return Err(StarknetRpcApiError::BlockNotFound);
+            }
+            block_n
+        }
         None => 0,
     };
 
     let to_block = match filter.event_filter.to_block {
         Some(BlockId::Tag(BlockTag::Pending)) => latest_block + 1,
-        Some(block_id) => starknet.get_block_n(&block_id)?,
+        Some(block_id) => {
+            let block_n = starknet.get_block_n(&block_id)?;
+            if block_n > latest_block {
+                return Err(StarknetRpcApiError::BlockNotFound);
+            }
+            block_n
+        }
         None => latest_block,
     };
-
-    if from_block > latest_block || to_block > latest_block {
-        return Err(StarknetRpcApiError::BlockNotFound);
-    }
 
     if from_block > to_block {
         return Ok(EventsPage { events: vec![], continuation_token: None });
@@ -184,6 +192,16 @@ mod test {
         })
     }
 
+    fn block_info_pending(n: u64) -> mp_block::MadaraMaybePendingBlockInfo {
+        mp_block::MadaraMaybePendingBlockInfo::Pending(mp_block::MadaraPendingBlockInfo {
+            header: mp_block::header::PendingHeader {
+                parent_block_hash: starknet_core::types::Felt::from(n),
+                ..Default::default()
+            },
+            tx_hashes: vec![],
+        })
+    }
+
     fn block_events(n: u64) -> Vec<mp_receipt::Event> {
         vec![
             mp_receipt::Event {
@@ -196,7 +214,7 @@ mod test {
                 data: vec![],
             },
             mp_receipt::Event {
-                from_address: starknet_core::types::Felt::from(n),
+                from_address: starknet_core::types::Felt::from(n.saturating_add(1)),
                 keys: vec![
                     starknet_core::types::Felt::ZERO,
                     starknet_core::types::Felt::TWO,
@@ -204,7 +222,11 @@ mod test {
                 ],
                 data: vec![],
             },
-            mp_receipt::Event { from_address: starknet_core::types::Felt::from(n), keys: vec![], data: vec![] },
+            mp_receipt::Event {
+                from_address: starknet_core::types::Felt::from(n.saturating_add(1)),
+                keys: vec![],
+                data: vec![],
+            },
         ]
     }
 
@@ -219,7 +241,7 @@ mod test {
                 }),
                 mp_receipt::TransactionReceipt::Invoke(mp_receipt::InvokeTransactionReceipt {
                     events: block_events(n),
-                    transaction_hash: starknet_core::types::Felt::from(n + 1),
+                    transaction_hash: starknet_core::types::Felt::from(n),
                     ..Default::default()
                 }),
             ],
@@ -259,6 +281,37 @@ mod test {
                 })
                 .collect()
         })
+    }
+
+    fn generator_events_pending(backend: &mc_db::MadaraBackend) -> Vec<starknet_core::types::EmittedEvent> {
+        let info = block_info_pending(u64::MAX);
+        let inner = block_inner(u64::MAX);
+
+        backend
+            .store_block(
+                mp_block::MadaraMaybePendingBlock { info: info.clone(), inner: inner.clone() },
+                mp_state_update::StateDiff::default(),
+                vec![],
+            )
+            .expect("Storing block");
+
+        inner
+            .receipts
+            .into_iter()
+            .flat_map(move |receipt| {
+                let block_hash = info.block_hash();
+                let block_number = info.block_n();
+                let transaction_hash = receipt.transaction_hash();
+                receipt.events_owned().into_iter().map(move |event| starknet_core::types::EmittedEvent {
+                    from_address: event.from_address,
+                    keys: event.keys,
+                    data: event.data,
+                    block_hash,
+                    block_number,
+                    transaction_hash,
+                })
+            })
+            .collect()
     }
 
     fn generator_blocks(backend: &mc_db::MadaraBackend) -> impl Iterator<Item = mp_block::MadaraBlock> + '_ {
@@ -338,7 +391,177 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
+                },
+            })
+            .await
+            .expect("starknet_getEvents")
+            .events;
+
+        if events != expected {
+            let file_events = std::fs::File::create("./test_output_actual.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_events);
+            serde_json::to_writer_pretty(writter, &events).unwrap_or_default();
+
+            let file_expected = std::fs::File::create("./test_output_events.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_expected);
+            serde_json::to_writer_pretty(writter, &expected).unwrap_or_default();
+
+            panic!(
+                "actual: {}\nexpected:{}",
+                serde_json::to_string_pretty(&events).unwrap_or_default(),
+                serde_json::to_string_pretty(&expected).unwrap_or_default()
+            )
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_events_pending(rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet)) {
+        let (backend, starknet) = rpc_test_setup;
+        let server = jsonrpsee::server::Server::builder().build("127.0.0.1:0").await.expect("Starting server");
+        let server_url = format!("http://{}", server.local_addr().expect("Retrieving server local address"));
+
+        // Server will be stopped once this is dropped
+        let _server_handle = server.start(StarknetReadRpcApiV0_7_1Server::into_rpc(starknet));
+        let client = HttpClientBuilder::default().build(&server_url).expect("Building client");
+
+        let mut generator = generator_events(&backend);
+        let mut expected = Vec::default();
+
+        expected.extend(generator.next().expect("Retrieving event from backend"));
+        expected.extend(generator_events_pending(&backend));
+
+        let events = client
+            .get_events(starknet_core::types::EventFilterWithPage {
+                event_filter: starknet_core::types::EventFilter {
+                    from_block: None,
+                    to_block: Some(starknet_core::types::BlockId::Tag(starknet_core::types::BlockTag::Pending)),
+                    address: None,
+                    keys: None,
+                },
+                result_page_request: starknet_core::types::ResultPageRequest {
+                    continuation_token: None,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
+                },
+            })
+            .await
+            .expect("starknet_getEvents")
+            .events;
+
+        if events != expected {
+            let file_events = std::fs::File::create("./test_output_actual.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_events);
+            serde_json::to_writer_pretty(writter, &events).unwrap_or_default();
+
+            let file_expected = std::fs::File::create("./test_output_events.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_expected);
+            serde_json::to_writer_pretty(writter, &expected).unwrap_or_default();
+
+            panic!(
+                "actual: {}\nexpected:{}",
+                serde_json::to_string_pretty(&events).unwrap_or_default(),
+                serde_json::to_string_pretty(&expected).unwrap_or_default()
+            )
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_events_from_address(rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet)) {
+        let (backend, starknet) = rpc_test_setup;
+        let server = jsonrpsee::server::Server::builder().build("127.0.0.1:0").await.expect("Starting server");
+        let server_url = format!("http://{}", server.local_addr().expect("Retrieving server local address"));
+
+        // Server will be stopped once this is dropped
+        let _server_handle = server.start(StarknetReadRpcApiV0_7_1Server::into_rpc(starknet));
+        let client = HttpClientBuilder::default().build(&server_url).expect("Building client");
+
+        let mut generator = generator_events(&backend);
+        let mut expected = Vec::default();
+
+        for _ in 0..3 {
+            generator
+                .next()
+                .expect("Retrieving event from backend")
+                .into_iter()
+                .filter(|event| event.from_address == starknet_core::types::Felt::TWO)
+                .collect_into(&mut expected);
+        }
+
+        let events = client
+            .get_events(starknet_core::types::EventFilterWithPage {
+                event_filter: starknet_core::types::EventFilter {
+                    from_block: None,
+                    to_block: None,
+                    address: Some(starknet_core::types::Felt::TWO),
+                    keys: None,
+                },
+                result_page_request: starknet_core::types::ResultPageRequest {
+                    continuation_token: None,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
+                },
+            })
+            .await
+            .expect("starknet_getEvents")
+            .events;
+
+        if events != expected {
+            let file_events = std::fs::File::create("./test_output_actual.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_events);
+            serde_json::to_writer_pretty(writter, &events).unwrap_or_default();
+
+            let file_expected = std::fs::File::create("./test_output_events.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_expected);
+            serde_json::to_writer_pretty(writter, &expected).unwrap_or_default();
+
+            panic!(
+                "actual: {}\nexpected:{}",
+                serde_json::to_string_pretty(&events).unwrap_or_default(),
+                serde_json::to_string_pretty(&expected).unwrap_or_default()
+            )
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_events_from_address_pending(rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet)) {
+        let (backend, starknet) = rpc_test_setup;
+        let server = jsonrpsee::server::Server::builder().build("127.0.0.1:0").await.expect("Starting server");
+        let server_url = format!("http://{}", server.local_addr().expect("Retrieving server local address"));
+
+        // Server will be stopped once this is dropped
+        let _server_handle = server.start(StarknetReadRpcApiV0_7_1Server::into_rpc(starknet));
+        let client = HttpClientBuilder::default().build(&server_url).expect("Building client");
+
+        let mut generator = generator_events(&backend);
+        let mut expected = Vec::default();
+
+        for _ in 0..3 {
+            generator
+                .next()
+                .expect("Retrieving event from backend")
+                .into_iter()
+                .filter(|event| event.from_address == starknet_core::types::Felt::from(u64::MAX))
+                .collect_into(&mut expected);
+        }
+
+        generator_events_pending(&backend)
+            .into_iter()
+            .filter(|event| event.from_address == starknet_core::types::Felt::from(u64::MAX))
+            .collect_into(&mut expected);
+
+        let events = client
+            .get_events(starknet_core::types::EventFilterWithPage {
+                event_filter: starknet_core::types::EventFilter {
+                    from_block: None,
+                    to_block: Some(starknet_core::types::BlockId::Tag(starknet_core::types::BlockTag::Pending)),
+                    address: Some(starknet_core::types::Felt::from(u64::MAX)),
+                    keys: None,
+                },
+                result_page_request: starknet_core::types::ResultPageRequest {
+                    continuation_token: None,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -382,7 +605,6 @@ mod test {
                 .expect("Retrieving event from backend")
                 .into_iter()
                 .filter(|event| !event.keys.is_empty() && event.keys[0] == starknet_core::types::Felt::ZERO)
-                .take(10 - expected.len())
                 .collect_into(&mut expected);
         }
 
@@ -396,7 +618,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -440,7 +662,6 @@ mod test {
                 .expect("Retrieving event from backend")
                 .into_iter()
                 .filter(|event| event.keys.len() > 1 && event.keys[1] == starknet_core::types::Felt::ONE)
-                .take(10 - expected.len())
                 .collect_into(&mut expected);
         }
 
@@ -454,7 +675,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -498,7 +719,6 @@ mod test {
                 .expect("Retrieving event from backend")
                 .into_iter()
                 .filter(|event| event.keys.len() > 2 && event.keys[2] == starknet_core::types::Felt::TWO)
-                .take(10 - expected.len())
                 .collect_into(&mut expected);
         }
 
@@ -512,7 +732,69 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
+                },
+            })
+            .await
+            .expect("starknet_getEvents")
+            .events;
+
+        if events != expected {
+            let file_events = std::fs::File::create("./test_output_actual.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_events);
+            serde_json::to_writer_pretty(writter, &events).unwrap_or_default();
+
+            let file_expected = std::fs::File::create("./test_output_events.json").expect("Opening file");
+            let writter = std::io::BufWriter::new(file_expected);
+            serde_json::to_writer_pretty(writter, &expected).unwrap_or_default();
+
+            panic!(
+                "actual: {}\nexpected:{}",
+                serde_json::to_string_pretty(&events).unwrap_or_default(),
+                serde_json::to_string_pretty(&expected).unwrap_or_default()
+            )
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_events_with_keys_pending(rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet)) {
+        let (backend, starknet) = rpc_test_setup;
+        let server = jsonrpsee::server::Server::builder().build("127.0.0.1:0").await.expect("Starting server");
+        let server_url = format!("http://{}", server.local_addr().expect("Retrieving server local address"));
+
+        // Server will be stopped once this is dropped
+        let _server_handle = server.start(StarknetReadRpcApiV0_7_1Server::into_rpc(starknet));
+        let client = HttpClientBuilder::default().build(&server_url).expect("Building client");
+
+        let mut generator = generator_events(&backend);
+        let mut expected = Vec::default();
+
+        for _ in 0..3 {
+            generator
+                .next()
+                .expect("Retrieving event from backend")
+                .into_iter()
+                .filter(|event| !event.keys.is_empty() && event.keys[0] == starknet_core::types::Felt::ZERO)
+                .collect_into(&mut expected);
+        }
+
+        generator_events_pending(&backend)
+            .into_iter()
+            .filter(|event| !event.keys.is_empty() && event.keys[0] == starknet_core::types::Felt::ZERO)
+            .collect_into(&mut expected);
+
+        let events = client
+            .get_events(starknet_core::types::EventFilterWithPage {
+                event_filter: starknet_core::types::EventFilter {
+                    from_block: None,
+                    to_block: Some(starknet_core::types::BlockId::Tag(starknet_core::types::BlockTag::Pending)),
+                    address: None,
+                    keys: Some(vec![vec![starknet_core::types::Felt::ZERO]]),
+                },
+                result_page_request: starknet_core::types::ResultPageRequest {
+                    continuation_token: None,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -648,7 +930,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -689,7 +971,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -730,7 +1012,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -814,7 +1096,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: Some("".to_string()),
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -857,7 +1139,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: Some("0-100".to_string()),
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await
@@ -895,7 +1177,7 @@ mod test {
                 },
                 result_page_request: starknet_core::types::ResultPageRequest {
                     continuation_token: None,
-                    chunk_size: 10,
+                    chunk_size: crate::constants::MAX_EVENTS_CHUNK_SIZE,
                 },
             })
             .await

--- a/crates/primitives/block/src/lib.rs
+++ b/crates/primitives/block/src/lib.rs
@@ -260,7 +260,7 @@ impl MadaraMaybePendingBlock {
 }
 
 /// Starknet block definition.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MadaraBlock {
     pub info: MadaraBlockInfo,
     pub inner: MadaraBlockInner,

--- a/crates/primitives/receipt/src/lib.rs
+++ b/crates/primitives/receipt/src/lib.rs
@@ -110,6 +110,16 @@ impl TransactionReceipt {
         }
     }
 
+    pub fn events_owned(self) -> Vec<Event> {
+        match self {
+            TransactionReceipt::Invoke(receipt) => receipt.events,
+            TransactionReceipt::L1Handler(receipt) => receipt.events,
+            TransactionReceipt::Declare(receipt) => receipt.events,
+            TransactionReceipt::Deploy(receipt) => receipt.events,
+            TransactionReceipt::DeployAccount(receipt) => receipt.events,
+        }
+    }
+
     pub fn execution_result(&self) -> ExecutionResult {
         match self {
             TransactionReceipt::Invoke(receipt) => receipt.execution_result.clone(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current implementation of `starknet_getEvents` in Madara suffers from very poor performance compared to other nodes. This pr's goal is to improve this (will benchmark this again before un-drafting the pull request).

![image](https://github.com/user-attachments/assets/f7654fff-9f25-4a96-8700-84164bc37b24)
_`starknet_getEvents` performance across nodes, bench measured with sync from a local fgw_

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Refactored block event retrieval to avoid unnecessary allocations, clones and key checks
- Better handling of `StarknetRpcApiError::BlockNotFound` edge cases.
- Added tests to `starknet_getEvents` to ensure proper functionality

> [!NOTE]
> Further new behavior will be documented as this PR is developed

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

Yes. Calls to `starknet_getEvent` would previously return `Ok()` if `from_block` or `to_block` were higher than the latest block. This has been changed to return `StarknetRpcApiError::BlockNotFound`.