### PR TITLE
fix v0.13.4 gateway client deserialization

### DIFF
--- a/.github/workflows/orchestrator-changelog.yml
+++ b/.github/workflows/orchestrator-changelog.yml
@@ -2,6 +2,9 @@ name: "Changelog Workflow (Orchestrator)"
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
+    paths:
+      - "orchestrator/**"
 
 jobs:
   # Enforces the update of a changelog file on every pull request

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,9 +20,9 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/db-version.yml
 
-  changelog_orchestrator:
-    name: Update Orchestrator Changelog
-    uses: ./.github/workflows/orchestrator-changelog.yml
+  # changelog_orchestrator:
+  #   name: Update Orchestrator Changelog
+  #   uses: ./.github/workflows/orchestrator-changelog.yml
 
   linters:
     name: Run linters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(gateway-client): fix v0.13.4 gateway deserialization
 - chore: Merge entire madara-orchestrator project into this one
 - fix(primitives): limit legacy class sizes
 - fix(block_production): dynamic block closing now adds special address with prev block hash

--- a/madara/crates/primitives/gateway/src/block.rs
+++ b/madara/crates/primitives/gateway/src/block.rs
@@ -1,3 +1,7 @@
+use super::{
+    receipt::{ConfirmedReceipt, MsgToL2},
+    transaction::Transaction,
+};
 use anyhow::Context;
 use mp_block::header::{BlockTimestamp, L1DataAvailabilityMode};
 use mp_chain_config::StarknetVersion;
@@ -5,11 +9,6 @@ use mp_convert::hex_serde::U128AsHex;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet_types_core::felt::Felt;
-
-use super::{
-    receipt::{ConfirmedReceipt, MsgToL2},
-    transaction::Transaction,
-};
 
 #[derive(Debug, Clone, PartialEq, Serialize)] // no Deserialize because it's untagged
 #[serde(untagged)]
@@ -57,7 +56,7 @@ impl ProviderBlockPendingMaybe {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+// #[serde(deny_unknown_fields)] // TODO(v0.13.4): Re-add this attribute when v0.13.4 is supported.
 #[cfg_attr(test, derive(Eq))]
 pub struct ProviderBlock {
     pub block_hash: Felt,
@@ -170,7 +169,7 @@ impl ProviderBlock {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+// #[serde(deny_unknown_fields)] // TODO(v0.13.4): Re-add this attribute when v0.13.4 is supported.
 #[cfg_attr(test, derive(Eq))]
 pub struct ProviderBlockPending {
     pub parent_block_hash: Felt,
@@ -250,7 +249,7 @@ impl ProviderBlockPending {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+// #[serde(deny_unknown_fields)] // TODO(v0.13.4): Re-add this attribute when v0.13.4 is supported.
 #[cfg_attr(test, derive(Eq))]
 pub struct ProviderBlockSignature {
     pub block_hash: Felt,
@@ -259,7 +258,7 @@ pub struct ProviderBlockSignature {
 
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+// #[serde(deny_unknown_fields)] // TODO(v0.13.4): Re-add this attribute when v0.13.4 is supported.
 #[cfg_attr(test, derive(Eq))]
 pub struct ResourcePrice {
     #[serde_as(as = "U128AsHex")]
@@ -270,7 +269,7 @@ pub struct ResourcePrice {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[serde(deny_unknown_fields)]
+// #[serde(deny_unknown_fields)] // TODO(v0.13.4): Re-add this attribute when v0.13.4 is supported.
 pub enum BlockStatus {
     Pending,
     Aborted,


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

serde deny_unknown_fields - the reason we put that is because it forced us to support any new fields when syncing from integration and sepolia testnets.

## What is the new behavior?

We don't support v0.13.4, and it seems the madara-alliance is not wanting to support it. The CI however tests the import of a few blocks on sepolia, and it is now failing because we have not implemented the new v0.13.4 changes.
This PR allows the tests to pass.

Note that however, the new v0.13.4 blocks probably still can't be imported.

## Does this introduce a breaking change?

No