### PR TITLE
chore(deps): internalize rpc types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
@@ -1427,7 +1427,7 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "thiserror 2.0.3",
 ]
 
@@ -2350,7 +2350,7 @@ dependencies = [
  "rand",
  "sha2",
  "smol_str 0.2.2",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "thiserror 1.0.65",
 ]
 
@@ -2539,7 +2539,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str 0.2.2",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "thiserror 1.0.65",
 ]
 
@@ -2833,7 +2833,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "thiserror 1.0.65",
 ]
 
@@ -2993,7 +2993,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str 0.2.2",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "thiserror 1.0.65",
 ]
 
@@ -3016,7 +3016,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str 0.2.2",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "thiserror 1.0.65",
 ]
 
@@ -3229,7 +3229,7 @@ dependencies = [
  "sha2",
  "sha3",
  "starknet-crypto 0.6.2",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "thiserror-no-std",
  "zip",
 ]
@@ -5492,7 +5492,7 @@ dependencies = [
  "rayon",
  "rstest 0.18.2",
  "serde",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 2.0.3",
@@ -5538,7 +5538,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde_json",
  "starknet-core",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
  "tokio",
@@ -5563,6 +5563,7 @@ dependencies = [
  "mp-chain-config",
  "mp-class",
  "mp-receipt",
+ "mp-rpc",
  "mp-state-update",
  "mp-transactions",
  "mp-utils",
@@ -5575,8 +5576,7 @@ dependencies = [
  "rayon",
  "rocksdb",
  "serde",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 2.0.3",
@@ -5605,6 +5605,7 @@ dependencies = [
  "mp-class",
  "mp-convert",
  "mp-receipt",
+ "mp-rpc",
  "mp-state-update",
  "mp-transactions",
  "opentelemetry",
@@ -5619,8 +5620,7 @@ dependencies = [
  "serde_json",
  "starknet-core",
  "starknet-signers",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "starknet_api",
  "tokio",
  "tracing",
@@ -5642,7 +5642,7 @@ dependencies = [
  "starknet",
  "starknet-core",
  "starknet-providers",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "tempfile",
  "tokio",
  "tracing",
@@ -5679,7 +5679,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 2.0.3",
@@ -5705,6 +5705,7 @@ dependencies = [
  "mp-class",
  "mp-convert",
  "mp-receipt",
+ "mp-rpc",
  "mp-transactions",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -5713,8 +5714,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "rstest 0.18.2",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
  "tokio",
@@ -5740,12 +5740,12 @@ dependencies = [
  "mp-block",
  "mp-class",
  "mp-gateway",
+ "mp-rpc",
  "rstest 0.18.2",
  "serde",
  "serde_json",
  "starknet-core",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -5767,12 +5767,12 @@ dependencies = [
  "mp-block",
  "mp-class",
  "mp-gateway",
+ "mp-rpc",
  "mp-utils",
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "thiserror 2.0.3",
  "tokio",
  "tokio-util",
@@ -5799,6 +5799,7 @@ dependencies = [
  "mp-convert",
  "mp-oracle",
  "mp-receipt",
+ "mp-rpc",
  "mp-state-update",
  "mp-transactions",
  "mp-utils",
@@ -5815,8 +5816,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
  "tokio",
@@ -5847,14 +5847,14 @@ dependencies = [
  "mp-convert",
  "mp-gateway",
  "mp-receipt",
+ "mp-rpc",
  "mp-state-update",
  "mp-transactions",
  "mp-utils",
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
  "tokio",
@@ -5891,7 +5891,7 @@ dependencies = [
  "regex",
  "rstest 0.18.2",
  "serde_json",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 2.0.3",
@@ -6002,6 +6002,7 @@ dependencies = [
  "blockifier",
  "mp-chain-config",
  "mp-receipt",
+ "mp-rpc",
  "mp-transactions",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -6011,8 +6012,7 @@ dependencies = [
  "opentelemetry_sdk",
  "primitive-types",
  "serde",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "thiserror 2.0.3",
  "tracing",
  "tracing-core",
@@ -6033,7 +6033,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
  "tracing",
@@ -6058,13 +6058,13 @@ dependencies = [
  "flate2",
  "lazy_static",
  "mp-convert",
+ "mp-rpc",
  "num-bigint",
  "serde",
  "serde_json",
  "starknet-core",
  "starknet-providers",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "thiserror 2.0.3",
  "tokio",
 ]
@@ -6079,7 +6079,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "starknet-core",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
 ]
@@ -6098,6 +6098,7 @@ dependencies = [
  "mp-class",
  "mp-convert",
  "mp-receipt",
+ "mp-rpc",
  "mp-state-update",
  "mp-transactions",
  "primitive-types",
@@ -6106,8 +6107,7 @@ dependencies = [
  "serde_with",
  "sha3",
  "starknet-core",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "thiserror 2.0.3",
  "url",
 ]
@@ -6130,15 +6130,25 @@ dependencies = [
  "bincode 1.3.3",
  "blockifier",
  "cairo-vm",
+ "mp-rpc",
  "primitive-types",
  "rstest 0.18.2",
  "serde",
  "starknet-core",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
  "tracing",
+]
+
+[[package]]
+name = "mp-rpc"
+version = "0.7.0"
+dependencies = [
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -6147,9 +6157,9 @@ version = "0.7.0"
 dependencies = [
  "bincode 1.3.3",
  "mp-convert",
+ "mp-rpc",
  "serde",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -6166,13 +6176,13 @@ dependencies = [
  "mp-chain-config",
  "mp-class",
  "mp-convert",
+ "mp-rpc",
  "num-bigint",
  "serde",
  "serde_json",
  "serde_with",
  "starknet-core",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
- "starknet-types-rpc",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.3",
  "tracing",
@@ -6201,7 +6211,7 @@ dependencies = [
  "serde_yaml",
  "starknet-core",
  "starknet-crypto 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8250,7 +8260,7 @@ dependencies = [
  "serde_with",
  "sha3",
  "starknet-crypto 0.7.2 (git+https://github.com/kasarlabs/starknet-rs.git?branch=fork)",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -8308,7 +8318,7 @@ dependencies = [
  "rfc6979",
  "sha2",
  "starknet-curve 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "zeroize",
 ]
 
@@ -8326,7 +8336,7 @@ dependencies = [
  "rfc6979",
  "sha2",
  "starknet-curve 0.5.1 (git+https://github.com/kasarlabs/starknet-rs.git?branch=fork)",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "zeroize",
 ]
 
@@ -8365,7 +8375,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
 dependencies = [
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -8373,7 +8383,7 @@ name = "starknet-curve"
 version = "0.5.1"
 source = "git+https://github.com/kasarlabs/starknet-rs.git?branch=fork#70e1ee45dc701afc2a7629bf88bb5d90a93d51a7"
 dependencies = [
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -8453,28 +8463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-types-core"
-version = "0.1.7"
-source = "git+https://github.com/jbcaron/types-rs.git?branch=fork#570eb3eb21d64afef90242c9e5132c1e58b6b62c"
-dependencies = [
- "lambdaworks-crypto",
- "lambdaworks-math",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.19",
- "serde",
-]
-
-[[package]]
-name = "starknet-types-rpc"
-version = "0.7.1"
-source = "git+https://github.com/jbcaron/types-rs.git?branch=fork#570eb3eb21d64afef90242c9e5132c1e58b6b62c"
-dependencies = [
- "serde",
- "starknet-types-core 0.1.7 (git+https://github.com/jbcaron/types-rs.git?branch=fork)",
-]
-
-[[package]]
 name = "starknet_api"
 version = "0.13.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8492,7 +8480,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-crypto 0.5.2",
- "starknet-types-core 0.1.7 (git+https://github.com/kasarlabs/types-rs.git?branch=feat-deserialize-v0.1.7)",
+ "starknet-types-core",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "thiserror 1.0.65",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "crates/madara/primitives/transactions",
   "crates/madara/primitives/class",
   "crates/madara/primitives/gateway",
+  "crates/madara/primitives/rpc",
   "crates/madara/primitives/receipt",
   "crates/madara/primitives/state_update",
   "crates/madara/primitives/chain_config",
@@ -50,6 +51,7 @@ default-members = [
   "crates/madara/primitives/transactions",
   "crates/madara/primitives/class",
   "crates/madara/primitives/gateway",
+  "crates/madara/primitives/rpc",
   "crates/madara/primitives/receipt",
   "crates/madara/primitives/state_update",
   "crates/madara/primitives/chain_config",
@@ -114,6 +116,7 @@ mp-convert = { path = "crates/madara/primitives/convert", default-features = fal
 mp-transactions = { path = "crates/madara/primitives/transactions", default-features = false }
 mp-class = { path = "crates/madara/primitives/class", default-features = false }
 mp-gateway = { path = "crates/madara/primitives/gateway", default-features = false }
+mp-rpc = { path = "crates/madara/primitives/rpc", default-features = false }
 mp-receipt = { path = "crates/madara/primitives/receipt", default-features = false }
 mp-state-update = { path = "crates/madara/primitives/state_update", default-features = false }
 mp-utils = { path = "crates/madara/primitives/utils", default-features = false }
@@ -149,7 +152,6 @@ starknet = "0.12.0"
 starknet-types-core = { version = "0.1.7", default-features = false, features = [
   "hash",
 ] }
-starknet-types-rpc = "0.7.1"
 
 blockifier = "=0.8.0"
 starknet_api = "=0.13.0-rc.1"
@@ -271,6 +273,5 @@ rocksdb = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "r
 librocksdb-sys = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
 
 starknet-types-core = { git = "https://github.com/kasarlabs/types-rs.git", branch = "feat-deserialize-v0.1.7" }
-starknet-types-rpc = { git = "https://github.com/jbcaron/types-rs.git", branch = "fork" }
 
 starknet-core = { git = "https://github.com/kasarlabs/starknet-rs.git", branch = "fork" }

--- a/crates/madara/client/db/Cargo.toml
+++ b/crates/madara/client/db/Cargo.toml
@@ -24,6 +24,7 @@ mp-block = { workspace = true }
 mp-chain-config = { workspace = true }
 mp-class = { workspace = true }
 mp-receipt = { workspace = true }
+mp-rpc = { workspace = true }
 mp-state-update = { workspace = true }
 mp-transactions = { workspace = true }
 mp-utils = { workspace = true }
@@ -32,7 +33,6 @@ mp-utils = { workspace = true }
 blockifier = { workspace = true }
 bonsai-trie = { workspace = true }
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 starknet_api = { workspace = true }
 
 # Other

--- a/crates/madara/client/db/src/block_db.rs
+++ b/crates/madara/client/db/src/block_db.rs
@@ -8,11 +8,11 @@ use mp_block::{
     BlockId, BlockTag, MadaraBlock, MadaraBlockInfo, MadaraBlockInner, MadaraMaybePendingBlock,
     MadaraMaybePendingBlockInfo, MadaraPendingBlock, MadaraPendingBlockInfo, VisitedSegments,
 };
+use mp_rpc::EmittedEvent;
 use mp_state_update::StateDiff;
 use rocksdb::WriteOptions;
 use starknet_api::core::ChainId;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::EmittedEvent;
 
 type Result<T, E = MadaraStorageError> = std::result::Result<T, E>;
 
@@ -431,7 +431,7 @@ impl MadaraBackend {
     }
 
     #[tracing::instrument(skip(self), fields(module = "BlockDB"))]
-    pub fn subscribe_events(&self, from_address: Option<Felt>) -> tokio::sync::broadcast::Receiver<EmittedEvent<Felt>> {
+    pub fn subscribe_events(&self, from_address: Option<Felt>) -> tokio::sync::broadcast::Receiver<EmittedEvent> {
         self.sender_event.subscribe(from_address)
     }
 

--- a/crates/madara/client/db/src/lib.rs
+++ b/crates/madara/client/db/src/lib.rs
@@ -6,6 +6,7 @@ use bonsai_db::{BonsaiDb, DatabaseKeyMapping};
 use bonsai_trie::{BonsaiStorage, BonsaiStorageConfig};
 use db_metrics::DbMetrics;
 use mp_chain_config::ChainConfig;
+use mp_rpc::EmittedEvent;
 use mp_utils::service::{MadaraServiceId, PowerOfTwo, Service, ServiceId};
 use rocksdb::backup::{BackupEngine, BackupEngineOptions};
 use rocksdb::{
@@ -15,7 +16,6 @@ use rocksdb_options::rocksdb_global_options;
 use snapshots::Snapshots;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Pedersen, Poseidon, StarkHash};
-use starknet_types_rpc::EmittedEvent;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, fs};
@@ -291,10 +291,10 @@ impl Default for TrieLogConfig {
 /// by subscribing to the corresponding channel.
 pub struct EventChannels {
     /// Broadcast channel that receives all events regardless of their sender's address
-    all_channels: tokio::sync::broadcast::Sender<EmittedEvent<Felt>>,
+    all_channels: tokio::sync::broadcast::Sender<EmittedEvent>,
     /// Array of 16 broadcast channels, each handling events from a subset of sender addresses
     /// The target channel for an event is determined by the sender's address mapping
-    specific_channels: [tokio::sync::broadcast::Sender<EmittedEvent<Felt>>; 16],
+    specific_channels: [tokio::sync::broadcast::Sender<EmittedEvent>; 16],
 }
 
 impl EventChannels {
@@ -344,7 +344,7 @@ impl EventChannels {
     /// 2. Subscribes to the corresponding specific channel
     ///
     /// This means you'll receive events from all senders whose addresses map to the same channel
-    pub fn subscribe(&self, from_address: Option<Felt>) -> tokio::sync::broadcast::Receiver<EmittedEvent<Felt>> {
+    pub fn subscribe(&self, from_address: Option<Felt>) -> tokio::sync::broadcast::Receiver<EmittedEvent> {
         match from_address {
             Some(address) => {
                 let channel_index = self.calculate_channel_index(&address);
@@ -366,8 +366,8 @@ impl EventChannels {
     /// * `Err` - If the event couldn't be sent
     pub fn publish(
         &self,
-        event: EmittedEvent<Felt>,
-    ) -> Result<usize, Box<tokio::sync::broadcast::error::SendError<EmittedEvent<Felt>>>> {
+        event: EmittedEvent,
+    ) -> Result<usize, Box<tokio::sync::broadcast::error::SendError<EmittedEvent>>> {
         let channel_index = self.calculate_channel_index(&event.event.from_address);
         let specific_channel = &self.specific_channels[channel_index];
 

--- a/crates/madara/client/devnet/Cargo.toml
+++ b/crates/madara/client/devnet/Cargo.toml
@@ -40,6 +40,7 @@ mp-chain-config.workspace = true
 mp-class.workspace = true
 mp-convert.workspace = true
 mp-receipt.workspace = true
+mp-rpc.workspace = true
 mp-state-update.workspace = true
 mp-transactions.workspace = true
 
@@ -48,7 +49,6 @@ blockifier.workspace = true
 starknet-core.workspace = true
 starknet-signers.workspace = true
 starknet-types-core.workspace = true
-starknet-types-rpc.workspace = true
 starknet_api.workspace = true
 
 # Other

--- a/crates/madara/client/devnet/src/lib.rs
+++ b/crates/madara/client/devnet/src/lib.rs
@@ -195,15 +195,15 @@ mod tests {
     use mp_class::{ClassInfo, FlattenedSierraClass};
 
     use mp_receipt::{Event, ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, TransactionReceipt};
-    use mp_transactions::compute_hash::calculate_contract_address;
-    use mp_transactions::BroadcastedTransactionExt;
-    use rstest::{fixture, rstest};
-    use starknet_core::types::contract::SierraClass;
-    use starknet_types_rpc::{
+    use mp_rpc::{
         AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeclareTxnV3, BroadcastedDeployAccountTxn,
         BroadcastedInvokeTxn, BroadcastedTxn, ClassAndTxnHash, ContractAndTxnHash, DaMode, DeployAccountTxnV3,
         InvokeTxnV3, ResourceBounds, ResourceBoundsMapping,
     };
+    use mp_transactions::compute_hash::calculate_contract_address;
+    use mp_transactions::BroadcastedTransactionExt;
+    use rstest::{fixture, rstest};
+    use starknet_core::types::contract::SierraClass;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -217,9 +217,9 @@ mod tests {
     impl DevnetForTesting {
         pub fn sign_and_add_invoke_tx(
             &self,
-            mut tx: BroadcastedInvokeTxn<Felt>,
+            mut tx: BroadcastedInvokeTxn,
             contract: &DevnetPredeployedContract,
-        ) -> Result<AddInvokeTransactionResult<Felt>, mc_mempool::MempoolError> {
+        ) -> Result<AddInvokeTransactionResult, mc_mempool::MempoolError> {
             let (blockifier_tx, _classes) = BroadcastedTxn::Invoke(tx.clone())
                 .into_blockifier(
                     self.backend.chain_config().chain_id.to_felt(),
@@ -243,9 +243,9 @@ mod tests {
 
         pub fn sign_and_add_declare_tx(
             &self,
-            mut tx: BroadcastedDeclareTxn<Felt>,
+            mut tx: BroadcastedDeclareTxn,
             contract: &DevnetPredeployedContract,
-        ) -> Result<ClassAndTxnHash<Felt>, mc_mempool::MempoolError> {
+        ) -> Result<ClassAndTxnHash, mc_mempool::MempoolError> {
             let (blockifier_tx, _classes) = BroadcastedTxn::Declare(tx.clone())
                 .into_blockifier(
                     self.backend.chain_config().chain_id.to_felt(),
@@ -267,9 +267,9 @@ mod tests {
 
         pub fn sign_and_add_deploy_account_tx(
             &self,
-            mut tx: BroadcastedDeployAccountTxn<Felt>,
+            mut tx: BroadcastedDeployAccountTxn,
             contract: &DevnetPredeployedContract,
-        ) -> Result<ContractAndTxnHash<Felt>, mc_mempool::MempoolError> {
+        ) -> Result<ContractAndTxnHash, mc_mempool::MempoolError> {
             let (blockifier_tx, _classes) = BroadcastedTxn::DeployAccount(tx.clone())
                 .into_blockifier(
                     self.backend.chain_config().chain_id.to_felt(),
@@ -363,7 +363,7 @@ mod tests {
         let compiled_contract_class_hash =
             Felt::from_hex("0x0138105ded3d2e4ea1939a0bc106fb80fd8774c9eb89c1890d4aeac88e6a1b27").unwrap();
 
-        let declare_txn: BroadcastedDeclareTxn<Felt> = BroadcastedDeclareTxn::V3(BroadcastedDeclareTxnV3 {
+        let declare_txn: BroadcastedDeclareTxn = BroadcastedDeclareTxn::V3(BroadcastedDeclareTxnV3 {
             sender_address: sender_address.address,
             compiled_class_hash: compiled_contract_class_hash,
             signature: vec![],

--- a/crates/madara/client/exec/Cargo.toml
+++ b/crates/madara/client/exec/Cargo.toml
@@ -23,13 +23,13 @@ mp-chain-config = { workspace = true }
 mp-class = { workspace = true }
 mp-convert = { workspace = true }
 mp-receipt = { workspace = true }
+mp-rpc = { workspace = true }
 mp-transactions = { workspace = true }
 
 # Starknet
 blockifier = { workspace = true }
 cairo-vm = { workspace = true }
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 starknet_api = { workspace = true }
 
 # Other

--- a/crates/madara/client/exec/src/fee.rs
+++ b/crates/madara/client/exec/src/fee.rs
@@ -1,12 +1,8 @@
 use crate::{ExecutionContext, ExecutionResult};
 use blockifier::transaction::objects::FeeType;
-use starknet_types_core::felt::Felt;
 
 impl ExecutionContext {
-    pub fn execution_result_to_fee_estimate(
-        &self,
-        executions_result: &ExecutionResult,
-    ) -> starknet_types_rpc::FeeEstimate<Felt> {
+    pub fn execution_result_to_fee_estimate(&self, executions_result: &ExecutionResult) -> mp_rpc::FeeEstimate {
         let gas_price =
             self.block_context.block_info().gas_prices.get_gas_price_by_fee_type(&executions_result.fee_type).get();
         let data_gas_price = self
@@ -28,10 +24,10 @@ impl ExecutionContext {
             gas_consumed.saturating_mul(gas_price).saturating_add(data_gas_consumed.saturating_mul(data_gas_price));
 
         let unit = match executions_result.fee_type {
-            FeeType::Eth => starknet_types_rpc::PriceUnit::Wei,
-            FeeType::Strk => starknet_types_rpc::PriceUnit::Fri,
+            FeeType::Eth => mp_rpc::PriceUnit::Wei,
+            FeeType::Strk => mp_rpc::PriceUnit::Fri,
         };
-        starknet_types_rpc::FeeEstimate {
+        mp_rpc::FeeEstimate {
             gas_consumed: gas_consumed.into(),
             gas_price: gas_price.into(),
             data_gas_consumed: data_gas_consumed.into(),

--- a/crates/madara/client/gateway/client/Cargo.toml
+++ b/crates/madara/client/gateway/client/Cargo.toml
@@ -20,11 +20,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 mp-block.workspace = true
 mp-class.workspace = true
 mp-gateway.workspace = true
+mp-rpc.workspace = true
 
 # Starknet
 starknet-core.workspace = true
 starknet-types-core.workspace = true
-starknet-types-rpc.workspace = true
 
 # Other
 anyhow.workspace = true

--- a/crates/madara/client/gateway/client/src/methods.rs
+++ b/crates/madara/client/gateway/client/src/methods.rs
@@ -13,11 +13,11 @@ use mp_gateway::{
         UserDeclareTransaction, UserDeployAccountTransaction, UserInvokeFunctionTransaction, UserTransaction,
     },
 };
+use mp_rpc::{AddInvokeTransactionResult, ClassAndTxnHash, ContractAndTxnHash};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use starknet_core::types::contract::legacy::LegacyContractClass;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{AddInvokeTransactionResult, ClassAndTxnHash, ContractAndTxnHash};
 
 use super::{builder::GatewayProvider, request_builder::RequestBuilder};
 
@@ -122,21 +122,21 @@ impl GatewayProvider {
     pub async fn add_invoke_transaction(
         &self,
         transaction: UserInvokeFunctionTransaction,
-    ) -> Result<AddInvokeTransactionResult<Felt>, SequencerError> {
+    ) -> Result<AddInvokeTransactionResult, SequencerError> {
         self.add_transaction(UserTransaction::InvokeFunction(transaction)).await
     }
 
     pub async fn add_declare_transaction(
         &self,
         transaction: UserDeclareTransaction,
-    ) -> Result<ClassAndTxnHash<Felt>, SequencerError> {
+    ) -> Result<ClassAndTxnHash, SequencerError> {
         self.add_transaction(UserTransaction::Declare(transaction)).await
     }
 
     pub async fn add_deploy_account_transaction(
         &self,
         transaction: UserDeployAccountTransaction,
-    ) -> Result<ContractAndTxnHash<Felt>, SequencerError> {
+    ) -> Result<ContractAndTxnHash, SequencerError> {
         self.add_transaction(UserTransaction::DeployAccount(transaction)).await
     }
 }

--- a/crates/madara/client/gateway/server/Cargo.toml
+++ b/crates/madara/client/gateway/server/Cargo.toml
@@ -22,11 +22,11 @@ mc-rpc.workspace = true
 mp-block.workspace = true
 mp-class.workspace = true
 mp-gateway.workspace = true
+mp-rpc.workspace = true
 mp-utils.workspace = true
 
 # Starknet
 starknet-types-core.workspace = true
-starknet-types-rpc.workspace = true
 
 # Other
 anyhow.workspace = true

--- a/crates/madara/client/gateway/server/src/handler.rs
+++ b/crates/madara/client/gateway/server/src/handler.rs
@@ -20,11 +20,11 @@ use mp_gateway::{
     block::{BlockStatus, ProviderBlock, ProviderBlockPending, ProviderBlockSignature},
     state_update::{ProviderStateUpdate, ProviderStateUpdatePending},
 };
+use mp_rpc::{BroadcastedDeclareTxn, TraceBlockTransactionsResult};
 use mp_utils::service::ServiceContext;
 use serde::Serialize;
 use serde_json::json;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{BroadcastedDeclareTxn, TraceBlockTransactionsResult};
 
 use super::{
     error::{GatewayError, OptionExt, ResultExt},
@@ -238,7 +238,7 @@ pub async fn handle_get_block_traces(
 
     #[derive(Serialize)]
     struct BlockTraces {
-        traces: Vec<TraceBlockTransactionsResult<Felt>>,
+        traces: Vec<TraceBlockTransactionsResult>,
     }
 
     let traces = v0_7_1_trace_block_transactions(
@@ -350,7 +350,7 @@ async fn declare_transaction(
     tx: UserDeclareTransaction,
     add_transaction_provider: Arc<dyn AddTransactionProvider>,
 ) -> Response<String> {
-    let tx: BroadcastedDeclareTxn<Felt> = match tx.try_into() {
+    let tx: BroadcastedDeclareTxn = match tx.try_into() {
         Ok(tx) => tx,
         Err(e) => {
             let error = StarknetError::new(StarknetErrorCode::InvalidContractDefinition, e.to_string());

--- a/crates/madara/client/mempool/Cargo.toml
+++ b/crates/madara/client/mempool/Cargo.toml
@@ -48,6 +48,7 @@ mp-class.workspace = true
 mp-convert.workspace = true
 mp-oracle.workspace = true
 mp-receipt.workspace = true
+mp-rpc.workspace = true
 mp-state-update.workspace = true
 mp-transactions.workspace = true
 mp-utils.workspace = true
@@ -55,7 +56,6 @@ mp-utils.workspace = true
 # Starknet
 blockifier.workspace = true
 starknet-types-core.workspace = true
-starknet-types-rpc.workspace = true
 starknet_api.workspace = true
 
 # Other

--- a/crates/madara/client/rpc/Cargo.toml
+++ b/crates/madara/client/rpc/Cargo.toml
@@ -34,6 +34,7 @@ mp-class = { workspace = true }
 mp-convert = { workspace = true, default-features = true }
 mp-gateway = { workspace = true }
 mp-receipt = { workspace = true }
+mp-rpc = { workspace = true }
 mp-state-update = { workspace = true }
 mp-transactions = { workspace = true }
 mp-utils = { workspace = true }
@@ -41,7 +42,6 @@ mp-utils = { workspace = true }
 # Starknet
 blockifier = { workspace = true, default-features = true }
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 starknet_api = { workspace = true, default-features = true }
 
 # Others

--- a/crates/madara/client/rpc/src/providers/forward_to_provider.rs
+++ b/crates/madara/client/rpc/src/providers/forward_to_provider.rs
@@ -2,12 +2,11 @@ use crate::{bail_internal_server_error, errors::StarknetRpcApiError};
 use jsonrpsee::core::{async_trait, RpcResult};
 use mc_gateway_client::GatewayProvider;
 use mp_gateway::error::SequencerError;
-use mp_transactions::BroadcastedDeclareTransactionV0;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
     ClassAndTxnHash, ContractAndTxnHash,
 };
+use mp_transactions::BroadcastedDeclareTransactionV0;
 
 use super::AddTransactionProvider;
 
@@ -26,13 +25,10 @@ impl AddTransactionProvider for ForwardToProvider {
     async fn add_declare_v0_transaction(
         &self,
         _declare_v0_transaction: BroadcastedDeclareTransactionV0,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    ) -> RpcResult<ClassAndTxnHash> {
         Err(StarknetRpcApiError::UnimplementedMethod.into())
     }
-    async fn add_declare_transaction(
-        &self,
-        declare_transaction: BroadcastedDeclareTxn<Felt>,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    async fn add_declare_transaction(&self, declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash> {
         let sequencer_response = match self
             .provider
             .add_declare_transaction(declare_transaction.try_into().map_err(StarknetRpcApiError::from)?)
@@ -49,8 +45,8 @@ impl AddTransactionProvider for ForwardToProvider {
     }
     async fn add_deploy_account_transaction(
         &self,
-        deploy_account_transaction: BroadcastedDeployAccountTxn<Felt>,
-    ) -> RpcResult<ContractAndTxnHash<Felt>> {
+        deploy_account_transaction: BroadcastedDeployAccountTxn,
+    ) -> RpcResult<ContractAndTxnHash> {
         let sequencer_response = match self
             .provider
             .add_deploy_account_transaction(deploy_account_transaction.try_into().map_err(StarknetRpcApiError::from)?)
@@ -68,8 +64,8 @@ impl AddTransactionProvider for ForwardToProvider {
 
     async fn add_invoke_transaction(
         &self,
-        invoke_transaction: BroadcastedInvokeTxn<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult<Felt>> {
+        invoke_transaction: BroadcastedInvokeTxn,
+    ) -> RpcResult<AddInvokeTransactionResult> {
         let sequencer_response = match self
             .provider
             .add_invoke_transaction(invoke_transaction.try_into().map_err(StarknetRpcApiError::from)?)

--- a/crates/madara/client/rpc/src/providers/mempool.rs
+++ b/crates/madara/client/rpc/src/providers/mempool.rs
@@ -3,12 +3,11 @@ use crate::{errors::StarknetRpcApiError, utils::display_internal_server_error};
 use jsonrpsee::core::{async_trait, RpcResult};
 use mc_mempool::Mempool;
 use mc_mempool::MempoolProvider;
-use mp_transactions::BroadcastedDeclareTransactionV0;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::AddInvokeTransactionResult;
-use starknet_types_rpc::{
+use mp_rpc::AddInvokeTransactionResult;
+use mp_rpc::{
     BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, ClassAndTxnHash, ContractAndTxnHash,
 };
+use mp_transactions::BroadcastedDeclareTransactionV0;
 use std::sync::Arc;
 
 /// This [`AddTransactionProvider`] adds the received transactions to a mempool.
@@ -57,25 +56,22 @@ impl AddTransactionProvider for MempoolAddTxProvider {
     async fn add_declare_v0_transaction(
         &self,
         declare_v0_transaction: BroadcastedDeclareTransactionV0,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    ) -> RpcResult<ClassAndTxnHash> {
         Ok(self.mempool.tx_accept_declare_v0(declare_v0_transaction).map_err(StarknetRpcApiError::from)?)
     }
-    async fn add_declare_transaction(
-        &self,
-        declare_transaction: BroadcastedDeclareTxn<Felt>,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    async fn add_declare_transaction(&self, declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash> {
         Ok(self.mempool.tx_accept_declare(declare_transaction).map_err(StarknetRpcApiError::from)?)
     }
     async fn add_deploy_account_transaction(
         &self,
-        deploy_account_transaction: BroadcastedDeployAccountTxn<Felt>,
-    ) -> RpcResult<ContractAndTxnHash<Felt>> {
+        deploy_account_transaction: BroadcastedDeployAccountTxn,
+    ) -> RpcResult<ContractAndTxnHash> {
         Ok(self.mempool.tx_accept_deploy_account(deploy_account_transaction).map_err(StarknetRpcApiError::from)?)
     }
     async fn add_invoke_transaction(
         &self,
-        invoke_transaction: BroadcastedInvokeTxn<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult<Felt>> {
+        invoke_transaction: BroadcastedInvokeTxn,
+    ) -> RpcResult<AddInvokeTransactionResult> {
         Ok(self.mempool.tx_accept_invoke(invoke_transaction).map_err(StarknetRpcApiError::from)?)
     }
 }

--- a/crates/madara/client/rpc/src/providers/mod.rs
+++ b/crates/madara/client/rpc/src/providers/mod.rs
@@ -7,13 +7,12 @@ pub use forward_to_provider::*;
 pub use mempool::*;
 
 use jsonrpsee::core::{async_trait, RpcResult};
-use mp_transactions::BroadcastedDeclareTransactionV0;
-use mp_utils::service::{MadaraServiceId, ServiceContext};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
     ClassAndTxnHash, ContractAndTxnHash,
 };
+use mp_transactions::BroadcastedDeclareTransactionV0;
+use mp_utils::service::{MadaraServiceId, ServiceContext};
 
 use crate::utils::OptionExt;
 
@@ -22,21 +21,18 @@ pub trait AddTransactionProvider: Send + Sync {
     async fn add_declare_v0_transaction(
         &self,
         declare_v0_transaction: BroadcastedDeclareTransactionV0,
-    ) -> RpcResult<ClassAndTxnHash<Felt>>;
-    async fn add_declare_transaction(
-        &self,
-        declare_transaction: BroadcastedDeclareTxn<Felt>,
-    ) -> RpcResult<ClassAndTxnHash<Felt>>;
+    ) -> RpcResult<ClassAndTxnHash>;
+    async fn add_declare_transaction(&self, declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash>;
 
     async fn add_deploy_account_transaction(
         &self,
-        deploy_account_transaction: BroadcastedDeployAccountTxn<Felt>,
-    ) -> RpcResult<ContractAndTxnHash<Felt>>;
+        deploy_account_transaction: BroadcastedDeployAccountTxn,
+    ) -> RpcResult<ContractAndTxnHash>;
 
     async fn add_invoke_transaction(
         &self,
-        invoke_transaction: BroadcastedInvokeTxn<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult<Felt>>;
+        invoke_transaction: BroadcastedInvokeTxn,
+    ) -> RpcResult<AddInvokeTransactionResult>;
 }
 
 /// A simple struct whose sole purpose is to toggle between a L2 sync and local
@@ -87,24 +83,21 @@ impl AddTransactionProvider for AddTransactionProviderGroup {
     async fn add_declare_v0_transaction(
         &self,
         declare_v0_transaction: BroadcastedDeclareTransactionV0,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    ) -> RpcResult<ClassAndTxnHash> {
         self.provider()
             .ok_or_internal_server_error(Self::ERROR)?
             .add_declare_v0_transaction(declare_v0_transaction)
             .await
     }
 
-    async fn add_declare_transaction(
-        &self,
-        declare_transaction: BroadcastedDeclareTxn<Felt>,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    async fn add_declare_transaction(&self, declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash> {
         self.provider().ok_or_internal_server_error(Self::ERROR)?.add_declare_transaction(declare_transaction).await
     }
 
     async fn add_deploy_account_transaction(
         &self,
-        deploy_account_transaction: BroadcastedDeployAccountTxn<Felt>,
-    ) -> RpcResult<ContractAndTxnHash<Felt>> {
+        deploy_account_transaction: BroadcastedDeployAccountTxn,
+    ) -> RpcResult<ContractAndTxnHash> {
         self.provider()
             .ok_or_internal_server_error(Self::ERROR)?
             .add_deploy_account_transaction(deploy_account_transaction)
@@ -113,8 +106,8 @@ impl AddTransactionProvider for AddTransactionProviderGroup {
 
     async fn add_invoke_transaction(
         &self,
-        invoke_transaction: BroadcastedInvokeTxn<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult<Felt>> {
+        invoke_transaction: BroadcastedInvokeTxn,
+    ) -> RpcResult<AddInvokeTransactionResult> {
         self.provider().ok_or_internal_server_error(Self::ERROR)?.add_invoke_transaction(invoke_transaction).await
     }
 }

--- a/crates/madara/client/rpc/src/test_utils.rs
+++ b/crates/madara/client/rpc/src/test_utils.rs
@@ -9,6 +9,10 @@ use mp_chain_config::{ChainConfig, StarknetVersion};
 use mp_receipt::{
     ExecutionResources, ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, TransactionReceipt,
 };
+use mp_rpc::{
+    AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
+    ClassAndTxnHash, ContractAndTxnHash, TxnReceipt, TxnWithHash,
+};
 use mp_state_update::{
     ContractStorageDiffItem, DeclaredClassItem, DeployedContractItem, NonceUpdate, ReplacedClassItem, StateDiff,
     StorageEntry,
@@ -17,10 +21,6 @@ use mp_transactions::{BroadcastedDeclareTransactionV0, InvokeTransaction, Invoke
 use mp_utils::service::ServiceContext;
 use rstest::fixture;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
-    AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
-    ClassAndTxnHash, ContractAndTxnHash, TxnReceipt, TxnWithHash,
-};
 use std::sync::Arc;
 
 use crate::{providers::AddTransactionProvider, Starknet};
@@ -34,25 +34,22 @@ impl AddTransactionProvider for TestTransactionProvider {
     async fn add_declare_v0_transaction(
         &self,
         _declare_v0_transaction: BroadcastedDeclareTransactionV0,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    ) -> RpcResult<ClassAndTxnHash> {
         unimplemented!()
     }
-    async fn add_declare_transaction(
-        &self,
-        _declare_transaction: BroadcastedDeclareTxn<Felt>,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    async fn add_declare_transaction(&self, _declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash> {
         unimplemented!()
     }
     async fn add_deploy_account_transaction(
         &self,
-        _deploy_account_transaction: BroadcastedDeployAccountTxn<Felt>,
-    ) -> RpcResult<ContractAndTxnHash<Felt>> {
+        _deploy_account_transaction: BroadcastedDeployAccountTxn,
+    ) -> RpcResult<ContractAndTxnHash> {
         unimplemented!()
     }
     async fn add_invoke_transaction(
         &self,
-        _invoke_transaction: BroadcastedInvokeTxn<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult<Felt>> {
+        _invoke_transaction: BroadcastedInvokeTxn,
+    ) -> RpcResult<AddInvokeTransactionResult> {
         unimplemented!()
     }
 }
@@ -74,8 +71,8 @@ pub fn rpc_test_setup() -> (Arc<MadaraBackend>, Starknet) {
 pub struct SampleChainForBlockGetters {
     pub block_hashes: Vec<Felt>,
     pub tx_hashes: Vec<Felt>,
-    pub expected_txs: Vec<starknet_types_rpc::TxnWithHash<Felt>>,
-    pub expected_receipts: Vec<TxnReceipt<Felt>>,
+    pub expected_txs: Vec<mp_rpc::TxnWithHash>,
+    pub expected_receipts: Vec<TxnReceipt>,
 }
 
 #[fixture]
@@ -96,7 +93,7 @@ pub fn make_sample_chain_for_block_getters(backend: &MadaraBackend) -> SampleCha
         Felt::from_hex_unchecked("0xdd84847784"),
     ];
     let expected_txs = {
-        use starknet_types_rpc::{InvokeTxn, InvokeTxnV0, Txn};
+        use mp_rpc::{InvokeTxn, InvokeTxnV0, Txn};
         vec![
             TxnWithHash {
                 transaction: Txn::Invoke(InvokeTxn::V0(InvokeTxnV0 {
@@ -141,11 +138,9 @@ pub fn make_sample_chain_for_block_getters(backend: &MadaraBackend) -> SampleCha
         ]
     };
     let expected_receipts = {
-        use starknet_types_rpc::{
-            CommonReceiptProperties, FeePayment, InvokeTxnReceipt, PriceUnit, TxnFinalityStatus, TxnReceipt,
-        };
+        use mp_rpc::{CommonReceiptProperties, FeePayment, InvokeTxnReceipt, PriceUnit, TxnFinalityStatus, TxnReceipt};
         vec![
-            TxnReceipt::<Felt>::Invoke(InvokeTxnReceipt {
+            TxnReceipt::Invoke(InvokeTxnReceipt {
                 common_receipt_properties: CommonReceiptProperties {
                     transaction_hash: Felt::from_hex_unchecked("0x8888888"),
                     actual_fee: FeePayment { amount: Felt::from_hex_unchecked("0x9"), unit: PriceUnit::Wei },
@@ -153,10 +148,10 @@ pub fn make_sample_chain_for_block_getters(backend: &MadaraBackend) -> SampleCha
                     events: vec![],
                     execution_resources: defaut_execution_resources(),
                     finality_status: TxnFinalityStatus::L1,
-                    execution_status: starknet_types_rpc::ExecutionStatus::Successful,
+                    execution_status: mp_rpc::ExecutionStatus::Successful,
                 },
             }),
-            TxnReceipt::<Felt>::Invoke(InvokeTxnReceipt {
+            TxnReceipt::Invoke(InvokeTxnReceipt {
                 common_receipt_properties: CommonReceiptProperties {
                     transaction_hash: Felt::from_hex_unchecked("0xdd848484"),
                     actual_fee: FeePayment { amount: Felt::from_hex_unchecked("0x94"), unit: PriceUnit::Wei },
@@ -164,10 +159,10 @@ pub fn make_sample_chain_for_block_getters(backend: &MadaraBackend) -> SampleCha
                     events: vec![],
                     execution_resources: defaut_execution_resources(),
                     finality_status: TxnFinalityStatus::L2,
-                    execution_status: starknet_types_rpc::ExecutionStatus::Successful,
+                    execution_status: mp_rpc::ExecutionStatus::Successful,
                 },
             }),
-            TxnReceipt::<Felt>::Invoke(InvokeTxnReceipt {
+            TxnReceipt::Invoke(InvokeTxnReceipt {
                 common_receipt_properties: CommonReceiptProperties {
                     transaction_hash: Felt::from_hex_unchecked("0xdd84848407"),
                     actual_fee: FeePayment { amount: Felt::from_hex_unchecked("0x94dd"), unit: PriceUnit::Fri },
@@ -175,10 +170,10 @@ pub fn make_sample_chain_for_block_getters(backend: &MadaraBackend) -> SampleCha
                     events: vec![],
                     execution_resources: defaut_execution_resources(),
                     finality_status: TxnFinalityStatus::L2,
-                    execution_status: starknet_types_rpc::ExecutionStatus::Reverted("too bad".into()),
+                    execution_status: mp_rpc::ExecutionStatus::Reverted("too bad".into()),
                 },
             }),
-            TxnReceipt::<Felt>::Invoke(InvokeTxnReceipt {
+            TxnReceipt::Invoke(InvokeTxnReceipt {
                 common_receipt_properties: CommonReceiptProperties {
                     transaction_hash: Felt::from_hex_unchecked("0xdd84847784"),
                     actual_fee: FeePayment { amount: Felt::from_hex_unchecked("0x94"), unit: PriceUnit::Wei },
@@ -186,7 +181,7 @@ pub fn make_sample_chain_for_block_getters(backend: &MadaraBackend) -> SampleCha
                     events: vec![],
                     execution_resources: defaut_execution_resources(),
                     finality_status: TxnFinalityStatus::L2,
-                    execution_status: starknet_types_rpc::ExecutionStatus::Successful,
+                    execution_status: mp_rpc::ExecutionStatus::Successful,
                 },
             }),
         ]
@@ -384,8 +379,8 @@ pub fn make_sample_chain_for_block_getters(backend: &MadaraBackend) -> SampleCha
     SampleChainForBlockGetters { block_hashes, tx_hashes, expected_txs, expected_receipts }
 }
 
-fn defaut_execution_resources() -> starknet_types_rpc::ExecutionResources {
-    starknet_types_rpc::ExecutionResources {
+fn defaut_execution_resources() -> mp_rpc::ExecutionResources {
+    mp_rpc::ExecutionResources {
         bitwise_builtin_applications: None,
         ec_op_builtin_applications: None,
         ecdsa_builtin_applications: None,
@@ -396,7 +391,7 @@ fn defaut_execution_resources() -> starknet_types_rpc::ExecutionResources {
         range_check_builtin_applications: None,
         segment_arena_builtin: None,
         steps: 0,
-        data_availability: starknet_types_rpc::DataAvailability { l1_data_gas: 0, l1_gas: 0 },
+        data_availability: mp_rpc::DataAvailability { l1_data_gas: 0, l1_gas: 0 },
     }
 }
 

--- a/crates/madara/client/rpc/src/utils/mod.rs
+++ b/crates/madara/client/rpc/src/utils/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
+use mp_rpc::Event;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::Event;
 
 use crate::StarknetRpcApiError;
 
@@ -131,7 +131,7 @@ impl<T> OptionExt<T> for Option<T> {
 /// * `true` if the event matches the address and keys pattern.
 /// * `false` otherwise.
 #[inline]
-pub fn event_match_filter(event: &Event<Felt>, address: Option<&Felt>, keys: Option<&[Vec<Felt>]>) -> bool {
+pub fn event_match_filter(event: &Event, address: Option<&Felt>, keys: Option<&[Vec<Felt>]>) -> bool {
     // Check if the event's address matches the provided address, if any.
     if let Some(addr) = address {
         if addr != &event.from_address {
@@ -161,11 +161,11 @@ pub fn event_match_filter(event: &Event<Felt>, address: Option<&Felt>, keys: Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mp_rpc::EventContent;
     use rstest::*;
-    use starknet_types_rpc::EventContent;
 
     #[fixture]
-    fn base_event() -> Event<Felt> {
+    fn base_event() -> Event {
         Event {
             from_address: Felt::from_hex_unchecked("0x1234"),
             event_content: EventContent {
@@ -196,32 +196,32 @@ mod tests {
     }
 
     #[rstest]
-    fn test_address_and_keys_match(base_event: Event<Felt>, matching_address: Felt, matching_keys: Vec<Vec<Felt>>) {
+    fn test_address_and_keys_match(base_event: Event, matching_address: Felt, matching_keys: Vec<Vec<Felt>>) {
         assert!(event_match_filter(&base_event, Some(&matching_address), Some(&matching_keys)));
     }
 
     #[rstest]
-    fn test_address_does_not_match(base_event: Event<Felt>, non_matching_address: Felt, matching_keys: Vec<Vec<Felt>>) {
+    fn test_address_does_not_match(base_event: Event, non_matching_address: Felt, matching_keys: Vec<Vec<Felt>>) {
         assert!(!event_match_filter(&base_event, Some(&non_matching_address), Some(&matching_keys)));
     }
 
     #[rstest]
-    fn test_keys_do_not_match(base_event: Event<Felt>, matching_address: Felt, non_matching_keys: Vec<Vec<Felt>>) {
+    fn test_keys_do_not_match(base_event: Event, matching_address: Felt, non_matching_keys: Vec<Vec<Felt>>) {
         assert!(!event_match_filter(&base_event, Some(&matching_address), Some(&non_matching_keys)));
     }
 
     #[rstest]
-    fn test_no_address_provided(base_event: Event<Felt>, matching_keys: Vec<Vec<Felt>>) {
+    fn test_no_address_provided(base_event: Event, matching_keys: Vec<Vec<Felt>>) {
         assert!(event_match_filter(&base_event, None, Some(&matching_keys)));
     }
 
     #[rstest]
-    fn test_no_keys_provided(base_event: Event<Felt>, matching_address: Felt) {
+    fn test_no_keys_provided(base_event: Event, matching_address: Felt) {
         assert!(event_match_filter(&base_event, Some(&matching_address), None));
     }
 
     #[rstest]
-    fn test_keys_with_pattern(base_event: Event<Felt>, matching_address: Felt) {
+    fn test_keys_with_pattern(base_event: Event, matching_address: Felt) {
         // [0x1 | 0x2, 0x2]
         let keys = vec![
             vec![Felt::from_hex_unchecked("0x1"), Felt::from_hex_unchecked("0x2")],

--- a/crates/madara/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/crates/madara/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -1,10 +1,9 @@
 use jsonrpsee::core::RpcResult;
 use m_proc_macros::versioned_rpc;
+use mp_rpc::ClassAndTxnHash;
 use mp_transactions::BroadcastedDeclareTransactionV0;
 use mp_utils::service::{MadaraServiceId, MadaraServiceStatus};
 use serde::{Deserialize, Serialize};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::ClassAndTxnHash;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -22,7 +21,7 @@ pub trait MadaraWriteRpcApi {
     async fn add_declare_v0_transaction(
         &self,
         declare_v0_transaction: BroadcastedDeclareTransactionV0,
-    ) -> RpcResult<ClassAndTxnHash<Felt>>;
+    ) -> RpcResult<ClassAndTxnHash>;
 }
 
 #[versioned_rpc("V0_1_0", "madara")]

--- a/crates/madara/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/crates/madara/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -1,7 +1,6 @@
 use jsonrpsee::core::{async_trait, RpcResult};
+use mp_rpc::ClassAndTxnHash;
 use mp_transactions::BroadcastedDeclareTransactionV0;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::ClassAndTxnHash;
 
 use crate::{versions::admin::v0_1_0::MadaraWriteRpcApiV0_1_0Server, Starknet};
 
@@ -19,7 +18,7 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
     async fn add_declare_v0_transaction(
         &self,
         declare_transaction: BroadcastedDeclareTransactionV0,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    ) -> RpcResult<ClassAndTxnHash> {
         self.add_transaction_provider.add_declare_v0_transaction(declare_transaction).await
     }
 }

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/api.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/api.rs
@@ -1,8 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use m_proc_macros::versioned_rpc;
 use mp_block::BlockId;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     AddInvokeTransactionResult, BlockHashAndNumber, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn,
     BroadcastedInvokeTxn, BroadcastedTxn, ClassAndTxnHash, ContractAndTxnHash, EventFilterWithPageRequest, EventsChunk,
     FeeEstimate, FunctionCall, MaybeDeprecatedContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
@@ -10,6 +9,7 @@ use starknet_types_rpc::{
     StarknetGetBlockWithTxsAndReceiptsResult, SyncingStatus, TraceBlockTransactionsResult,
     TxnFinalityAndExecutionStatus, TxnReceiptWithBlockInfo, TxnWithHash,
 };
+use starknet_types_core::felt::Felt;
 
 // Starknet RPC API trait and types
 //
@@ -23,22 +23,19 @@ pub trait StarknetWriteRpcApi {
     #[method(name = "addInvokeTransaction", and_versions = ["V0_8_0"])]
     async fn add_invoke_transaction(
         &self,
-        invoke_transaction: BroadcastedInvokeTxn<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult<Felt>>;
+        invoke_transaction: BroadcastedInvokeTxn,
+    ) -> RpcResult<AddInvokeTransactionResult>;
 
     /// Submit a new deploy account transaction
     #[method(name = "addDeployAccountTransaction", and_versions = ["V0_8_0"])]
     async fn add_deploy_account_transaction(
         &self,
-        deploy_account_transaction: BroadcastedDeployAccountTxn<Felt>,
-    ) -> RpcResult<ContractAndTxnHash<Felt>>;
+        deploy_account_transaction: BroadcastedDeployAccountTxn,
+    ) -> RpcResult<ContractAndTxnHash>;
 
     /// Submit a new class declaration transaction
     #[method(name = "addDeclareTransaction", and_versions = ["V0_8_0"])]
-    async fn add_declare_transaction(
-        &self,
-        declare_transaction: BroadcastedDeclareTxn<Felt>,
-    ) -> RpcResult<ClassAndTxnHash<Felt>>;
+    async fn add_declare_transaction(&self, declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash>;
 }
 
 #[versioned_rpc("V0_7_1", "starknet")]
@@ -53,11 +50,11 @@ pub trait StarknetReadRpcApi {
 
     // Get the most recent accepted block hash and number
     #[method(name = "blockHashAndNumber", and_versions = ["V0_8_0"])]
-    fn block_hash_and_number(&self) -> RpcResult<BlockHashAndNumber<Felt>>;
+    fn block_hash_and_number(&self) -> RpcResult<BlockHashAndNumber>;
 
     /// Call a contract function at a given block id
     #[method(name = "call", and_versions = ["V0_8_0"])]
-    fn call(&self, request: FunctionCall<Felt>, block_id: BlockId) -> RpcResult<Vec<Felt>>;
+    fn call(&self, request: FunctionCall, block_id: BlockId) -> RpcResult<Vec<Felt>>;
 
     /// Get the chain id
     #[method(name = "chainId", and_versions = ["V0_8_0"])]
@@ -71,33 +68,30 @@ pub trait StarknetReadRpcApi {
     #[method(name = "estimateFee", and_versions = ["V0_8_0"])]
     async fn estimate_fee(
         &self,
-        request: Vec<BroadcastedTxn<Felt>>,
+        request: Vec<BroadcastedTxn>,
         simulation_flags: Vec<SimulationFlagForEstimateFee>,
         block_id: BlockId,
-    ) -> RpcResult<Vec<FeeEstimate<Felt>>>;
+    ) -> RpcResult<Vec<FeeEstimate>>;
 
     /// Estimate the L2 fee of a message sent on L1
     #[method(name = "estimateMessageFee", and_versions = ["V0_8_0"])]
-    async fn estimate_message_fee(&self, message: MsgFromL1<Felt>, block_id: BlockId) -> RpcResult<FeeEstimate<Felt>>;
+    async fn estimate_message_fee(&self, message: MsgFromL1, block_id: BlockId) -> RpcResult<FeeEstimate>;
 
     /// Get block information with full transactions and receipts given the block id
     #[method(name = "getBlockWithReceipts", and_versions = ["V0_8_0"])]
-    async fn get_block_with_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> RpcResult<StarknetGetBlockWithTxsAndReceiptsResult<Felt>>;
+    async fn get_block_with_receipts(&self, block_id: BlockId) -> RpcResult<StarknetGetBlockWithTxsAndReceiptsResult>;
 
     /// Get block information with transaction hashes given the block id
     #[method(name = "getBlockWithTxHashes", and_versions = ["V0_8_0"])]
-    fn get_block_with_tx_hashes(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxHashes<Felt>>;
+    fn get_block_with_tx_hashes(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxHashes>;
 
     /// Get block information with full transactions given the block id
     #[method(name = "getBlockWithTxs", and_versions = ["V0_8_0"])]
-    fn get_block_with_txs(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxs<Felt>>;
+    fn get_block_with_txs(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxs>;
 
     /// Get the contract class at a given contract address for a given block id
     #[method(name = "getClassAt", and_versions = ["V0_8_0"])]
-    fn get_class_at(&self, block_id: BlockId, contract_address: Felt) -> RpcResult<MaybeDeprecatedContractClass<Felt>>;
+    fn get_class_at(&self, block_id: BlockId, contract_address: Felt) -> RpcResult<MaybeDeprecatedContractClass>;
 
     /// Get the contract class hash in the given block for the contract deployed at the given
     /// address
@@ -106,11 +100,11 @@ pub trait StarknetReadRpcApi {
 
     /// Get the contract class definition in the given block associated with the given hash
     #[method(name = "getClass", and_versions = ["V0_8_0"])]
-    fn get_class(&self, block_id: BlockId, class_hash: Felt) -> RpcResult<MaybeDeprecatedContractClass<Felt>>;
+    fn get_class(&self, block_id: BlockId, class_hash: Felt) -> RpcResult<MaybeDeprecatedContractClass>;
 
     /// Returns all events matching the given filter
     #[method(name = "getEvents", and_versions = ["V0_8_0"])]
-    async fn get_events(&self, filter: EventFilterWithPageRequest<Felt>) -> RpcResult<EventsChunk<Felt>>;
+    async fn get_events(&self, filter: EventFilterWithPageRequest) -> RpcResult<EventsChunk>;
 
     /// Get the nonce associated with the given address at the given block
     #[method(name = "getNonce", and_versions = ["V0_8_0"])]
@@ -122,15 +116,15 @@ pub trait StarknetReadRpcApi {
 
     /// Get the details of a transaction by a given block id and index
     #[method(name = "getTransactionByBlockIdAndIndex", and_versions = ["V0_8_0"])]
-    fn get_transaction_by_block_id_and_index(&self, block_id: BlockId, index: u64) -> RpcResult<TxnWithHash<Felt>>;
+    fn get_transaction_by_block_id_and_index(&self, block_id: BlockId, index: u64) -> RpcResult<TxnWithHash>;
 
     /// Returns the information about a transaction by transaction hash.
     #[method(name = "getTransactionByHash", and_versions = ["V0_8_0"])]
-    fn get_transaction_by_hash(&self, transaction_hash: Felt) -> RpcResult<TxnWithHash<Felt>>;
+    fn get_transaction_by_hash(&self, transaction_hash: Felt) -> RpcResult<TxnWithHash>;
 
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt", and_versions = ["V0_8_0"])]
-    async fn get_transaction_receipt(&self, transaction_hash: Felt) -> RpcResult<TxnReceiptWithBlockInfo<Felt>>;
+    async fn get_transaction_receipt(&self, transaction_hash: Felt) -> RpcResult<TxnReceiptWithBlockInfo>;
 
     /// Gets the Transaction Status, Including Mempool Status and Execution Details
     #[method(name = "getTransactionStatus", and_versions = ["V0_8_0"])]
@@ -138,11 +132,11 @@ pub trait StarknetReadRpcApi {
 
     /// Get an object about the sync status, or false if the node is not syncing
     #[method(name = "syncing", and_versions = ["V0_8_0"])]
-    async fn syncing(&self) -> RpcResult<SyncingStatus<Felt>>;
+    async fn syncing(&self) -> RpcResult<SyncingStatus>;
 
     /// Get the information about the result of executing the requested block
     #[method(name = "getStateUpdate", and_versions = ["V0_8_0"])]
-    fn get_state_update(&self, block_id: BlockId) -> RpcResult<MaybePendingStateUpdate<Felt>>;
+    fn get_state_update(&self, block_id: BlockId) -> RpcResult<MaybePendingStateUpdate>;
 }
 
 #[versioned_rpc("V0_7_1", "starknet")]
@@ -152,15 +146,15 @@ pub trait StarknetTraceRpcApi {
     async fn simulate_transactions(
         &self,
         block_id: BlockId,
-        transactions: Vec<BroadcastedTxn<Felt>>,
+        transactions: Vec<BroadcastedTxn>,
         simulation_flags: Vec<SimulationFlag>,
-    ) -> RpcResult<Vec<SimulateTransactionsResult<Felt>>>;
+    ) -> RpcResult<Vec<SimulateTransactionsResult>>;
 
     #[method(name = "traceBlockTransactions", and_versions = ["V0_8_0"])]
     /// Returns the execution traces of all transactions included in the given block
-    async fn trace_block_transactions(&self, block_id: BlockId) -> RpcResult<Vec<TraceBlockTransactionsResult<Felt>>>;
+    async fn trace_block_transactions(&self, block_id: BlockId) -> RpcResult<Vec<TraceBlockTransactionsResult>>;
 
     #[method(name = "traceTransaction", and_versions = ["V0_8_0"])]
     /// Returns the execution trace of a transaction
-    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceBlockTransactionsResult<Felt>>;
+    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceBlockTransactionsResult>;
 }

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/block_hash_and_number.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/block_hash_and_number.rs
@@ -1,6 +1,5 @@
 use mp_block::{BlockId, BlockTag};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::BlockHashAndNumber;
+use mp_rpc::BlockHashAndNumber;
 
 use crate::errors::StarknetRpcResult;
 use crate::{utils::OptionExt, Starknet};
@@ -15,7 +14,7 @@ use crate::{utils::OptionExt, Starknet};
 ///
 /// * `block_hash_and_number` - A tuple containing the latest block hash and number of the current
 ///   network.
-pub fn block_hash_and_number(starknet: &Starknet) -> StarknetRpcResult<BlockHashAndNumber<Felt>> {
+pub fn block_hash_and_number(starknet: &Starknet) -> StarknetRpcResult<BlockHashAndNumber> {
     let block_info = starknet.get_block_info(&BlockId::Tag(BlockTag::Latest))?;
     let block_info = block_info.as_nonpending().ok_or_internal_server_error("Latest block is pending")?;
 

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/call.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/call.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use mc_exec::ExecutionContext;
 use mp_block::BlockId;
+use mp_rpc::FunctionCall;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::FunctionCall;
 
 use crate::errors::StarknetRpcApiError;
 use crate::errors::StarknetRpcResult;
@@ -30,7 +30,7 @@ use crate::Starknet;
 /// * `CONTRACT_NOT_FOUND` - If the specified contract address does not exist.
 /// * `CONTRACT_ERROR` - If there is an error with the contract or the function call.
 /// * `BLOCK_NOT_FOUND` - If the specified block does not exist in the blockchain.
-pub fn call(starknet: &Starknet, request: FunctionCall<Felt>, block_id: BlockId) -> StarknetRpcResult<Vec<Felt>> {
+pub fn call(starknet: &Starknet, request: FunctionCall, block_id: BlockId) -> StarknetRpcResult<Vec<Felt>> {
     let block_info = starknet.get_block_info(&block_id)?;
 
     let exec_context = ExecutionContext::new_at_block_end(Arc::clone(&starknet.backend), &block_info)?;

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
@@ -5,9 +5,8 @@ use crate::versions::user::v0_7_1::methods::trace::trace_transaction::EXECUTION_
 use crate::Starknet;
 use mc_exec::ExecutionContext;
 use mp_block::BlockId;
+use mp_rpc::{BroadcastedTxn, FeeEstimate, SimulationFlagForEstimateFee};
 use mp_transactions::BroadcastedTransactionExt;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{BroadcastedTxn, FeeEstimate, SimulationFlagForEstimateFee};
 use std::sync::Arc;
 
 /// Estimate the fee associated with transaction
@@ -22,10 +21,10 @@ use std::sync::Arc;
 /// * `fee_estimate` - fee estimate in gwei
 pub async fn estimate_fee(
     starknet: &Starknet,
-    request: Vec<BroadcastedTxn<Felt>>,
+    request: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlagForEstimateFee>,
     block_id: BlockId,
-) -> StarknetRpcResult<Vec<FeeEstimate<Felt>>> {
+) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
     let block_info = starknet.get_block_info(&block_id)?;
     let starknet_version = *block_info.protocol_version();

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_message_fee.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_message_fee.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use mc_exec::ExecutionContext;
 use mp_block::BlockId;
+use mp_rpc::{FeeEstimate, MsgFromL1};
 use mp_transactions::L1HandlerTransaction;
 use starknet_api::transaction::{Fee, TransactionHash};
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{FeeEstimate, MsgFromL1};
 
 use crate::errors::StarknetRpcApiError;
 use crate::errors::StarknetRpcResult;
@@ -31,9 +31,9 @@ use crate::Starknet;
 /// ContractError : If there is an error with the contract.
 pub async fn estimate_message_fee(
     starknet: &Starknet,
-    message: MsgFromL1<Felt>,
+    message: MsgFromL1,
     block_id: BlockId,
-) -> StarknetRpcResult<FeeEstimate<Felt>> {
+) -> StarknetRpcResult<FeeEstimate> {
     let block_info = starknet.get_block_info(&block_id)?;
 
     if block_info.protocol_version() < &EXECUTION_UNSUPPORTED_BELOW_VERSION {
@@ -54,7 +54,7 @@ pub async fn estimate_message_fee(
 }
 
 pub fn convert_message_into_transaction(
-    message: MsgFromL1<Felt>,
+    message: MsgFromL1,
     chain_id: Felt,
 ) -> blockifier::transaction::transaction_execution::Transaction {
     let l1_handler: L1HandlerTransaction = message.into();

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_receipts.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_receipts.rs
@@ -1,6 +1,5 @@
 use mp_block::{BlockId, MadaraMaybePendingBlockInfo};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     BlockHeader, BlockStatus, BlockWithReceipts, PendingBlockHeader, PendingBlockWithReceipts,
     StarknetGetBlockWithTxsAndReceiptsResult, TransactionAndReceipt, TxnFinalityStatus,
 };
@@ -11,7 +10,7 @@ use crate::Starknet;
 pub fn get_block_with_receipts(
     starknet: &Starknet,
     block_id: BlockId,
-) -> StarknetRpcResult<StarknetGetBlockWithTxsAndReceiptsResult<Felt>> {
+) -> StarknetRpcResult<StarknetGetBlockWithTxsAndReceiptsResult> {
     tracing::debug!("get_block_with_receipts called with {:?}", block_id);
     let block = starknet.get_block(&block_id)?;
 
@@ -84,10 +83,11 @@ mod tests {
     use mp_receipt::{
         ExecutionResources, ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, TransactionReceipt,
     };
+    use mp_rpc::{L1DaMode, ResourcePrice};
     use mp_state_update::StateDiff;
     use mp_transactions::{InvokeTransaction, InvokeTransactionV0, Transaction};
     use rstest::rstest;
-    use starknet_types_rpc::{L1DaMode, ResourcePrice};
+    use starknet_types_core::felt::Felt;
     use std::sync::Arc;
 
     #[rstest]

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_tx_hashes.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_tx_hashes.rs
@@ -1,6 +1,5 @@
 use mp_block::{BlockId, MadaraMaybePendingBlockInfo};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     BlockHeader, BlockStatus, BlockWithTxHashes, MaybePendingBlockWithTxHashes, PendingBlockHeader,
     PendingBlockWithTxHashes,
 };
@@ -23,7 +22,7 @@ use crate::Starknet;
 pub fn get_block_with_tx_hashes(
     starknet: &Starknet,
     block_id: BlockId,
-) -> StarknetRpcResult<MaybePendingBlockWithTxHashes<Felt>> {
+) -> StarknetRpcResult<MaybePendingBlockWithTxHashes> {
     let block = starknet.get_block_info(&block_id)?;
 
     let block_txs_hashes = block.tx_hashes().to_vec();
@@ -77,9 +76,9 @@ mod tests {
         test_utils::{sample_chain_for_block_getters, SampleChainForBlockGetters},
     };
     use mp_block::BlockTag;
+    use mp_rpc::{BlockHeader, L1DaMode, ResourcePrice};
     use rstest::rstest;
     use starknet_types_core::felt::Felt;
-    use starknet_types_rpc::{BlockHeader, L1DaMode, ResourcePrice};
 
     #[rstest]
     fn test_get_block_with_tx_hashes(sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet)) {

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_txs.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_txs.rs
@@ -1,7 +1,6 @@
 use jsonrpsee::core::RpcResult;
 use mp_block::{BlockId, MadaraMaybePendingBlockInfo};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     BlockHeader, BlockStatus, BlockWithTxs, MaybePendingBlockWithTxs, PendingBlockHeader, PendingBlockWithTxs,
     TxnWithHash,
 };
@@ -26,7 +25,7 @@ use crate::Starknet;
 /// the block, this can include either a confirmed block or a pending block with its
 /// transactions. In case the specified block is not found, returns a `StarknetRpcApiError` with
 /// `BlockNotFound`.
-pub fn get_block_with_txs(starknet: &Starknet, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxs<Felt>> {
+pub fn get_block_with_txs(starknet: &Starknet, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxs> {
     let block = starknet.get_block(&block_id)?;
 
     let transactions_with_hash = Iterator::zip(block.inner.transactions.into_iter(), block.info.tx_hashes())
@@ -80,8 +79,9 @@ mod tests {
         test_utils::{sample_chain_for_block_getters, SampleChainForBlockGetters},
     };
     use mp_block::BlockTag;
+    use mp_rpc::{L1DaMode, ResourcePrice};
     use rstest::rstest;
-    use starknet_types_rpc::{L1DaMode, ResourcePrice};
+    use starknet_types_core::felt::Felt;
 
     #[rstest]
     fn test_get_block_with_txs(sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet)) {

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_class.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_class.rs
@@ -1,6 +1,6 @@
 use mp_block::BlockId;
+use mp_rpc::MaybeDeprecatedContractClass;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::MaybeDeprecatedContractClass;
 
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::utils::ResultExt;
@@ -10,7 +10,7 @@ pub fn get_class(
     starknet: &Starknet,
     block_id: BlockId,
     class_hash: Felt,
-) -> StarknetRpcResult<MaybeDeprecatedContractClass<Felt>> {
+) -> StarknetRpcResult<MaybeDeprecatedContractClass> {
     let class_data = starknet
         .backend
         .get_class_info(&block_id, &class_hash)

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_class_at.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_class_at.rs
@@ -1,6 +1,6 @@
 use mp_block::BlockId;
+use mp_rpc::MaybeDeprecatedContractClass;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::MaybeDeprecatedContractClass;
 
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::utils::{OptionExt, ResultExt};
@@ -29,7 +29,7 @@ pub fn get_class_at(
     starknet: &Starknet,
     block_id: BlockId,
     contract_address: Felt,
-) -> StarknetRpcResult<MaybeDeprecatedContractClass<Felt>> {
+) -> StarknetRpcResult<MaybeDeprecatedContractClass> {
     let resolved_block_id = starknet
         .backend
         .resolve_block_id(&block_id)

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_state_update.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_state_update.rs
@@ -1,6 +1,6 @@
 use mp_block::{BlockId, BlockTag};
+use mp_rpc::{MaybePendingStateUpdate, PendingStateUpdate, StateUpdate};
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{MaybePendingStateUpdate, PendingStateUpdate, StateUpdate};
 
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::utils::OptionExt;
@@ -26,7 +26,7 @@ use mc_db::db_block_id::DbBlockId;
 /// the state of the network as a result of the block's execution. This can include a confirmed
 /// state update or a pending state update. If the block is not found, returns a
 /// `StarknetRpcApiError` with `BlockNotFound`.
-pub fn get_state_update(starknet: &Starknet, block_id: BlockId) -> StarknetRpcResult<MaybePendingStateUpdate<Felt>> {
+pub fn get_state_update(starknet: &Starknet, block_id: BlockId) -> StarknetRpcResult<MaybePendingStateUpdate> {
     let resolved_block_id = starknet
         .backend
         .resolve_block_id(&block_id)

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_by_block_id_and_index.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_by_block_id_and_index.rs
@@ -1,6 +1,5 @@
 use mp_block::BlockId;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::TxnWithHash;
+use mp_rpc::TxnWithHash;
 
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::Starknet;
@@ -29,7 +28,7 @@ pub fn get_transaction_by_block_id_and_index(
     starknet: &Starknet,
     block_id: BlockId,
     index: u64,
-) -> StarknetRpcResult<TxnWithHash<Felt>> {
+) -> StarknetRpcResult<TxnWithHash> {
     let block = starknet.get_block(&block_id)?;
     let transaction_hash = block.info.tx_hashes().get(index as usize).ok_or(StarknetRpcApiError::InvalidTxnIndex)?;
     let transaction =

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_by_hash.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_by_hash.rs
@@ -1,5 +1,5 @@
+use mp_rpc::TxnWithHash;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::TxnWithHash;
 
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::utils::{OptionExt, ResultExt};
@@ -32,7 +32,7 @@ use crate::Starknet;
 /// - `BLOCK_NOT_FOUND` if the specified block is not found.
 /// - `TOO_MANY_KEYS_IN_FILTER` if there are too many keys in the filter, which may exceed the
 ///   system's capacity.
-pub fn get_transaction_by_hash(starknet: &Starknet, transaction_hash: Felt) -> StarknetRpcResult<TxnWithHash<Felt>> {
+pub fn get_transaction_by_hash(starknet: &Starknet, transaction_hash: Felt) -> StarknetRpcResult<TxnWithHash> {
     let (block, tx_index) = starknet
         .backend
         .find_tx_hash_block(&transaction_hash)

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_receipt.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_receipt.rs
@@ -1,6 +1,6 @@
 use mp_block::MadaraMaybePendingBlockInfo;
+use mp_rpc::{TxnFinalityStatus, TxnReceiptWithBlockInfo};
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{TxnFinalityStatus, TxnReceiptWithBlockInfo};
 
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 
@@ -32,7 +32,7 @@ use crate::Starknet;
 pub fn get_transaction_receipt(
     starknet: &Starknet,
     transaction_hash: Felt,
-) -> StarknetRpcResult<TxnReceiptWithBlockInfo<Felt>> {
+) -> StarknetRpcResult<TxnReceiptWithBlockInfo> {
     let (block, tx_index) = starknet
         .backend
         .find_tx_hash_block(&transaction_hash)
@@ -60,7 +60,7 @@ pub fn get_transaction_receipt(
         MadaraMaybePendingBlockInfo::NotPending(block) => (Some(block.header.block_number), Some(block.block_hash)),
     };
 
-    Ok(TxnReceiptWithBlockInfo::<Felt> { transaction_receipt, block_hash, block_number })
+    Ok(TxnReceiptWithBlockInfo { transaction_receipt, block_hash, block_number })
 }
 
 #[cfg(test)]
@@ -75,7 +75,7 @@ mod tests {
             sample_chain_for_block_getters;
 
         // Block 0
-        let res = TxnReceiptWithBlockInfo::<Felt> {
+        let res = TxnReceiptWithBlockInfo {
             transaction_receipt: expected_receipts[0].clone(),
             block_hash: Some(block_hashes[0]),
             block_number: Some(0),
@@ -85,13 +85,13 @@ mod tests {
         // Block 1
 
         // Block 2
-        let res = TxnReceiptWithBlockInfo::<Felt> {
+        let res = TxnReceiptWithBlockInfo {
             transaction_receipt: expected_receipts[1].clone(),
             block_hash: Some(block_hashes[2]),
             block_number: Some(2),
         };
         assert_eq!(get_transaction_receipt(&rpc, tx_hashes[1]).unwrap(), res);
-        let res = TxnReceiptWithBlockInfo::<Felt> {
+        let res = TxnReceiptWithBlockInfo {
             transaction_receipt: expected_receipts[2].clone(),
             block_hash: Some(block_hashes[2]),
             block_number: Some(2),
@@ -99,7 +99,7 @@ mod tests {
         assert_eq!(get_transaction_receipt(&rpc, tx_hashes[2]).unwrap(), res);
 
         // Pending
-        let res = TxnReceiptWithBlockInfo::<Felt> {
+        let res = TxnReceiptWithBlockInfo {
             transaction_receipt: expected_receipts[3].clone(),
             block_hash: None,
             block_number: None,

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_status.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_status.rs
@@ -1,7 +1,7 @@
 use mp_block::MadaraMaybePendingBlockInfo;
 use mp_receipt::ExecutionResult;
+use mp_rpc::{TxnExecutionStatus, TxnFinalityAndExecutionStatus, TxnStatus};
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{TxnExecutionStatus, TxnFinalityAndExecutionStatus, TxnStatus};
 
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::utils::ResultExt;

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/lib.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/lib.rs
@@ -1,14 +1,14 @@
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_block::BlockId;
 use mp_chain_config::RpcVersion;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     BlockHashAndNumber, EventFilterWithPageRequest, EventsChunk, FeeEstimate, FunctionCall,
     MaybeDeprecatedContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingStateUpdate,
     MsgFromL1, StarknetGetBlockWithTxsAndReceiptsResult, SyncingStatus, TxnFinalityAndExecutionStatus,
     TxnReceiptWithBlockInfo, TxnWithHash,
 };
-use starknet_types_rpc::{BroadcastedTxn, SimulationFlagForEstimateFee};
+use mp_rpc::{BroadcastedTxn, SimulationFlagForEstimateFee};
+use starknet_types_core::felt::Felt;
 
 use super::block_hash_and_number::*;
 use super::call::*;
@@ -44,11 +44,11 @@ impl StarknetReadRpcApiV0_7_1Server for Starknet {
         Ok(self.current_block_number()?)
     }
 
-    fn block_hash_and_number(&self) -> RpcResult<BlockHashAndNumber<Felt>> {
+    fn block_hash_and_number(&self) -> RpcResult<BlockHashAndNumber> {
         Ok(block_hash_and_number(self)?)
     }
 
-    fn call(&self, request: FunctionCall<Felt>, block_id: BlockId) -> RpcResult<Vec<Felt>> {
+    fn call(&self, request: FunctionCall, block_id: BlockId) -> RpcResult<Vec<Felt>> {
         Ok(call(self, request, block_id)?)
     }
 
@@ -62,33 +62,30 @@ impl StarknetReadRpcApiV0_7_1Server for Starknet {
 
     async fn estimate_fee(
         &self,
-        request: Vec<BroadcastedTxn<Felt>>,
+        request: Vec<BroadcastedTxn>,
         simulation_flags: Vec<SimulationFlagForEstimateFee>,
         block_id: BlockId,
-    ) -> RpcResult<Vec<FeeEstimate<Felt>>> {
+    ) -> RpcResult<Vec<FeeEstimate>> {
         Ok(estimate_fee(self, request, simulation_flags, block_id).await?)
     }
 
-    async fn estimate_message_fee(&self, message: MsgFromL1<Felt>, block_id: BlockId) -> RpcResult<FeeEstimate<Felt>> {
+    async fn estimate_message_fee(&self, message: MsgFromL1, block_id: BlockId) -> RpcResult<FeeEstimate> {
         Ok(estimate_message_fee(self, message, block_id).await?)
     }
 
-    async fn get_block_with_receipts(
-        &self,
-        block_id: BlockId,
-    ) -> RpcResult<StarknetGetBlockWithTxsAndReceiptsResult<Felt>> {
+    async fn get_block_with_receipts(&self, block_id: BlockId) -> RpcResult<StarknetGetBlockWithTxsAndReceiptsResult> {
         Ok(get_block_with_receipts(self, block_id)?)
     }
 
-    fn get_block_with_tx_hashes(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxHashes<Felt>> {
+    fn get_block_with_tx_hashes(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxHashes> {
         Ok(get_block_with_tx_hashes(self, block_id)?)
     }
 
-    fn get_block_with_txs(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxs<Felt>> {
+    fn get_block_with_txs(&self, block_id: BlockId) -> RpcResult<MaybePendingBlockWithTxs> {
         get_block_with_txs(self, block_id)
     }
 
-    fn get_class_at(&self, block_id: BlockId, contract_address: Felt) -> RpcResult<MaybeDeprecatedContractClass<Felt>> {
+    fn get_class_at(&self, block_id: BlockId, contract_address: Felt) -> RpcResult<MaybeDeprecatedContractClass> {
         Ok(get_class_at(self, block_id, contract_address)?)
     }
 
@@ -96,11 +93,11 @@ impl StarknetReadRpcApiV0_7_1Server for Starknet {
         Ok(get_class_hash_at(self, block_id, contract_address)?)
     }
 
-    fn get_class(&self, block_id: BlockId, class_hash: Felt) -> RpcResult<MaybeDeprecatedContractClass<Felt>> {
+    fn get_class(&self, block_id: BlockId, class_hash: Felt) -> RpcResult<MaybeDeprecatedContractClass> {
         Ok(get_class(self, block_id, class_hash)?)
     }
 
-    async fn get_events(&self, filter: EventFilterWithPageRequest<Felt>) -> RpcResult<EventsChunk<Felt>> {
+    async fn get_events(&self, filter: EventFilterWithPageRequest) -> RpcResult<EventsChunk> {
         Ok(get_events(self, filter).await?)
     }
 
@@ -112,15 +109,15 @@ impl StarknetReadRpcApiV0_7_1Server for Starknet {
         Ok(get_storage_at(self, contract_address, key, block_id)?)
     }
 
-    fn get_transaction_by_block_id_and_index(&self, block_id: BlockId, index: u64) -> RpcResult<TxnWithHash<Felt>> {
+    fn get_transaction_by_block_id_and_index(&self, block_id: BlockId, index: u64) -> RpcResult<TxnWithHash> {
         Ok(get_transaction_by_block_id_and_index(self, block_id, index)?)
     }
 
-    fn get_transaction_by_hash(&self, transaction_hash: Felt) -> RpcResult<TxnWithHash<Felt>> {
+    fn get_transaction_by_hash(&self, transaction_hash: Felt) -> RpcResult<TxnWithHash> {
         Ok(get_transaction_by_hash(self, transaction_hash)?)
     }
 
-    async fn get_transaction_receipt(&self, transaction_hash: Felt) -> RpcResult<TxnReceiptWithBlockInfo<Felt>> {
+    async fn get_transaction_receipt(&self, transaction_hash: Felt) -> RpcResult<TxnReceiptWithBlockInfo> {
         Ok(get_transaction_receipt(self, transaction_hash)?)
     }
 
@@ -128,11 +125,11 @@ impl StarknetReadRpcApiV0_7_1Server for Starknet {
         Ok(get_transaction_status(self, transaction_hash)?)
     }
 
-    async fn syncing(&self) -> RpcResult<SyncingStatus<Felt>> {
+    async fn syncing(&self) -> RpcResult<SyncingStatus> {
         Ok(syncing(self).await?)
     }
 
-    fn get_state_update(&self, block_id: BlockId) -> RpcResult<MaybePendingStateUpdate<Felt>> {
+    fn get_state_update(&self, block_id: BlockId) -> RpcResult<MaybePendingStateUpdate> {
         Ok(get_state_update(self, block_id)?)
     }
 }

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/syncing.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/read/syncing.rs
@@ -1,6 +1,5 @@
 use mp_block::{BlockId, BlockTag};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{SyncStatus, SyncingStatus};
+use mp_rpc::{SyncStatus, SyncingStatus};
 
 use crate::errors::StarknetRpcResult;
 use crate::utils::{OptionExt, ResultExt};
@@ -16,7 +15,7 @@ use crate::Starknet;
 ///
 /// * `Syncing` - An Enum that can either be a `mc_rpc_core::SyncStatus` struct representing the
 ///   sync status, or a `Boolean` (`false`) indicating that the node is not currently synchronizing.
-pub async fn syncing(starknet: &Starknet) -> StarknetRpcResult<SyncingStatus<Felt>> {
+pub async fn syncing(starknet: &Starknet) -> StarknetRpcResult<SyncingStatus> {
     // obtain best seen (highest) block number
     let Some(current_block_info) = starknet
         .backend

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/mod.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/mod.rs
@@ -1,9 +1,9 @@
 use crate::{versions::user::v0_7_1::StarknetTraceRpcApiV0_7_1Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_block::BlockId;
+use mp_rpc::{BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult};
 use simulate_transactions::simulate_transactions;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult};
 use trace_block_transactions::trace_block_transactions;
 use trace_transaction::trace_transaction;
 
@@ -16,17 +16,17 @@ impl StarknetTraceRpcApiV0_7_1Server for Starknet {
     async fn simulate_transactions(
         &self,
         block_id: BlockId,
-        transactions: Vec<BroadcastedTxn<Felt>>,
+        transactions: Vec<BroadcastedTxn>,
         simulation_flags: Vec<SimulationFlag>,
-    ) -> RpcResult<Vec<SimulateTransactionsResult<Felt>>> {
+    ) -> RpcResult<Vec<SimulateTransactionsResult>> {
         Ok(simulate_transactions(self, block_id, transactions, simulation_flags).await?)
     }
 
-    async fn trace_block_transactions(&self, block_id: BlockId) -> RpcResult<Vec<TraceBlockTransactionsResult<Felt>>> {
+    async fn trace_block_transactions(&self, block_id: BlockId) -> RpcResult<Vec<TraceBlockTransactionsResult>> {
         Ok(trace_block_transactions(self, block_id).await?)
     }
 
-    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceBlockTransactionsResult<Felt>> {
+    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceBlockTransactionsResult> {
         Ok(trace_transaction(self, transaction_hash).await?)
     }
 }

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
@@ -4,17 +4,16 @@ use crate::utils::ResultExt;
 use crate::Starknet;
 use mc_exec::{execution_result_to_tx_trace, ExecutionContext};
 use mp_block::BlockId;
+use mp_rpc::{BroadcastedTxn, SimulateTransactionsResult, SimulationFlag};
 use mp_transactions::BroadcastedTransactionExt;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{BroadcastedTxn, SimulateTransactionsResult, SimulationFlag};
 use std::sync::Arc;
 
 pub async fn simulate_transactions(
     starknet: &Starknet,
     block_id: BlockId,
-    transactions: Vec<BroadcastedTxn<Felt>>,
+    transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
-) -> StarknetRpcResult<Vec<SimulateTransactionsResult<Felt>>> {
+) -> StarknetRpcResult<Vec<SimulateTransactionsResult>> {
     let block_info = starknet.get_block_info(&block_id)?;
     let starknet_version = *block_info.protocol_version();
 

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/trace_block_transactions.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/trace_block_transactions.rs
@@ -2,9 +2,8 @@ use mc_exec::transaction::to_blockifier_transaction;
 use mc_exec::{execution_result_to_tx_trace, ExecutionContext};
 use mp_block::BlockId;
 use mp_convert::ToFelt;
+use mp_rpc::TraceBlockTransactionsResult;
 use starknet_api::transaction::TransactionHash;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::TraceBlockTransactionsResult;
 use std::sync::Arc;
 
 use super::trace_transaction::EXECUTION_UNSUPPORTED_BELOW_VERSION;
@@ -15,7 +14,7 @@ use crate::Starknet;
 pub async fn trace_block_transactions(
     starknet: &Starknet,
     block_id: BlockId,
-) -> StarknetRpcResult<Vec<TraceBlockTransactionsResult<Felt>>> {
+) -> StarknetRpcResult<Vec<TraceBlockTransactionsResult>> {
     let block = starknet.get_block(&block_id)?;
 
     if block.info.protocol_version() < &EXECUTION_UNSUPPORTED_BELOW_VERSION {

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/trace_transaction.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/trace/trace_transaction.rs
@@ -6,9 +6,9 @@ use mc_exec::execution_result_to_tx_trace;
 use mc_exec::transaction::to_blockifier_transaction;
 use mc_exec::ExecutionContext;
 use mp_chain_config::StarknetVersion;
+use mp_rpc::TraceBlockTransactionsResult;
 use starknet_api::transaction::TransactionHash;
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::TraceBlockTransactionsResult;
 use std::sync::Arc;
 
 /// Blockifier does not support execution for versions earlier than that.
@@ -17,7 +17,7 @@ pub const EXECUTION_UNSUPPORTED_BELOW_VERSION: StarknetVersion = StarknetVersion
 pub async fn trace_transaction(
     starknet: &Starknet,
     transaction_hash: Felt,
-) -> StarknetRpcResult<TraceBlockTransactionsResult<Felt>> {
+) -> StarknetRpcResult<TraceBlockTransactionsResult> {
     let (block, tx_index) = starknet
         .backend
         .find_tx_hash_block(&transaction_hash)

--- a/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/write/mod.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_7_1/methods/write/mod.rs
@@ -1,7 +1,6 @@
 use crate::{versions::user::v0_7_1::StarknetWriteRpcApiV0_7_1Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
     ClassAndTxnHash, ContractAndTxnHash,
 };
@@ -17,10 +16,7 @@ impl StarknetWriteRpcApiV0_7_1Server for Starknet {
     /// # Returns
     ///
     /// * `declare_transaction_result` - the result of the declare transaction
-    async fn add_declare_transaction(
-        &self,
-        declare_transaction: BroadcastedDeclareTxn<Felt>,
-    ) -> RpcResult<ClassAndTxnHash<Felt>> {
+    async fn add_declare_transaction(&self, declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash> {
         self.add_transaction_provider.add_declare_transaction(declare_transaction).await
     }
 
@@ -36,8 +32,8 @@ impl StarknetWriteRpcApiV0_7_1Server for Starknet {
     /// * `contract_address` - address of the deployed contract account
     async fn add_deploy_account_transaction(
         &self,
-        deploy_account_transaction: BroadcastedDeployAccountTxn<Felt>,
-    ) -> RpcResult<ContractAndTxnHash<Felt>> {
+        deploy_account_transaction: BroadcastedDeployAccountTxn,
+    ) -> RpcResult<ContractAndTxnHash> {
         self.add_transaction_provider.add_deploy_account_transaction(deploy_account_transaction).await
     }
 
@@ -52,8 +48,8 @@ impl StarknetWriteRpcApiV0_7_1Server for Starknet {
     /// * `transaction_hash` - transaction hash corresponding to the invocation
     async fn add_invoke_transaction(
         &self,
-        invoke_transaction: BroadcastedInvokeTxn<Felt>,
-    ) -> RpcResult<AddInvokeTransactionResult<Felt>> {
+        invoke_transaction: BroadcastedInvokeTxn,
+    ) -> RpcResult<AddInvokeTransactionResult> {
         self.add_transaction_provider.add_invoke_transaction(invoke_transaction).await
     }
 }

--- a/crates/madara/client/rpc/src/versions/user/v0_8_0/api.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_8_0/api.rs
@@ -4,8 +4,8 @@ use mp_block::BlockId;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-pub(crate) type NewHead = starknet_types_rpc::BlockHeader<Felt>;
-pub(crate) type EmittedEvent = starknet_types_rpc::EmittedEvent<Felt>;
+pub(crate) type NewHead = mp_rpc::BlockHeader;
+pub(crate) type EmittedEvent = mp_rpc::EmittedEvent;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContractStorageKeysItem {

--- a/crates/madara/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_events.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_events.rs
@@ -80,7 +80,7 @@ mod test {
     use crate::test_utils::rpc_test_setup;
     use jsonrpsee::ws_client::WsClientBuilder;
     use mp_receipt::{InvokeTransactionReceipt, TransactionReceipt};
-    use starknet_types_rpc::{EmittedEvent, Event, EventContent};
+    use mp_rpc::{EmittedEvent, Event, EventContent};
 
     /// Generates a transaction receipt with predictable event values for testing purposes.
     /// Values are generated using binary patterns for easy verification.
@@ -129,7 +129,7 @@ mod test {
     // Each block contains two receipts:
     // 1. First receipt with 1 event and 1 key
     // 2. Second receipt with 2 events and 2 keys
-    fn block_generator(backend: &mc_db::MadaraBackend) -> impl Iterator<Item = Vec<EmittedEvent<Felt>>> + '_ {
+    fn block_generator(backend: &mc_db::MadaraBackend) -> impl Iterator<Item = Vec<EmittedEvent>> + '_ {
         (0..).map(|n| {
             let block_info = mp_block::MadaraBlockInfo {
                 header: mp_block::Header { parent_block_hash: Felt::from(n), block_number: n, ..Default::default() },

--- a/crates/madara/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_new_heads.rs
+++ b/crates/madara/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_new_heads.rs
@@ -122,7 +122,7 @@ async fn send_block_header<'a>(
     block_info: mp_block::MadaraBlockInfo,
     block_n: u64,
 ) -> Result<(), StarknetWsApiError> {
-    let header = starknet_types_rpc::BlockHeader::from(block_info);
+    let header = mp_rpc::BlockHeader::from(block_info);
     let msg = jsonrpsee::SubscriptionMessage::from_json(&header)
         .or_else_internal_server_error(|| format!("Failed to create response message for block {block_n}"))?;
 

--- a/crates/madara/primitives/block/Cargo.toml
+++ b/crates/madara/primitives/block/Cargo.toml
@@ -19,12 +19,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 # Madara
 mp-chain-config = { workspace = true }
 mp-receipt = { workspace = true }
+mp-rpc = { workspace = true }
 mp-transactions = { workspace = true }
 
 # Starknet
 blockifier = { workspace = true }
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 
 # Other
 primitive-types.workspace = true

--- a/crates/madara/primitives/block/src/header.rs
+++ b/crates/madara/primitives/block/src/header.rs
@@ -22,13 +22,13 @@ pub enum BlockStatus {
     Rejected,
 }
 
-impl From<BlockStatus> for starknet_types_rpc::BlockStatus {
+impl From<BlockStatus> for mp_rpc::BlockStatus {
     fn from(status: BlockStatus) -> Self {
         match status {
-            BlockStatus::Pending => starknet_types_rpc::BlockStatus::Pending,
-            BlockStatus::AcceptedOnL2 => starknet_types_rpc::BlockStatus::AcceptedOnL2,
-            BlockStatus::AcceptedOnL1 => starknet_types_rpc::BlockStatus::AcceptedOnL1,
-            BlockStatus::Rejected => starknet_types_rpc::BlockStatus::Rejected,
+            BlockStatus::Pending => mp_rpc::BlockStatus::Pending,
+            BlockStatus::AcceptedOnL2 => mp_rpc::BlockStatus::AcceptedOnL2,
+            BlockStatus::AcceptedOnL1 => mp_rpc::BlockStatus::AcceptedOnL1,
+            BlockStatus::Rejected => mp_rpc::BlockStatus::Rejected,
         }
     }
 }
@@ -123,15 +123,15 @@ impl From<&GasPrices> for blockifier::blockifier::block::GasPrices {
 }
 
 impl GasPrices {
-    pub fn l1_gas_price(&self) -> starknet_types_rpc::ResourcePrice<Felt> {
-        starknet_types_rpc::ResourcePrice {
+    pub fn l1_gas_price(&self) -> mp_rpc::ResourcePrice {
+        mp_rpc::ResourcePrice {
             price_in_fri: self.strk_l1_gas_price.into(),
             price_in_wei: self.eth_l1_gas_price.into(),
         }
     }
 
-    pub fn l1_data_gas_price(&self) -> starknet_types_rpc::ResourcePrice<Felt> {
-        starknet_types_rpc::ResourcePrice {
+    pub fn l1_data_gas_price(&self) -> mp_rpc::ResourcePrice {
+        mp_rpc::ResourcePrice {
             price_in_fri: self.strk_l1_data_gas_price.into(),
             price_in_wei: self.eth_l1_data_gas_price.into(),
         }
@@ -148,7 +148,7 @@ pub enum L1DataAvailabilityMode {
     Blob,
 }
 
-impl From<L1DataAvailabilityMode> for starknet_types_rpc::L1DaMode {
+impl From<L1DataAvailabilityMode> for mp_rpc::L1DaMode {
     fn from(value: L1DataAvailabilityMode) -> Self {
         match value {
             L1DataAvailabilityMode::Calldata => Self::Calldata,

--- a/crates/madara/primitives/block/src/lib.rs
+++ b/crates/madara/primitives/block/src/lib.rs
@@ -10,8 +10,8 @@ use starknet_types_core::felt::Felt;
 pub mod header;
 pub use header::Header;
 pub use primitive_types::{H160, U256};
-pub type BlockId = starknet_types_rpc::BlockId<Felt>;
-pub type BlockTag = starknet_types_rpc::BlockTag;
+pub type BlockId = mp_rpc::BlockId;
+pub type BlockTag = mp_rpc::BlockTag;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[allow(clippy::large_enum_variant)]
@@ -91,7 +91,7 @@ impl From<MadaraBlockInfo> for MadaraMaybePendingBlockInfo {
     }
 }
 
-impl From<MadaraBlockInfo> for starknet_types_rpc::BlockHeader<Felt> {
+impl From<MadaraBlockInfo> for mp_rpc::BlockHeader {
     fn from(info: MadaraBlockInfo) -> Self {
         let MadaraBlockInfo {
             header:
@@ -116,14 +116,14 @@ impl From<MadaraBlockInfo> for starknet_types_rpc::BlockHeader<Felt> {
             block_hash,
             block_number,
             l1_da_mode: match l1_da_mode {
-                L1DataAvailabilityMode::Blob => starknet_types_rpc::L1DaMode::Blob,
-                L1DataAvailabilityMode::Calldata => starknet_types_rpc::L1DaMode::Calldata,
+                L1DataAvailabilityMode::Blob => mp_rpc::L1DaMode::Blob,
+                L1DataAvailabilityMode::Calldata => mp_rpc::L1DaMode::Calldata,
             },
-            l1_data_gas_price: starknet_types_rpc::ResourcePrice {
+            l1_data_gas_price: mp_rpc::ResourcePrice {
                 price_in_fri: Felt::from(strk_l1_data_gas_price),
                 price_in_wei: Felt::from(eth_l1_data_gas_price),
             },
-            l1_gas_price: starknet_types_rpc::ResourcePrice {
+            l1_gas_price: mp_rpc::ResourcePrice {
                 price_in_fri: Felt::from(strk_l1_gas_price),
                 price_in_wei: Felt::from(eth_l1_gas_price),
             },

--- a/crates/madara/primitives/class/Cargo.toml
+++ b/crates/madara/primitives/class/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 # Madara
 mp-convert = { workspace = true }
+mp-rpc = { workspace = true }
 
 # Starknet
 blockifier = { workspace = true }
@@ -32,7 +33,6 @@ casm-utils-v1_1_1 = { package = "cairo-lang-utils", version = "=1.1.1" }
 casm-utils-v2 = { package = "cairo-lang-utils", version = "=2.8.4" }
 starknet-core = { workspace = true }
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 
 # Other
 base64 = { workspace = true }

--- a/crates/madara/primitives/class/src/into_starknet_types.rs
+++ b/crates/madara/primitives/class/src/into_starknet_types.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use starknet_types_core::felt::Felt;
-
 use crate::{
     CompressedLegacyContractClass, ContractClass, EntryPointsByType, FlattenedSierraClass, FunctionStateMutability,
     LegacyContractAbiEntry, LegacyContractEntryPoint, LegacyEntryPointsByType, LegacyEventAbiEntry, LegacyEventAbiType,
@@ -9,40 +7,36 @@ use crate::{
     LegacyTypedParameter, SierraEntryPoint,
 };
 
-impl TryFrom<starknet_types_rpc::MaybeDeprecatedContractClass<Felt>> for ContractClass {
+impl TryFrom<mp_rpc::MaybeDeprecatedContractClass> for ContractClass {
     type Error = std::io::Error;
 
-    fn try_from(contract_class: starknet_types_rpc::MaybeDeprecatedContractClass<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(contract_class: mp_rpc::MaybeDeprecatedContractClass) -> Result<Self, Self::Error> {
         match contract_class {
-            starknet_types_rpc::MaybeDeprecatedContractClass::ContractClass(flattened_sierra_class) => {
+            mp_rpc::MaybeDeprecatedContractClass::ContractClass(flattened_sierra_class) => {
                 Ok(ContractClass::Sierra(Arc::new(flattened_sierra_class.into())))
             }
-            starknet_types_rpc::MaybeDeprecatedContractClass::Deprecated(compressed_legacy_contract_class) => {
+            mp_rpc::MaybeDeprecatedContractClass::Deprecated(compressed_legacy_contract_class) => {
                 Ok(ContractClass::Legacy(Arc::new(compressed_legacy_contract_class.try_into()?)))
             }
         }
     }
 }
 
-impl From<ContractClass> for starknet_types_rpc::MaybeDeprecatedContractClass<Felt> {
+impl From<ContractClass> for mp_rpc::MaybeDeprecatedContractClass {
     fn from(contract_class: ContractClass) -> Self {
         match contract_class {
             ContractClass::Sierra(flattened_sierra_class) => {
-                starknet_types_rpc::MaybeDeprecatedContractClass::ContractClass(
-                    (*flattened_sierra_class).clone().into(),
-                )
+                mp_rpc::MaybeDeprecatedContractClass::ContractClass((*flattened_sierra_class).clone().into())
             }
             ContractClass::Legacy(compressed_legacy_contract_class) => {
-                starknet_types_rpc::MaybeDeprecatedContractClass::Deprecated(
-                    (*compressed_legacy_contract_class).clone().into(),
-                )
+                mp_rpc::MaybeDeprecatedContractClass::Deprecated((*compressed_legacy_contract_class).clone().into())
             }
         }
     }
 }
 
-impl From<starknet_types_rpc::ContractClass<Felt>> for FlattenedSierraClass {
-    fn from(flattened_sierra_class: starknet_types_rpc::ContractClass<Felt>) -> Self {
+impl From<mp_rpc::ContractClass> for FlattenedSierraClass {
+    fn from(flattened_sierra_class: mp_rpc::ContractClass) -> Self {
         FlattenedSierraClass {
             sierra_program: flattened_sierra_class.sierra_program,
             contract_class_version: flattened_sierra_class.contract_class_version,
@@ -52,9 +46,9 @@ impl From<starknet_types_rpc::ContractClass<Felt>> for FlattenedSierraClass {
     }
 }
 
-impl From<FlattenedSierraClass> for starknet_types_rpc::ContractClass<Felt> {
+impl From<FlattenedSierraClass> for mp_rpc::ContractClass {
     fn from(flattened_sierra_class: FlattenedSierraClass) -> Self {
-        starknet_types_rpc::ContractClass {
+        mp_rpc::ContractClass {
             sierra_program: flattened_sierra_class.sierra_program,
             contract_class_version: flattened_sierra_class.contract_class_version,
             entry_points_by_type: flattened_sierra_class.entry_points_by_type.into(),
@@ -63,8 +57,8 @@ impl From<FlattenedSierraClass> for starknet_types_rpc::ContractClass<Felt> {
     }
 }
 
-impl From<starknet_types_rpc::EntryPointsByType<Felt>> for EntryPointsByType {
-    fn from(entry_points_by_type: starknet_types_rpc::EntryPointsByType<Felt>) -> Self {
+impl From<mp_rpc::EntryPointsByType> for EntryPointsByType {
+    fn from(entry_points_by_type: mp_rpc::EntryPointsByType) -> Self {
         EntryPointsByType {
             constructor: entry_points_by_type
                 .constructor
@@ -85,9 +79,9 @@ impl From<starknet_types_rpc::EntryPointsByType<Felt>> for EntryPointsByType {
     }
 }
 
-impl From<EntryPointsByType> for starknet_types_rpc::EntryPointsByType<Felt> {
+impl From<EntryPointsByType> for mp_rpc::EntryPointsByType {
     fn from(entry_points_by_type: EntryPointsByType) -> Self {
-        starknet_types_rpc::EntryPointsByType {
+        mp_rpc::EntryPointsByType {
             constructor: entry_points_by_type
                 .constructor
                 .into_iter()
@@ -107,27 +101,25 @@ impl From<EntryPointsByType> for starknet_types_rpc::EntryPointsByType<Felt> {
     }
 }
 
-impl From<starknet_types_rpc::SierraEntryPoint<Felt>> for SierraEntryPoint {
-    fn from(sierra_entry_point: starknet_types_rpc::SierraEntryPoint<Felt>) -> Self {
+impl From<mp_rpc::SierraEntryPoint> for SierraEntryPoint {
+    fn from(sierra_entry_point: mp_rpc::SierraEntryPoint) -> Self {
         SierraEntryPoint { selector: sierra_entry_point.selector, function_idx: sierra_entry_point.function_idx }
     }
 }
 
-impl From<SierraEntryPoint> for starknet_types_rpc::SierraEntryPoint<Felt> {
+impl From<SierraEntryPoint> for mp_rpc::SierraEntryPoint {
     fn from(sierra_entry_point: SierraEntryPoint) -> Self {
-        starknet_types_rpc::SierraEntryPoint {
+        mp_rpc::SierraEntryPoint {
             selector: sierra_entry_point.selector,
             function_idx: sierra_entry_point.function_idx,
         }
     }
 }
 
-impl TryFrom<starknet_types_rpc::DeprecatedContractClass<Felt>> for CompressedLegacyContractClass {
+impl TryFrom<mp_rpc::DeprecatedContractClass> for CompressedLegacyContractClass {
     type Error = std::io::Error;
 
-    fn try_from(
-        compressed_legacy_contract_class: starknet_types_rpc::DeprecatedContractClass<Felt>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(compressed_legacy_contract_class: mp_rpc::DeprecatedContractClass) -> Result<Self, Self::Error> {
         use base64::Engine;
 
         let decoded_program = base64::engine::general_purpose::STANDARD
@@ -144,14 +136,14 @@ impl TryFrom<starknet_types_rpc::DeprecatedContractClass<Felt>> for CompressedLe
     }
 }
 
-impl From<CompressedLegacyContractClass> for starknet_types_rpc::DeprecatedContractClass<Felt> {
+impl From<CompressedLegacyContractClass> for mp_rpc::DeprecatedContractClass {
     fn from(compressed_legacy_contract_class: CompressedLegacyContractClass) -> Self {
         use base64::Engine;
 
         let encoded_program =
             base64::engine::general_purpose::STANDARD.encode(&compressed_legacy_contract_class.program);
 
-        starknet_types_rpc::DeprecatedContractClass {
+        mp_rpc::DeprecatedContractClass {
             program: encoded_program,
             entry_points_by_type: compressed_legacy_contract_class.entry_points_by_type.into(),
             abi: compressed_legacy_contract_class
@@ -161,8 +153,8 @@ impl From<CompressedLegacyContractClass> for starknet_types_rpc::DeprecatedContr
     }
 }
 
-impl From<starknet_types_rpc::DeprecatedEntryPointsByType<Felt>> for LegacyEntryPointsByType {
-    fn from(legacy_entry_points_by_type: starknet_types_rpc::DeprecatedEntryPointsByType<Felt>) -> Self {
+impl From<mp_rpc::DeprecatedEntryPointsByType> for LegacyEntryPointsByType {
+    fn from(legacy_entry_points_by_type: mp_rpc::DeprecatedEntryPointsByType) -> Self {
         LegacyEntryPointsByType {
             constructor: legacy_entry_points_by_type
                 .constructor
@@ -183,9 +175,9 @@ impl From<starknet_types_rpc::DeprecatedEntryPointsByType<Felt>> for LegacyEntry
     }
 }
 
-impl From<LegacyEntryPointsByType> for starknet_types_rpc::DeprecatedEntryPointsByType<Felt> {
+impl From<LegacyEntryPointsByType> for mp_rpc::DeprecatedEntryPointsByType {
     fn from(legacy_entry_points_by_type: LegacyEntryPointsByType) -> Self {
-        starknet_types_rpc::DeprecatedEntryPointsByType {
+        mp_rpc::DeprecatedEntryPointsByType {
             constructor: legacy_entry_points_by_type
                 .constructor
                 .into_iter()
@@ -205,8 +197,8 @@ impl From<LegacyEntryPointsByType> for starknet_types_rpc::DeprecatedEntryPoints
     }
 }
 
-impl From<starknet_types_rpc::DeprecatedCairoEntryPoint<Felt>> for LegacyContractEntryPoint {
-    fn from(legacy_contract_entry_point: starknet_types_rpc::DeprecatedCairoEntryPoint<Felt>) -> Self {
+impl From<mp_rpc::DeprecatedCairoEntryPoint> for LegacyContractEntryPoint {
+    fn from(legacy_contract_entry_point: mp_rpc::DeprecatedCairoEntryPoint) -> Self {
         LegacyContractEntryPoint {
             offset: legacy_contract_entry_point.offset,
             selector: legacy_contract_entry_point.selector,
@@ -214,49 +206,49 @@ impl From<starknet_types_rpc::DeprecatedCairoEntryPoint<Felt>> for LegacyContrac
     }
 }
 
-impl From<LegacyContractEntryPoint> for starknet_types_rpc::DeprecatedCairoEntryPoint<Felt> {
+impl From<LegacyContractEntryPoint> for mp_rpc::DeprecatedCairoEntryPoint {
     fn from(legacy_contract_entry_point: LegacyContractEntryPoint) -> Self {
-        starknet_types_rpc::DeprecatedCairoEntryPoint {
+        mp_rpc::DeprecatedCairoEntryPoint {
             offset: legacy_contract_entry_point.offset,
             selector: legacy_contract_entry_point.selector,
         }
     }
 }
 
-impl From<starknet_types_rpc::ContractAbiEntry> for LegacyContractAbiEntry {
-    fn from(legacy_contract_abi_entry: starknet_types_rpc::ContractAbiEntry) -> Self {
+impl From<mp_rpc::ContractAbiEntry> for LegacyContractAbiEntry {
+    fn from(legacy_contract_abi_entry: mp_rpc::ContractAbiEntry) -> Self {
         match legacy_contract_abi_entry {
-            starknet_types_rpc::ContractAbiEntry::Function(legacy_function_abi_entry) => {
+            mp_rpc::ContractAbiEntry::Function(legacy_function_abi_entry) => {
                 LegacyContractAbiEntry::Function(legacy_function_abi_entry.into())
             }
-            starknet_types_rpc::ContractAbiEntry::Event(legacy_event_abi_entry) => {
+            mp_rpc::ContractAbiEntry::Event(legacy_event_abi_entry) => {
                 LegacyContractAbiEntry::Event(legacy_event_abi_entry.into())
             }
-            starknet_types_rpc::ContractAbiEntry::Struct(legacy_struct_abi_entry) => {
+            mp_rpc::ContractAbiEntry::Struct(legacy_struct_abi_entry) => {
                 LegacyContractAbiEntry::Struct(legacy_struct_abi_entry.into())
             }
         }
     }
 }
 
-impl From<LegacyContractAbiEntry> for starknet_types_rpc::ContractAbiEntry {
+impl From<LegacyContractAbiEntry> for mp_rpc::ContractAbiEntry {
     fn from(legacy_contract_abi_entry: LegacyContractAbiEntry) -> Self {
         match legacy_contract_abi_entry {
             LegacyContractAbiEntry::Function(legacy_function_abi_entry) => {
-                starknet_types_rpc::ContractAbiEntry::Function(legacy_function_abi_entry.into())
+                mp_rpc::ContractAbiEntry::Function(legacy_function_abi_entry.into())
             }
             LegacyContractAbiEntry::Event(legacy_event_abi_entry) => {
-                starknet_types_rpc::ContractAbiEntry::Event(legacy_event_abi_entry.into())
+                mp_rpc::ContractAbiEntry::Event(legacy_event_abi_entry.into())
             }
             LegacyContractAbiEntry::Struct(legacy_struct_abi_entry) => {
-                starknet_types_rpc::ContractAbiEntry::Struct(legacy_struct_abi_entry.into())
+                mp_rpc::ContractAbiEntry::Struct(legacy_struct_abi_entry.into())
             }
         }
     }
 }
 
-impl From<starknet_types_rpc::FunctionAbiEntry> for LegacyFunctionAbiEntry {
-    fn from(legacy_function_abi_entry: starknet_types_rpc::FunctionAbiEntry) -> Self {
+impl From<mp_rpc::FunctionAbiEntry> for LegacyFunctionAbiEntry {
+    fn from(legacy_function_abi_entry: mp_rpc::FunctionAbiEntry) -> Self {
         LegacyFunctionAbiEntry {
             r#type: legacy_function_abi_entry.ty.into(),
             name: legacy_function_abi_entry.name,
@@ -269,9 +261,9 @@ impl From<starknet_types_rpc::FunctionAbiEntry> for LegacyFunctionAbiEntry {
     }
 }
 
-impl From<LegacyFunctionAbiEntry> for starknet_types_rpc::FunctionAbiEntry {
+impl From<LegacyFunctionAbiEntry> for mp_rpc::FunctionAbiEntry {
     fn from(legacy_function_abi_entry: LegacyFunctionAbiEntry) -> Self {
-        starknet_types_rpc::FunctionAbiEntry {
+        mp_rpc::FunctionAbiEntry {
             ty: legacy_function_abi_entry.r#type.into(),
             name: legacy_function_abi_entry.name,
             inputs: legacy_function_abi_entry.inputs.into_iter().map(|abi_entry| abi_entry.into()).collect(),
@@ -283,8 +275,8 @@ impl From<LegacyFunctionAbiEntry> for starknet_types_rpc::FunctionAbiEntry {
     }
 }
 
-impl From<starknet_types_rpc::EventAbiEntry> for LegacyEventAbiEntry {
-    fn from(legacy_event_abi_entry: starknet_types_rpc::EventAbiEntry) -> Self {
+impl From<mp_rpc::EventAbiEntry> for LegacyEventAbiEntry {
+    fn from(legacy_event_abi_entry: mp_rpc::EventAbiEntry) -> Self {
         LegacyEventAbiEntry {
             r#type: legacy_event_abi_entry.ty.into(),
             name: legacy_event_abi_entry.name,
@@ -294,9 +286,9 @@ impl From<starknet_types_rpc::EventAbiEntry> for LegacyEventAbiEntry {
     }
 }
 
-impl From<LegacyEventAbiEntry> for starknet_types_rpc::EventAbiEntry {
+impl From<LegacyEventAbiEntry> for mp_rpc::EventAbiEntry {
     fn from(legacy_event_abi_entry: LegacyEventAbiEntry) -> Self {
-        starknet_types_rpc::EventAbiEntry {
+        mp_rpc::EventAbiEntry {
             ty: legacy_event_abi_entry.r#type.into(),
             name: legacy_event_abi_entry.name,
             keys: legacy_event_abi_entry.keys.into_iter().map(|abi_entry| abi_entry.into()).collect(),
@@ -305,8 +297,8 @@ impl From<LegacyEventAbiEntry> for starknet_types_rpc::EventAbiEntry {
     }
 }
 
-impl From<starknet_types_rpc::StructAbiEntry> for LegacyStructAbiEntry {
-    fn from(legacy_struct_abi_entry: starknet_types_rpc::StructAbiEntry) -> Self {
+impl From<mp_rpc::StructAbiEntry> for LegacyStructAbiEntry {
+    fn from(legacy_struct_abi_entry: mp_rpc::StructAbiEntry) -> Self {
         LegacyStructAbiEntry {
             r#type: legacy_struct_abi_entry.ty.into(),
             name: legacy_struct_abi_entry.name,
@@ -316,9 +308,9 @@ impl From<starknet_types_rpc::StructAbiEntry> for LegacyStructAbiEntry {
     }
 }
 
-impl From<LegacyStructAbiEntry> for starknet_types_rpc::StructAbiEntry {
+impl From<LegacyStructAbiEntry> for mp_rpc::StructAbiEntry {
     fn from(legacy_struct_abi_entry: LegacyStructAbiEntry) -> Self {
-        starknet_types_rpc::StructAbiEntry {
+        mp_rpc::StructAbiEntry {
             ty: legacy_struct_abi_entry.r#type.into(),
             name: legacy_struct_abi_entry.name,
             size: legacy_struct_abi_entry.size,
@@ -327,8 +319,8 @@ impl From<LegacyStructAbiEntry> for starknet_types_rpc::StructAbiEntry {
     }
 }
 
-impl From<starknet_types_rpc::StructMember> for LegacyStructMember {
-    fn from(legacy_struct_member: starknet_types_rpc::StructMember) -> Self {
+impl From<mp_rpc::StructMember> for LegacyStructMember {
+    fn from(legacy_struct_member: mp_rpc::StructMember) -> Self {
         LegacyStructMember {
             name: legacy_struct_member.typed_parameter.name,
             r#type: legacy_struct_member.typed_parameter.ty,
@@ -337,10 +329,10 @@ impl From<starknet_types_rpc::StructMember> for LegacyStructMember {
     }
 }
 
-impl From<LegacyStructMember> for starknet_types_rpc::StructMember {
+impl From<LegacyStructMember> for mp_rpc::StructMember {
     fn from(legacy_struct_member: LegacyStructMember) -> Self {
-        starknet_types_rpc::StructMember {
-            typed_parameter: starknet_types_rpc::TypedParameter {
+        mp_rpc::StructMember {
+            typed_parameter: mp_rpc::TypedParameter {
                 name: legacy_struct_member.name,
                 ty: legacy_struct_member.r#type,
             },
@@ -349,45 +341,45 @@ impl From<LegacyStructMember> for starknet_types_rpc::StructMember {
     }
 }
 
-impl From<starknet_types_rpc::TypedParameter> for LegacyTypedParameter {
-    fn from(legacy_typed_parameter: starknet_types_rpc::TypedParameter) -> Self {
+impl From<mp_rpc::TypedParameter> for LegacyTypedParameter {
+    fn from(legacy_typed_parameter: mp_rpc::TypedParameter) -> Self {
         LegacyTypedParameter { r#type: legacy_typed_parameter.ty, name: legacy_typed_parameter.name }
     }
 }
 
-impl From<LegacyTypedParameter> for starknet_types_rpc::TypedParameter {
+impl From<LegacyTypedParameter> for mp_rpc::TypedParameter {
     fn from(legacy_typed_parameter: LegacyTypedParameter) -> Self {
-        starknet_types_rpc::TypedParameter { ty: legacy_typed_parameter.r#type, name: legacy_typed_parameter.name }
+        mp_rpc::TypedParameter { ty: legacy_typed_parameter.r#type, name: legacy_typed_parameter.name }
     }
 }
 
-impl From<starknet_types_rpc::FunctionAbiType> for LegacyFunctionAbiType {
-    fn from(legacy_function_abi_type: starknet_types_rpc::FunctionAbiType) -> Self {
+impl From<mp_rpc::FunctionAbiType> for LegacyFunctionAbiType {
+    fn from(legacy_function_abi_type: mp_rpc::FunctionAbiType) -> Self {
         match legacy_function_abi_type {
-            starknet_types_rpc::FunctionAbiType::Function => LegacyFunctionAbiType::Function,
-            starknet_types_rpc::FunctionAbiType::L1Handler => LegacyFunctionAbiType::L1Handler,
-            starknet_types_rpc::FunctionAbiType::Constructor => LegacyFunctionAbiType::Constructor,
+            mp_rpc::FunctionAbiType::Function => LegacyFunctionAbiType::Function,
+            mp_rpc::FunctionAbiType::L1Handler => LegacyFunctionAbiType::L1Handler,
+            mp_rpc::FunctionAbiType::Constructor => LegacyFunctionAbiType::Constructor,
         }
     }
 }
 
-impl From<LegacyFunctionAbiType> for starknet_types_rpc::FunctionAbiType {
+impl From<LegacyFunctionAbiType> for mp_rpc::FunctionAbiType {
     fn from(legacy_function_abi_type: LegacyFunctionAbiType) -> Self {
         match legacy_function_abi_type {
-            LegacyFunctionAbiType::Function => starknet_types_rpc::FunctionAbiType::Function,
-            LegacyFunctionAbiType::L1Handler => starknet_types_rpc::FunctionAbiType::L1Handler,
-            LegacyFunctionAbiType::Constructor => starknet_types_rpc::FunctionAbiType::Constructor,
+            LegacyFunctionAbiType::Function => mp_rpc::FunctionAbiType::Function,
+            LegacyFunctionAbiType::L1Handler => mp_rpc::FunctionAbiType::L1Handler,
+            LegacyFunctionAbiType::Constructor => mp_rpc::FunctionAbiType::Constructor,
         }
     }
 }
 
-impl From<starknet_types_rpc::EventAbiType> for LegacyEventAbiType {
-    fn from(_: starknet_types_rpc::EventAbiType) -> Self {
+impl From<mp_rpc::EventAbiType> for LegacyEventAbiType {
+    fn from(_: mp_rpc::EventAbiType) -> Self {
         LegacyEventAbiType::Event
     }
 }
 
-impl From<LegacyEventAbiType> for starknet_types_rpc::EventAbiType {
+impl From<LegacyEventAbiType> for mp_rpc::EventAbiType {
     fn from(legacy_event_abi_type: LegacyEventAbiType) -> Self {
         match legacy_event_abi_type {
             LegacyEventAbiType::Event => "event".to_string(),
@@ -395,13 +387,13 @@ impl From<LegacyEventAbiType> for starknet_types_rpc::EventAbiType {
     }
 }
 
-impl From<starknet_types_rpc::StructAbiType> for LegacyStructAbiType {
-    fn from(_: starknet_types_rpc::StructAbiType) -> Self {
+impl From<mp_rpc::StructAbiType> for LegacyStructAbiType {
+    fn from(_: mp_rpc::StructAbiType) -> Self {
         LegacyStructAbiType::Struct
     }
 }
 
-impl From<LegacyStructAbiType> for starknet_types_rpc::StructAbiType {
+impl From<LegacyStructAbiType> for mp_rpc::StructAbiType {
     fn from(legacy_struct_abi_type: LegacyStructAbiType) -> Self {
         match legacy_struct_abi_type {
             LegacyStructAbiType::Struct => "struct".to_string(),
@@ -409,13 +401,13 @@ impl From<LegacyStructAbiType> for starknet_types_rpc::StructAbiType {
     }
 }
 
-impl From<starknet_types_rpc::FunctionStateMutability> for FunctionStateMutability {
-    fn from(_: starknet_types_rpc::FunctionStateMutability) -> Self {
+impl From<mp_rpc::FunctionStateMutability> for FunctionStateMutability {
+    fn from(_: mp_rpc::FunctionStateMutability) -> Self {
         FunctionStateMutability::View
     }
 }
 
-impl From<FunctionStateMutability> for starknet_types_rpc::FunctionStateMutability {
+impl From<FunctionStateMutability> for mp_rpc::FunctionStateMutability {
     fn from(function_state_mutability: FunctionStateMutability) -> Self {
         match function_state_mutability {
             FunctionStateMutability::View => "view".to_string(),
@@ -432,8 +424,8 @@ mod tests {
         LegacyStructMember, LegacyTypedParameter, SierraEntryPoint,
     };
     use mp_convert::test::assert_consistent_conversion;
+    use mp_rpc::MaybeDeprecatedContractClass as StarknetContractClass;
     use starknet_types_core::felt::Felt;
-    use starknet_types_rpc::MaybeDeprecatedContractClass as StarknetContractClass;
 
     #[test]
     fn test_legacy_contract_class_conversion() {
@@ -473,7 +465,7 @@ mod tests {
 
         let contract_class: ContractClass = legacy_contract_class.clone().into();
 
-        assert_consistent_conversion::<_, StarknetContractClass<Felt>>(contract_class);
+        assert_consistent_conversion::<_, StarknetContractClass>(contract_class);
     }
 
     #[test]
@@ -491,6 +483,6 @@ mod tests {
 
         let contract_class: ContractClass = sierra_contract_class.into();
 
-        assert_consistent_conversion::<_, StarknetContractClass<Felt>>(contract_class);
+        assert_consistent_conversion::<_, StarknetContractClass>(contract_class);
     }
 }

--- a/crates/madara/primitives/gateway/Cargo.toml
+++ b/crates/madara/primitives/gateway/Cargo.toml
@@ -23,13 +23,13 @@ mp-chain-config.workspace = true
 mp-class.workspace = true
 mp-convert.workspace = true
 mp-receipt.workspace = true
+mp-rpc.workspace = true
 mp-state-update.workspace = true
 mp-transactions.workspace = true
 
 # Starknet
 starknet-core.workspace = true
 starknet-types-core.workspace = true
-starknet-types-rpc.workspace = true
 
 # Other
 anyhow.workspace = true

--- a/crates/madara/primitives/gateway/src/user_transaction.rs
+++ b/crates/madara/primitives/gateway/src/user_transaction.rs
@@ -35,16 +35,16 @@
 
 use mp_class::{CompressedLegacyContractClass, CompressedSierraClass, FlattenedSierraClass};
 use mp_convert::hex_serde::U64AsHex;
-use mp_transactions::{DataAvailabilityMode, ResourceBoundsMapping};
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{
+use mp_rpc::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeclareTxnV1, BroadcastedDeclareTxnV2,
     BroadcastedDeclareTxnV3, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, BroadcastedTxn,
     ClassAndTxnHash as AddDeclareTransactionResult, ContractAndTxnHash as AddDeployAccountTransactionResult,
     DeployAccountTxnV1, DeployAccountTxnV3, InvokeTxnV0, InvokeTxnV1, InvokeTxnV3,
 };
+use mp_transactions::{DataAvailabilityMode, ResourceBoundsMapping};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use starknet_types_core::felt::Felt;
 
 /// Gateway response when a transaction is successfully added to the mempool.
 /// Generic type T represents the specific transaction result type
@@ -63,9 +63,9 @@ pub struct AddTransactionResult<T> {
 pub trait ValidTransactionResult {}
 
 // Implement the marker trait for the three valid transaction result types
-impl<T> ValidTransactionResult for AddInvokeTransactionResult<T> {}
-impl<T> ValidTransactionResult for AddDeclareTransactionResult<T> {}
-impl<T> ValidTransactionResult for AddDeployAccountTransactionResult<T> {}
+impl ValidTransactionResult for AddInvokeTransactionResult {}
+impl ValidTransactionResult for AddDeclareTransactionResult {}
+impl ValidTransactionResult for AddDeployAccountTransactionResult {}
 
 // Conversion from a valid transaction result into a gateway response.
 /// This ensures the response can only be created from permitted transaction types.
@@ -103,7 +103,7 @@ pub enum UserTransaction {
     DeployAccount(UserDeployAccountTransaction),
 }
 
-impl TryFrom<UserTransaction> for BroadcastedTxn<Felt> {
+impl TryFrom<UserTransaction> for BroadcastedTxn {
     type Error = UserTransactionConversionError;
 
     fn try_from(transaction: UserTransaction) -> Result<Self, Self::Error> {
@@ -115,10 +115,10 @@ impl TryFrom<UserTransaction> for BroadcastedTxn<Felt> {
     }
 }
 
-impl TryFrom<BroadcastedTxn<Felt>> for UserTransaction {
+impl TryFrom<BroadcastedTxn> for UserTransaction {
     type Error = UserTransactionConversionError;
 
-    fn try_from(transaction: BroadcastedTxn<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(transaction: BroadcastedTxn) -> Result<Self, Self::Error> {
         match transaction {
             BroadcastedTxn::Declare(tx) => Ok(UserTransaction::Declare(tx.try_into()?)),
             BroadcastedTxn::Invoke(tx) => Ok(UserTransaction::InvokeFunction(tx.try_into()?)),
@@ -138,7 +138,7 @@ pub enum UserDeclareTransaction {
     V3(UserDeclareV3Transaction),
 }
 
-impl TryFrom<UserDeclareTransaction> for BroadcastedDeclareTxn<Felt> {
+impl TryFrom<UserDeclareTransaction> for BroadcastedDeclareTxn {
     type Error = UserTransactionConversionError;
 
     fn try_from(transaction: UserDeclareTransaction) -> Result<Self, Self::Error> {
@@ -150,10 +150,10 @@ impl TryFrom<UserDeclareTransaction> for BroadcastedDeclareTxn<Felt> {
     }
 }
 
-impl TryFrom<BroadcastedDeclareTxn<Felt>> for UserDeclareTransaction {
+impl TryFrom<BroadcastedDeclareTxn> for UserDeclareTransaction {
     type Error = UserTransactionConversionError;
 
-    fn try_from(transaction: BroadcastedDeclareTxn<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(transaction: BroadcastedDeclareTxn) -> Result<Self, Self::Error> {
         match transaction {
             BroadcastedDeclareTxn::V1(tx) => Ok(UserDeclareTransaction::V1(tx.try_into()?)),
             BroadcastedDeclareTxn::V2(tx) => Ok(UserDeclareTransaction::V2(tx.try_into()?)),
@@ -174,7 +174,7 @@ pub struct UserDeclareV1Transaction {
     pub nonce: Felt,
 }
 
-impl From<UserDeclareV1Transaction> for BroadcastedDeclareTxnV1<Felt> {
+impl From<UserDeclareV1Transaction> for BroadcastedDeclareTxnV1 {
     fn from(transaction: UserDeclareV1Transaction) -> Self {
         Self {
             sender_address: transaction.sender_address,
@@ -186,10 +186,10 @@ impl From<UserDeclareV1Transaction> for BroadcastedDeclareTxnV1<Felt> {
     }
 }
 
-impl TryFrom<BroadcastedDeclareTxnV1<Felt>> for UserDeclareV1Transaction {
+impl TryFrom<BroadcastedDeclareTxnV1> for UserDeclareV1Transaction {
     type Error = std::io::Error;
 
-    fn try_from(transaction: BroadcastedDeclareTxnV1<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(transaction: BroadcastedDeclareTxnV1) -> Result<Self, Self::Error> {
         Ok(Self {
             sender_address: transaction.sender_address,
             max_fee: transaction.max_fee,
@@ -210,7 +210,7 @@ pub struct UserDeclareV2Transaction {
     pub nonce: Felt,
 }
 
-impl TryFrom<UserDeclareV2Transaction> for BroadcastedDeclareTxnV2<Felt> {
+impl TryFrom<UserDeclareV2Transaction> for BroadcastedDeclareTxnV2 {
     type Error = std::io::Error;
 
     fn try_from(transaction: UserDeclareV2Transaction) -> Result<Self, Self::Error> {
@@ -227,10 +227,10 @@ impl TryFrom<UserDeclareV2Transaction> for BroadcastedDeclareTxnV2<Felt> {
     }
 }
 
-impl TryFrom<BroadcastedDeclareTxnV2<Felt>> for UserDeclareV2Transaction {
+impl TryFrom<BroadcastedDeclareTxnV2> for UserDeclareV2Transaction {
     type Error = std::io::Error;
 
-    fn try_from(transaction: BroadcastedDeclareTxnV2<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(transaction: BroadcastedDeclareTxnV2) -> Result<Self, Self::Error> {
         let flattened_sierra_class: FlattenedSierraClass = transaction.contract_class.into();
 
         Ok(Self {
@@ -261,7 +261,7 @@ pub struct UserDeclareV3Transaction {
     pub account_deployment_data: Vec<Felt>,
 }
 
-impl TryFrom<UserDeclareV3Transaction> for BroadcastedDeclareTxnV3<Felt> {
+impl TryFrom<UserDeclareV3Transaction> for BroadcastedDeclareTxnV3 {
     type Error = std::io::Error;
 
     fn try_from(transaction: UserDeclareV3Transaction) -> Result<Self, Self::Error> {
@@ -283,10 +283,10 @@ impl TryFrom<UserDeclareV3Transaction> for BroadcastedDeclareTxnV3<Felt> {
     }
 }
 
-impl TryFrom<BroadcastedDeclareTxnV3<Felt>> for UserDeclareV3Transaction {
+impl TryFrom<BroadcastedDeclareTxnV3> for UserDeclareV3Transaction {
     type Error = std::io::Error;
 
-    fn try_from(transaction: BroadcastedDeclareTxnV3<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(transaction: BroadcastedDeclareTxnV3) -> Result<Self, Self::Error> {
         let flattened_sierra_class: FlattenedSierraClass = transaction.contract_class.into();
 
         Ok(Self {
@@ -316,7 +316,7 @@ pub enum UserInvokeFunctionTransaction {
     V3(UserInvokeFunctionV3Transaction),
 }
 
-impl From<UserInvokeFunctionTransaction> for BroadcastedInvokeTxn<Felt> {
+impl From<UserInvokeFunctionTransaction> for BroadcastedInvokeTxn {
     fn from(transaction: UserInvokeFunctionTransaction) -> Self {
         match transaction {
             UserInvokeFunctionTransaction::V0(tx) => BroadcastedInvokeTxn::V0(tx.into()),
@@ -326,10 +326,10 @@ impl From<UserInvokeFunctionTransaction> for BroadcastedInvokeTxn<Felt> {
     }
 }
 
-impl TryFrom<BroadcastedInvokeTxn<Felt>> for UserInvokeFunctionTransaction {
+impl TryFrom<BroadcastedInvokeTxn> for UserInvokeFunctionTransaction {
     type Error = UserTransactionConversionError;
 
-    fn try_from(transaction: BroadcastedInvokeTxn<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(transaction: BroadcastedInvokeTxn) -> Result<Self, Self::Error> {
         match transaction {
             BroadcastedInvokeTxn::V0(tx) => Ok(UserInvokeFunctionTransaction::V0(tx.into())),
             BroadcastedInvokeTxn::V1(tx) => Ok(UserInvokeFunctionTransaction::V1(tx.into())),
@@ -350,7 +350,7 @@ pub struct UserInvokeFunctionV0Transaction {
     pub max_fee: Felt,
 }
 
-impl From<UserInvokeFunctionV0Transaction> for InvokeTxnV0<Felt> {
+impl From<UserInvokeFunctionV0Transaction> for InvokeTxnV0 {
     fn from(transaction: UserInvokeFunctionV0Transaction) -> Self {
         Self {
             contract_address: transaction.sender_address,
@@ -362,8 +362,8 @@ impl From<UserInvokeFunctionV0Transaction> for InvokeTxnV0<Felt> {
     }
 }
 
-impl From<InvokeTxnV0<Felt>> for UserInvokeFunctionV0Transaction {
-    fn from(transaction: InvokeTxnV0<Felt>) -> Self {
+impl From<InvokeTxnV0> for UserInvokeFunctionV0Transaction {
+    fn from(transaction: InvokeTxnV0) -> Self {
         Self {
             sender_address: transaction.contract_address,
             entry_point_selector: transaction.entry_point_selector,
@@ -383,7 +383,7 @@ pub struct UserInvokeFunctionV1Transaction {
     pub nonce: Felt,
 }
 
-impl From<UserInvokeFunctionV1Transaction> for InvokeTxnV1<Felt> {
+impl From<UserInvokeFunctionV1Transaction> for InvokeTxnV1 {
     fn from(transaction: UserInvokeFunctionV1Transaction) -> Self {
         Self {
             sender_address: transaction.sender_address,
@@ -395,8 +395,8 @@ impl From<UserInvokeFunctionV1Transaction> for InvokeTxnV1<Felt> {
     }
 }
 
-impl From<InvokeTxnV1<Felt>> for UserInvokeFunctionV1Transaction {
-    fn from(transaction: InvokeTxnV1<Felt>) -> Self {
+impl From<InvokeTxnV1> for UserInvokeFunctionV1Transaction {
+    fn from(transaction: InvokeTxnV1) -> Self {
         Self {
             sender_address: transaction.sender_address,
             calldata: transaction.calldata,
@@ -423,7 +423,7 @@ pub struct UserInvokeFunctionV3Transaction {
     pub account_deployment_data: Vec<Felt>,
 }
 
-impl From<UserInvokeFunctionV3Transaction> for InvokeTxnV3<Felt> {
+impl From<UserInvokeFunctionV3Transaction> for InvokeTxnV3 {
     fn from(transaction: UserInvokeFunctionV3Transaction) -> Self {
         Self {
             sender_address: transaction.sender_address,
@@ -440,8 +440,8 @@ impl From<UserInvokeFunctionV3Transaction> for InvokeTxnV3<Felt> {
     }
 }
 
-impl From<InvokeTxnV3<Felt>> for UserInvokeFunctionV3Transaction {
-    fn from(transaction: InvokeTxnV3<Felt>) -> Self {
+impl From<InvokeTxnV3> for UserInvokeFunctionV3Transaction {
+    fn from(transaction: InvokeTxnV3) -> Self {
         Self {
             sender_address: transaction.sender_address,
             calldata: transaction.calldata,
@@ -466,7 +466,7 @@ pub enum UserDeployAccountTransaction {
     V3(UserDeployAccountV3Transaction),
 }
 
-impl From<UserDeployAccountTransaction> for BroadcastedDeployAccountTxn<Felt> {
+impl From<UserDeployAccountTransaction> for BroadcastedDeployAccountTxn {
     fn from(transaction: UserDeployAccountTransaction) -> Self {
         match transaction {
             UserDeployAccountTransaction::V1(tx) => BroadcastedDeployAccountTxn::V1(tx.into()),
@@ -475,10 +475,10 @@ impl From<UserDeployAccountTransaction> for BroadcastedDeployAccountTxn<Felt> {
     }
 }
 
-impl TryFrom<BroadcastedDeployAccountTxn<Felt>> for UserDeployAccountTransaction {
+impl TryFrom<BroadcastedDeployAccountTxn> for UserDeployAccountTransaction {
     type Error = UserTransactionConversionError;
 
-    fn try_from(transaction: BroadcastedDeployAccountTxn<Felt>) -> Result<Self, Self::Error> {
+    fn try_from(transaction: BroadcastedDeployAccountTxn) -> Result<Self, Self::Error> {
         match transaction {
             BroadcastedDeployAccountTxn::V1(tx) => Ok(UserDeployAccountTransaction::V1(tx.into())),
             BroadcastedDeployAccountTxn::V3(tx) => Ok(UserDeployAccountTransaction::V3(tx.into())),
@@ -499,7 +499,7 @@ pub struct UserDeployAccountV1Transaction {
     pub nonce: Felt,
 }
 
-impl From<UserDeployAccountV1Transaction> for DeployAccountTxnV1<Felt> {
+impl From<UserDeployAccountV1Transaction> for DeployAccountTxnV1 {
     fn from(transaction: UserDeployAccountV1Transaction) -> Self {
         Self {
             class_hash: transaction.class_hash,
@@ -512,8 +512,8 @@ impl From<UserDeployAccountV1Transaction> for DeployAccountTxnV1<Felt> {
     }
 }
 
-impl From<DeployAccountTxnV1<Felt>> for UserDeployAccountV1Transaction {
-    fn from(transaction: DeployAccountTxnV1<Felt>) -> Self {
+impl From<DeployAccountTxnV1> for UserDeployAccountV1Transaction {
+    fn from(transaction: DeployAccountTxnV1) -> Self {
         Self {
             class_hash: transaction.class_hash,
             contract_address_salt: transaction.contract_address_salt,
@@ -541,7 +541,7 @@ pub struct UserDeployAccountV3Transaction {
     pub paymaster_data: Vec<Felt>,
 }
 
-impl From<UserDeployAccountV3Transaction> for DeployAccountTxnV3<Felt> {
+impl From<UserDeployAccountV3Transaction> for DeployAccountTxnV3 {
     fn from(transaction: UserDeployAccountV3Transaction) -> Self {
         Self {
             class_hash: transaction.class_hash,
@@ -558,8 +558,8 @@ impl From<UserDeployAccountV3Transaction> for DeployAccountTxnV3<Felt> {
     }
 }
 
-impl From<DeployAccountTxnV3<Felt>> for UserDeployAccountV3Transaction {
-    fn from(transaction: DeployAccountTxnV3<Felt>) -> Self {
+impl From<DeployAccountTxnV3> for UserDeployAccountV3Transaction {
+    fn from(transaction: DeployAccountTxnV3) -> Self {
         Self {
             class_hash: transaction.class_hash,
             contract_address_salt: transaction.contract_address_salt,

--- a/crates/madara/primitives/receipt/Cargo.toml
+++ b/crates/madara/primitives/receipt/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+# Madara
+mp-rpc = { workspace = true }
 
 # Starknet
 blockifier = { workspace = true }
@@ -22,7 +24,6 @@ cairo-vm = { workspace = true }
 rstest.workspace = true
 starknet-core = { workspace = true }
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 starknet_api = { workspace = true }
 thiserror = { workspace = true }
 tracing.workspace = true

--- a/crates/madara/primitives/receipt/src/to_starknet_types.rs
+++ b/crates/madara/primitives/receipt/src/to_starknet_types.rs
@@ -1,5 +1,4 @@
 use primitive_types::H256;
-use starknet_types_core::felt::Felt;
 
 use crate::{
     DeclareTransactionReceipt, DeployAccountTransactionReceipt, DeployTransactionReceipt, Event, ExecutionResources,
@@ -8,42 +7,36 @@ use crate::{
 };
 
 impl TransactionReceipt {
-    pub fn to_starknet_types(
-        self,
-        finality_status: starknet_types_rpc::TxnFinalityStatus,
-    ) -> starknet_types_rpc::TxnReceipt<Felt> {
+    pub fn to_starknet_types(self, finality_status: mp_rpc::TxnFinalityStatus) -> mp_rpc::TxnReceipt {
         match self {
             TransactionReceipt::Invoke(receipt) => {
-                starknet_types_rpc::TxnReceipt::Invoke(receipt.to_starknet_types(finality_status))
+                mp_rpc::TxnReceipt::Invoke(receipt.to_starknet_types(finality_status))
             }
             TransactionReceipt::L1Handler(receipt) => {
-                starknet_types_rpc::TxnReceipt::L1Handler(receipt.to_starknet_types(finality_status))
+                mp_rpc::TxnReceipt::L1Handler(receipt.to_starknet_types(finality_status))
             }
             TransactionReceipt::Declare(receipt) => {
-                starknet_types_rpc::TxnReceipt::Declare(receipt.to_starknet_types(finality_status))
+                mp_rpc::TxnReceipt::Declare(receipt.to_starknet_types(finality_status))
             }
             TransactionReceipt::Deploy(receipt) => {
-                starknet_types_rpc::TxnReceipt::Deploy(receipt.to_starknet_types(finality_status))
+                mp_rpc::TxnReceipt::Deploy(receipt.to_starknet_types(finality_status))
             }
             TransactionReceipt::DeployAccount(receipt) => {
-                starknet_types_rpc::TxnReceipt::DeployAccount(receipt.to_starknet_types(finality_status))
+                mp_rpc::TxnReceipt::DeployAccount(receipt.to_starknet_types(finality_status))
             }
         }
     }
 }
 
 impl InvokeTransactionReceipt {
-    pub fn to_starknet_types(
-        self,
-        finality_status: starknet_types_rpc::TxnFinalityStatus,
-    ) -> starknet_types_rpc::InvokeTxnReceipt<Felt> {
-        starknet_types_rpc::InvokeTxnReceipt::<Felt> {
-            common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
+    pub fn to_starknet_types(self, finality_status: mp_rpc::TxnFinalityStatus) -> mp_rpc::InvokeTxnReceipt {
+        mp_rpc::InvokeTxnReceipt {
+            common_receipt_properties: mp_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
-                events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),
+                events: self.events.into_iter().map(mp_rpc::Event::from).collect(),
                 execution_resources: self.execution_resources.into(),
                 finality_status,
-                messages_sent: self.messages_sent.into_iter().map(starknet_types_rpc::MsgToL1::from).collect(),
+                messages_sent: self.messages_sent.into_iter().map(mp_rpc::MsgToL1::from).collect(),
                 transaction_hash: self.transaction_hash,
                 execution_status: self.execution_result.into(),
             },
@@ -55,20 +48,17 @@ impl InvokeTransactionReceipt {
 // which is insufficient for representing the full 256-bit hash value.
 // See: https://github.com/starknet-io/types-rs/issues/103
 impl L1HandlerTransactionReceipt {
-    pub fn to_starknet_types(
-        self,
-        finality_status: starknet_types_rpc::TxnFinalityStatus,
-    ) -> starknet_types_rpc::L1HandlerTxnReceipt<Felt> {
-        starknet_types_rpc::L1HandlerTxnReceipt::<Felt> {
+    pub fn to_starknet_types(self, finality_status: mp_rpc::TxnFinalityStatus) -> mp_rpc::L1HandlerTxnReceipt {
+        mp_rpc::L1HandlerTxnReceipt {
             // We have to manually convert the H256 bytes to a hex hash as the
             // impl of Display for H256 skips the middle bytes.
             message_hash: hash_as_string(self.message_hash),
-            common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
+            common_receipt_properties: mp_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
-                events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),
+                events: self.events.into_iter().map(mp_rpc::Event::from).collect(),
                 execution_resources: self.execution_resources.into(),
                 finality_status,
-                messages_sent: self.messages_sent.into_iter().map(starknet_types_rpc::MsgToL1::from).collect(),
+                messages_sent: self.messages_sent.into_iter().map(mp_rpc::MsgToL1::from).collect(),
                 transaction_hash: self.transaction_hash,
                 execution_status: self.execution_result.into(),
             },
@@ -94,17 +84,14 @@ fn hash_as_string(message_hash: H256) -> String {
 }
 
 impl DeclareTransactionReceipt {
-    pub fn to_starknet_types(
-        self,
-        finality_status: starknet_types_rpc::TxnFinalityStatus,
-    ) -> starknet_types_rpc::DeclareTxnReceipt<Felt> {
-        starknet_types_rpc::DeclareTxnReceipt::<Felt> {
-            common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
+    pub fn to_starknet_types(self, finality_status: mp_rpc::TxnFinalityStatus) -> mp_rpc::DeclareTxnReceipt {
+        mp_rpc::DeclareTxnReceipt {
+            common_receipt_properties: mp_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
-                events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),
+                events: self.events.into_iter().map(mp_rpc::Event::from).collect(),
                 execution_resources: self.execution_resources.into(),
                 finality_status,
-                messages_sent: self.messages_sent.into_iter().map(starknet_types_rpc::MsgToL1::from).collect(),
+                messages_sent: self.messages_sent.into_iter().map(mp_rpc::MsgToL1::from).collect(),
                 transaction_hash: self.transaction_hash,
                 execution_status: self.execution_result.into(),
             },
@@ -113,18 +100,15 @@ impl DeclareTransactionReceipt {
 }
 
 impl DeployTransactionReceipt {
-    pub fn to_starknet_types(
-        self,
-        finality_status: starknet_types_rpc::TxnFinalityStatus,
-    ) -> starknet_types_rpc::DeployTxnReceipt<Felt> {
-        starknet_types_rpc::DeployTxnReceipt::<Felt> {
+    pub fn to_starknet_types(self, finality_status: mp_rpc::TxnFinalityStatus) -> mp_rpc::DeployTxnReceipt {
+        mp_rpc::DeployTxnReceipt {
             contract_address: self.contract_address,
-            common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
+            common_receipt_properties: mp_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
-                events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),
+                events: self.events.into_iter().map(mp_rpc::Event::from).collect(),
                 execution_resources: self.execution_resources.into(),
                 finality_status,
-                messages_sent: self.messages_sent.into_iter().map(starknet_types_rpc::MsgToL1::from).collect(),
+                messages_sent: self.messages_sent.into_iter().map(mp_rpc::MsgToL1::from).collect(),
                 transaction_hash: self.transaction_hash,
                 execution_status: self.execution_result.into(),
             },
@@ -133,18 +117,15 @@ impl DeployTransactionReceipt {
 }
 
 impl DeployAccountTransactionReceipt {
-    pub fn to_starknet_types(
-        self,
-        finality_status: starknet_types_rpc::TxnFinalityStatus,
-    ) -> starknet_types_rpc::DeployAccountTxnReceipt<Felt> {
-        starknet_types_rpc::DeployAccountTxnReceipt::<Felt> {
+    pub fn to_starknet_types(self, finality_status: mp_rpc::TxnFinalityStatus) -> mp_rpc::DeployAccountTxnReceipt {
+        mp_rpc::DeployAccountTxnReceipt {
             contract_address: self.contract_address,
-            common_receipt_properties: starknet_types_rpc::CommonReceiptProperties {
+            common_receipt_properties: mp_rpc::CommonReceiptProperties {
                 actual_fee: self.actual_fee.into(),
-                events: self.events.into_iter().map(starknet_types_rpc::Event::from).collect(),
+                events: self.events.into_iter().map(mp_rpc::Event::from).collect(),
                 execution_resources: self.execution_resources.into(),
                 finality_status,
-                messages_sent: self.messages_sent.into_iter().map(starknet_types_rpc::MsgToL1::from).collect(),
+                messages_sent: self.messages_sent.into_iter().map(mp_rpc::MsgToL1::from).collect(),
                 transaction_hash: self.transaction_hash,
                 execution_status: self.execution_result.into(),
             },
@@ -152,37 +133,37 @@ impl DeployAccountTransactionReceipt {
     }
 }
 
-impl From<FeePayment> for starknet_types_rpc::FeePayment<Felt> {
+impl From<FeePayment> for mp_rpc::FeePayment {
     fn from(fee: FeePayment) -> Self {
         Self { amount: fee.amount, unit: fee.unit.into() }
     }
 }
 
-impl From<PriceUnit> for starknet_types_rpc::PriceUnit {
+impl From<PriceUnit> for mp_rpc::PriceUnit {
     fn from(unit: PriceUnit) -> Self {
         match unit {
-            PriceUnit::Wei => starknet_types_rpc::PriceUnit::Wei,
-            PriceUnit::Fri => starknet_types_rpc::PriceUnit::Fri,
+            PriceUnit::Wei => mp_rpc::PriceUnit::Wei,
+            PriceUnit::Fri => mp_rpc::PriceUnit::Fri,
         }
     }
 }
 
-impl From<MsgToL1> for starknet_types_rpc::MsgToL1<Felt> {
+impl From<MsgToL1> for mp_rpc::MsgToL1 {
     fn from(msg: MsgToL1) -> Self {
         Self { from_address: msg.from_address, to_address: msg.to_address, payload: msg.payload }
     }
 }
 
-impl From<Event> for starknet_types_rpc::Event<Felt> {
+impl From<Event> for mp_rpc::Event {
     fn from(event: Event) -> Self {
         Self {
             from_address: event.from_address,
-            event_content: starknet_types_rpc::EventContent { keys: event.keys, data: event.data },
+            event_content: mp_rpc::EventContent { keys: event.keys, data: event.data },
         }
     }
 }
 
-impl From<ExecutionResources> for starknet_types_rpc::ExecutionResources {
+impl From<ExecutionResources> for mp_rpc::ExecutionResources {
     fn from(resources: ExecutionResources) -> Self {
         Self {
             bitwise_builtin_applications: nullify_zero(resources.bitwise_builtin_applications),
@@ -207,17 +188,17 @@ fn nullify_zero(u: u64) -> Option<u64> {
     }
 }
 
-impl From<L1Gas> for starknet_types_rpc::DataAvailability {
+impl From<L1Gas> for mp_rpc::DataAvailability {
     fn from(resources: L1Gas) -> Self {
         Self { l1_gas: resources.l1_gas, l1_data_gas: resources.l1_data_gas }
     }
 }
 
-impl From<ExecutionResult> for starknet_types_rpc::ExecutionStatus {
+impl From<ExecutionResult> for mp_rpc::ExecutionStatus {
     fn from(result: ExecutionResult) -> Self {
         match result {
-            ExecutionResult::Succeeded => starknet_types_rpc::ExecutionStatus::Successful,
-            ExecutionResult::Reverted { reason } => starknet_types_rpc::ExecutionStatus::Reverted(reason),
+            ExecutionResult::Succeeded => mp_rpc::ExecutionStatus::Successful,
+            ExecutionResult::Reverted { reason } => mp_rpc::ExecutionStatus::Reverted(reason),
         }
     }
 }
@@ -243,8 +224,7 @@ mod test {
     fn test_l1_tx_receipt_full_hash() {
         let l1_transaction_receipt =
             L1HandlerTransactionReceipt { message_hash: H256::from_slice(&[u8::MAX; 32]), ..Default::default() };
-        let message_hash =
-            l1_transaction_receipt.to_starknet_types(starknet_types_rpc::TxnFinalityStatus::L1).message_hash;
+        let message_hash = l1_transaction_receipt.to_starknet_types(mp_rpc::TxnFinalityStatus::L1).message_hash;
 
         let mut hash = String::with_capacity(68);
         hash.push_str("0x");

--- a/crates/madara/primitives/rpc/Cargo.toml
+++ b/crates/madara/primitives/rpc/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+description = "Madara primitive for RPC"
+name = "mp-rpc"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[package.metadata.attribution]
+includes-code-from = [
+  "starknet-types-rpc (MIT) - https://github.com/starknet-io/types-rs",
+]
+
+[dependencies]
+
+# Starknet
+starknet-types-core = { workspace = true }
+
+# Other
+primitive-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/madara/primitives/rpc/LICENSE
+++ b/crates/madara/primitives/rpc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Starknet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/madara/primitives/rpc/ORIGINAL_AUTHORS.md
+++ b/crates/madara/primitives/rpc/ORIGINAL_AUTHORS.md
@@ -16,6 +16,6 @@ Original authors:
 - Jonathan Lei (@xJonathanLEI)
 - Maciej Kamiński (@maciejka)
 
-Original repository: https://github.com/starknet-io/types-rs
+Original repository: [https://github.com/starknet-io/types-rs]
 Original version: 0.7.1
 License: MIT

--- a/crates/madara/primitives/rpc/ORIGINAL_AUTHORS.md
+++ b/crates/madara/primitives/rpc/ORIGINAL_AUTHORS.md
@@ -1,0 +1,21 @@
+This crate is a fork of the original [starknet-types-rpc](https://github.com/starknet-io/types-rs) v0.7.1,
+which was originally developed by the Starknet team under the MIT license.
+
+The original crate is no longer actively maintained, so this fork has been created
+to ensure continued maintenance and compatibility with our project needs.
+
+Original authors:
+
+- Pedro Fontana (@pefontana)
+- Mario Rugiero (@Oppen)
+- Lucas Levy (@LucasLvy)
+- Shahar Papini (@spapinistarkware)
+- Abdelhamid Bakhta (@abdelhamidbakhta)
+- Dan Brownstein (@dan-starkware)
+- Federico Carrone (@unbalancedparentheses)
+- Jonathan Lei (@xJonathanLEI)
+- Maciej Kamiński (@maciejka)
+
+Original repository: https://github.com/starknet-io/types-rs
+Original version: 0.7.1
+License: MIT

--- a/crates/madara/primitives/rpc/src/custom/block_id.rs
+++ b/crates/madara/primitives/rpc/src/custom/block_id.rs
@@ -1,0 +1,129 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::{BlockHash, BlockNumber, BlockTag};
+
+/// A hexadecimal number.
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub enum BlockId {
+    /// The tag of the block.
+    Tag(BlockTag),
+    /// The hash of the block.
+    Hash(BlockHash),
+    /// The height of the block.
+    Number(BlockNumber),
+}
+
+#[derive(Serialize, Deserialize)]
+struct BlockHashHelper {
+    block_hash: BlockHash,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BlockNumberHelper {
+    block_number: BlockNumber,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum BlockIdHelper {
+    Tag(BlockTag),
+    Hash(BlockHashHelper),
+    Number(BlockNumberHelper),
+}
+
+impl serde::Serialize for BlockId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            BlockId::Tag(tag) => tag.serialize(serializer),
+            BlockId::Hash(block_hash) => {
+                let helper = BlockHashHelper { block_hash: *block_hash };
+                helper.serialize(serializer)
+            }
+            BlockId::Number(block_number) => {
+                let helper = BlockNumberHelper { block_number: *block_number };
+                helper.serialize(serializer)
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for BlockId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let helper = BlockIdHelper::deserialize(deserializer)?;
+        match helper {
+            BlockIdHelper::Tag(tag) => Ok(BlockId::Tag(tag)),
+            BlockIdHelper::Hash(helper) => Ok(BlockId::Hash(helper.block_hash)),
+            BlockIdHelper::Number(helper) => Ok(BlockId::Number(helper.block_number)),
+        }
+    }
+}
+
+#[test]
+fn block_id_from_hash() {
+    pub use starknet_types_core::felt::Felt;
+
+    let s = "{\"block_hash\":\"0x123\"}";
+    let block_id: BlockId = serde_json::from_str(s).unwrap();
+    assert_eq!(block_id, BlockId::Hash(Felt::from_hex("0x123").unwrap()));
+}
+
+#[test]
+fn block_id_from_number() {
+    let s = "{\"block_number\":123}";
+    let block_id: BlockId = serde_json::from_str(s).unwrap();
+    assert_eq!(block_id, BlockId::Number(123));
+}
+
+#[test]
+fn block_id_from_latest() {
+    let s = "\"latest\"";
+    let block_id: BlockId = serde_json::from_str(s).unwrap();
+    assert_eq!(block_id, BlockId::Tag(BlockTag::Latest));
+}
+
+#[test]
+fn block_id_from_pending() {
+    let s = "\"pending\"";
+    let block_id: BlockId = serde_json::from_str(s).unwrap();
+    assert_eq!(block_id, BlockId::Tag(BlockTag::Pending));
+}
+
+#[cfg(test)]
+#[test]
+fn block_id_to_hash() {
+    pub use starknet_types_core::felt::Felt;
+
+    let block_id = BlockId::Hash(Felt::from_hex("0x123").unwrap());
+    let s = serde_json::to_string(&block_id).unwrap();
+    assert_eq!(s, "{\"block_hash\":\"0x123\"}");
+}
+
+#[cfg(test)]
+#[test]
+fn block_id_to_number() {
+    let block_id = BlockId::Number(123);
+    let s = serde_json::to_string(&block_id).unwrap();
+    assert_eq!(s, "{\"block_number\":123}");
+}
+
+#[cfg(test)]
+#[test]
+fn block_id_to_latest() {
+    let block_id = BlockId::Tag(BlockTag::Latest);
+    let s = serde_json::to_string(&block_id).unwrap();
+    assert_eq!(s, "\"latest\"");
+}
+
+#[cfg(test)]
+#[test]
+fn block_id_to_pending() {
+    let block_id = BlockId::Tag(BlockTag::Pending);
+    let s = serde_json::to_string(&block_id).unwrap();
+    assert_eq!(s, "\"pending\"");
+}

--- a/crates/madara/primitives/rpc/src/custom/mod.rs
+++ b/crates/madara/primitives/rpc/src/custom/mod.rs
@@ -1,0 +1,7 @@
+mod block_id;
+mod query;
+mod syncing_status;
+
+pub use self::block_id::*;
+pub use self::query::*;
+pub use self::syncing_status::*;

--- a/crates/madara/primitives/rpc/src/custom/query.rs
+++ b/crates/madara/primitives/rpc/src/custom/query.rs
@@ -1,0 +1,98 @@
+// query offset:
+//     0x0000000000000000000000000000000100000000000000000000000000000000
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BroadcastedDeclareTxnV1, BroadcastedDeclareTxnV2, BroadcastedDeclareTxnV3, DeployAccountTxnV1, DeployAccountTxnV3,
+    InvokeTxnV0, InvokeTxnV1, InvokeTxnV3,
+};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "version")]
+pub enum BroadcastedDeclareTxn {
+    #[serde(rename = "0x1")]
+    V1(BroadcastedDeclareTxnV1),
+    #[serde(rename = "0x2")]
+    V2(BroadcastedDeclareTxnV2),
+    #[serde(rename = "0x3")]
+    V3(BroadcastedDeclareTxnV3),
+
+    /// Query-only broadcasted declare transaction.
+    #[serde(rename = "0x100000000000000000000000000000001")]
+    QueryV1(BroadcastedDeclareTxnV1),
+    /// Query-only broadcasted declare transaction.
+    #[serde(rename = "0x100000000000000000000000000000002")]
+    QueryV2(BroadcastedDeclareTxnV2),
+    /// Query-only broadcasted declare transaction.
+    #[serde(rename = "0x100000000000000000000000000000003")]
+    QueryV3(BroadcastedDeclareTxnV3),
+}
+
+impl BroadcastedDeclareTxn {
+    pub fn is_query(&self) -> bool {
+        match self {
+            BroadcastedDeclareTxn::QueryV1(_)
+            | BroadcastedDeclareTxn::QueryV2(_)
+            | BroadcastedDeclareTxn::QueryV3(_) => true,
+            BroadcastedDeclareTxn::V1(_) | BroadcastedDeclareTxn::V2(_) | BroadcastedDeclareTxn::V3(_) => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "version")]
+pub enum BroadcastedDeployAccountTxn {
+    #[serde(rename = "0x1")]
+    V1(DeployAccountTxnV1),
+    #[serde(rename = "0x3")]
+    V3(DeployAccountTxnV3),
+
+    /// Query-only broadcasted deploy account transaction.
+    #[serde(rename = "0x100000000000000000000000000000001")]
+    QueryV1(DeployAccountTxnV1),
+    /// Query-only broadcasted deploy account transaction.
+    #[serde(rename = "0x100000000000000000000000000000003")]
+    QueryV3(DeployAccountTxnV3),
+}
+
+impl BroadcastedDeployAccountTxn {
+    pub fn is_query(&self) -> bool {
+        match self {
+            BroadcastedDeployAccountTxn::QueryV1(_) | BroadcastedDeployAccountTxn::QueryV3(_) => true,
+            BroadcastedDeployAccountTxn::V1(_) | BroadcastedDeployAccountTxn::V3(_) => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "version")]
+pub enum BroadcastedInvokeTxn {
+    #[serde(rename = "0x0")]
+    V0(InvokeTxnV0),
+    #[serde(rename = "0x1")]
+    V1(InvokeTxnV1),
+    #[serde(rename = "0x3")]
+    V3(InvokeTxnV3),
+
+    /// Query-only broadcasted invoke transaction.
+    #[serde(rename = "0x100000000000000000000000000000000")]
+    QueryV0(InvokeTxnV0),
+    /// Query-only broadcasted invoke transaction.
+    #[serde(rename = "0x100000000000000000000000000000001")]
+    QueryV1(InvokeTxnV1),
+    /// Query-only broadcasted invoke transaction.
+    #[serde(rename = "0x100000000000000000000000000000003")]
+    QueryV3(InvokeTxnV3),
+}
+
+impl BroadcastedInvokeTxn {
+    pub fn is_query(&self) -> bool {
+        match self {
+            BroadcastedInvokeTxn::QueryV0(_) | BroadcastedInvokeTxn::QueryV1(_) | BroadcastedInvokeTxn::QueryV3(_) => {
+                true
+            }
+            BroadcastedInvokeTxn::V0(_) | BroadcastedInvokeTxn::V1(_) | BroadcastedInvokeTxn::V3(_) => false,
+        }
+    }
+}

--- a/crates/madara/primitives/rpc/src/custom/query.rs
+++ b/crates/madara/primitives/rpc/src/custom/query.rs
@@ -1,6 +1,3 @@
-// query offset:
-//     0x0000000000000000000000000000000100000000000000000000000000000000
-
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/madara/primitives/rpc/src/custom/syncing_status.rs
+++ b/crates/madara/primitives/rpc/src/custom/syncing_status.rs
@@ -1,0 +1,87 @@
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::SyncStatus;
+
+/// The syncing status of a node.
+#[derive(Clone, Debug)]
+pub enum SyncingStatus {
+    /// The node is not syncing.
+    NotSyncing,
+    /// The node is syncing.
+    Syncing(SyncStatus),
+}
+
+impl Serialize for SyncingStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            SyncingStatus::NotSyncing => serializer.serialize_bool(false),
+            SyncingStatus::Syncing(status) => status.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SyncingStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SyncingStatusVisitor;
+
+        impl<'de> Visitor<'de> for SyncingStatusVisitor {
+            type Value = SyncingStatus;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                writeln!(formatter, "a syncing status")
+            }
+
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v {
+                    Err(serde::de::Error::custom("expected a syncing status"))
+                } else {
+                    Ok(SyncingStatus::NotSyncing)
+                }
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let status = SyncStatus::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(SyncingStatus::Syncing(status))
+            }
+        }
+
+        deserializer.deserialize_any(SyncingStatusVisitor)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn syncing_status_from_false() {
+    let s = "false";
+    let syncing_status: SyncingStatus = serde_json::from_str(s).unwrap();
+    assert!(matches!(syncing_status, SyncingStatus::NotSyncing));
+}
+
+#[cfg(test)]
+#[test]
+fn syncing_status_to_false() {
+    let syncing_status = SyncingStatus::NotSyncing;
+    let s = serde_json::to_string(&syncing_status).unwrap();
+    assert_eq!(s, "false");
+}
+
+#[cfg(test)]
+#[test]
+fn syncing_status_from_true() {
+    let s = "true";
+    assert!(serde_json::from_str::<SyncingStatus>(s).is_err());
+}

--- a/crates/madara/primitives/rpc/src/custom_serde/mod.rs
+++ b/crates/madara/primitives/rpc/src/custom_serde/mod.rs
@@ -1,0 +1,5 @@
+//! Custom serialization and deserialization routines.
+
+mod num_as_hex;
+
+pub use self::num_as_hex::NumAsHex;

--- a/crates/madara/primitives/rpc/src/custom_serde/num_as_hex.rs
+++ b/crates/madara/primitives/rpc/src/custom_serde/num_as_hex.rs
@@ -1,0 +1,390 @@
+use core::marker::PhantomData;
+
+/// A trait for types that should be serialized or deserialized as hexadecimal strings.
+pub trait NumAsHex: Sized {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer;
+
+    fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>;
+}
+
+impl NumAsHex for u64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        /// The symbols to be used for the hexadecimal representation.
+        const HEX_DIGITS: [u8; 16] = *b"0123456789abcdef";
+        /// The maximum number of digits in the hexadecimal representation of a `u64`.
+        const MAX_NUMBER_SIZE: usize = u64::MAX.ilog(16) as usize + 1;
+
+        if *self == 0 {
+            return serializer.serialize_str("0x0");
+        }
+
+        // The following code can be very much optimized simply by making everything
+        // `unsafe` and using pointers to write to the buffer.
+        // Let's benchmark it first to ensure that it's actually worth it.
+
+        // The buffer is filled from the end to the beginning.
+        // We know that it will always have the correct size because we made it have the
+        // maximum possible size for a base-16 representation of a `u64`.
+        //
+        // +-----------------------------------+
+        // +                           1 2 f a +
+        // +-----------------------------------+
+        //                           ^ cursor
+        //
+        // Once the number has been written to the buffer, we simply add a `0x` prefix
+        // to the beginning of the buffer. Just like the digits, we know the buffer is
+        // large enough to hold the prefix.
+        //
+        // +-----------------------------------+
+        // +                       0 x 1 2 f a +
+        // +-----------------------------------+
+        //                       ^ cursor
+        // |-----------------------| remaining
+        //
+        // The output string is the part of the buffer that has been written. In other
+        // words, we have to skip all the bytes that *were not* written yet (remaining).
+
+        let mut buffer = [0u8; MAX_NUMBER_SIZE + 2]; // + 2 to account for 0x
+        let mut cursor = buffer.iter_mut().rev();
+        let mut n = *self;
+        while n != 0 {
+            *cursor.next().unwrap() = HEX_DIGITS[(n % 16) as usize];
+            n /= 16;
+        }
+        *cursor.next().unwrap() = b'x';
+        *cursor.next().unwrap() = b'0';
+
+        let remaining = cursor.len();
+
+        // SAFETY:
+        //  We only wrote ASCII characters to the buffer, ensuring that it is only composed
+        //  of valid UTF-8 code points. This unwrap can never fail. Just like the code above,
+        //  using `from_utf8_unchecked` is safe.
+        let s = core::str::from_utf8(&buffer[remaining..]).unwrap();
+
+        serializer.serialize_str(s)
+    }
+
+    fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NumAsHexVisitor;
+
+        impl serde::de::Visitor<'_> for NumAsHexVisitor {
+            type Value = u64;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("a hexadecimal string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                // Just like the serialization code, this can be further optimized using
+                // unsafe code and pointers. Though the gain will probably be less interesting.
+
+                // Explicitly avoid being UTF-8 aware.
+                let mut bytes = v.as_bytes();
+
+                // If the input string does not start with the `0x` prefix, then it's an
+                // error. The `NUM_AS_HEX` regex defined in the specification specifies
+                // this prefix as mandatory.
+                bytes = bytes
+                    .strip_prefix(b"0x")
+                    .ok_or_else(|| E::custom("expected a hexadecimal string starting with 0x"))?;
+
+                if bytes.is_empty() {
+                    return Err(E::custom("expected a hexadecimal string"));
+                }
+
+                // Remove the leading zeros from the string, if any.
+                // We need this in order to optimize the code below with the knowledge of the
+                // length of the hexadecimal representation of the number.
+                while let Some(rest) = bytes.strip_prefix(b"0") {
+                    bytes = rest;
+                }
+
+                // If the string has a size larger than the maximum size of the hexadecimal
+                // representation of a `u64`, then we're forced to overflow.
+                if bytes.len() > u64::MAX.ilog(16) as usize + 1 {
+                    return Err(E::custom("integer overflowed 64-bit"));
+                }
+
+                // Aggregate the digits into `n`,
+                // Digits from `0` to `9` represent numbers from `0` to `9`.
+                // Letters from `a` to `f` represent numbers from `10` to `15`.
+                //
+                // As specified in the spec, both uppercase and lowercase characters are
+                // allowed.
+                //
+                // Because we already checked the size of the string earlier, we know that
+                // the following code will never overflow.
+                let mut n = 0u64;
+                for &b in bytes.iter() {
+                    let unit = match b {
+                        b'0'..=b'9' => b as u64 - b'0' as u64,
+                        b'a'..=b'f' => b as u64 - b'a' as u64 + 10,
+                        b'A'..=b'F' => b as u64 - b'A' as u64 + 10,
+                        _ => return Err(E::custom("invalid hexadecimal digit")),
+                    };
+
+                    n = n * 16 + unit;
+                }
+
+                Ok(n)
+            }
+        }
+
+        deserializer.deserialize_str(NumAsHexVisitor)
+    }
+}
+
+impl NumAsHex for u128 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        /// The symbols to be used for the hexadecimal representation.
+        const HEX_DIGITS: [u8; 16] = *b"0123456789abcdef";
+        /// The maximum number of digits in the hexadecimal representation of a `u64`.
+        const MAX_NUMBER_SIZE: usize = u128::MAX.ilog(16) as usize + 1;
+
+        if *self == 0 {
+            return serializer.serialize_str("0x0");
+        }
+
+        let mut buffer = [0u8; MAX_NUMBER_SIZE + 2]; // + 2 to account for 0x
+        let mut cursor = buffer.iter_mut().rev();
+        let mut n = *self;
+        while n != 0 {
+            *cursor.next().unwrap() = HEX_DIGITS[(n % 16) as usize];
+            n /= 16;
+        }
+        *cursor.next().unwrap() = b'x';
+        *cursor.next().unwrap() = b'0';
+
+        let remaining = cursor.len();
+
+        // SAFETY:
+        //  We only wrote ASCII characters to the buffer, ensuring that it is only composed
+        //  of valid UTF-8 code points. This unwrap can never fail. Just like the code above,
+        //  using `from_utf8_unchecked` is safe.
+        let s = core::str::from_utf8(&buffer[remaining..]).unwrap();
+
+        serializer.serialize_str(s)
+    }
+
+    fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NumAsHexVisitor;
+
+        impl serde::de::Visitor<'_> for NumAsHexVisitor {
+            type Value = u128;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("a hexadecimal string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                // Explicitly avoid being UTF-8 aware.
+                let mut bytes = v.as_bytes();
+
+                // If the input string does not start with the `0x` prefix, then it's an
+                // error. The `NUM_AS_HEX` regex defined in the specification specifies
+                // this prefix as mandatory.
+                bytes = bytes
+                    .strip_prefix(b"0x")
+                    .ok_or_else(|| E::custom("expected a hexadecimal string starting with 0x"))?;
+
+                if bytes.is_empty() {
+                    return Err(E::custom("expected a hexadecimal string"));
+                }
+
+                // Remove the leading zeros from the string, if any.
+                // We need this in order to optimize the code below with the knowledge of the
+                // length of the hexadecimal representation of the number.
+                while let Some(rest) = bytes.strip_prefix(b"0") {
+                    bytes = rest;
+                }
+
+                // If the string has a size larger than the maximum size of the hexadecimal
+                // representation of a `u64`, then we're forced to overflow.
+                if bytes.len() > u128::MAX.ilog(16) as usize + 1 {
+                    return Err(E::custom("integer overflowed 64-bit"));
+                }
+
+                // Aggregate the digits into `n`,
+                // Digits from `0` to `9` represent numbers from `0` to `9`.
+                // Letters from `a` to `f` represent numbers from `10` to `15`.
+                //
+                // As specified in the spec, both uppercase and lowercase characters are
+                // allowed.
+                //
+                // Because we already checked the size of the string earlier, we know that
+                // the following code will never overflow.
+                let mut n = 0u128;
+                for &b in bytes.iter() {
+                    let unit = match b {
+                        b'0'..=b'9' => b as u128 - b'0' as u128,
+                        b'a'..=b'f' => b as u128 - b'a' as u128 + 10,
+                        b'A'..=b'F' => b as u128 - b'A' as u128 + 10,
+                        _ => return Err(E::custom("invalid hexadecimal digit")),
+                    };
+
+                    n = n * 16 + unit;
+                }
+
+                Ok(n)
+            }
+        }
+
+        deserializer.deserialize_str(NumAsHexVisitor)
+    }
+}
+
+impl<T> NumAsHex for Option<T>
+where
+    T: NumAsHex,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            None => serializer.serialize_none(),
+            Some(v) => v.serialize(serializer),
+        }
+    }
+
+    fn deserialize<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct OptionVisitor<T>(PhantomData<T>);
+
+        impl<'de, T> serde::de::Visitor<'de> for OptionVisitor<T>
+        where
+            T: NumAsHex,
+        {
+            type Value = Option<T>;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                writeln!(formatter, "an optional number as a hexadecimal string")
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                T::deserialize(deserializer).map(Some)
+            }
+        }
+
+        deserializer.deserialize_option(OptionVisitor(PhantomData))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(transparent)]
+    struct Helper<T>
+    where
+        T: NumAsHex,
+    {
+        #[serde(with = "NumAsHex")]
+        num: T,
+    }
+
+    fn serialize<T: NumAsHex>(num: T) -> serde_json::Result<String> {
+        let helper = Helper { num };
+        serde_json::to_string(&helper)
+    }
+
+    fn deserialize<T: NumAsHex>(s: &str) -> serde_json::Result<T> {
+        let helper: Helper<T> = serde_json::from_str(s)?;
+        Ok(helper.num)
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn serialize_0_hex() {
+        assert_eq!(serialize(0u64).unwrap(), "\"0x0\"");
+        assert_eq!(serialize(0u128).unwrap(), "\"0x0\"");
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn srialize_hex() {
+        assert_eq!(serialize(0x1234u64).unwrap(), "\"0x1234\"");
+        assert_eq!(serialize(0x1234u128).unwrap(), "\"0x1234\"");
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn srialize_max() {
+        assert_eq!(serialize(u64::MAX).unwrap(), "\"0xffffffffffffffff\"");
+        assert_eq!(serialize(u128::MAX).unwrap(), "\"0xffffffffffffffffffffffffffffffff\"");
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn deserialize_zero() {
+        assert_eq!(deserialize::<u64>("\"0x0\"").unwrap(), 0);
+        assert_eq!(deserialize::<u128>("\"0x0\"").unwrap(), 0);
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn deserialize_zeros() {
+        assert_eq!(deserialize::<u64>("\"0x00000\"").unwrap(), 0);
+        assert_eq!(deserialize::<u128>("\"0x00000\"").unwrap(), 0);
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn deserialize_max() {
+        assert_eq!(deserialize::<u64>("\"0xFFFFFFFFFFFFFFFF\"").unwrap(), u64::MAX);
+        assert_eq!(deserialize::<u128>("\"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF\"").unwrap(), u128::MAX);
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn deserialize_big_one() {
+        assert_eq!(deserialize::<u64>("\"0x000000000000000000000000000001\"").unwrap(), 1);
+        assert_eq!(
+            deserialize::<u128>("\"0x00000000000000000000000000000000000000000000000000000000001\"").unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    #[cfg(test)]
+    fn deserialize_hex() {
+        assert_eq!(deserialize::<u64>("\"0x1234\"").unwrap(), 0x1234);
+        assert_eq!(deserialize::<u128>("\"0x1234\"").unwrap(), 0x1234);
+    }
+}

--- a/crates/madara/primitives/rpc/src/lib.rs
+++ b/crates/madara/primitives/rpc/src/lib.rs
@@ -1,0 +1,27 @@
+//! This crate is a fork of the original [starknet-types-rpc](https://github.com/starknet-io/types-rs) v0.7.1,
+//! which was originally developed by the Starknet team under the MIT license.
+//!
+//! The original crate is no longer actively maintained, so this fork has been created
+//! to ensure continued maintenance and compatibility with our project needs.
+//!
+//! Original authors:
+//! - Pedro Fontana (@pefontana)
+//! - Mario Rugiero (@Oppen)
+//! - Lucas Levy (@LucasLvy)
+//! - Shahar Papini (@spapinistarkware)
+//! - Abdelhamid Bakhta (@abdelhamidbakhta)
+//! - Dan Brownstein (@dan-starkware)
+//! - Federico Carrone (@unbalancedparentheses)
+//! - Jonathan Lei (@xJonathanLEI)
+//! - Maciej Kamiński (@maciejka)
+//!
+//! Original repository: https://github.com/starknet-io/types-rs
+//! Original version: 0.7.1
+//! License: MIT
+
+mod custom;
+mod custom_serde;
+
+pub mod v0_7_1;
+
+pub use self::v0_7_1::*;

--- a/crates/madara/primitives/rpc/src/lib.rs
+++ b/crates/madara/primitives/rpc/src/lib.rs
@@ -1,24 +1,3 @@
-//! This crate is a fork of the original [starknet-types-rpc](https://github.com/starknet-io/types-rs) v0.7.1,
-//! which was originally developed by the Starknet team under the MIT license.
-//!
-//! The original crate is no longer actively maintained, so this fork has been created
-//! to ensure continued maintenance and compatibility with our project needs.
-//!
-//! Original authors:
-//! - Pedro Fontana (@pefontana)
-//! - Mario Rugiero (@Oppen)
-//! - Lucas Levy (@LucasLvy)
-//! - Shahar Papini (@spapinistarkware)
-//! - Abdelhamid Bakhta (@abdelhamidbakhta)
-//! - Dan Brownstein (@dan-starkware)
-//! - Federico Carrone (@unbalancedparentheses)
-//! - Jonathan Lei (@xJonathanLEI)
-//! - Maciej Kamiński (@maciejka)
-//!
-//! Original repository: https://github.com/starknet-io/types-rs
-//! Original version: 0.7.1
-//! License: MIT
-
 mod custom;
 mod custom_serde;
 

--- a/crates/madara/primitives/rpc/src/v0_7_1/mod.rs
+++ b/crates/madara/primitives/rpc/src/v0_7_1/mod.rs
@@ -1,0 +1,12 @@
+//! v0.7.1 of the API.
+pub use crate::custom::{
+    BlockId, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, SyncingStatus,
+};
+
+mod starknet_api_openrpc;
+mod starknet_trace_api_openrpc;
+mod starknet_write_api;
+
+pub use self::starknet_api_openrpc::*;
+pub use self::starknet_trace_api_openrpc::*;
+pub use self::starknet_write_api::*;

--- a/crates/madara/primitives/rpc/src/v0_7_1/starknet_api_openrpc.rs
+++ b/crates/madara/primitives/rpc/src/v0_7_1/starknet_api_openrpc.rs
@@ -1,0 +1,2657 @@
+use super::{BlockId, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn};
+use crate::custom_serde::NumAsHex;
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+pub type Address = Felt;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TransactionAndReceipt {
+    pub receipt: TxnReceipt,
+    pub transaction: Txn,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TxnWithHash {
+    #[serde(flatten)]
+    pub transaction: Txn,
+    pub transaction_hash: TxnHash,
+}
+
+pub type BlockHash = Felt;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BlockHeader {
+    pub block_hash: BlockHash,
+    /// The block number (its height)
+    pub block_number: BlockNumber,
+    /// specifies whether the data of this block is published via blob data or calldata
+    pub l1_da_mode: L1DaMode,
+    /// The price of l1 data gas in the block
+    pub l1_data_gas_price: ResourcePrice,
+    /// The price of l1 gas in the block
+    pub l1_gas_price: ResourcePrice,
+    /// The new global state root
+    pub new_root: Felt,
+    /// The hash of this block's parent
+    pub parent_hash: BlockHash,
+    /// The StarkNet identity of the sequencer submitting this block
+    pub sequencer_address: Felt,
+    /// Semver of the current Starknet protocol
+    pub starknet_version: String,
+    /// The time in which the block was created, encoded in Unix time
+    pub timestamp: u64,
+}
+
+/// The block's number (its height)
+pub type BlockNumber = u64;
+
+/// The status of the block
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum BlockStatus {
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    AcceptedOnL1,
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    AcceptedOnL2,
+    #[serde(rename = "PENDING")]
+    Pending,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+}
+
+/// A tag specifying a dynamic reference to a block
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum BlockTag {
+    #[serde(rename = "latest")]
+    Latest,
+    #[serde(rename = "pending")]
+    Pending,
+}
+
+/// The block object
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BlockWithReceipts {
+    /// The transactions in this block
+    pub transactions: Vec<TransactionAndReceipt>,
+    pub status: BlockStatus,
+    #[serde(flatten)]
+    pub block_header: BlockHeader,
+}
+
+/// The block object
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BlockWithTxs {
+    /// The transactions in this block
+    pub transactions: Vec<TxnWithHash>,
+    pub status: BlockStatus,
+    #[serde(flatten)]
+    pub block_header: BlockHeader,
+}
+
+/// The block object
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BlockWithTxHashes {
+    /// The hashes of the transactions included in this block
+    pub transactions: Vec<TxnHash>,
+    pub status: BlockStatus,
+    #[serde(flatten)]
+    pub block_header: BlockHeader,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BroadcastedDeclareTxnV1 {
+    /// The class to be declared
+    pub contract_class: DeprecatedContractClass,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    pub nonce: Felt,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BroadcastedDeclareTxnV2 {
+    /// The hash of the Cairo assembly resulting from the Sierra compilation
+    pub compiled_class_hash: Felt,
+    /// The class to be declared
+    pub contract_class: ContractClass,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    pub nonce: Felt,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BroadcastedDeclareTxnV3 {
+    /// data needed to deploy the account contract from which this tx will be initiated
+    pub account_deployment_data: Vec<Felt>,
+    /// The hash of the Cairo assembly resulting from the Sierra compilation
+    pub compiled_class_hash: Felt,
+    /// The class to be declared
+    pub contract_class: ContractClass,
+    /// The storage domain of the account's balance from which fee will be charged
+    pub fee_data_availability_mode: DaMode,
+    pub nonce: Felt,
+    /// The storage domain of the account's nonce (an account has a nonce per DA mode)
+    pub nonce_data_availability_mode: DaMode,
+    /// data needed to allow the paymaster to pay for the transaction in native tokens
+    pub paymaster_data: Vec<Felt>,
+    /// resource bounds for the transaction execution
+    pub resource_bounds: ResourceBoundsMapping,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+    /// the tip for the transaction
+    #[serde(with = "NumAsHex")]
+    pub tip: u64,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type")]
+pub enum BroadcastedTxn {
+    #[serde(rename = "INVOKE")]
+    Invoke(BroadcastedInvokeTxn),
+    #[serde(rename = "DECLARE")]
+    Declare(BroadcastedDeclareTxn),
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(BroadcastedDeployAccountTxn),
+}
+
+impl BroadcastedTxn {
+    pub fn is_query(&self) -> bool {
+        match self {
+            BroadcastedTxn::Invoke(txn) => txn.is_query(),
+            BroadcastedTxn::Declare(txn) => txn.is_query(),
+            BroadcastedTxn::DeployAccount(txn) => txn.is_query(),
+        }
+    }
+}
+
+/// StarkNet chain id, given in hex representation.
+pub type ChainId = u64;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct CommonReceiptProperties {
+    /// The fee that was charged by the sequencer
+    pub actual_fee: FeePayment,
+    /// The events emitted as part of this transaction
+    pub events: Vec<Event>,
+    /// The resources consumed by the transaction
+    pub execution_resources: ExecutionResources,
+    /// finality status of the tx
+    pub finality_status: TxnFinalityStatus,
+    pub messages_sent: Vec<MsgToL1>,
+    /// The hash identifying the transaction
+    pub transaction_hash: TxnHash,
+    #[serde(flatten)]
+    pub execution_status: ExecutionStatus,
+}
+
+// The execution status of the transaction
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "execution_status", content = "revert_reason")]
+pub enum ExecutionStatus {
+    #[serde(rename = "SUCCEEDED")]
+    Successful,
+    #[serde(rename = "REVERTED")]
+    Reverted(String),
+}
+
+/// The resources consumed by the VM
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ComputationResources {
+    /// the number of BITWISE builtin instances
+    #[serde(default)]
+    pub bitwise_builtin_applications: Option<u64>,
+    /// the number of EC_OP builtin instances
+    #[serde(default)]
+    pub ec_op_builtin_applications: Option<u64>,
+    /// the number of ECDSA builtin instances
+    #[serde(default)]
+    pub ecdsa_builtin_applications: Option<u64>,
+    /// The number of KECCAK builtin instances
+    #[serde(default)]
+    pub keccak_builtin_applications: Option<u64>,
+    /// The number of unused memory cells (each cell is roughly equivalent to a step)
+    #[serde(default)]
+    pub memory_holes: Option<u64>,
+    /// The number of Pedersen builtin instances
+    #[serde(default)]
+    pub pedersen_builtin_applications: Option<u64>,
+    /// The number of Poseidon builtin instances
+    #[serde(default)]
+    pub poseidon_builtin_applications: Option<u64>,
+    /// The number of RANGE_CHECK builtin instances
+    #[serde(default)]
+    pub range_check_builtin_applications: Option<u64>,
+    /// The number of accesses to the segment arena
+    #[serde(default)]
+    pub segment_arena_builtin: Option<u64>,
+    /// The number of Cairo steps used
+    pub steps: u64,
+}
+
+pub type ContractAbi = Vec<ContractAbiEntry>;
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ContractAbiEntry {
+    Function(FunctionAbiEntry),
+    Event(EventAbiEntry),
+    Struct(StructAbiEntry),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ContractClass {
+    /// The class ABI, as supplied by the user declaring the class
+    #[serde(default)]
+    pub abi: Option<String>,
+    /// The version of the contract class object. Currently, the Starknet OS supports version 0.1.0
+    pub contract_class_version: String,
+    pub entry_points_by_type: EntryPointsByType,
+    /// The list of Sierra instructions of which the program consists
+    pub sierra_program: Vec<Felt>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct EntryPointsByType {
+    #[serde(rename = "CONSTRUCTOR")]
+    pub constructor: Vec<SierraEntryPoint>,
+    #[serde(rename = "EXTERNAL")]
+    pub external: Vec<SierraEntryPoint>,
+    #[serde(rename = "L1_HANDLER")]
+    pub l1_handler: Vec<SierraEntryPoint>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ContractStorageDiffItem {
+    /// The contract address for which the storage changed
+    pub address: Felt,
+    /// The changes in the storage of the contract
+    pub storage_entries: Vec<KeyValuePair>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct KeyValuePair {
+    /// The key of the changed value
+    pub key: Felt,
+    /// The new value applied to the given address
+    pub value: Felt,
+}
+
+/// Specifies a storage domain in Starknet. Each domain has different gurantess regarding availability
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum DaMode {
+    L1,
+    L2,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "version")]
+pub enum DeclareTxn {
+    #[serde(rename = "0x0")]
+    V0(DeclareTxnV0),
+    #[serde(rename = "0x1")]
+    V1(DeclareTxnV1),
+    #[serde(rename = "0x2")]
+    V2(DeclareTxnV2),
+    #[serde(rename = "0x3")]
+    V3(DeclareTxnV3),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeclareTxnReceipt {
+    #[serde(flatten)]
+    pub common_receipt_properties: CommonReceiptProperties,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeclareTxnV0 {
+    /// The hash of the declared class
+    pub class_hash: Felt,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeclareTxnV1 {
+    /// The hash of the declared class
+    pub class_hash: Felt,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    pub nonce: Felt,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeclareTxnV2 {
+    /// The hash of the declared class
+    pub class_hash: Felt,
+    /// The hash of the Cairo assembly resulting from the Sierra compilation
+    pub compiled_class_hash: Felt,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    pub nonce: Felt,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeclareTxnV3 {
+    /// data needed to deploy the account contract from which this tx will be initiated
+    pub account_deployment_data: Vec<Felt>,
+    /// The hash of the declared class
+    pub class_hash: Felt,
+    /// The hash of the Cairo assembly resulting from the Sierra compilation
+    pub compiled_class_hash: Felt,
+    /// The storage domain of the account's balance from which fee will be charged
+    pub fee_data_availability_mode: DaMode,
+    pub nonce: Felt,
+    /// The storage domain of the account's nonce (an account has a nonce per DA mode)
+    pub nonce_data_availability_mode: DaMode,
+    /// data needed to allow the paymaster to pay for the transaction in native tokens
+    pub paymaster_data: Vec<Felt>,
+    /// resource bounds for the transaction execution
+    pub resource_bounds: ResourceBoundsMapping,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+    /// the tip for the transaction
+    #[serde(with = "NumAsHex")]
+    pub tip: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployedContractItem {
+    /// The address of the contract
+    pub address: Felt,
+    /// The hash of the contract code
+    pub class_hash: Felt,
+}
+
+/// deploys a new account contract
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "version")]
+pub enum DeployAccountTxn {
+    #[serde(rename = "0x1")]
+    V1(DeployAccountTxnV1),
+    #[serde(rename = "0x3")]
+    V3(DeployAccountTxnV3),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployAccountTxnReceipt {
+    #[serde(flatten)]
+    pub common_receipt_properties: CommonReceiptProperties,
+    /// The address of the deployed contract
+    pub contract_address: Felt,
+}
+
+/// Deploys an account contract, charges fee from the pre-funded account addresses
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployAccountTxnV1 {
+    /// The hash of the deployed contract's class
+    pub class_hash: Felt,
+    /// The parameters passed to the constructor
+    pub constructor_calldata: Vec<Felt>,
+    /// The salt for the address of the deployed contract
+    pub contract_address_salt: Felt,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    pub nonce: Felt,
+    pub signature: Signature,
+}
+
+/// Deploys an account contract, charges fee from the pre-funded account addresses
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployAccountTxnV3 {
+    /// The hash of the deployed contract's class
+    pub class_hash: Felt,
+    /// The parameters passed to the constructor
+    pub constructor_calldata: Vec<Felt>,
+    /// The salt for the address of the deployed contract
+    pub contract_address_salt: Felt,
+    /// The storage domain of the account's balance from which fee will be charged
+    pub fee_data_availability_mode: DaMode,
+    pub nonce: Felt,
+    /// The storage domain of the account's nonce (an account has a nonce per DA mode)
+    pub nonce_data_availability_mode: DaMode,
+    /// data needed to allow the paymaster to pay for the transaction in native tokens
+    pub paymaster_data: Vec<Felt>,
+    /// resource bounds for the transaction execution
+    pub resource_bounds: ResourceBoundsMapping,
+    pub signature: Signature,
+    /// the tip for the transaction
+    #[serde(with = "NumAsHex")]
+    pub tip: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployTxn {
+    /// The hash of the deployed contract's class
+    pub class_hash: Felt,
+    /// The parameters passed to the constructor
+    pub constructor_calldata: Vec<Felt>,
+    /// The salt for the address of the deployed contract
+    pub contract_address_salt: Felt,
+    /// Version of the transaction scheme
+    pub version: Felt,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployTxnReceipt {
+    #[serde(flatten)]
+    pub common_receipt_properties: CommonReceiptProperties,
+    /// The address of the deployed contract
+    pub contract_address: Felt,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeprecatedCairoEntryPoint {
+    /// The offset of the entry point in the program
+    #[serde(with = "NumAsHex")]
+    pub offset: u64,
+    /// A unique identifier of the entry point (function) in the program
+    pub selector: Felt,
+}
+
+/// The definition of a StarkNet contract class
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeprecatedContractClass {
+    #[serde(default)]
+    pub abi: Option<ContractAbi>,
+    pub entry_points_by_type: DeprecatedEntryPointsByType,
+    /// A base64 representation of the compressed program code
+    pub program: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeprecatedEntryPointsByType {
+    #[serde(rename = "CONSTRUCTOR")]
+    pub constructor: Vec<DeprecatedCairoEntryPoint>,
+    #[serde(rename = "EXTERNAL")]
+    pub external: Vec<DeprecatedCairoEntryPoint>,
+    #[serde(rename = "L1_HANDLER")]
+    pub l1_handler: Vec<DeprecatedCairoEntryPoint>,
+}
+
+/// Event information decorated with metadata on where it was emitted / An event emitted as a result of transaction execution
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct EmittedEvent {
+    /// The event information
+    #[serde(flatten)]
+    pub event: Event,
+    /// The hash of the block in which the event was emitted
+    #[serde(default)]
+    pub block_hash: Option<BlockHash>,
+    /// The number of the block in which the event was emitted
+    #[serde(default)]
+    pub block_number: Option<BlockNumber>,
+    /// The transaction that emitted the event
+    pub transaction_hash: TxnHash,
+}
+
+/// an ethereum address represented as 40 hex digits
+pub type EthAddress = String;
+
+/// A StarkNet event
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct Event {
+    pub from_address: Address,
+    #[serde(flatten)]
+    pub event_content: EventContent,
+}
+
+/// The content of an event
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct EventContent {
+    pub data: Vec<Felt>,
+    pub keys: Vec<Felt>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct EventsChunk {
+    /// Use this token in a subsequent query to obtain the next page. Should not appear if there are no more pages.
+    #[serde(default)]
+    pub continuation_token: Option<String>,
+    pub events: Vec<EmittedEvent>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct EventAbiEntry {
+    pub data: Vec<TypedParameter>,
+    pub keys: Vec<TypedParameter>,
+    /// The event name
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: EventAbiType,
+}
+
+pub type EventAbiType = String;
+
+/// the resources consumed by the transaction, includes both computation and data
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionResources {
+    /// the number of BITWISE builtin instances
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bitwise_builtin_applications: Option<u64>,
+    /// the number of EC_OP builtin instances
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ec_op_builtin_applications: Option<u64>,
+    /// the number of ECDSA builtin instances
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ecdsa_builtin_applications: Option<u64>,
+    /// The number of KECCAK builtin instances
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keccak_builtin_applications: Option<u64>,
+    /// The number of unused memory cells (each cell is roughly equivalent to a step)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_holes: Option<u64>,
+    /// The number of Pedersen builtin instances
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pedersen_builtin_applications: Option<u64>,
+    /// The number of Poseidon builtin instances
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub poseidon_builtin_applications: Option<u64>,
+    /// The number of RANGE_CHECK builtin instances
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range_check_builtin_applications: Option<u64>,
+    /// The number of accesses to the segment arena
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment_arena_builtin: Option<u64>,
+    /// The number of Cairo steps used
+    pub steps: u64,
+    pub data_availability: DataAvailability,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DataAvailability {
+    /// the data gas consumed by this transaction's data, 0 if it uses gas for DA
+    pub l1_data_gas: u128,
+    /// the gas consumed by this transaction's data, 0 if it uses data gas for DA
+    pub l1_gas: u128,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FeeEstimate {
+    /// The Ethereum data gas consumption of the transaction
+    pub data_gas_consumed: Felt,
+    /// The data gas price (in wei or fri, depending on the tx version) that was used in the cost estimation
+    pub data_gas_price: Felt,
+    /// The Ethereum gas consumption of the transaction
+    pub gas_consumed: Felt,
+    /// The gas price (in wei or fri, depending on the tx version) that was used in the cost estimation
+    pub gas_price: Felt,
+    /// The estimated fee for the transaction (in wei or fri, depending on the tx version), equals to gas_consumed*gas_price + data_gas_consumed*data_gas_price
+    pub overall_fee: Felt,
+    /// units in which the fee is given
+    pub unit: PriceUnit,
+}
+
+/// fee payment info as it appears in receipts
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FeePayment {
+    /// amount paid
+    pub amount: Felt,
+    /// units in which the fee is given
+    pub unit: PriceUnit,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FunctionAbiEntry {
+    pub inputs: Vec<TypedParameter>,
+    /// The function name
+    pub name: String,
+    pub outputs: Vec<TypedParameter>,
+    #[serde(default)]
+    #[serde(rename = "stateMutability")]
+    pub state_mutability: Option<FunctionStateMutability>,
+    #[serde(rename = "type")]
+    pub ty: FunctionAbiType,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum FunctionAbiType {
+    #[serde(rename = "constructor")]
+    Constructor,
+    #[serde(rename = "function")]
+    Function,
+    #[serde(rename = "l1_handler")]
+    L1Handler,
+}
+
+/// Function call information
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FunctionCall {
+    /// The parameters passed to the function
+    pub calldata: Vec<Felt>,
+    pub contract_address: Address,
+    pub entry_point_selector: Felt,
+}
+
+pub type FunctionStateMutability = String;
+
+/// Initiate a transaction from an account
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "version")]
+pub enum InvokeTxn {
+    #[serde(rename = "0x0")]
+    V0(InvokeTxnV0),
+    #[serde(rename = "0x1")]
+    V1(InvokeTxnV1),
+    #[serde(rename = "0x3")]
+    V3(InvokeTxnV3),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct InvokeTxnReceipt {
+    #[serde(flatten)]
+    pub common_receipt_properties: CommonReceiptProperties,
+}
+
+/// invokes a specific function in the desired contract (not necessarily an account)
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct InvokeTxnV0 {
+    /// The parameters passed to the function
+    pub calldata: Vec<Felt>,
+    pub contract_address: Address,
+    pub entry_point_selector: Felt,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct InvokeTxnV1 {
+    /// The data expected by the account's `execute` function (in most usecases, this includes the called contract address and a function selector)
+    pub calldata: Vec<Felt>,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    pub nonce: Felt,
+    pub sender_address: Address,
+    pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct InvokeTxnV3 {
+    /// data needed to deploy the account contract from which this tx will be initiated
+    pub account_deployment_data: Vec<Felt>,
+    /// The data expected by the account's `execute` function (in most usecases, this includes the called contract address and a function selector)
+    pub calldata: Vec<Felt>,
+    /// The storage domain of the account's balance from which fee will be charged
+    pub fee_data_availability_mode: DaMode,
+    pub nonce: Felt,
+    /// The storage domain of the account's nonce (an account has a nonce per DA mode)
+    pub nonce_data_availability_mode: DaMode,
+    /// data needed to allow the paymaster to pay for the transaction in native tokens
+    pub paymaster_data: Vec<Felt>,
+    /// resource bounds for the transaction execution
+    pub resource_bounds: ResourceBoundsMapping,
+    pub sender_address: Address,
+    pub signature: Signature,
+    /// the tip for the transaction
+    #[serde(with = "NumAsHex")]
+    pub tip: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct L1HandlerTxn {
+    /// The L1->L2 message nonce field of the SN Core L1 contract at the time the transaction was sent
+    #[serde(with = "NumAsHex")]
+    pub nonce: u64,
+    /// Version of the transaction scheme
+    pub version: String, /* 0x0 */
+    #[serde(flatten)]
+    pub function_call: FunctionCall,
+}
+
+/// receipt for l1 handler transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct L1HandlerTxnReceipt {
+    /// The message hash as it appears on the L1 core contract
+    pub message_hash: String,
+    #[serde(flatten)]
+    pub common_receipt_properties: CommonReceiptProperties,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct MsgFromL1 {
+    /// The selector of the l1_handler in invoke in the target contract
+    pub entry_point_selector: Felt,
+    /// The address of the L1 contract sending the message
+    pub from_address: EthAddress,
+    /// The payload of the message
+    pub payload: Vec<Felt>,
+    /// The target L2 address the message is sent to
+    pub to_address: Address,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct MsgToL1 {
+    /// The address of the L2 contract sending the message
+    pub from_address: Felt,
+    /// The payload of the message
+    pub payload: Vec<Felt>,
+    /// The target L1 address the message is sent to
+    pub to_address: Felt,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PendingBlockHeader {
+    /// specifies whether the data of this block is published via blob data or calldata
+    pub l1_da_mode: L1DaMode,
+    /// The price of l1 data gas in the block
+    pub l1_data_gas_price: ResourcePrice,
+    /// The price of l1 gas in the block
+    pub l1_gas_price: ResourcePrice,
+    /// The hash of this block's parent
+    pub parent_hash: BlockHash,
+    /// The StarkNet identity of the sequencer submitting this block
+    pub sequencer_address: Felt,
+    /// Semver of the current Starknet protocol
+    pub starknet_version: String,
+    /// The time in which the block was created, encoded in Unix time
+    pub timestamp: u64,
+}
+
+/// specifies whether the data of this block is published via blob data or calldata
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum L1DaMode {
+    #[serde(rename = "BLOB")]
+    Blob,
+    #[serde(rename = "CALLDATA")]
+    Calldata,
+}
+
+/// The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PendingBlockWithReceipts {
+    /// The transactions in this block
+    pub transactions: Vec<TransactionAndReceipt>,
+    #[serde(flatten)]
+    pub pending_block_header: PendingBlockHeader,
+}
+
+/// The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PendingBlockWithTxs {
+    /// The transactions in this block
+    pub transactions: Vec<TxnWithHash>,
+    #[serde(flatten)]
+    pub pending_block_header: PendingBlockHeader,
+}
+
+/// The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PendingBlockWithTxHashes {
+    /// The hashes of the transactions included in this block
+    pub transactions: Vec<TxnHash>,
+    #[serde(flatten)]
+    pub pending_block_header: PendingBlockHeader,
+}
+
+/// Pending state update
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct PendingStateUpdate {
+    /// The previous global state root
+    pub old_root: Felt,
+    pub state_diff: StateDiff,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum PriceUnit {
+    #[serde(rename = "FRI")]
+    Fri,
+    #[serde(rename = "WEI")]
+    Wei,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ResourceBounds {
+    /// the max amount of the resource that can be used in the tx
+    #[serde(with = "NumAsHex")]
+    pub max_amount: u64,
+    /// the max price per unit of this resource for this tx
+    #[serde(with = "NumAsHex")]
+    pub max_price_per_unit: u128,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ResourceBoundsMapping {
+    /// The max amount and max price per unit of L1 gas used in this tx
+    pub l1_gas: ResourceBounds,
+    /// The max amount and max price per unit of L2 gas used in this tx
+    pub l2_gas: ResourceBounds,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ResourcePrice {
+    /// the price of one unit of the given resource, denominated in fri (10^-18 strk)
+    pub price_in_fri: Felt,
+    /// the price of one unit of the given resource, denominated in wei
+    pub price_in_wei: Felt,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SierraEntryPoint {
+    /// The index of the function in the program
+    pub function_idx: u64,
+    /// A unique identifier of the entry point (function) in the program
+    pub selector: Felt,
+}
+
+/// A transaction signature
+pub type Signature = Vec<Felt>;
+
+/// Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum SimulationFlagForEstimateFee {
+    #[serde(rename = "SKIP_VALIDATE")]
+    SkipValidate,
+}
+
+/// The change in state applied in this block, given as a mapping of addresses to the new values and/or new contracts
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct StateDiff {
+    pub declared_classes: Vec<NewClasses>,
+    pub deployed_contracts: Vec<DeployedContractItem>,
+    pub deprecated_declared_classes: Vec<Felt>,
+    pub nonces: Vec<NonceUpdate>,
+    pub replaced_classes: Vec<ReplacedClass>,
+    pub storage_diffs: Vec<ContractStorageDiffItem>,
+}
+
+/// The declared class hash and compiled class hash
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct NewClasses {
+    /// The hash of the declared class
+    pub class_hash: Felt,
+    /// The Cairo assembly hash corresponding to the declared class
+    pub compiled_class_hash: Felt,
+}
+
+/// The updated nonce per contract address
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct NonceUpdate {
+    /// The address of the contract
+    pub contract_address: Address,
+    /// The nonce for the given address at the end of the block
+    pub nonce: Felt,
+}
+
+/// The list of contracts whose class was replaced
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ReplacedClass {
+    /// The new class hash
+    pub class_hash: Felt,
+    /// The address of the contract whose class was replaced
+    pub contract_address: Address,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct StateUpdate {
+    pub block_hash: BlockHash,
+    /// The new global state root
+    pub new_root: Felt,
+    /// The previous global state root
+    pub old_root: Felt,
+    pub state_diff: StateDiff,
+}
+
+/// A storage key. Represented as up to 62 hex digits, 3 bits, and 5 leading zeroes.
+pub type StorageKey = String;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct StructAbiEntry {
+    pub members: Vec<StructMember>,
+    /// The struct name
+    pub name: String,
+    pub size: u64,
+    #[serde(rename = "type")]
+    pub ty: StructAbiType,
+}
+
+pub type StructAbiType = String;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct StructMember {
+    #[serde(flatten)]
+    pub typed_parameter: TypedParameter,
+    /// offset of this property within the struct
+    pub offset: u64,
+}
+
+/// An object describing the node synchronization status
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SyncStatus {
+    /// The hash of the current block being synchronized
+    pub current_block_hash: BlockHash,
+    /// The number (height) of the current block being synchronized
+    pub current_block_num: BlockNumber,
+    /// The hash of the estimated highest block to be synchronized
+    pub highest_block_hash: BlockHash,
+    /// The number (height) of the estimated highest block to be synchronized
+    pub highest_block_num: BlockNumber,
+    /// The hash of the block from which the sync started
+    pub starting_block_hash: BlockHash,
+    /// The number (height) of the block from which the sync started
+    pub starting_block_num: BlockNumber,
+}
+
+/// The transaction schema, as it appears inside a block
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type")]
+pub enum Txn {
+    #[serde(rename = "INVOKE")]
+    Invoke(InvokeTxn),
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler(L1HandlerTxn),
+    #[serde(rename = "DECLARE")]
+    Declare(DeclareTxn),
+    #[serde(rename = "DEPLOY")]
+    Deploy(DeployTxn),
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(DeployAccountTxn),
+}
+
+/// The execution status of the transaction
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum TxnExecutionStatus {
+    #[serde(rename = "REVERTED")]
+    Reverted,
+    #[serde(rename = "SUCCEEDED")]
+    Succeeded,
+}
+
+/// The finality status of the transaction
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum TxnFinalityStatus {
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    L1,
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    L2,
+}
+
+/// The transaction hash, as assigned in StarkNet
+pub type TxnHash = Felt;
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type")]
+pub enum TxnReceipt {
+    #[serde(rename = "INVOKE")]
+    Invoke(InvokeTxnReceipt),
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler(L1HandlerTxnReceipt),
+    #[serde(rename = "DECLARE")]
+    Declare(DeclareTxnReceipt),
+    #[serde(rename = "DEPLOY")]
+    Deploy(DeployTxnReceipt),
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(DeployAccountTxnReceipt),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TxnReceiptWithBlockInfo {
+    #[serde(flatten)]
+    pub transaction_receipt: TxnReceipt,
+    /// If this field is missing, it means the receipt belongs to the pending block
+    #[serde(default)]
+    pub block_hash: Option<BlockHash>,
+    /// If this field is missing, it means the receipt belongs to the pending block
+    #[serde(default)]
+    pub block_number: Option<BlockNumber>,
+}
+
+/// The finality status of the transaction, including the case the txn is still in the mempool or failed validation during the block construction phase
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum TxnStatus {
+    #[serde(rename = "ACCEPTED_ON_L1")]
+    AcceptedOnL1,
+    #[serde(rename = "ACCEPTED_ON_L2")]
+    AcceptedOnL2,
+    #[serde(rename = "RECEIVED")]
+    Received,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TypedParameter {
+    /// The parameter's name
+    pub name: String,
+    /// The parameter's type
+    #[serde(rename = "type")]
+    pub ty: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BlockHashAndNumber {
+    pub block_hash: BlockHash,
+    pub block_number: BlockNumber,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum StarknetGetBlockWithTxsAndReceiptsResult {
+    Block(BlockWithReceipts),
+    Pending(PendingBlockWithReceipts),
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum MaybePendingBlockWithTxHashes {
+    Block(BlockWithTxHashes),
+    Pending(PendingBlockWithTxHashes),
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum MaybePendingBlockWithTxs {
+    Block(BlockWithTxs),
+    Pending(PendingBlockWithTxs),
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum MaybeDeprecatedContractClass {
+    Deprecated(DeprecatedContractClass),
+    ContractClass(ContractClass),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct EventFilterWithPageRequest {
+    #[serde(default)]
+    pub address: Option<Address>,
+    #[serde(default)]
+    pub from_block: Option<BlockId>,
+    /// The values used to filter the events
+    #[serde(default)]
+    pub keys: Option<Vec<Vec<Felt>>>,
+    #[serde(default)]
+    pub to_block: Option<BlockId>,
+    pub chunk_size: u64,
+    /// The token returned from the previous query. If no token is provided the first page is returned.
+    #[serde(default)]
+    pub continuation_token: Option<String>,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum MaybePendingStateUpdate {
+    Block(StateUpdate),
+    Pending(PendingStateUpdate),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TxnFinalityAndExecutionStatus {
+    #[serde(default)]
+    pub execution_status: Option<TxnExecutionStatus>,
+    pub finality_status: TxnStatus,
+}
+
+/// Parameters of the `starknet_specVersion` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpecVersionParams {}
+
+impl Serialize for SpecVersionParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for SpecVersionParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = SpecVersionParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_specVersion`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(1, &"expected 0 parameters"));
+                }
+
+                Ok(SpecVersionParams {})
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {}
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(SpecVersionParams {})
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getBlockWithTxHashes` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetBlockWithTxHashesParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+}
+
+impl Serialize for GetBlockWithTxHashesParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetBlockWithTxHashesParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetBlockWithTxHashesParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getBlockWithTxHashes`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(GetBlockWithTxHashesParams { block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetBlockWithTxHashesParams { block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getBlockWithTxs` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetBlockWithTxsParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+}
+
+impl Serialize for GetBlockWithTxsParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetBlockWithTxsParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetBlockWithTxsParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getBlockWithTxs`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(GetBlockWithTxsParams { block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetBlockWithTxsParams { block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getBlockWithReceipts` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetBlockWithReceiptsParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+}
+
+impl Serialize for GetBlockWithReceiptsParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetBlockWithReceiptsParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetBlockWithReceiptsParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getBlockWithReceipts`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(GetBlockWithReceiptsParams { block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetBlockWithReceiptsParams { block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getStateUpdate` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetStateUpdateParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+}
+
+impl Serialize for GetStateUpdateParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetStateUpdateParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetStateUpdateParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getStateUpdate`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(GetStateUpdateParams { block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetStateUpdateParams { block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getStorageAt` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetStorageAtParams {
+    /// The address of the contract to read from
+    pub contract_address: Address,
+    /// The key to the storage value for the given contract
+    pub key: StorageKey,
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+}
+
+impl Serialize for GetStorageAtParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("contract_address", &self.contract_address)?;
+        map.serialize_entry("key", &self.key)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetStorageAtParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetStorageAtParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getStorageAt`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let contract_address: Address =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 3 parameters"))?;
+                let key: StorageKey =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 3 parameters"))?;
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(3, &"expected 3 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(4, &"expected 3 parameters"));
+                }
+
+                Ok(GetStorageAtParams { contract_address, key, block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    contract_address: Address,
+                    key: StorageKey,
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetStorageAtParams {
+                    contract_address: helper.contract_address,
+                    key: helper.key,
+                    block_id: helper.block_id,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getTransactionStatus` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetTransactionStatusParams {
+    /// The hash of the requested transaction
+    pub transaction_hash: TxnHash,
+}
+
+impl Serialize for GetTransactionStatusParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("transaction_hash", &self.transaction_hash)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetTransactionStatusParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetTransactionStatusParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getTransactionStatus`")
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    transaction_hash: TxnHash,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetTransactionStatusParams { transaction_hash: helper.transaction_hash })
+            }
+        }
+
+        deserializer.deserialize_map(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getTransactionByHash` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetTransactionByHashParams {
+    /// The hash of the requested transaction
+    pub transaction_hash: TxnHash,
+}
+
+impl Serialize for GetTransactionByHashParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("transaction_hash", &self.transaction_hash)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetTransactionByHashParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetTransactionByHashParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getTransactionByHash`")
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    transaction_hash: TxnHash,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetTransactionByHashParams { transaction_hash: helper.transaction_hash })
+            }
+        }
+
+        deserializer.deserialize_map(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getTransactionByBlockIdAndIndex` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetTransactionByBlockIdAndIndexParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+    /// The index in the block to search for the transaction
+    pub index: u64,
+}
+
+impl Serialize for GetTransactionByBlockIdAndIndexParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.serialize_entry("index", &self.index)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetTransactionByBlockIdAndIndexParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetTransactionByBlockIdAndIndexParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getTransactionByBlockIdAndIndex`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 2 parameters"))?;
+                let index: u64 =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 2 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &"expected 2 parameters"));
+                }
+
+                Ok(GetTransactionByBlockIdAndIndexParams { block_id, index })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                    index: u64,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetTransactionByBlockIdAndIndexParams { block_id: helper.block_id, index: helper.index })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getTransactionReceipt` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetTransactionReceiptParams {
+    /// The hash of the requested transaction
+    pub transaction_hash: TxnHash,
+}
+
+impl Serialize for GetTransactionReceiptParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("transaction_hash", &self.transaction_hash)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetTransactionReceiptParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetTransactionReceiptParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getTransactionReceipt`")
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    transaction_hash: TxnHash,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetTransactionReceiptParams { transaction_hash: helper.transaction_hash })
+            }
+        }
+
+        deserializer.deserialize_map(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getClass` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetClassParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+    /// The hash of the requested contract class
+    pub class_hash: Felt,
+}
+
+impl Serialize for GetClassParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.serialize_entry("class_hash", &self.class_hash)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetClassParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetClassParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getClass`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 2 parameters"))?;
+                let class_hash: Felt =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 2 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &"expected 2 parameters"));
+                }
+
+                Ok(GetClassParams { block_id, class_hash })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                    class_hash: Felt,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetClassParams { block_id: helper.block_id, class_hash: helper.class_hash })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getClassHashAt` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetClassHashAtParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+    /// The address of the contract whose class hash will be returned
+    pub contract_address: Address,
+}
+
+impl Serialize for GetClassHashAtParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.serialize_entry("contract_address", &self.contract_address)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetClassHashAtParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetClassHashAtParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getClassHashAt`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 2 parameters"))?;
+                let contract_address: Address =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 2 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &"expected 2 parameters"));
+                }
+
+                Ok(GetClassHashAtParams { block_id, contract_address })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                    contract_address: Address,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetClassHashAtParams { block_id: helper.block_id, contract_address: helper.contract_address })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getClassAt` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetClassAtParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+    /// The address of the contract whose class definition will be returned
+    pub contract_address: Address,
+}
+
+impl Serialize for GetClassAtParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.serialize_entry("contract_address", &self.contract_address)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetClassAtParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetClassAtParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getClassAt`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 2 parameters"))?;
+                let contract_address: Address =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 2 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &"expected 2 parameters"));
+                }
+
+                Ok(GetClassAtParams { block_id, contract_address })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                    contract_address: Address,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetClassAtParams { block_id: helper.block_id, contract_address: helper.contract_address })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getBlockTransactionCount` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetBlockTransactionCountParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+}
+
+impl Serialize for GetBlockTransactionCountParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetBlockTransactionCountParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetBlockTransactionCountParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getBlockTransactionCount`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(GetBlockTransactionCountParams { block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetBlockTransactionCountParams { block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_call` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CallParams {
+    /// The details of the function call
+    pub request: FunctionCall,
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.
+    pub block_id: BlockId,
+}
+
+impl Serialize for CallParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("request", &self.request)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CallParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = CallParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_call`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let request: FunctionCall =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 2 parameters"))?;
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 2 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &"expected 2 parameters"));
+                }
+
+                Ok(CallParams { request, block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    request: FunctionCall,
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(CallParams { request: helper.request, block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_estimateFee` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EstimateFeeParams {
+    /// The transaction to estimate
+    pub request: Vec<BroadcastedTxn>,
+    /// describes what parts of the transaction should be executed
+    pub simulation_flags: Vec<SimulationFlagForEstimateFee>,
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.
+    pub block_id: BlockId,
+}
+
+impl Serialize for EstimateFeeParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("request", &self.request)?;
+        map.serialize_entry("simulation_flags", &self.simulation_flags)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for EstimateFeeParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = EstimateFeeParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_estimateFee`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let request: Vec<BroadcastedTxn> =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 3 parameters"))?;
+                let simulation_flags: Vec<SimulationFlagForEstimateFee> =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 3 parameters"))?;
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(3, &"expected 3 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(4, &"expected 3 parameters"));
+                }
+
+                Ok(EstimateFeeParams { request, simulation_flags, block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    request: Vec<BroadcastedTxn>,
+                    simulation_flags: Vec<SimulationFlagForEstimateFee>,
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(EstimateFeeParams {
+                    request: helper.request,
+                    simulation_flags: helper.simulation_flags,
+                    block_id: helper.block_id,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_estimateMessageFee` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EstimateMessageFeeParams {
+    /// the message's parameters
+    pub message: MsgFromL1,
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.
+    pub block_id: BlockId,
+}
+
+impl Serialize for EstimateMessageFeeParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("message", &self.message)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for EstimateMessageFeeParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = EstimateMessageFeeParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_estimateMessageFee`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let message: MsgFromL1 =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 2 parameters"))?;
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 2 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &"expected 2 parameters"));
+                }
+
+                Ok(EstimateMessageFeeParams { message, block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    message: MsgFromL1,
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(EstimateMessageFeeParams { message: helper.message, block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_blockNumber` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockNumberParams {}
+
+impl Serialize for BlockNumberParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for BlockNumberParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = BlockNumberParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_blockNumber`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(1, &"expected 0 parameters"));
+                }
+
+                Ok(BlockNumberParams {})
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {}
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(BlockNumberParams {})
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_blockHashAndNumber` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockHashAndNumberParams {}
+
+impl Serialize for BlockHashAndNumberParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for BlockHashAndNumberParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = BlockHashAndNumberParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_blockHashAndNumber`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(1, &"expected 0 parameters"));
+                }
+
+                Ok(BlockHashAndNumberParams {})
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {}
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(BlockHashAndNumberParams {})
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_chainId` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainIdParams {}
+
+impl Serialize for ChainIdParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ChainIdParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = ChainIdParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_chainId`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(1, &"expected 0 parameters"));
+                }
+
+                Ok(ChainIdParams {})
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {}
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(ChainIdParams {})
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_syncing` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SyncingParams {}
+
+impl Serialize for SyncingParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for SyncingParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = SyncingParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_syncing`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(1, &"expected 0 parameters"));
+                }
+
+                Ok(SyncingParams {})
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {}
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(SyncingParams {})
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getEvents` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetEventsParams {
+    /// The conditions used to filter the returned events
+    pub filter: EventFilterWithPageRequest,
+}
+
+impl Serialize for GetEventsParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("filter", &self.filter)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetEventsParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetEventsParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getEvents`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let filter: EventFilterWithPageRequest =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(GetEventsParams { filter })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    filter: EventFilterWithPageRequest,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetEventsParams { filter: helper.filter })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_getNonce` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetNonceParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+    /// The address of the contract whose nonce we're seeking
+    pub contract_address: Address,
+}
+
+impl Serialize for GetNonceParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.serialize_entry("contract_address", &self.contract_address)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GetNonceParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = GetNonceParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_getNonce`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 2 parameters"))?;
+                let contract_address: Address =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 2 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &"expected 2 parameters"));
+                }
+
+                Ok(GetNonceParams { block_id, contract_address })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                    contract_address: Address,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(GetNonceParams { block_id: helper.block_id, contract_address: helper.contract_address })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}

--- a/crates/madara/primitives/rpc/src/v0_7_1/starknet_trace_api_openrpc.rs
+++ b/crates/madara/primitives/rpc/src/v0_7_1/starknet_trace_api_openrpc.rs
@@ -1,0 +1,401 @@
+use super::{
+    BlockId, BroadcastedTxn, ComputationResources, EventContent, ExecutionResources, FeeEstimate, FunctionCall,
+    MsgToL1, StateDiff, TxnHash,
+};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum CallType {
+    #[serde(rename = "CALL")]
+    Regular,
+    #[serde(rename = "DELEGATE")]
+    Delegate,
+    #[serde(rename = "LIBRARY_CALL")]
+    LibraryCall,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum EntryPointType {
+    #[serde(rename = "CONSTRUCTOR")]
+    Constructor,
+    #[serde(rename = "EXTERNAL")]
+    External,
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct FunctionInvocation {
+    #[serde(flatten)]
+    pub function_call: FunctionCall,
+    pub call_type: CallType,
+    /// The address of the invoking contract. 0 for the root invocation
+    pub caller_address: Felt,
+    /// The calls made by this invocation
+    pub calls: Vec<NestedCall>,
+    /// The hash of the class being called
+    pub class_hash: Felt,
+    pub entry_point_type: EntryPointType,
+    /// The events emitted in this invocation
+    pub events: Vec<OrderedEvent>,
+    /// Resources consumed by the internal call. This is named execution_resources for legacy reasons
+    pub execution_resources: ComputationResources,
+    /// The messages sent by this invocation to L1
+    pub messages: Vec<OrderedMessage>,
+    /// The value returned from the function invocation
+    pub result: Vec<Felt>,
+}
+
+pub type NestedCall = FunctionInvocation;
+
+/// an event alongside its order within the transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct OrderedEvent {
+    /// the order of the event within the transaction
+    pub order: u64,
+    #[serde(flatten)]
+    pub event: EventContent,
+}
+
+/// a message alongside its order within the transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct OrderedMessage {
+    /// the order of the message within the transaction
+    pub order: u64,
+    #[serde(flatten)]
+    pub msg_to_l_1: MsgToL1,
+}
+
+/// Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally (enough funds are expected to be in the account, and fee will be deducted from the balance before the simulation of the next transaction). To skip the fee charge, use the SKIP_FEE_CHARGE flag.
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+pub enum SimulationFlag {
+    #[serde(rename = "SKIP_FEE_CHARGE")]
+    SkipFeeCharge,
+    #[serde(rename = "SKIP_VALIDATE")]
+    SkipValidate,
+}
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type")]
+pub enum TransactionTrace {
+    /// the execution trace of an invoke transaction
+    #[serde(rename = "INVOKE")]
+    Invoke(InvokeTransactionTrace),
+    /// the execution trace of a declare transaction
+    #[serde(rename = "DECLARE")]
+    Declare(DeclareTransactionTrace),
+    /// the execution trace of a deploy account transaction
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(DeployAccountTransactionTrace),
+    /// the execution trace of an L1 handler transaction
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler(L1HandlerTransactionTrace),
+}
+
+/// the execution trace of an invoke transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct InvokeTransactionTrace {
+    /// the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)
+    pub execute_invocation: ExecuteInvocation,
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    #[serde(default)]
+    pub fee_transfer_invocation: Option<FunctionInvocation>,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+    #[serde(default)]
+    pub validate_invocation: Option<FunctionInvocation>,
+}
+
+/// the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)
+#[allow(clippy::large_enum_variant)]
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ExecuteInvocation {
+    FunctionInvocation(FunctionInvocation),
+    Anon(RevertedInvocation),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct RevertedInvocation {
+    /// the revert reason for the failed execution
+    pub revert_reason: String,
+}
+
+/// the execution trace of a declare transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeclareTransactionTrace {
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    #[serde(default)]
+    pub fee_transfer_invocation: Option<FunctionInvocation>,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+    #[serde(default)]
+    pub validate_invocation: Option<FunctionInvocation>,
+}
+
+/// the execution trace of a deploy account transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployAccountTransactionTrace {
+    /// the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)
+    pub constructor_invocation: FunctionInvocation,
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    #[serde(default)]
+    pub fee_transfer_invocation: Option<FunctionInvocation>,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+    #[serde(default)]
+    pub validate_invocation: Option<FunctionInvocation>,
+}
+
+/// the execution trace of an L1 handler transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct L1HandlerTransactionTrace {
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    /// the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)
+    pub function_invocation: FunctionInvocation,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SimulateTransactionsResult {
+    pub fee_estimation: FeeEstimate,
+    pub transaction_trace: TransactionTrace,
+}
+
+/// A single pair of transaction hash and corresponding trace
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TraceBlockTransactionsResult {
+    pub trace_root: TransactionTrace,
+    pub transaction_hash: Felt,
+}
+
+/// Parameters of the `starknet_traceTransaction` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraceTransactionParams {
+    /// The hash of the transaction to trace
+    pub transaction_hash: TxnHash,
+}
+
+impl Serialize for TraceTransactionParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("transaction_hash", &self.transaction_hash)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TraceTransactionParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = TraceTransactionParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_traceTransaction`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let transaction_hash: TxnHash =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(TraceTransactionParams { transaction_hash })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    transaction_hash: TxnHash,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(TraceTransactionParams { transaction_hash: helper.transaction_hash })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_simulateTransactions` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SimulateTransactionsParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.
+    pub block_id: BlockId,
+    /// The transactions to simulate
+    pub transactions: Vec<BroadcastedTxn>,
+    /// describes what parts of the transaction should be executed
+    pub simulation_flags: Vec<SimulationFlag>,
+}
+
+impl Serialize for SimulateTransactionsParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.serialize_entry("transactions", &self.transactions)?;
+        map.serialize_entry("simulation_flags", &self.simulation_flags)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for SimulateTransactionsParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = SimulateTransactionsParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_simulateTransactions`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 3 parameters"))?;
+                let transactions: Vec<BroadcastedTxn> =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(2, &"expected 3 parameters"))?;
+                let simulation_flags: Vec<SimulationFlag> =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(3, &"expected 3 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(4, &"expected 3 parameters"));
+                }
+
+                Ok(SimulateTransactionsParams { block_id, transactions, simulation_flags })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                    transactions: Vec<BroadcastedTxn>,
+                    simulation_flags: Vec<SimulationFlag>,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(SimulateTransactionsParams {
+                    block_id: helper.block_id,
+                    transactions: helper.transactions,
+                    simulation_flags: helper.simulation_flags,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_traceBlockTransactions` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraceBlockTransactionsParams {
+    /// The hash of the requested block, or number (height) of the requested block, or a block tag
+    pub block_id: BlockId,
+}
+
+impl Serialize for TraceBlockTransactionsParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("block_id", &self.block_id)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TraceBlockTransactionsParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = TraceBlockTransactionsParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_traceBlockTransactions`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let block_id: BlockId =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(TraceBlockTransactionsParams { block_id })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    block_id: BlockId,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(TraceBlockTransactionsParams { block_id: helper.block_id })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}

--- a/crates/madara/primitives/rpc/src/v0_7_1/starknet_write_api.rs
+++ b/crates/madara/primitives/rpc/src/v0_7_1/starknet_write_api.rs
@@ -1,0 +1,225 @@
+use super::{BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, TxnHash};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ClassAndTxnHash {
+    pub class_hash: Felt,
+    pub transaction_hash: TxnHash,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct ContractAndTxnHash {
+    pub contract_address: Felt,
+    pub transaction_hash: TxnHash,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct AddInvokeTransactionResult {
+    pub transaction_hash: TxnHash,
+}
+
+/// Parameters of the `starknet_addInvokeTransaction` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AddInvokeTransactionParams {
+    /// The information needed to invoke the function (or account, for version 1 transactions)
+    pub invoke_transaction: BroadcastedInvokeTxn,
+}
+
+impl Serialize for AddInvokeTransactionParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("invoke_transaction", &self.invoke_transaction)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AddInvokeTransactionParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = AddInvokeTransactionParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_addInvokeTransaction`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let invoke_transaction: BroadcastedInvokeTxn =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(AddInvokeTransactionParams { invoke_transaction })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    invoke_transaction: BroadcastedInvokeTxn,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(AddInvokeTransactionParams { invoke_transaction: helper.invoke_transaction })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_addDeclareTransaction` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AddDeclareTransactionParams {
+    /// Declare transaction required to declare a new class on Starknet
+    pub declare_transaction: BroadcastedDeclareTxn,
+}
+
+impl Serialize for AddDeclareTransactionParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("declare_transaction", &self.declare_transaction)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AddDeclareTransactionParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = AddDeclareTransactionParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_addDeclareTransaction`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let declare_transaction: BroadcastedDeclareTxn =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(AddDeclareTransactionParams { declare_transaction })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    declare_transaction: BroadcastedDeclareTxn,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(AddDeclareTransactionParams { declare_transaction: helper.declare_transaction })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+/// Parameters of the `starknet_addDeployAccountTransaction` method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AddDeployAccountTransactionParams {
+    /// The deploy account transaction
+    pub deploy_account_transaction: BroadcastedDeployAccountTxn,
+}
+
+impl Serialize for AddDeployAccountTransactionParams {
+    #[allow(unused_mut)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("deploy_account_transaction", &self.deploy_account_transaction)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AddDeployAccountTransactionParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = AddDeployAccountTransactionParams;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "the parameters for `starknet_addDeployAccountTransaction`")
+            }
+
+            #[allow(unused_mut)]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let deploy_account_transaction: BroadcastedDeployAccountTxn =
+                    seq.next_element()?.ok_or_else(|| serde::de::Error::invalid_length(1, &"expected 1 parameters"))?;
+
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(2, &"expected 1 parameters"));
+                }
+
+                Ok(AddDeployAccountTransactionParams { deploy_account_transaction })
+            }
+
+            #[allow(unused_variables)]
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct Helper {
+                    deploy_account_transaction: BroadcastedDeployAccountTxn,
+                }
+
+                let helper = Helper::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(AddDeployAccountTransactionParams { deploy_account_transaction: helper.deploy_account_transaction })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}

--- a/crates/madara/primitives/state_update/Cargo.toml
+++ b/crates/madara/primitives/state_update/Cargo.toml
@@ -15,10 +15,11 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+# Madara
+mp-rpc = { workspace = true }
 
 # Starknet
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 
 # Other
 serde = { workspace = true, features = ["derive"] }

--- a/crates/madara/primitives/state_update/src/into_starknet_types.rs
+++ b/crates/madara/primitives/state_update/src/into_starknet_types.rs
@@ -1,12 +1,10 @@
-use starknet_types_core::felt::Felt;
-
 use crate::{
     ContractStorageDiffItem, DeclaredClassItem, DeployedContractItem, NonceUpdate, PendingStateUpdate,
     ReplacedClassItem, StateDiff, StateUpdate, StorageEntry,
 };
 
-impl From<starknet_types_rpc::StateUpdate<Felt>> for StateUpdate {
-    fn from(state_update: starknet_types_rpc::StateUpdate<Felt>) -> Self {
+impl From<mp_rpc::StateUpdate> for StateUpdate {
+    fn from(state_update: mp_rpc::StateUpdate) -> Self {
         Self {
             block_hash: state_update.block_hash,
             old_root: state_update.old_root,
@@ -16,7 +14,7 @@ impl From<starknet_types_rpc::StateUpdate<Felt>> for StateUpdate {
     }
 }
 
-impl From<StateUpdate> for starknet_types_rpc::StateUpdate<Felt> {
+impl From<StateUpdate> for mp_rpc::StateUpdate {
     fn from(state_update: StateUpdate) -> Self {
         Self {
             block_hash: state_update.block_hash,
@@ -27,20 +25,20 @@ impl From<StateUpdate> for starknet_types_rpc::StateUpdate<Felt> {
     }
 }
 
-impl From<starknet_types_rpc::PendingStateUpdate<Felt>> for PendingStateUpdate {
-    fn from(pending_state_update: starknet_types_rpc::PendingStateUpdate<Felt>) -> Self {
+impl From<mp_rpc::PendingStateUpdate> for PendingStateUpdate {
+    fn from(pending_state_update: mp_rpc::PendingStateUpdate) -> Self {
         Self { old_root: pending_state_update.old_root, state_diff: pending_state_update.state_diff.into() }
     }
 }
 
-impl From<PendingStateUpdate> for starknet_types_rpc::PendingStateUpdate<Felt> {
+impl From<PendingStateUpdate> for mp_rpc::PendingStateUpdate {
     fn from(pending_state_update: PendingStateUpdate) -> Self {
         Self { old_root: pending_state_update.old_root, state_diff: pending_state_update.state_diff.into() }
     }
 }
 
-impl From<starknet_types_rpc::StateDiff<Felt>> for StateDiff {
-    fn from(state_diff: starknet_types_rpc::StateDiff<Felt>) -> Self {
+impl From<mp_rpc::StateDiff> for StateDiff {
+    fn from(state_diff: mp_rpc::StateDiff) -> Self {
         Self {
             storage_diffs: state_diff.storage_diffs.into_iter().map(|diff| diff.into()).collect(),
             deprecated_declared_classes: state_diff.deprecated_declared_classes,
@@ -64,7 +62,7 @@ impl From<starknet_types_rpc::StateDiff<Felt>> for StateDiff {
     }
 }
 
-impl From<StateDiff> for starknet_types_rpc::StateDiff<Felt> {
+impl From<StateDiff> for mp_rpc::StateDiff {
     fn from(state_diff: StateDiff) -> Self {
         Self {
             storage_diffs: state_diff.storage_diffs.into_iter().map(|diff| diff.into()).collect(),
@@ -89,8 +87,8 @@ impl From<StateDiff> for starknet_types_rpc::StateDiff<Felt> {
     }
 }
 
-impl From<starknet_types_rpc::ContractStorageDiffItem<Felt>> for ContractStorageDiffItem {
-    fn from(contract_storage_diff_item: starknet_types_rpc::ContractStorageDiffItem<Felt>) -> Self {
+impl From<mp_rpc::ContractStorageDiffItem> for ContractStorageDiffItem {
+    fn from(contract_storage_diff_item: mp_rpc::ContractStorageDiffItem) -> Self {
         Self {
             address: contract_storage_diff_item.address,
             storage_entries: contract_storage_diff_item.storage_entries.into_iter().map(|entry| entry.into()).collect(),
@@ -98,7 +96,7 @@ impl From<starknet_types_rpc::ContractStorageDiffItem<Felt>> for ContractStorage
     }
 }
 
-impl From<ContractStorageDiffItem> for starknet_types_rpc::ContractStorageDiffItem<Felt> {
+impl From<ContractStorageDiffItem> for mp_rpc::ContractStorageDiffItem {
     fn from(contract_storage_diff_item: ContractStorageDiffItem) -> Self {
         Self {
             address: contract_storage_diff_item.address,
@@ -107,20 +105,20 @@ impl From<ContractStorageDiffItem> for starknet_types_rpc::ContractStorageDiffIt
     }
 }
 
-impl From<starknet_types_rpc::KeyValuePair<Felt>> for StorageEntry {
-    fn from(storage_entry: starknet_types_rpc::KeyValuePair<Felt>) -> Self {
+impl From<mp_rpc::KeyValuePair> for StorageEntry {
+    fn from(storage_entry: mp_rpc::KeyValuePair) -> Self {
         Self { key: storage_entry.key, value: storage_entry.value }
     }
 }
 
-impl From<StorageEntry> for starknet_types_rpc::KeyValuePair<Felt> {
+impl From<StorageEntry> for mp_rpc::KeyValuePair {
     fn from(storage_entry: StorageEntry) -> Self {
         Self { key: storage_entry.key, value: storage_entry.value }
     }
 }
 
-impl From<starknet_types_rpc::NewClasses<Felt>> for DeclaredClassItem {
-    fn from(declared_class_item: starknet_types_rpc::NewClasses<Felt>) -> Self {
+impl From<mp_rpc::NewClasses> for DeclaredClassItem {
+    fn from(declared_class_item: mp_rpc::NewClasses) -> Self {
         Self {
             class_hash: declared_class_item.class_hash,
             compiled_class_hash: declared_class_item.compiled_class_hash,
@@ -128,7 +126,7 @@ impl From<starknet_types_rpc::NewClasses<Felt>> for DeclaredClassItem {
     }
 }
 
-impl From<DeclaredClassItem> for starknet_types_rpc::NewClasses<Felt> {
+impl From<DeclaredClassItem> for mp_rpc::NewClasses {
     fn from(declared_class_item: DeclaredClassItem) -> Self {
         Self {
             class_hash: declared_class_item.class_hash,
@@ -137,37 +135,37 @@ impl From<DeclaredClassItem> for starknet_types_rpc::NewClasses<Felt> {
     }
 }
 
-impl From<starknet_types_rpc::DeployedContractItem<Felt>> for DeployedContractItem {
-    fn from(deployed_contract_item: starknet_types_rpc::DeployedContractItem<Felt>) -> Self {
+impl From<mp_rpc::DeployedContractItem> for DeployedContractItem {
+    fn from(deployed_contract_item: mp_rpc::DeployedContractItem) -> Self {
         Self { address: deployed_contract_item.address, class_hash: deployed_contract_item.class_hash }
     }
 }
 
-impl From<DeployedContractItem> for starknet_types_rpc::DeployedContractItem<Felt> {
+impl From<DeployedContractItem> for mp_rpc::DeployedContractItem {
     fn from(deployed_contract_item: DeployedContractItem) -> Self {
         Self { address: deployed_contract_item.address, class_hash: deployed_contract_item.class_hash }
     }
 }
 
-impl From<starknet_types_rpc::ReplacedClass<Felt>> for ReplacedClassItem {
-    fn from(replaced_class_item: starknet_types_rpc::ReplacedClass<Felt>) -> Self {
+impl From<mp_rpc::ReplacedClass> for ReplacedClassItem {
+    fn from(replaced_class_item: mp_rpc::ReplacedClass) -> Self {
         Self { contract_address: replaced_class_item.contract_address, class_hash: replaced_class_item.class_hash }
     }
 }
 
-impl From<ReplacedClassItem> for starknet_types_rpc::ReplacedClass<Felt> {
+impl From<ReplacedClassItem> for mp_rpc::ReplacedClass {
     fn from(replaced_class_item: ReplacedClassItem) -> Self {
         Self { contract_address: replaced_class_item.contract_address, class_hash: replaced_class_item.class_hash }
     }
 }
 
-impl From<starknet_types_rpc::NonceUpdate<Felt>> for NonceUpdate {
-    fn from(nonce_update: starknet_types_rpc::NonceUpdate<Felt>) -> Self {
+impl From<mp_rpc::NonceUpdate> for NonceUpdate {
+    fn from(nonce_update: mp_rpc::NonceUpdate) -> Self {
         Self { contract_address: nonce_update.contract_address, nonce: nonce_update.nonce }
     }
 }
 
-impl From<NonceUpdate> for starknet_types_rpc::NonceUpdate<Felt> {
+impl From<NonceUpdate> for mp_rpc::NonceUpdate {
     fn from(nonce_update: NonceUpdate) -> Self {
         Self { contract_address: nonce_update.contract_address, nonce: nonce_update.nonce }
     }
@@ -191,7 +189,7 @@ mod test {
             state_diff: dummy_state_diff(),
         };
 
-        assert_consistent_conversion::<_, starknet_types_rpc::StateUpdate<Felt>>(state_update);
+        assert_consistent_conversion::<_, mp_rpc::StateUpdate>(state_update);
     }
 
     #[test]
@@ -199,6 +197,6 @@ mod test {
         let pending_state_update =
             PendingStateUpdate { old_root: Felt::from_hex_unchecked("0x5678"), state_diff: dummy_state_diff() };
 
-        assert_consistent_conversion::<_, starknet_types_rpc::PendingStateUpdate<Felt>>(pending_state_update);
+        assert_consistent_conversion::<_, mp_rpc::PendingStateUpdate>(pending_state_update);
     }
 }

--- a/crates/madara/primitives/transactions/Cargo.toml
+++ b/crates/madara/primitives/transactions/Cargo.toml
@@ -20,6 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 mp-chain-config = { workspace = true }
 mp-class = { workspace = true }
 mp-convert = { workspace = true }
+mp-rpc = { workspace = true }
 
 # Starknet
 blockifier = { workspace = true }
@@ -28,7 +29,6 @@ cairo-lang-utils = { workspace = true }
 cairo-vm = { workspace = true }
 starknet-core = { workspace = true }
 starknet-types-core = { workspace = true }
-starknet-types-rpc = { workspace = true }
 starknet_api = { workspace = true }
 
 # Other

--- a/crates/madara/primitives/transactions/src/from_broadcasted_transaction.rs
+++ b/crates/madara/primitives/transactions/src/from_broadcasted_transaction.rs
@@ -9,53 +9,48 @@ use starknet_types_core::felt::Felt;
 // class_hash is required for DeclareTransaction
 impl TransactionWithHash {
     pub fn from_broadcasted(
-        tx: starknet_types_rpc::BroadcastedTxn<Felt>,
+        tx: mp_rpc::BroadcastedTxn,
         chain_id: Felt,
         starknet_version: StarknetVersion,
         class_hash: Option<Felt>,
     ) -> Self {
         let is_query = is_query(&tx);
         let transaction: Transaction = match tx {
-            starknet_types_rpc::BroadcastedTxn::Invoke(tx) => Transaction::Invoke(tx.into()),
-            starknet_types_rpc::BroadcastedTxn::Declare(tx) => {
-                Transaction::Declare(DeclareTransaction::from_broadcasted(
-                    tx,
-                    class_hash.expect("Class hash must be provided for DeclareTransaction"),
-                ))
-            }
-            starknet_types_rpc::BroadcastedTxn::DeployAccount(tx) => Transaction::DeployAccount(tx.into()),
+            mp_rpc::BroadcastedTxn::Invoke(tx) => Transaction::Invoke(tx.into()),
+            mp_rpc::BroadcastedTxn::Declare(tx) => Transaction::Declare(DeclareTransaction::from_broadcasted(
+                tx,
+                class_hash.expect("Class hash must be provided for DeclareTransaction"),
+            )),
+            mp_rpc::BroadcastedTxn::DeployAccount(tx) => Transaction::DeployAccount(tx.into()),
         };
         let hash = transaction.compute_hash(chain_id, starknet_version, is_query);
         Self { hash, transaction }
     }
 }
 
-impl From<starknet_types_rpc::BroadcastedInvokeTxn<Felt>> for InvokeTransaction {
-    fn from(tx: starknet_types_rpc::BroadcastedInvokeTxn<Felt>) -> Self {
+impl From<mp_rpc::BroadcastedInvokeTxn> for InvokeTransaction {
+    fn from(tx: mp_rpc::BroadcastedInvokeTxn) -> Self {
         match tx {
-            starknet_types_rpc::BroadcastedInvokeTxn::V0(tx) => InvokeTransaction::V0(tx.into()),
-            starknet_types_rpc::BroadcastedInvokeTxn::V1(tx) => InvokeTransaction::V1(tx.into()),
-            starknet_types_rpc::BroadcastedInvokeTxn::V3(tx) => InvokeTransaction::V3(tx.into()),
-            starknet_types_rpc::BroadcastedInvokeTxn::QueryV0(tx) => InvokeTransaction::V0(tx.into()),
-            starknet_types_rpc::BroadcastedInvokeTxn::QueryV1(tx) => InvokeTransaction::V1(tx.into()),
-            starknet_types_rpc::BroadcastedInvokeTxn::QueryV3(tx) => InvokeTransaction::V3(tx.into()),
+            mp_rpc::BroadcastedInvokeTxn::V0(tx) => InvokeTransaction::V0(tx.into()),
+            mp_rpc::BroadcastedInvokeTxn::V1(tx) => InvokeTransaction::V1(tx.into()),
+            mp_rpc::BroadcastedInvokeTxn::V3(tx) => InvokeTransaction::V3(tx.into()),
+            mp_rpc::BroadcastedInvokeTxn::QueryV0(tx) => InvokeTransaction::V0(tx.into()),
+            mp_rpc::BroadcastedInvokeTxn::QueryV1(tx) => InvokeTransaction::V1(tx.into()),
+            mp_rpc::BroadcastedInvokeTxn::QueryV3(tx) => InvokeTransaction::V3(tx.into()),
         }
     }
 }
 
 impl DeclareTransaction {
-    fn from_broadcasted(tx: starknet_types_rpc::BroadcastedDeclareTxn<Felt>, class_hash: Felt) -> Self {
+    fn from_broadcasted(tx: mp_rpc::BroadcastedDeclareTxn, class_hash: Felt) -> Self {
         match tx {
-            starknet_types_rpc::BroadcastedDeclareTxn::V1(tx)
-            | starknet_types_rpc::BroadcastedDeclareTxn::QueryV1(tx) => {
+            mp_rpc::BroadcastedDeclareTxn::V1(tx) | mp_rpc::BroadcastedDeclareTxn::QueryV1(tx) => {
                 DeclareTransaction::V1(DeclareTransactionV1::from_broadcasted(tx, class_hash))
             }
-            starknet_types_rpc::BroadcastedDeclareTxn::V2(tx)
-            | starknet_types_rpc::BroadcastedDeclareTxn::QueryV2(tx) => {
+            mp_rpc::BroadcastedDeclareTxn::V2(tx) | mp_rpc::BroadcastedDeclareTxn::QueryV2(tx) => {
                 DeclareTransaction::V2(DeclareTransactionV2::from_broadcasted(tx, class_hash))
             }
-            starknet_types_rpc::BroadcastedDeclareTxn::V3(tx)
-            | starknet_types_rpc::BroadcastedDeclareTxn::QueryV3(tx) => {
+            mp_rpc::BroadcastedDeclareTxn::V3(tx) | mp_rpc::BroadcastedDeclareTxn::QueryV3(tx) => {
                 DeclareTransaction::V3(DeclareTransactionV3::from_broadcasted(tx, class_hash))
             }
         }
@@ -73,7 +68,7 @@ impl DeclareTransactionV0 {
 }
 
 impl DeclareTransactionV1 {
-    fn from_broadcasted(tx: starknet_types_rpc::BroadcastedDeclareTxnV1<Felt>, class_hash: Felt) -> Self {
+    fn from_broadcasted(tx: mp_rpc::BroadcastedDeclareTxnV1, class_hash: Felt) -> Self {
         Self {
             sender_address: tx.sender_address,
             max_fee: tx.max_fee,
@@ -85,7 +80,7 @@ impl DeclareTransactionV1 {
 }
 
 impl DeclareTransactionV2 {
-    fn from_broadcasted(tx: starknet_types_rpc::BroadcastedDeclareTxnV2<Felt>, class_hash: Felt) -> Self {
+    fn from_broadcasted(tx: mp_rpc::BroadcastedDeclareTxnV2, class_hash: Felt) -> Self {
         Self {
             sender_address: tx.sender_address,
             compiled_class_hash: tx.compiled_class_hash,
@@ -98,7 +93,7 @@ impl DeclareTransactionV2 {
 }
 
 impl DeclareTransactionV3 {
-    fn from_broadcasted(tx: starknet_types_rpc::BroadcastedDeclareTxnV3<Felt>, class_hash: Felt) -> Self {
+    fn from_broadcasted(tx: mp_rpc::BroadcastedDeclareTxnV3, class_hash: Felt) -> Self {
         Self {
             sender_address: tx.sender_address,
             compiled_class_hash: tx.compiled_class_hash,
@@ -115,21 +110,21 @@ impl DeclareTransactionV3 {
     }
 }
 
-impl From<starknet_types_rpc::BroadcastedDeployAccountTxn<Felt>> for DeployAccountTransaction {
-    fn from(tx: starknet_types_rpc::BroadcastedDeployAccountTxn<Felt>) -> Self {
+impl From<mp_rpc::BroadcastedDeployAccountTxn> for DeployAccountTransaction {
+    fn from(tx: mp_rpc::BroadcastedDeployAccountTxn) -> Self {
         match tx {
-            starknet_types_rpc::BroadcastedDeployAccountTxn::V1(tx)
-            | starknet_types_rpc::BroadcastedDeployAccountTxn::QueryV1(tx) => DeployAccountTransaction::V1(tx.into()),
-            starknet_types_rpc::BroadcastedDeployAccountTxn::V3(tx)
-            | starknet_types_rpc::BroadcastedDeployAccountTxn::QueryV3(tx) => DeployAccountTransaction::V3(tx.into()),
+            mp_rpc::BroadcastedDeployAccountTxn::V1(tx) | mp_rpc::BroadcastedDeployAccountTxn::QueryV1(tx) => {
+                DeployAccountTransaction::V1(tx.into())
+            }
+            mp_rpc::BroadcastedDeployAccountTxn::V3(tx) | mp_rpc::BroadcastedDeployAccountTxn::QueryV3(tx) => {
+                DeployAccountTransaction::V3(tx.into())
+            }
         }
     }
 }
 
-pub(crate) fn is_query(tx: &starknet_types_rpc::BroadcastedTxn<Felt>) -> bool {
-    use starknet_types_rpc::{
-        BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, BroadcastedTxn,
-    };
+pub(crate) fn is_query(tx: &mp_rpc::BroadcastedTxn) -> bool {
+    use mp_rpc::{BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, BroadcastedTxn};
 
     match tx {
         BroadcastedTxn::Invoke(tx) => matches!(

--- a/crates/madara/primitives/transactions/src/from_starknet_types.rs
+++ b/crates/madara/primitives/transactions/src/from_starknet_types.rs
@@ -7,30 +7,30 @@ use crate::{
     Transaction,
 };
 
-impl From<starknet_types_rpc::Txn<Felt>> for Transaction {
-    fn from(tx: starknet_types_rpc::Txn<Felt>) -> Self {
+impl From<mp_rpc::Txn> for Transaction {
+    fn from(tx: mp_rpc::Txn) -> Self {
         match tx {
-            starknet_types_rpc::Txn::Invoke(tx) => Self::Invoke(tx.into()),
-            starknet_types_rpc::Txn::L1Handler(tx) => Self::L1Handler(tx.into()),
-            starknet_types_rpc::Txn::Declare(tx) => Self::Declare(tx.into()),
-            starknet_types_rpc::Txn::Deploy(tx) => Self::Deploy(tx.into()),
-            starknet_types_rpc::Txn::DeployAccount(tx) => Self::DeployAccount(tx.into()),
+            mp_rpc::Txn::Invoke(tx) => Self::Invoke(tx.into()),
+            mp_rpc::Txn::L1Handler(tx) => Self::L1Handler(tx.into()),
+            mp_rpc::Txn::Declare(tx) => Self::Declare(tx.into()),
+            mp_rpc::Txn::Deploy(tx) => Self::Deploy(tx.into()),
+            mp_rpc::Txn::DeployAccount(tx) => Self::DeployAccount(tx.into()),
         }
     }
 }
 
-impl From<starknet_types_rpc::InvokeTxn<Felt>> for InvokeTransaction {
-    fn from(tx: starknet_types_rpc::InvokeTxn<Felt>) -> Self {
+impl From<mp_rpc::InvokeTxn> for InvokeTransaction {
+    fn from(tx: mp_rpc::InvokeTxn) -> Self {
         match tx {
-            starknet_types_rpc::InvokeTxn::V0(tx) => Self::V0(tx.into()),
-            starknet_types_rpc::InvokeTxn::V1(tx) => Self::V1(tx.into()),
-            starknet_types_rpc::InvokeTxn::V3(tx) => Self::V3(tx.into()),
+            mp_rpc::InvokeTxn::V0(tx) => Self::V0(tx.into()),
+            mp_rpc::InvokeTxn::V1(tx) => Self::V1(tx.into()),
+            mp_rpc::InvokeTxn::V3(tx) => Self::V3(tx.into()),
         }
     }
 }
 
-impl From<starknet_types_rpc::InvokeTxnV0<Felt>> for InvokeTransactionV0 {
-    fn from(tx: starknet_types_rpc::InvokeTxnV0<Felt>) -> Self {
+impl From<mp_rpc::InvokeTxnV0> for InvokeTransactionV0 {
+    fn from(tx: mp_rpc::InvokeTxnV0) -> Self {
         Self {
             max_fee: tx.max_fee,
             signature: tx.signature,
@@ -41,8 +41,8 @@ impl From<starknet_types_rpc::InvokeTxnV0<Felt>> for InvokeTransactionV0 {
     }
 }
 
-impl From<starknet_types_rpc::InvokeTxnV1<Felt>> for InvokeTransactionV1 {
-    fn from(tx: starknet_types_rpc::InvokeTxnV1<Felt>) -> Self {
+impl From<mp_rpc::InvokeTxnV1> for InvokeTransactionV1 {
+    fn from(tx: mp_rpc::InvokeTxnV1) -> Self {
         Self {
             sender_address: tx.sender_address,
             calldata: tx.calldata,
@@ -53,8 +53,8 @@ impl From<starknet_types_rpc::InvokeTxnV1<Felt>> for InvokeTransactionV1 {
     }
 }
 
-impl From<starknet_types_rpc::InvokeTxnV3<Felt>> for InvokeTransactionV3 {
-    fn from(tx: starknet_types_rpc::InvokeTxnV3<Felt>) -> Self {
+impl From<mp_rpc::InvokeTxnV3> for InvokeTransactionV3 {
+    fn from(tx: mp_rpc::InvokeTxnV3) -> Self {
         Self {
             sender_address: tx.sender_address,
             calldata: tx.calldata,
@@ -70,8 +70,8 @@ impl From<starknet_types_rpc::InvokeTxnV3<Felt>> for InvokeTransactionV3 {
     }
 }
 
-impl From<starknet_types_rpc::L1HandlerTxn<Felt>> for L1HandlerTransaction {
-    fn from(tx: starknet_types_rpc::L1HandlerTxn<Felt>) -> Self {
+impl From<mp_rpc::L1HandlerTxn> for L1HandlerTransaction {
+    fn from(tx: mp_rpc::L1HandlerTxn) -> Self {
         Self {
             version: Felt::from_hex(&tx.version).unwrap_or(Felt::ZERO),
             nonce: tx.nonce,
@@ -82,19 +82,19 @@ impl From<starknet_types_rpc::L1HandlerTxn<Felt>> for L1HandlerTransaction {
     }
 }
 
-impl From<starknet_types_rpc::DeclareTxn<Felt>> for DeclareTransaction {
-    fn from(tx: starknet_types_rpc::DeclareTxn<Felt>) -> Self {
+impl From<mp_rpc::DeclareTxn> for DeclareTransaction {
+    fn from(tx: mp_rpc::DeclareTxn) -> Self {
         match tx {
-            starknet_types_rpc::DeclareTxn::V0(tx) => Self::V0(tx.into()),
-            starknet_types_rpc::DeclareTxn::V1(tx) => Self::V1(tx.into()),
-            starknet_types_rpc::DeclareTxn::V2(tx) => Self::V2(tx.into()),
-            starknet_types_rpc::DeclareTxn::V3(tx) => Self::V3(tx.into()),
+            mp_rpc::DeclareTxn::V0(tx) => Self::V0(tx.into()),
+            mp_rpc::DeclareTxn::V1(tx) => Self::V1(tx.into()),
+            mp_rpc::DeclareTxn::V2(tx) => Self::V2(tx.into()),
+            mp_rpc::DeclareTxn::V3(tx) => Self::V3(tx.into()),
         }
     }
 }
 
-impl From<starknet_types_rpc::DeclareTxnV0<Felt>> for DeclareTransactionV0 {
-    fn from(tx: starknet_types_rpc::DeclareTxnV0<Felt>) -> Self {
+impl From<mp_rpc::DeclareTxnV0> for DeclareTransactionV0 {
+    fn from(tx: mp_rpc::DeclareTxnV0) -> Self {
         Self {
             sender_address: tx.sender_address,
             max_fee: tx.max_fee,
@@ -104,8 +104,8 @@ impl From<starknet_types_rpc::DeclareTxnV0<Felt>> for DeclareTransactionV0 {
     }
 }
 
-impl From<starknet_types_rpc::DeclareTxnV1<Felt>> for DeclareTransactionV1 {
-    fn from(tx: starknet_types_rpc::DeclareTxnV1<Felt>) -> Self {
+impl From<mp_rpc::DeclareTxnV1> for DeclareTransactionV1 {
+    fn from(tx: mp_rpc::DeclareTxnV1) -> Self {
         Self {
             sender_address: tx.sender_address,
             max_fee: tx.max_fee,
@@ -116,8 +116,8 @@ impl From<starknet_types_rpc::DeclareTxnV1<Felt>> for DeclareTransactionV1 {
     }
 }
 
-impl From<starknet_types_rpc::DeclareTxnV2<Felt>> for DeclareTransactionV2 {
-    fn from(tx: starknet_types_rpc::DeclareTxnV2<Felt>) -> Self {
+impl From<mp_rpc::DeclareTxnV2> for DeclareTransactionV2 {
+    fn from(tx: mp_rpc::DeclareTxnV2) -> Self {
         Self {
             sender_address: tx.sender_address,
             compiled_class_hash: tx.compiled_class_hash,
@@ -129,8 +129,8 @@ impl From<starknet_types_rpc::DeclareTxnV2<Felt>> for DeclareTransactionV2 {
     }
 }
 
-impl From<starknet_types_rpc::DeclareTxnV3<Felt>> for DeclareTransactionV3 {
-    fn from(tx: starknet_types_rpc::DeclareTxnV3<Felt>) -> Self {
+impl From<mp_rpc::DeclareTxnV3> for DeclareTransactionV3 {
+    fn from(tx: mp_rpc::DeclareTxnV3) -> Self {
         Self {
             sender_address: tx.sender_address,
             compiled_class_hash: tx.compiled_class_hash,
@@ -147,8 +147,8 @@ impl From<starknet_types_rpc::DeclareTxnV3<Felt>> for DeclareTransactionV3 {
     }
 }
 
-impl From<starknet_types_rpc::DeployTxn<Felt>> for DeployTransaction {
-    fn from(tx: starknet_types_rpc::DeployTxn<Felt>) -> Self {
+impl From<mp_rpc::DeployTxn> for DeployTransaction {
+    fn from(tx: mp_rpc::DeployTxn) -> Self {
         Self {
             version: tx.version,
             contract_address_salt: tx.contract_address_salt,
@@ -158,17 +158,17 @@ impl From<starknet_types_rpc::DeployTxn<Felt>> for DeployTransaction {
     }
 }
 
-impl From<starknet_types_rpc::DeployAccountTxn<Felt>> for DeployAccountTransaction {
-    fn from(tx: starknet_types_rpc::DeployAccountTxn<Felt>) -> Self {
+impl From<mp_rpc::DeployAccountTxn> for DeployAccountTransaction {
+    fn from(tx: mp_rpc::DeployAccountTxn) -> Self {
         match tx {
-            starknet_types_rpc::DeployAccountTxn::V1(tx) => Self::V1(tx.into()),
-            starknet_types_rpc::DeployAccountTxn::V3(tx) => Self::V3(tx.into()),
+            mp_rpc::DeployAccountTxn::V1(tx) => Self::V1(tx.into()),
+            mp_rpc::DeployAccountTxn::V3(tx) => Self::V3(tx.into()),
         }
     }
 }
 
-impl From<starknet_types_rpc::DeployAccountTxnV1<Felt>> for DeployAccountTransactionV1 {
-    fn from(tx: starknet_types_rpc::DeployAccountTxnV1<Felt>) -> Self {
+impl From<mp_rpc::DeployAccountTxnV1> for DeployAccountTransactionV1 {
+    fn from(tx: mp_rpc::DeployAccountTxnV1) -> Self {
         Self {
             max_fee: tx.max_fee,
             signature: tx.signature,
@@ -179,8 +179,8 @@ impl From<starknet_types_rpc::DeployAccountTxnV1<Felt>> for DeployAccountTransac
         }
     }
 }
-impl From<starknet_types_rpc::DeployAccountTxnV3<Felt>> for DeployAccountTransactionV3 {
-    fn from(tx: starknet_types_rpc::DeployAccountTxnV3<Felt>) -> Self {
+impl From<mp_rpc::DeployAccountTxnV3> for DeployAccountTransactionV3 {
+    fn from(tx: mp_rpc::DeployAccountTxnV3) -> Self {
         Self {
             signature: tx.signature,
             nonce: tx.nonce,

--- a/crates/madara/primitives/transactions/src/lib.rs
+++ b/crates/madara/primitives/transactions/src/lib.rs
@@ -386,14 +386,14 @@ impl L1HandlerTransaction {
     }
 }
 
-impl From<starknet_types_rpc::MsgFromL1<Felt>> for L1HandlerTransaction {
-    fn from(msg: starknet_types_rpc::MsgFromL1<Felt>) -> Self {
+impl From<mp_rpc::MsgFromL1> for L1HandlerTransaction {
+    fn from(msg: mp_rpc::MsgFromL1) -> Self {
         Self {
             version: Felt::ZERO,
             nonce: 0,
             contract_address: msg.to_address,
             entry_point_selector: msg.entry_point_selector,
-            // TODO: fix type from_address on starknet_types_rpc::MsgFromL1
+            // TODO: fix type from_address on mp_rpc::MsgFromL1
             calldata: std::iter::once(Felt::from_hex(&msg.from_address).unwrap()).chain(msg.payload).collect(),
         }
     }
@@ -706,31 +706,31 @@ pub struct ResourceBounds {
     pub max_price_per_unit: u128,
 }
 
-impl From<ResourceBoundsMapping> for starknet_types_rpc::ResourceBoundsMapping {
+impl From<ResourceBoundsMapping> for mp_rpc::ResourceBoundsMapping {
     fn from(resource: ResourceBoundsMapping) -> Self {
         Self { l1_gas: resource.l1_gas.into(), l2_gas: resource.l2_gas.into() }
     }
 }
 
-impl From<starknet_types_rpc::ResourceBoundsMapping> for ResourceBoundsMapping {
-    fn from(resource: starknet_types_rpc::ResourceBoundsMapping) -> Self {
+impl From<mp_rpc::ResourceBoundsMapping> for ResourceBoundsMapping {
+    fn from(resource: mp_rpc::ResourceBoundsMapping) -> Self {
         Self { l1_gas: resource.l1_gas.into(), l2_gas: resource.l2_gas.into() }
     }
 }
 
-impl From<ResourceBounds> for starknet_types_rpc::ResourceBounds {
+impl From<ResourceBounds> for mp_rpc::ResourceBounds {
     fn from(resource: ResourceBounds) -> Self {
         Self { max_amount: resource.max_amount, max_price_per_unit: resource.max_price_per_unit }
     }
 }
 
-impl From<starknet_types_rpc::ResourceBounds> for ResourceBounds {
-    fn from(resource: starknet_types_rpc::ResourceBounds) -> Self {
+impl From<mp_rpc::ResourceBounds> for ResourceBounds {
+    fn from(resource: mp_rpc::ResourceBounds) -> Self {
         Self { max_amount: resource.max_amount, max_price_per_unit: resource.max_price_per_unit }
     }
 }
 
-impl From<DataAvailabilityMode> for starknet_types_rpc::DaMode {
+impl From<DataAvailabilityMode> for mp_rpc::DaMode {
     fn from(da_mode: DataAvailabilityMode) -> Self {
         match da_mode {
             DataAvailabilityMode::L1 => Self::L1,
@@ -739,11 +739,11 @@ impl From<DataAvailabilityMode> for starknet_types_rpc::DaMode {
     }
 }
 
-impl From<starknet_types_rpc::DaMode> for DataAvailabilityMode {
-    fn from(da_mode: starknet_types_rpc::DaMode) -> Self {
+impl From<mp_rpc::DaMode> for DataAvailabilityMode {
+    fn from(da_mode: mp_rpc::DaMode) -> Self {
         match da_mode {
-            starknet_types_rpc::DaMode::L1 => Self::L1,
-            starknet_types_rpc::DaMode::L2 => Self::L2,
+            mp_rpc::DaMode::L1 => Self::L1,
+            mp_rpc::DaMode::L2 => Self::L2,
         }
     }
 }
@@ -983,7 +983,7 @@ mod tests {
 
     #[test]
     fn test_msg_to_l1_handler() {
-        let msg = starknet_types_rpc::MsgFromL1 {
+        let msg = mp_rpc::MsgFromL1 {
             from_address: "0x0000000000000000000000000000000000000001".to_string(),
             to_address: Felt::from(2),
             entry_point_selector: Felt::from(3),
@@ -1008,7 +1008,7 @@ mod tests {
             l2_gas: ResourceBounds { max_amount: 3, max_price_per_unit: 4 },
         };
 
-        let starknet_resource_mapping: starknet_types_rpc::ResourceBoundsMapping = resource_mapping.clone().into();
+        let starknet_resource_mapping: mp_rpc::ResourceBoundsMapping = resource_mapping.clone().into();
         let resource_mapping_back: ResourceBoundsMapping = starknet_resource_mapping.into();
 
         assert_eq!(resource_mapping, resource_mapping_back);
@@ -1017,7 +1017,7 @@ mod tests {
     #[test]
     fn test_data_availability_mode_conversion() {
         let da_mode = DataAvailabilityMode::L1;
-        let starknet_da_mode: starknet_types_rpc::DaMode = da_mode.into();
+        let starknet_da_mode: mp_rpc::DaMode = da_mode.into();
         let da_mode_back: DataAvailabilityMode = starknet_da_mode.into();
 
         assert_eq!(da_mode, da_mode_back);

--- a/crates/madara/primitives/transactions/src/to_blockifier.rs
+++ b/crates/madara/primitives/transactions/src/to_blockifier.rs
@@ -11,9 +11,9 @@ use mp_class::{
     class_hash, compile::ClassCompilationError, CompressedLegacyContractClass, ConvertedClass, FlattenedSierraClass,
     LegacyClassInfo, LegacyConvertedClass, SierraClassInfo, SierraConvertedClass,
 };
+use mp_rpc::{BroadcastedDeclareTxn, BroadcastedTxn};
 use starknet_api::transaction::{Fee, TransactionHash};
 use starknet_types_core::felt::Felt;
-use starknet_types_rpc::{BroadcastedDeclareTxn, BroadcastedTxn};
 use std::sync::Arc;
 
 impl TransactionWithHash {
@@ -72,7 +72,7 @@ pub trait BroadcastedTransactionExt {
     ) -> Result<(BTransaction, Option<ConvertedClass>), ToBlockifierError>;
 }
 
-impl BroadcastedTransactionExt for BroadcastedTxn<Felt> {
+impl BroadcastedTransactionExt for BroadcastedTxn {
     fn into_blockifier(
         self,
         chain_id: Felt,

--- a/crates/madara/primitives/transactions/src/to_starknet_types.rs
+++ b/crates/madara/primitives/transactions/src/to_starknet_types.rs
@@ -1,5 +1,3 @@
-use starknet_types_core::felt::Felt;
-
 use crate::{
     DeclareTransaction, DeclareTransactionV0, DeclareTransactionV1, DeclareTransactionV2, DeclareTransactionV3,
     DeployAccountTransaction, DeployAccountTransactionV1, DeployAccountTransactionV3, DeployTransaction,
@@ -7,29 +5,29 @@ use crate::{
     Transaction,
 };
 
-impl From<Transaction> for starknet_types_rpc::Txn<Felt> {
+impl From<Transaction> for mp_rpc::Txn {
     fn from(tx: Transaction) -> Self {
         match tx {
-            Transaction::Invoke(tx) => starknet_types_rpc::Txn::Invoke(tx.into()),
-            Transaction::L1Handler(tx) => starknet_types_rpc::Txn::L1Handler(tx.into()),
-            Transaction::Declare(tx) => starknet_types_rpc::Txn::Declare(tx.into()),
-            Transaction::Deploy(tx) => starknet_types_rpc::Txn::Deploy(tx.into()),
-            Transaction::DeployAccount(tx) => starknet_types_rpc::Txn::DeployAccount(tx.into()),
+            Transaction::Invoke(tx) => mp_rpc::Txn::Invoke(tx.into()),
+            Transaction::L1Handler(tx) => mp_rpc::Txn::L1Handler(tx.into()),
+            Transaction::Declare(tx) => mp_rpc::Txn::Declare(tx.into()),
+            Transaction::Deploy(tx) => mp_rpc::Txn::Deploy(tx.into()),
+            Transaction::DeployAccount(tx) => mp_rpc::Txn::DeployAccount(tx.into()),
         }
     }
 }
 
-impl From<InvokeTransaction> for starknet_types_rpc::InvokeTxn<Felt> {
+impl From<InvokeTransaction> for mp_rpc::InvokeTxn {
     fn from(tx: InvokeTransaction) -> Self {
         match tx {
-            InvokeTransaction::V0(tx) => starknet_types_rpc::InvokeTxn::V0(tx.into()),
-            InvokeTransaction::V1(tx) => starknet_types_rpc::InvokeTxn::V1(tx.into()),
-            InvokeTransaction::V3(tx) => starknet_types_rpc::InvokeTxn::V3(tx.into()),
+            InvokeTransaction::V0(tx) => mp_rpc::InvokeTxn::V0(tx.into()),
+            InvokeTransaction::V1(tx) => mp_rpc::InvokeTxn::V1(tx.into()),
+            InvokeTransaction::V3(tx) => mp_rpc::InvokeTxn::V3(tx.into()),
         }
     }
 }
 
-impl From<InvokeTransactionV0> for starknet_types_rpc::InvokeTxnV0<Felt> {
+impl From<InvokeTransactionV0> for mp_rpc::InvokeTxnV0 {
     fn from(tx: InvokeTransactionV0) -> Self {
         Self {
             calldata: tx.calldata,
@@ -41,7 +39,7 @@ impl From<InvokeTransactionV0> for starknet_types_rpc::InvokeTxnV0<Felt> {
     }
 }
 
-impl From<InvokeTransactionV1> for starknet_types_rpc::InvokeTxnV1<Felt> {
+impl From<InvokeTransactionV1> for mp_rpc::InvokeTxnV1 {
     fn from(tx: InvokeTransactionV1) -> Self {
         Self {
             calldata: tx.calldata,
@@ -53,7 +51,7 @@ impl From<InvokeTransactionV1> for starknet_types_rpc::InvokeTxnV1<Felt> {
     }
 }
 
-impl From<InvokeTransactionV3> for starknet_types_rpc::InvokeTxnV3<Felt> {
+impl From<InvokeTransactionV3> for mp_rpc::InvokeTxnV3 {
     fn from(tx: InvokeTransactionV3) -> Self {
         Self {
             account_deployment_data: tx.account_deployment_data,
@@ -70,12 +68,12 @@ impl From<InvokeTransactionV3> for starknet_types_rpc::InvokeTxnV3<Felt> {
     }
 }
 
-impl From<L1HandlerTransaction> for starknet_types_rpc::L1HandlerTxn<Felt> {
+impl From<L1HandlerTransaction> for mp_rpc::L1HandlerTxn {
     fn from(tx: L1HandlerTransaction) -> Self {
         Self {
             nonce: tx.nonce,
             version: tx.version.to_hex_string(),
-            function_call: starknet_types_rpc::FunctionCall {
+            function_call: mp_rpc::FunctionCall {
                 calldata: tx.calldata,
                 contract_address: tx.contract_address,
                 entry_point_selector: tx.entry_point_selector,
@@ -84,18 +82,18 @@ impl From<L1HandlerTransaction> for starknet_types_rpc::L1HandlerTxn<Felt> {
     }
 }
 
-impl From<DeclareTransaction> for starknet_types_rpc::DeclareTxn<Felt> {
+impl From<DeclareTransaction> for mp_rpc::DeclareTxn {
     fn from(tx: DeclareTransaction) -> Self {
         match tx {
-            DeclareTransaction::V0(tx) => starknet_types_rpc::DeclareTxn::V0(tx.into()),
-            DeclareTransaction::V1(tx) => starknet_types_rpc::DeclareTxn::V1(tx.into()),
-            DeclareTransaction::V2(tx) => starknet_types_rpc::DeclareTxn::V2(tx.into()),
-            DeclareTransaction::V3(tx) => starknet_types_rpc::DeclareTxn::V3(tx.into()),
+            DeclareTransaction::V0(tx) => mp_rpc::DeclareTxn::V0(tx.into()),
+            DeclareTransaction::V1(tx) => mp_rpc::DeclareTxn::V1(tx.into()),
+            DeclareTransaction::V2(tx) => mp_rpc::DeclareTxn::V2(tx.into()),
+            DeclareTransaction::V3(tx) => mp_rpc::DeclareTxn::V3(tx.into()),
         }
     }
 }
 
-impl From<DeclareTransactionV0> for starknet_types_rpc::DeclareTxnV0<Felt> {
+impl From<DeclareTransactionV0> for mp_rpc::DeclareTxnV0 {
     fn from(tx: DeclareTransactionV0) -> Self {
         Self {
             class_hash: tx.class_hash,
@@ -106,7 +104,7 @@ impl From<DeclareTransactionV0> for starknet_types_rpc::DeclareTxnV0<Felt> {
     }
 }
 
-impl From<DeclareTransactionV1> for starknet_types_rpc::DeclareTxnV1<Felt> {
+impl From<DeclareTransactionV1> for mp_rpc::DeclareTxnV1 {
     fn from(tx: DeclareTransactionV1) -> Self {
         Self {
             class_hash: tx.class_hash,
@@ -118,7 +116,7 @@ impl From<DeclareTransactionV1> for starknet_types_rpc::DeclareTxnV1<Felt> {
     }
 }
 
-impl From<DeclareTransactionV2> for starknet_types_rpc::DeclareTxnV2<Felt> {
+impl From<DeclareTransactionV2> for mp_rpc::DeclareTxnV2 {
     fn from(tx: DeclareTransactionV2) -> Self {
         Self {
             class_hash: tx.class_hash,
@@ -131,7 +129,7 @@ impl From<DeclareTransactionV2> for starknet_types_rpc::DeclareTxnV2<Felt> {
     }
 }
 
-impl From<DeclareTransactionV3> for starknet_types_rpc::DeclareTxnV3<Felt> {
+impl From<DeclareTransactionV3> for mp_rpc::DeclareTxnV3 {
     fn from(tx: DeclareTransactionV3) -> Self {
         Self {
             account_deployment_data: tx.account_deployment_data,
@@ -149,7 +147,7 @@ impl From<DeclareTransactionV3> for starknet_types_rpc::DeclareTxnV3<Felt> {
     }
 }
 
-impl From<DeployTransaction> for starknet_types_rpc::DeployTxn<Felt> {
+impl From<DeployTransaction> for mp_rpc::DeployTxn {
     fn from(tx: DeployTransaction) -> Self {
         Self {
             class_hash: tx.class_hash,
@@ -160,16 +158,16 @@ impl From<DeployTransaction> for starknet_types_rpc::DeployTxn<Felt> {
     }
 }
 
-impl From<DeployAccountTransaction> for starknet_types_rpc::DeployAccountTxn<Felt> {
+impl From<DeployAccountTransaction> for mp_rpc::DeployAccountTxn {
     fn from(tx: DeployAccountTransaction) -> Self {
         match tx {
-            DeployAccountTransaction::V1(tx) => starknet_types_rpc::DeployAccountTxn::V1(tx.into()),
-            DeployAccountTransaction::V3(tx) => starknet_types_rpc::DeployAccountTxn::V3(tx.into()),
+            DeployAccountTransaction::V1(tx) => mp_rpc::DeployAccountTxn::V1(tx.into()),
+            DeployAccountTransaction::V3(tx) => mp_rpc::DeployAccountTxn::V3(tx.into()),
         }
     }
 }
 
-impl From<DeployAccountTransactionV1> for starknet_types_rpc::DeployAccountTxnV1<Felt> {
+impl From<DeployAccountTransactionV1> for mp_rpc::DeployAccountTxnV1 {
     fn from(tx: DeployAccountTransactionV1) -> Self {
         Self {
             class_hash: tx.class_hash,
@@ -182,7 +180,7 @@ impl From<DeployAccountTransactionV1> for starknet_types_rpc::DeployAccountTxnV1
     }
 }
 
-impl From<DeployAccountTransactionV3> for starknet_types_rpc::DeployAccountTxnV3<Felt> {
+impl From<DeployAccountTransactionV3> for mp_rpc::DeployAccountTxnV3 {
     fn from(tx: DeployAccountTransactionV3) -> Self {
         Self {
             class_hash: tx.class_hash,

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             pkg-config
             protobuf
             nodePackages.prettier
+            nodePackages.markdownlint-cli
             taplo-cli
             yq
             scarb


### PR DESCRIPTION
## Pull Request type


Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)


## What is the current behavior?

Currently, Madara relies on the external starknet-types-rpc crate from the Starknet team, which is no longer actively maintained. This creates a dependency on an unmaintained third-party library for critical RPC types and functionality.

Resolves: #NA

## What is the new behavior?

- Creates a new mp-rpc crate that is a fork of starknet-types-rpc v0.7.1 under Madara's control
- Migrates all usage of starknet-types-rpc types to use the new mp-rpc types internally
- Updates imports and dependencies across all affected crates to use the new mp-rpc
- Removes starknet-types-rpc dependency
- Preserves all existing functionality while bringing type definitions under internal control

### Key changes:

- Copied and adapted RPC types from starknet-types-rpc to new mp-rpc crate
- Unified RPC type usage across Madara codebase
- Updated serialization/deserialization implementations
- Removed unnecessary genericity on `Felt` to reduce complexity
- Maintained compatibility with existing interfaces

## Does this introduce a breaking change?

No

## Other information

