### PR TITLE
chore(nix): add scarb package manager to development tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,14 +7,24 @@
   outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [ (import rust-overlay) ];
+        overlays = [ 
+          (import rust-overlay)
+          (final: prev: {
+            scarb = final.callPackage (./. + "/tools/scarb.nix") {};
+          })
+        ];
+
         pkgs = import nixpkgs {
           inherit system overlays;
         };
 
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
       in
       {
+        # Export the scarb package
+        packages.scarb = pkgs.scarb;
+        packages.default = pkgs.scarb;
 
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
@@ -24,6 +34,7 @@
             nodePackages.prettier
             taplo-cli
             yq
+            scarb
           ];
 
           buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,19 @@
 {
   inputs = {
-    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    flake-utils.url  = "github:numtide/flake-utils";
+    flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        overlays = [ 
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        overlays = [
           (import rust-overlay)
           (final: prev: {
             scarb = final.callPackage (./. + "/tools/scarb.nix") {};
@@ -19,9 +25,7 @@
         };
 
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-
-      in
-      {
+      in {
         # Export the scarb package
         packages.scarb = pkgs.scarb;
         packages.default = pkgs.scarb;
@@ -37,13 +41,15 @@
             scarb
           ];
 
-          buildInputs = with pkgs; [
-            rustToolchain
-            clang
-            rocksdb
-          ] ++ lib.optionals stdenv.isDarwin [
-            darwin.apple_sdk.frameworks.Security
-          ];
+          buildInputs = with pkgs;
+            [
+              rustToolchain
+              clang
+              rocksdb
+            ]
+            ++ lib.optionals stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.Security
+            ];
 
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
           PROTOC = "${pkgs.protobuf}/bin/protoc";

--- a/tools/scarb.nix
+++ b/tools/scarb.nix
@@ -1,0 +1,107 @@
+{ pkgs }:
+
+let
+  # Define versions and their hashes
+  versions = {
+    "2.8.2" = {
+      hashes = {
+        "aarch64-apple-darwin" = "59d041fca5404b0c60e0e1ff22e9d1929b118c9914ba80c012cac7c372168e2c";
+        "x86_64-apple-darwin" = "209979076e65ba3e0d53506cab826516a647f44c0d77fc4be221fea5bcb6607e";
+        "aarch64-unknown-linux-gnu" = "c4e0066b00af0e644585f4c27ecea55abed732679b7e8654876303bae982e2f6";
+        "x86_64-unknown-linux-gnu" = "2033173c4b8e72fd4bf1779baca6d5348d4f0b53327a14742cb2f65c2f0e892c";
+        "aarch64-unknown-linux-musl" = "35bb6f035691fe71faf5836b8e90d05671f4407a14758e31658fd5c7e97d2a08";
+        "x86_64-unknown-linux-musl" = "b8c99d5f917880f4416e443abfaeab9eb2af7b8d34d34a84e5c913b0e8149d22";
+        "x86_64-pc-windows-msvc" = "ef9161f4305c4ac3262810fb0e888835a00204b98dd185ec07d2cc4e3e9c0330";
+      };
+    };
+  };
+
+  # System mapping
+  systemMap = {
+    "aarch64-darwin" = "aarch64-apple-darwin";
+    "x86_64-darwin" = "x86_64-apple-darwin";
+    "aarch64-linux" = "aarch64-unknown-linux-gnu";
+    "x86_64-linux" = "x86_64-unknown-linux-gnu";
+    "aarch64-linux-musl" = "aarch64-unknown-linux-musl";
+    "x86_64-linux-musl" = "x86_64-unknown-linux-musl";
+    "x86_64-windows" = "x86_64-pc-windows-msvc";
+  };
+
+  # Get current system platform
+  currentSystem = pkgs.stdenv.hostPlatform.system;
+  platform = systemMap.${currentSystem} or (throw "Unsupported system: ${currentSystem}");
+  
+  # Get extension based on platform
+  extension = if platform == "x86_64-pc-windows-msvc" then "zip" else "tar.gz";
+
+  # Get version data
+  version = "2.8.2";
+  versionData = versions.${version} or (throw "Version ${version} not found");
+  sha256 = versionData.hashes.${platform} or (throw "Hash not found for ${platform} in version ${version}");
+
+in
+pkgs.stdenv.mkDerivation {
+  pname = "scarb";
+  inherit version;
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/software-mansion/scarb/releases/download/v${version}/scarb-v${version}-${platform}.${extension}";
+    inherit sha256;
+  };
+
+  # Add meta information
+  meta = with pkgs.lib; {
+    description = "Scarb package manager for Cairo/Starknet development";
+    homepage = "https://github.com/software-mansion/scarb";
+    license = licenses.mit;
+    platforms = builtins.attrNames systemMap;
+    maintainers = with maintainers; [ ];
+  };
+
+  # Installation phase
+  installPhase = ''
+    mkdir -p $out/{bin,doc}
+
+    ${if extension == "zip" then ''
+      unzip $src
+      cd scarb-v${version}-${platform}
+    '' else ''
+      tar xf $src
+      cd scarb-v${version}-${platform}
+    ''}
+
+    # Install binaries
+    mv bin/* $out/bin/
+    
+    # Install documentation
+    mv doc/* $out/doc/
+
+    # Make all binaries executable
+    chmod +x $out/bin/*
+
+    # Verify installation of all required binaries
+    required_bins=(
+      scarb
+      scarb-cairo-language-server
+      scarb-cairo-run
+      scarb-cairo-test
+      scarb-doc
+      scarb-snforge-test-collector
+    )
+
+    for bin in "''${required_bins[@]}"; do
+      if [ ! -x "$out/bin/$bin" ]; then
+        echo "Error: Required binary $bin not found or not executable"
+        exit 1
+      fi
+    done
+  '';
+
+  # Add required build inputs
+  nativeBuildInputs = with pkgs; [
+    gnutar
+    gzip
+  ] ++ pkgs.lib.optionals (extension == "zip") [
+    unzip
+  ];
+}


### PR DESCRIPTION

## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Build-related changes

## What is the current behavior?

Currently, the nix development environment doesn't include Scarb, which is necessary for e2e tests.

Resolves: #NA

## What is the new behavior?

- Adds Scarb package manager (v2.8.2) to the development environment
- Includes all necessary Scarb binaries
- Supports multiple platforms
- Properly integrates with the existing Nix development shell

## Does this introduce a breaking change?

No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
