### PR TITLE
fix: fix incorrect handling of contract_address as an array

### DIFF
--- a/tests/js_tests/basic.test.ts
+++ b/tests/js_tests/basic.test.ts
@@ -115,7 +115,7 @@ async function deployContract({ provider, account }: TestContext) {
   await provider.waitForTransaction(deployResult.transaction_hash);
 
   // Add assertion to check if the contract address is valid
-  expect(deployResult.contract_address[0]).toBeTruthy();
+  expect(deployResult.contract_address).toBeTruthy();
 
   // Retrieve the class hash for the deployed contract
   let response = await provider.getClassHashAt(


### PR DESCRIPTION
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

I noticed that `contract_address` was being treated as an array in the code, which caused an issue when trying to access `contract_address[0]`.

Since `contract_address` is actually a string, I've updated the code to correctly check its truthiness.

The fix ensures the test works as intended.  

```javascript
expect(deployResult.contract_address).toBeTruthy();
```  

This change resolves the issue and aligns with the expected data type.

## Does this introduce a breaking change?
no

## Other information

