### PR TITLE
fix(analytics): adjust opentelemetry batch size

### DIFF
--- a/crates/madara/client/analytics/src/lib.rs
+++ b/crates/madara/client/analytics/src/lib.rs
@@ -62,7 +62,7 @@ impl Analytics {
             .clone()
             .ok_or(anyhow::anyhow!("OTEL endpoint is not set, not initializing otel providers."))?;
 
-        let batch_config = BatchConfigBuilder::default().build();
+        let batch_config = BatchConfigBuilder::default().with_max_export_batch_size(128).build();
 
         let provider = opentelemetry_otlp::new_pipeline()
             .tracing()


### PR DESCRIPTION
# Adjust OpenTelemetry batch size to prevent gRPC message size errors

## Pull Request type

- Bugfix

## What is the current behavior?

When sending traces to the OpenTelemetry collector, we occasionally encounter gRPC errors due to message size exceeding the maximum allowed size. By default, gRPC has a maximum message size limit of 4MB. This causes trace data loss and logging of errors:

```log
[ERROR] OpenTelemetry trace error occurred. Exporter otlp encountered the following error(s): the grpc server returns error (Some resource has been exhausted): , detailed error message: grpc: received message larger than max (13675090 vs. 4194304)
```

Resolves: #NA

## What is the new behavior?

- Reduces the maximum export batch size from the default value (512) to 128 spans per batch
- This ensures that individual gRPC messages remain under the 4MB default limit
- Prevents trace data loss while maintaining reliable telemetry export

## Does this introduce a breaking change?

No

## Other information

This change optimizes the balance between batch efficiency and reliability. The value of 128 was chosen as it provides a good safety margin below the gRPC message size limit (4MB) while still maintaining reasonable batching performance.
