### PR TITLE
Fix the GHA release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate Release Notes
         id: generate_notes
-        uses: conventional-changelog/releaser-action@v1
+        uses: TriPSs/conventional-changelog-action@v5
         with:
           preset: "angular"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ on:
       tag:
         description: tag (ex. v0.8.0) to generate release note from
         required: true
-      previous:
-        description: previous tag (ex. v0.7.0) to generate release note from
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref_name }}
 
-      - name: Generate CHANGELOG body
+      - name: Update CHANGELOG
         id: changelog
         uses: requarks/changelog-action@v1
         with:
@@ -42,3 +42,10 @@ jobs:
           draft: false
           prerelease: false
           body: ${{ steps.changelog.outputs.changes }}
+
+      - name: Commit CHANGELOG.md
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
+          file_pattern: CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
       tag:
         description: tag (ex. v0.8.0) to generate release note from
         required: true
+      previous:
+        description: previous tag (ex. v0.7.0) to generate release note from
 
 permissions:
   contents: write
@@ -25,19 +27,20 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref_name }}
 
-      - name: Generate Release Notes
-        id: generate_notes
-        uses: TriPSs/conventional-changelog-action@v5
+      - name: Generate CHANGELOG body
+        id: changelog
+        uses: requarks/changelog-action@v1
         with:
-          preset: "angular"
+          token: ${{ github.token }}
+          tag: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.RELEASE_ACTION }}
-          tag: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          tag: ${{ github.event.inputs.tag || github.ref_name }}
+          name: Release ${{ github.event.inputs.tag || github.ref_name }}
           commit: ${{ github.sha }}
           draft: false
           prerelease: false
-          body: ${{ steps.generate_notes.outputs.notes }}
+          body: ${{ steps.changelog.outputs.changes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*.*.*" # Triggers on version tags like v1.0.0
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: tag (ex. v0.8.0) to generate release note from
+        required: true
 
 permissions:
   contents: write
@@ -18,6 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Generate Release Notes
         id: generate_notes


### PR DESCRIPTION
* Fixes the wrong name of the github action for the release workflow
* Adds manual trigger for the release workflow (to help debugging it, and to support applying it retro-actively) 

## Pull Request type
- Build-related changes

Resolves: #501 

## Does this introduce a breaking change?

No
