### PR TITLE
Fix/rust log filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(tracing): RUST_LOG filtering support
 - fix(fgw): fetch class
 - feat: possibility of starting madara & kakarot-rpc in docker
 - feat(debug): service cancelling and profiling build

--- a/README.md
+++ b/README.md
@@ -478,7 +478,6 @@ Madara comes packed with OTEL integration, supporting export of traces, metrics 
 ### Basic Command-Line Option
 
 - **`--analytics-collection-endpoint <URL>`**: Endpoint for OTLP collector, if not provided then OTLP is not enabled.
-- **`--analytics-log-level <Log Level>`**: Picked up from `RUST_LOG` automatically, can be provided using this flag as well.
 - **`--analytics-service-name <Name>`**: Allows to customize the collection service name.
 
 #### Setting up Signoz

--- a/crates/client/analytics/src/lib.rs
+++ b/crates/client/analytics/src/lib.rs
@@ -28,10 +28,7 @@ pub struct Analytics {
 }
 
 impl Analytics {
-    pub fn new(
-        service_name: String,
-        collection_endpoint: Option<Url>,
-    ) -> anyhow::Result<Self> {
+    pub fn new(service_name: String, collection_endpoint: Option<Url>) -> anyhow::Result<Self> {
         Ok(Self { meter_provider: None, service_name, collection_endpoint })
     }
 

--- a/crates/client/analytics/src/lib.rs
+++ b/crates/client/analytics/src/lib.rs
@@ -18,22 +18,21 @@ use tracing::Level;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::EnvFilter;
 use url::Url;
 
 pub struct Analytics {
     meter_provider: Option<SdkMeterProvider>,
     service_name: String,
-    log_level: Level,
     collection_endpoint: Option<Url>,
 }
 
 impl Analytics {
     pub fn new(
         service_name: String,
-        log_level: tracing::Level,
         collection_endpoint: Option<Url>,
     ) -> anyhow::Result<Self> {
-        Ok(Self { meter_provider: None, service_name, log_level, collection_endpoint })
+        Ok(Self { meter_provider: None, service_name, collection_endpoint })
     }
 
     pub fn setup(&mut self) -> anyhow::Result<()> {
@@ -41,8 +40,8 @@ impl Analytics {
         let custom_formatter = CustomFormatter { local_offset };
 
         let tracing_subscriber = tracing_subscriber::registry()
-            .with(tracing_subscriber::filter::LevelFilter::from_level(self.log_level))
-            .with(tracing_subscriber::fmt::layer().event_format(custom_formatter));
+            .with(tracing_subscriber::fmt::layer().event_format(custom_formatter))
+            .with(EnvFilter::from_default_env());
 
         if self.collection_endpoint.is_none() {
             tracing_subscriber.init();

--- a/crates/node/src/cli/analytics.rs
+++ b/crates/node/src/cli/analytics.rs
@@ -1,6 +1,5 @@
 use clap::Args;
 use mp_utils::parsers::parse_url;
-use tracing::Level;
 use url::Url;
 
 /// Parameters used to config analytics.
@@ -9,10 +8,6 @@ pub struct AnalyticsParams {
     /// Name of the service.
     #[arg(env = "MADARA_ANALYTICS_SERVICE_NAME", long, alias = "analytics", default_value = "madara_analytics")]
     pub analytics_service_name: String,
-
-    /// Log level of the service.
-    #[arg(env = "RUST_LOG", long, default_value = "info")]
-    pub analytics_log_level: Level,
 
     /// Endpoint of the analytics server.
     #[arg(env = "OTEL_EXPORTER_OTLP_ENDPOINT", long, value_parser = parse_url, default_value = None)]

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -35,7 +35,6 @@ async fn main() -> anyhow::Result<()> {
 
     let mut analytics = Analytics::new(
         run_cmd.analytics_params.analytics_service_name.clone(),
-        run_cmd.analytics_params.analytics_log_level,
         run_cmd.analytics_params.analytics_collection_endpoint.clone(),
     )
     .context("Initializing analytics service")?;


### PR DESCRIPTION
Filtering based on RUST_LOG stopped working after adding log-level as a clap argument.
removed log_level from clap to get it and added code to pick `RUST_LOG` from env directly.