### PR TITLE
fix(fgw): include `l1_to_l2_consumed_message` in L1 handler receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(fgw): include `l1_to_l2_consumed_message` in L1 handler receipt
 - build: up starknet-rs, starknet-types, blockifier(v0.8.0), cairo
 - feat(rpc): added `getCompiledCasm` method
 - fix(error): Added a comment for non archive node L1 keys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6010,6 +6010,7 @@ dependencies = [
  "starknet-core",
  "starknet-types-core",
  "starknet_api",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/primitives/convert/Cargo.toml
+++ b/crates/primitives/convert/Cargo.toml
@@ -18,13 +18,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 # Starknet
 serde = { workspace = true, features = ["derive"] }
-serde_with = { workspace = true }
-starknet-core = { workspace = true }
-starknet-types-core = { workspace = true }
-starknet_api = { workspace = true }
+serde_with.workspace = true
+starknet-core.workspace = true
+starknet-types-core.workspace = true
+starknet_api.workspace = true
 
 # Other
-primitive-types = { workspace = true }
+primitive-types.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-assert_matches = { workspace = true }
+assert_matches.workspace = true

--- a/crates/primitives/convert/src/felt.rs
+++ b/crates/primitives/convert/src/felt.rs
@@ -6,12 +6,13 @@ use starknet_types_core::felt::Felt;
 pub struct FeltToH160Error;
 
 pub fn felt_to_h160(felt: &Felt) -> Result<H160, FeltToH160Error> {
-    let bytes = felt.to_bytes_be();
+    const MAX_H160: Felt = Felt::from_hex_unchecked("0xffffffffffffffffffffffffffffffffffffffff");
 
-    // check if the 12 first bytes are null
-    if !bytes.iter().take(12).all(|&b| b == 0) {
+    if felt > &MAX_H160 {
         return Err(FeltToH160Error);
     }
+
+    let bytes = felt.to_bytes_be();
 
     let mut h160_bytes = [0u8; 20];
     h160_bytes.copy_from_slice(&bytes[12..]);

--- a/crates/primitives/convert/src/felt.rs
+++ b/crates/primitives/convert/src/felt.rs
@@ -1,0 +1,38 @@
+use primitive_types::H160;
+use starknet_types_core::felt::Felt;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Felt is too big to convert to H160.")]
+pub struct FeltToH160Error;
+
+pub fn felt_to_h160(felt: &Felt) -> Result<H160, FeltToH160Error> {
+    let bytes = felt.to_bytes_be();
+
+    // check if the 12 first bytes are null
+    if !bytes.iter().take(12).all(|&b| b == 0) {
+        return Err(FeltToH160Error);
+    }
+
+    let mut h160_bytes = [0u8; 20];
+    h160_bytes.copy_from_slice(&bytes[12..]);
+    Ok(H160::from(h160_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn test_felt_tu_h160() {
+        const MAX_H160: [u8; 20] = [0xff; 20];
+        assert_eq!(felt_to_h160(&Felt::ZERO).unwrap(), H160::zero());
+        assert_eq!(felt_to_h160(&Felt::ONE).unwrap(), H160::from_low_u64_be(1));
+        assert_eq!(felt_to_h160(&Felt::TWO).unwrap(), H160::from_low_u64_be(2));
+        assert_eq!(felt_to_h160(&Felt::THREE).unwrap(), H160::from_low_u64_be(3));
+        assert_eq!(felt_to_h160(&Felt::from(u64::MAX)).unwrap(), H160::from_low_u64_be(u64::MAX));
+        assert_eq!(felt_to_h160(&Felt::from_bytes_be_slice(&MAX_H160)).unwrap(), H160::from_slice(&MAX_H160));
+        assert_matches!(felt_to_h160(&(Felt::from_bytes_be_slice(&MAX_H160) + Felt::ONE)), Err(FeltToH160Error));
+        assert_matches!(felt_to_h160(&Felt::MAX), Err(FeltToH160Error));
+    }
+}

--- a/crates/primitives/convert/src/lib.rs
+++ b/crates/primitives/convert/src/lib.rs
@@ -1,6 +1,8 @@
+mod felt;
 pub mod hex_serde;
 mod to_felt;
 
+pub use felt::felt_to_h160;
 pub use to_felt::{DisplayFeltAsHex, FeltHexDisplay, ToFelt};
 
 pub mod test {


### PR DESCRIPTION
## Pull Request type


Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

the `l1_to_l2_consumed_message` field is missing in the FGW receipt

Resolves: #375 

## What is the new behavior?

retrieve the `l1_to_l2_consumed_message` directly from the L1 handler transaction

## Does this introduce a breaking change?

No

## Other information

**⚠️ merge #380 before**
