### PR TITLE
fix(devnet): loosened devnet chain id restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(devnet): loosened devnet chain id restrictions
 - chore: Move crates under a madara subdir
 - chore(nix): resolve flake and direnv compatibility issues
 - fix: Gateway path fix

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ You can choose between different build modes:
 
 Start the Madara client with a basic set of arguments depending on your chosen mode:
 
+> [!NOTE]
+> Head to the [Configuration](#%EF%B8%8F-configuration) section to learn more about
+> customizing your node.
+
 #### Full Node
 
 Synchronizes the state of the chain from genesis.
@@ -125,16 +129,16 @@ cargo run --release --        \
 A node in a private local network.
 
 ```bash
-cargo run --release --        \
-  --name Madara               \
-  --devnet                    \
-  --base-path /var/lib/madara \
-  --preset sepolia
+ cargo run --release --    \
+  --name Madara            \
+  --devnet                 \
+  --base-path ../madara_db \
+  --chain-config-override=chain_id=MY_CUSTOM_DEVNET
 ```
 
-> [!NOTE]
-> Head to the [Configuration](#%EF%B8%8F-configuration) section to learn more about
-> customizing your node.
+> [!CAUTION]
+> Make sure to use a unique `chain_id` for your devnet to avoid potential replay
+> attacks in other chains with the same chain id!
 
 #### 4. Presets
 

--- a/crates/madara/node/src/cli/block_production.rs
+++ b/crates/madara/node/src/cli/block_production.rs
@@ -6,11 +6,6 @@ pub struct BlockProductionParams {
     #[arg(env = "MADARA_BLOCK_PRODUCTION_DISABLED", long, alias = "no-block-production")]
     pub block_production_disabled: bool,
 
-    /// Launch a devnet with a production chain id (like SN_MAINNET, SN_SEPOLIA).
-    /// This in unsafe because your devnet transactions can be replayed on the actual network.
-    #[arg(env = "MADARA_OVERRIDE_DEVNET_CHAIN_ID", long, default_value_t = false)]
-    pub override_devnet_chain_id: bool,
-
     /// Create this number of contracts in the genesis block for the devnet configuration.
     #[arg(env = "MADARA_DEVNET_CONTRACTS", long, default_value_t = 10)]
     pub devnet_contracts: u64,

--- a/crates/madara/node/src/cli/mod.rs
+++ b/crates/madara/node/src/cli/mod.rs
@@ -187,6 +187,10 @@ pub struct RunCmd {
     #[arg(env = "MADARA_DEVNET", long, group = "mode")]
     pub devnet: bool,
 
+    /// Allows a devnet to have SN_MAIN or SN_SEPOLIA as its chain ID.
+    #[arg(env = "MADARA_DEVNET_UNSAFE", long, requires = "devnet")]
+    pub devnet_unsafe: bool,
+
     /// The network chain configuration.
     #[clap(env = "MADARA_NETWORK", long, short, group = "full_mode_config")]
     pub network: Option<NetworkType>,

--- a/crates/madara/node/src/cli/mod.rs
+++ b/crates/madara/node/src/cli/mod.rs
@@ -16,7 +16,6 @@ pub use db::*;
 pub use gateway::*;
 pub use l2::*;
 pub use rpc::*;
-use starknet_api::core::ChainId;
 use std::str::FromStr;
 pub use telemetry::*;
 
@@ -311,17 +310,6 @@ pub enum NetworkType {
     /// A devnet for local testing
     #[value(alias("devnet"))]
     Devnet,
-}
-
-impl NetworkType {
-    pub fn chain_id(&self) -> ChainId {
-        match self {
-            NetworkType::Main => ChainId::Mainnet,
-            NetworkType::Test => ChainId::Sepolia,
-            NetworkType::Integration => ChainId::IntegrationSepolia,
-            NetworkType::Devnet => ChainId::Other("MADARA_DEVNET".to_string()),
-        }
-    }
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]

--- a/crates/madara/node/src/main.rs
+++ b/crates/madara/node/src/main.rs
@@ -55,9 +55,11 @@ async fn main() -> anyhow::Result<()> {
     // to avoid accidental setups which would allow for replay attacks. This is
     // possible if the devnet has the same chain id as another popular chain,
     // allowing txs which occur on it to also be replayed on that other chain.
-    if run_cmd.devnet && (chain_config.chain_id == ChainId::Mainnet || chain_config.chain_id == ChainId::Sepolia) {
-        tracing::error!("You're running a devnet with the network config of {0}. This means that devnet transactions can be replayed on the actual {0} network. Use `--network=devnet` instead.", chain_config.chain_name);
-        anyhow::bail!("Devnet")
+    if run_cmd.devnet
+        && (chain_config.chain_id == ChainId::Mainnet || chain_config.chain_id == ChainId::Sepolia)
+        && !run_cmd.devnet_unsafe
+    {
+        anyhow::bail!("You're running a devnet with the network config of {0}. This means that devnet transactions can be replayed on the actual {0} network. Use `--network=devnet` instead or force this configuration with `--devnet-unsafe`.", chain_config.chain_name);
     }
 
     let node_name = run_cmd.node_name_or_provide().await.to_string();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current restrictions around devnet chain id to avoid replay attacks do not make entire sense and are a bit too strict.

Resolves: #302  

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Devnet chain id restrictions have been loosed to only forbid devnets with `STARKNET_MAINNET` or `STARKNET_SEPOLIA` chain ids. An additinal warning has been added to the `README` to warn agains such potential replay attacks

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

No
