### PR TITLE
fix: Documentation Fixes and Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ are exposed on a separate port **9943** unless specified otherwise with
 </details>
 
 > [!CAUTION]
-> These methods are exposed on `locahost` by default for obvious security
+> These methods are exposed on `localhost` by default for obvious security
 > reasons. You can always exposes them externally using `--rpc-admin-external`,
 > but be _very careful_ when doing so as you might be compromising your node!
 > Madara does not do **any** authorization checks on the caller of these
@@ -591,7 +591,7 @@ the _source_ of the migration. You can do this with the `--warp-update-sender`
 [preset](#4.-presets):
 
 ```bash
-cargo run --releasae -- \
+cargo run --release -- \
   --name Sender         \
   --full                \ # This also works with other types of nodes
   --network mainnet     \
@@ -602,7 +602,7 @@ You will then need to start a second node to synchronize the state of your
 database:
 
 ```bash
-cargo run --releasae --       \
+cargo run --release --       \
   --name Receiver             \
   --base-path /tmp/madara_new \ # Where you want the new database to be stored
   --full                      \

--- a/crates/client/eth/README.md
+++ b/crates/client/eth/README.md
@@ -25,7 +25,7 @@ A few notes on the current design:
   - Launch Worker
   - Send L1->L2 message
   - Assert that event is emitted on L1
-  - Assert that even was caught by the worker with correct data
+  - Assert that event was caught by the worker with correct data
   - Assert the tx hash computed by the worker is correct
   - Assert that the tx has been included in the mempool
   - Assert that DB was correctly updated (last synced block & nonce)

--- a/crates/client/rpc/src/RPC.md
+++ b/crates/client/rpc/src/RPC.md
@@ -5,7 +5,7 @@ of Madara, as its structure can be quite confusing at first._
 
 ## Properties
 
-Madara RPC has the folliwing properties:
+Madara RPC has the following properties:
 
 **Each RPC category is independent** and decoupled from the rest, so `trace`
 methods exist in isolation from `read` methods for example.
@@ -14,7 +14,7 @@ methods exist in isolation from `read` methods for example.
 _different versions_ of the same RPC method. This is mostly present for ease of
 development of new RPC versions, but also serves to assure a level of backwards
 compatibility. To select a specific version of an rpc method, you will need to
-append `/rcp/v{version}` to the rpc url you are connecting to.
+append `/rpc/v{version}` to the rpc url you are connecting to.
 
 **RPC versions are grouped under the `Starknet` struct**. This serves as a
 common point of implementation for all RPC methods across all versions, and is


### PR DESCRIPTION
# Documentation Fixes and Improvements

## Pull Request Type

<!-- Mark the appropriate type(s) below -->
- Documentation content changes

## Description

This pull request fixes multiple typos and formatting issues in the project's documentation files, including `README.md`, `RPC.md`, and `crates/client/eth/README.md`. These changes improve readability and correct inaccuracies.

### Changes Summary
- Fixed the typo `locahost` → `localhost` in `README.md`.
- Corrected `releasae` → `release` in `README.md`.
- Fixed `even` → `event` in `crates/client/eth/README.md`.
- Corrected `folliwing` → `following` and `rcp` → `rpc` in `RPC.md`.

## Does this introduce a breaking change?

- No

## Other Information

These changes enhance the documentation for clarity and accuracy. No functional code changes are included in this pull request.
