### PR TITLE
Missing .db-versions.yml in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /usr/src/madara/
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 COPY cairo-artifacts cairo-artifacts
+COPY .db-versions.yml ./
 
 # Install runtime dependencies
 RUN apt-get -y update && \


### PR DESCRIPTION
The `.db-versions.yml` file is missing in the docker image and the build process will fail without it

## Pull Request type
- Bugfix


## What is the current behavior?
To reproduce the issue, just clone Madara repository and run: 
`docker build -t madara .`
The process will stop at the end of stage 1 since the compilation fails.
