### PR TITLE
fix(l1_receipt): trimmed hash

### DIFF
--- a/crates/madara/primitives/receipt/src/to_starknet_types.rs
+++ b/crates/madara/primitives/receipt/src/to_starknet_types.rs
@@ -59,7 +59,9 @@ impl L1HandlerTransactionReceipt {
         finality_status: starknet_types_rpc::TxnFinalityStatus,
     ) -> starknet_types_rpc::L1HandlerTxnReceipt<Felt> {
         starknet_types_rpc::L1HandlerTxnReceipt::<Felt> {
-            message_hash: self.message_hash.to_string(),
+            // We have to manually convert the H256 bytes to a hex hash as the
+            // impl of Display for H256 skips the middle bytes.
+            message_hash: self.message_hash.as_fixed_bytes().into_iter().map(|b| format!("{b:02x}")).collect(),
             common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
                 events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),

--- a/crates/madara/primitives/receipt/src/to_starknet_types.rs
+++ b/crates/madara/primitives/receipt/src/to_starknet_types.rs
@@ -1,3 +1,4 @@
+use primitive_types::H256;
 use starknet_types_core::felt::Felt;
 
 use crate::{
@@ -58,20 +59,10 @@ impl L1HandlerTransactionReceipt {
         self,
         finality_status: starknet_types_rpc::TxnFinalityStatus,
     ) -> starknet_types_rpc::L1HandlerTxnReceipt<Felt> {
-        use std::fmt::Write;
-
-        // 32 bytes x 2 (1 hex char = 4 bits) + 2 (for 0x)
-        let mut acc = String::with_capacity(68);
-        acc.push_str("0x");
-        let message_hash = self.message_hash.as_fixed_bytes().iter().fold(acc, |mut acc, b| {
-            write!(&mut acc, "{b:02x}").expect("Pre-allocated");
-            acc
-        });
-
         starknet_types_rpc::L1HandlerTxnReceipt::<Felt> {
             // We have to manually convert the H256 bytes to a hex hash as the
             // impl of Display for H256 skips the middle bytes.
-            message_hash,
+            message_hash: hash_as_string(self.message_hash),
             common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
                 events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),
@@ -83,6 +74,23 @@ impl L1HandlerTransactionReceipt {
             },
         }
     }
+}
+
+/// Gets the **full** string hex representation of an [H256].
+///
+/// This is necessary as the default implementation of [ToString] for [H256]
+/// will keep only the first and last 2 bytes, eliding the rest with '...'.
+fn hash_as_string(message_hash: H256) -> String {
+    use std::fmt::Write;
+
+    // 32 bytes x 2 (1 hex char = 4 bits) + 2 (for 0x)
+    let mut acc = String::with_capacity(68);
+    acc.push_str("0x");
+
+    message_hash.as_fixed_bytes().iter().fold(acc, |mut acc, b| {
+        write!(&mut acc, "{b:02x}").expect("Pre-allocated");
+        acc
+    })
 }
 
 impl DeclareTransactionReceipt {
@@ -211,5 +219,37 @@ impl From<ExecutionResult> for starknet_types_rpc::ExecutionStatus {
             ExecutionResult::Succeeded => starknet_types_rpc::ExecutionStatus::Successful,
             ExecutionResult::Reverted { reason } => starknet_types_rpc::ExecutionStatus::Reverted(reason),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use primitive_types::H256;
+
+    use crate::{to_starknet_types::hash_as_string, L1HandlerTransactionReceipt};
+
+    #[test]
+    fn test_hash_as_string() {
+        let mut hash = String::with_capacity(68);
+        hash.push_str("0x");
+        hash.push_str(&"f".repeat(64));
+        assert_eq!(hash_as_string(H256::from_slice(&[u8::MAX; 32])), hash);
+    }
+
+    /// The default implementation of [ToString] for [H256] will keep only the
+    /// first and last 2 bytes, eliding the rest with '...'. This test makes
+    /// sure this is not the case and we are using [hash_as_string] instead.
+    #[test]
+    fn test_l1_tx_receipt_full_hash() {
+        let l1_transaction_receipt =
+            L1HandlerTransactionReceipt { message_hash: H256::from_slice(&[u8::MAX; 32]), ..Default::default() };
+        let message_hash =
+            l1_transaction_receipt.to_starknet_types(starknet_types_rpc::TxnFinalityStatus::L1).message_hash;
+
+        let mut hash = String::with_capacity(68);
+        hash.push_str("0x");
+        hash.push_str(&"f".repeat(64));
+        assert_eq!(message_hash, hash);
+        assert!(!message_hash.contains("."));
     }
 }

--- a/crates/madara/primitives/receipt/src/to_starknet_types.rs
+++ b/crates/madara/primitives/receipt/src/to_starknet_types.rs
@@ -58,10 +58,20 @@ impl L1HandlerTransactionReceipt {
         self,
         finality_status: starknet_types_rpc::TxnFinalityStatus,
     ) -> starknet_types_rpc::L1HandlerTxnReceipt<Felt> {
+        use std::fmt::Write;
+
+        // 32 bytes x 2 (1 hex char = 4 bits) + 2 (for 0x)
+        let mut acc = String::with_capacity(68);
+        acc.push_str("0x");
+        let message_hash = self.message_hash.as_fixed_bytes().iter().fold(acc, |mut acc, b| {
+            write!(&mut acc, "{b:02x}").expect("Pre-allocated");
+            acc
+        });
+
         starknet_types_rpc::L1HandlerTxnReceipt::<Felt> {
             // We have to manually convert the H256 bytes to a hex hash as the
             // impl of Display for H256 skips the middle bytes.
-            message_hash: self.message_hash.as_fixed_bytes().into_iter().map(|b| format!("{b:02x}")).collect(),
+            message_hash,
             common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
                 events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #469

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Correctly converts the `H256` message hash of an `L1HandlerTransactionReceipt` to a `String`.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

No.