### PR TITLE
Fix spelling errors in `l1_gas_price.rs`, `trace.rs`, `l1_db.rs`, and `client.rs`

### DIFF
--- a/crates/madara/client/db/src/l1_db.rs
+++ b/crates/madara/client/db/src/l1_db.rs
@@ -9,7 +9,7 @@ type Result<T, E = MadaraStorageError> = std::result::Result<T, E>;
 
 pub const LAST_SYNCED_L1_EVENT_BLOCK: &[u8] = b"LAST_SYNCED_L1_EVENT_BLOCK";
 
-/// Struct to store block number and event_index where L1->L2 Message occured
+/// Struct to store block number and event_index where L1->L2 Message occurred
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LastSyncedEventBlock {
     pub block_number: u64,

--- a/crates/madara/client/eth/src/client.rs
+++ b/crates/madara/client/eth/src/client.rs
@@ -121,7 +121,7 @@ impl EthereumClient {
     pub async fn get_last_event_block_number<T: SolEvent>(&self) -> anyhow::Result<u64> {
         let latest_block: u64 = self.get_latest_block_number().await?;
 
-        // Assuming an avg Block time of 15sec we check for a LogStateUpdate occurence in the last ~24h
+        // Assuming an avg Block time of 15sec we check for a LogStateUpdate occurrence in the last ~24h
         let filter = Filter::new()
             .from_block(latest_block - 6000)
             .to_block(latest_block)

--- a/crates/madara/client/eth/src/l1_gas_price.rs
+++ b/crates/madara/client/eth/src/l1_gas_price.rs
@@ -25,13 +25,13 @@ pub async fn gas_price_worker_once(
     let last_update_timestamp = l1_gas_provider.get_gas_prices_last_update();
     let duration_since_last_update = SystemTime::now().duration_since(last_update_timestamp)?;
 
-    let last_update_timestemp =
+    let last_update_timestamp =
         last_update_timestamp.duration_since(UNIX_EPOCH).expect("SystemTime before UNIX EPOCH!").as_micros();
     if duration_since_last_update > 10 * gas_price_poll_ms {
         anyhow::bail!(
             "Gas prices have not been updated for {} ms. Last update was at {}",
             duration_since_last_update.as_micros(),
-            last_update_timestemp
+            last_update_timestamp
         );
     }
 

--- a/crates/madara/client/exec/src/trace.rs
+++ b/crates/madara/client/exec/src/trace.rs
@@ -44,7 +44,7 @@ pub fn execution_result_to_tx_trace(
     let fee_transfer_invocation =
         execution_info.fee_transfer_call_info.as_ref().map(try_get_funtion_invocation_from_call_info).transpose()?;
 
-    let computation_resources = agregate_execution_ressources(
+    let computation_resources = aggregate_execution_ressources(
         validate_invocation.as_ref().map(|value| value.execution_resources.clone()).as_ref(),
         execute_function_invocation.as_ref().map(|value| value.execution_resources.clone()).as_ref(),
         fee_transfer_invocation.as_ref().map(|value| value.execution_resources.clone()).as_ref(),
@@ -273,7 +273,7 @@ fn state_diff_is_empty(commitment_state_diff: &CommitmentStateDiff) -> bool {
         && commitment_state_diff.class_hash_to_compiled_class_hash.is_empty()
 }
 
-fn agregate_execution_ressources(
+fn aggregate_execution_ressources(
     a: Option<&starknet_types_rpc::ComputationResources>,
     b: Option<&starknet_types_rpc::ComputationResources>,
     c: Option<&starknet_types_rpc::ComputationResources>,


### PR DESCRIPTION
### Pull Request Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

### What Is the Current Behavior?
This PR corrects multiple spelling errors in comments and function names across different files, improving code clarity and consistency.

### What Is the New Behavior?
- **`l1_db.rs`**:
  - Fixed `occured` → `occurred` in a comment about L1 → L2 message events.

- **`client.rs`**:
  - Fixed `occurence` → `occurrence` in a comment about checking `LogStateUpdate`.

- **`l1_gas_price.rs`**:
  - Fixed `timestemp` → `timestamp` in variable naming for gas price updates.

- **`trace.rs`**:
  - Fixed `agregate_execution_ressources` → `aggregate_execution_ressources` in function definitions and calls.

### Does This Introduce a Breaking Change?
- [ ] Yes
- [x] No

### Other Information
These changes only affect comments and function names, ensuring better readability without modifying core functionality.

### Checklist
- [x] Performed a self-review of the changes.
- [ ] Opened or linked an existing issue if applicable.
