### PR TITLE
fix(block_production): dynamic block closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(block_production): dynamic block closing now adds special address with prev block hash
 - fix(compilation): crate-level compilation
 - chore: Move crates under a madara subdir
 - chore(nix): resolve flake and direnv compatibility issues


### PR DESCRIPTION
## Summary
This PR ensures that madara correctly adds a special address to the state diff when dynamically closing a block with a number greater than 10. The special address uses the current block number minus 10 as the key and the hash of (current block - 10) as the value. This is required for the SNOS.

## Pull Request Type
- **Bugfix**

## Current Behavior
When the bouncer configuration reaches its limit, Madara dynamically closes the block. However, during this process, the required special address is not added to the state diff for blocks numbered greater than 10.

## New Behavior
When closing a block dynamically, if the block number is greater than 10, a special address is now correctly added to the state diff with:
- **Key:** Current block number - 10
- **Value:** Hash of (current block - 10)

## Breaking Changes
No breaking changes introduced.

## Additional Notes
This fix ensures consistency in state diffs when dynamic block closing occurs, maintaining expected behavior for blocks greater than 10.

