### PR TITLE
quick fix: fix block production test

### DIFF
--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -2613,15 +2613,15 @@ mod tests {
             block_production_task.block_production_task(mp_utils::service::ServiceContext::new_for_testing()).await
         });
 
-        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         task_handle.abort();
 
         let pending_block: mp_block::MadaraMaybePendingBlock = backend.get_block(&DbBlockId::Pending).unwrap().unwrap();
 
         let block_inner = backend
             .get_block(&mp_block::BlockId::Number(1))
-            .expect("Failed to retrieve latest block from db")
-            .expect("Missing latest block")
+            .expect("Failed to retrieve block number one from db")
+            .expect("Missing first block")
             .inner;
 
         assert_eq!(block_inner.transactions.len(), 2);


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

The test sometimes fails due to the block not existing. I increased the wait time to guarantee the expected behavior.

Resolves: #NA

## What is the new behavior?

The test now waits 5 seconds instead of 1 before interrupting the thread.

## Does this introduce a breaking change?

No.
