### PR TITLE
chore(labels): add skip-changelog-orchestrator label to config

### DIFF
--- a/.github/config/labels.yml
+++ b/.github/config/labels.yml
@@ -80,6 +80,10 @@
 - name: invalid
   color: "e4e669"
   description: This issue or PR is not applicable
+- name: skip-changelog-orchestrator
+  color: "ffcc00"
+  description: Skip orchestrator changelog check
+  aliases: ["Skip-Changelog"]
 # ----------------------------------------
 # Color Scheme Reference:
 # - Reds (d73a4a, ee0701) for critical/blocking issues

--- a/.github/workflows/orchestrator-changelog.yml
+++ b/.github/workflows/orchestrator-changelog.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v3
         with:
           changeLogPath: "orchestrator/CHANGELOG.md"
+          skipLabels: "skip-changelog-orchestrator"


### PR DESCRIPTION
## Pull Request type


Please add the labels corresponding to the type of changes your PR introduces:

- Other (please describe): ci/label

## What is the current behavior?

The `Skip-Changelog` label was created manually, but we have a dedicated CI process for managing labels. Since it was not initially defined in label.yml, it was not automatically synchronized with other labels.

Resolves: #NA

## What is the new behavior?

This PR adds the skip-changelog label definition to label.yml, ensuring that label management is handled by the CI rather than manually.

This allows the CI to consistently manage labels instead of relying on manual additions.

## Does this introduce a breaking change?

No

## Other information

Once this PR is good to merge, the `Sync labels` workflow must be triggered to properly synchronize the labels across the repository, ensuring consistency between existing labels and those referenced in other workflows.
