### PR TITLE
fix(docs): Updated typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(docs): Updated typos in documentation 
 - fix: oracle need condition
 - fix(block_production): continue pending block now reexecutes the previous transactions
 - feat(services): reworked Madara services for better cancellation control

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ are exposed on a separate port **9943** unless specified otherwise with
 </details>
 
 > [!CAUTION]
-> These methods are exposed on `locahost` by default for obvious security
+> These methods are exposed on `localhost` by default for obvious security
 > reasons. You can always exposes them externally using `--rpc-admin-external`,
 > but be _very careful_ when doing so as you might be compromising your node!
 > Madara does not do **any** authorization checks on the caller of these

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ For more detailed information on how to call each method, please refer to the
 | Curl       | Latest  | `sudo apt install curl` |
 
 Here is an example of how to call a JSON-RPC method using Madara. Before running
-the bellow code, make sure you have a node running with rpc enabled on port 9944
+the below code, make sure you have a node running with rpc enabled on port 9944
 (this is the default configuration).
 
 > [!IMPORTANT]
@@ -538,7 +538,7 @@ into the subscription stream:
 { "jsonrpc": "2.0", "method": "starknet_unsubscribe", "params": ["your-subscription-id"], "id": 1 }
 ```
 
-Where `you-subscription-id` corresponds to the value of the `subscription` field
+Where `your-subscription-id` corresponds to the value of the `subscription` field
 which is returned with each websocket response.
 
 ## 📚 Database Migration

--- a/crates/client/eth/README.md
+++ b/crates/client/eth/README.md
@@ -25,7 +25,7 @@ A few notes on the current design:
   - Launch Worker
   - Send L1->L2 message
   - Assert that event is emitted on L1
-  - Assert that even was caught by the worker with correct data
+  - Assert that event was caught by the worker with correct data
   - Assert the tx hash computed by the worker is correct
   - Assert that the tx has been included in the mempool
   - Assert that DB was correctly updated (last synced block & nonce)

--- a/crates/client/rpc/src/RPC.md
+++ b/crates/client/rpc/src/RPC.md
@@ -5,7 +5,7 @@ of Madara, as its structure can be quite confusing at first._
 
 ## Properties
 
-Madara RPC has the folliwing properties:
+Madara RPC has the following properties:
 
 **Each RPC category is independent** and decoupled from the rest, so `trace`
 methods exist in isolation from `read` methods for example.
@@ -14,7 +14,7 @@ methods exist in isolation from `read` methods for example.
 _different versions_ of the same RPC method. This is mostly present for ease of
 development of new RPC versions, but also serves to assure a level of backwards
 compatibility. To select a specific version of an rpc method, you will need to
-append `/rcp/v{version}` to the rpc url you are connecting to.
+append `rpc/v{version}` to the rpc url you are connecting to.
 
 **RPC versions are grouped under the `Starknet` struct**. This serves as a
 common point of implementation for all RPC methods across all versions, and is


### PR DESCRIPTION
This pull request addresses several typos and formatting issues across the project's documentation, including README.md, RPC.md, and crates/client/eth/README.md. These updates enhance readability and correct minor inaccuracies.

# Changes Made 

Fixed the typo locahost → localhost in README.md.
Fixed even → event in crates/client/eth/README.md.
Corrected folliwing → following and rcp → rpc in RPC.md.
