### PR TITLE
fix: declare_v0

### DIFF
--- a/madara/crates/client/mempool/src/lib.rs
+++ b/madara/crates/client/mempool/src/lib.rs
@@ -14,11 +14,11 @@ use metrics::MempoolMetrics;
 use mp_block::{BlockId, BlockTag, MadaraPendingBlockInfo};
 use mp_class::ConvertedClass;
 use mp_convert::ToFelt;
+use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
     BroadcastedTxn, ClassAndTxnHash, ContractAndTxnHash,
 };
-use mp_transactions::BroadcastedDeclareTransactionV0;
 use mp_transactions::BroadcastedTransactionExt;
 use mp_transactions::L1HandlerTransaction;
 use mp_transactions::L1HandlerTransactionResult;
@@ -78,7 +78,7 @@ pub(crate) trait CheckInvariants {
 #[cfg_attr(test, mockall::automock)]
 pub trait MempoolProvider: Send + Sync {
     fn tx_accept_invoke(&self, tx: BroadcastedInvokeTxn) -> Result<AddInvokeTransactionResult, MempoolError>;
-    fn tx_accept_declare_v0(&self, tx: BroadcastedDeclareTransactionV0) -> Result<ClassAndTxnHash, MempoolError>;
+    fn tx_accept_declare_v0(&self, tx: BroadcastedDeclareTxnV0) -> Result<ClassAndTxnHash, MempoolError>;
     fn tx_accept_declare(&self, tx: BroadcastedDeclareTxn) -> Result<ClassAndTxnHash, MempoolError>;
     fn tx_accept_deploy_account(&self, tx: BroadcastedDeployAccountTxn) -> Result<ContractAndTxnHash, MempoolError>;
     fn tx_accept_l1_handler(
@@ -321,7 +321,7 @@ impl MempoolProvider for Mempool {
     }
 
     #[tracing::instrument(skip(self), fields(module = "Mempool"))]
-    fn tx_accept_declare_v0(&self, tx: BroadcastedDeclareTransactionV0) -> Result<ClassAndTxnHash, MempoolError> {
+    fn tx_accept_declare_v0(&self, tx: BroadcastedDeclareTxnV0) -> Result<ClassAndTxnHash, MempoolError> {
         let (btx, class) = tx.into_blockifier(self.chain_id(), self.backend.chain_config().latest_protocol_version)?;
 
         let res = ClassAndTxnHash {

--- a/madara/crates/client/rpc/src/providers/forward_to_provider.rs
+++ b/madara/crates/client/rpc/src/providers/forward_to_provider.rs
@@ -3,10 +3,9 @@ use jsonrpsee::core::{async_trait, RpcResult};
 use mc_gateway_client::GatewayProvider;
 use mp_gateway::error::SequencerError;
 use mp_rpc::{
-    AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
-    ClassAndTxnHash, ContractAndTxnHash,
+    admin::BroadcastedDeclareTxnV0, AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn,
+    BroadcastedInvokeTxn, ClassAndTxnHash, ContractAndTxnHash,
 };
-use mp_transactions::BroadcastedDeclareTransactionV0;
 
 use super::AddTransactionProvider;
 
@@ -24,7 +23,7 @@ impl ForwardToProvider {
 impl AddTransactionProvider for ForwardToProvider {
     async fn add_declare_v0_transaction(
         &self,
-        _declare_v0_transaction: BroadcastedDeclareTransactionV0,
+        _declare_v0_transaction: BroadcastedDeclareTxnV0,
     ) -> RpcResult<ClassAndTxnHash> {
         Err(StarknetRpcApiError::UnimplementedMethod.into())
     }

--- a/madara/crates/client/rpc/src/providers/mempool.rs
+++ b/madara/crates/client/rpc/src/providers/mempool.rs
@@ -3,11 +3,11 @@ use crate::{errors::StarknetRpcApiError, utils::display_internal_server_error};
 use jsonrpsee::core::{async_trait, RpcResult};
 use mc_mempool::Mempool;
 use mc_mempool::MempoolProvider;
+use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::AddInvokeTransactionResult;
 use mp_rpc::{
     BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, ClassAndTxnHash, ContractAndTxnHash,
 };
-use mp_transactions::BroadcastedDeclareTransactionV0;
 use std::sync::Arc;
 
 /// This [`AddTransactionProvider`] adds the received transactions to a mempool.
@@ -55,7 +55,7 @@ impl From<mc_mempool::MempoolError> for StarknetRpcApiError {
 impl AddTransactionProvider for MempoolAddTxProvider {
     async fn add_declare_v0_transaction(
         &self,
-        declare_v0_transaction: BroadcastedDeclareTransactionV0,
+        declare_v0_transaction: BroadcastedDeclareTxnV0,
     ) -> RpcResult<ClassAndTxnHash> {
         Ok(self.mempool.tx_accept_declare_v0(declare_v0_transaction).map_err(StarknetRpcApiError::from)?)
     }

--- a/madara/crates/client/rpc/src/providers/mod.rs
+++ b/madara/crates/client/rpc/src/providers/mod.rs
@@ -8,10 +8,9 @@ pub use mempool::*;
 
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_rpc::{
-    AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
-    ClassAndTxnHash, ContractAndTxnHash,
+    admin::BroadcastedDeclareTxnV0, AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn,
+    BroadcastedInvokeTxn, ClassAndTxnHash, ContractAndTxnHash,
 };
-use mp_transactions::BroadcastedDeclareTransactionV0;
 use mp_utils::service::{MadaraServiceId, ServiceContext};
 
 use crate::utils::OptionExt;
@@ -20,7 +19,7 @@ use crate::utils::OptionExt;
 pub trait AddTransactionProvider: Send + Sync {
     async fn add_declare_v0_transaction(
         &self,
-        declare_v0_transaction: BroadcastedDeclareTransactionV0,
+        declare_v0_transaction: BroadcastedDeclareTxnV0,
     ) -> RpcResult<ClassAndTxnHash>;
     async fn add_declare_transaction(&self, declare_transaction: BroadcastedDeclareTxn) -> RpcResult<ClassAndTxnHash>;
 
@@ -82,7 +81,7 @@ impl AddTransactionProviderGroup {
 impl AddTransactionProvider for AddTransactionProviderGroup {
     async fn add_declare_v0_transaction(
         &self,
-        declare_v0_transaction: BroadcastedDeclareTransactionV0,
+        declare_v0_transaction: BroadcastedDeclareTxnV0,
     ) -> RpcResult<ClassAndTxnHash> {
         self.provider()
             .ok_or_internal_server_error(Self::ERROR)?

--- a/madara/crates/client/rpc/src/test_utils.rs
+++ b/madara/crates/client/rpc/src/test_utils.rs
@@ -10,14 +10,14 @@ use mp_receipt::{
     ExecutionResources, ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, TransactionReceipt,
 };
 use mp_rpc::{
-    AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
-    ClassAndTxnHash, ContractAndTxnHash, TxnReceipt, TxnWithHash,
+    admin::BroadcastedDeclareTxnV0, AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn,
+    BroadcastedInvokeTxn, ClassAndTxnHash, ContractAndTxnHash, TxnReceipt, TxnWithHash,
 };
 use mp_state_update::{
     ContractStorageDiffItem, DeclaredClassItem, DeployedContractItem, NonceUpdate, ReplacedClassItem, StateDiff,
     StorageEntry,
 };
-use mp_transactions::{BroadcastedDeclareTransactionV0, InvokeTransaction, InvokeTransactionV0, Transaction};
+use mp_transactions::{InvokeTransaction, InvokeTransactionV0, Transaction};
 use mp_utils::service::ServiceContext;
 use rstest::fixture;
 use starknet_types_core::felt::Felt;
@@ -33,7 +33,7 @@ pub struct TestTransactionProvider;
 impl AddTransactionProvider for TestTransactionProvider {
     async fn add_declare_v0_transaction(
         &self,
-        _declare_v0_transaction: BroadcastedDeclareTransactionV0,
+        _declare_v0_transaction: BroadcastedDeclareTxnV0,
     ) -> RpcResult<ClassAndTxnHash> {
         unimplemented!()
     }

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -1,7 +1,6 @@
 use jsonrpsee::core::RpcResult;
 use m_proc_macros::versioned_rpc;
-use mp_rpc::ClassAndTxnHash;
-use mp_transactions::BroadcastedDeclareTransactionV0;
+use mp_rpc::{admin::BroadcastedDeclareTxnV0, ClassAndTxnHash};
 use mp_utils::service::{MadaraServiceId, MadaraServiceStatus};
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +19,7 @@ pub trait MadaraWriteRpcApi {
     #[method(name = "addDeclareV0Transaction")]
     async fn add_declare_v0_transaction(
         &self,
-        declare_v0_transaction: BroadcastedDeclareTransactionV0,
+        declare_v0_transaction: BroadcastedDeclareTxnV0,
     ) -> RpcResult<ClassAndTxnHash>;
 }
 

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -1,6 +1,5 @@
 use jsonrpsee::core::{async_trait, RpcResult};
-use mp_rpc::ClassAndTxnHash;
-use mp_transactions::BroadcastedDeclareTransactionV0;
+use mp_rpc::{admin::BroadcastedDeclareTxnV0, ClassAndTxnHash};
 
 use crate::{versions::admin::v0_1_0::MadaraWriteRpcApiV0_1_0Server, Starknet};
 
@@ -17,7 +16,7 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
     /// * `declare_transaction_result` - the result of the declare transaction
     async fn add_declare_v0_transaction(
         &self,
-        declare_transaction: BroadcastedDeclareTransactionV0,
+        declare_transaction: BroadcastedDeclareTxnV0,
     ) -> RpcResult<ClassAndTxnHash> {
         self.add_transaction_provider.add_declare_v0_transaction(declare_transaction).await
     }

--- a/madara/crates/primitives/rpc/src/admin/mod.rs
+++ b/madara/crates/primitives/rpc/src/admin/mod.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+use crate::{Address, DeprecatedContractClass, Signature};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct BroadcastedDeclareTxnV0 {
+    /// The class to be declared
+    pub contract_class: DeprecatedContractClass,
+    /// The maximal fee that can be charged for including the transaction
+    pub max_fee: Felt,
+    /// The address of the account contract sending the declaration transaction
+    pub sender_address: Address,
+    pub signature: Signature,
+    pub is_query: bool,
+}

--- a/madara/crates/primitives/rpc/src/lib.rs
+++ b/madara/crates/primitives/rpc/src/lib.rs
@@ -1,6 +1,7 @@
 mod custom;
 mod custom_serde;
 
+pub mod admin;
 pub mod v0_7_1;
 
 pub use self::v0_7_1::*;

--- a/madara/crates/primitives/transactions/src/from_broadcasted_transaction.rs
+++ b/madara/crates/primitives/transactions/src/from_broadcasted_transaction.rs
@@ -1,7 +1,6 @@
 use crate::{
-    BroadcastedDeclareTransactionV0, DeclareTransaction, DeclareTransactionV0, DeclareTransactionV1,
-    DeclareTransactionV2, DeclareTransactionV3, DeployAccountTransaction, InvokeTransaction, Transaction,
-    TransactionWithHash,
+    DeclareTransaction, DeclareTransactionV0, DeclareTransactionV1, DeclareTransactionV2, DeclareTransactionV3,
+    DeployAccountTransaction, InvokeTransaction, Transaction, TransactionWithHash,
 };
 use mp_chain_config::StarknetVersion;
 use starknet_types_core::felt::Felt;
@@ -56,13 +55,13 @@ impl DeclareTransaction {
         }
     }
 
-    pub fn from_broadcasted_declare_v0(tx: BroadcastedDeclareTransactionV0, class_hash: Felt) -> Self {
+    pub fn from_broadcasted_declare_v0(tx: mp_rpc::admin::BroadcastedDeclareTxnV0, class_hash: Felt) -> Self {
         DeclareTransaction::V0(DeclareTransactionV0::from_broadcasted_declare_v0(tx, class_hash))
     }
 }
 
 impl DeclareTransactionV0 {
-    fn from_broadcasted_declare_v0(tx: BroadcastedDeclareTransactionV0, class_hash: Felt) -> Self {
+    fn from_broadcasted_declare_v0(tx: mp_rpc::admin::BroadcastedDeclareTxnV0, class_hash: Felt) -> Self {
         Self { sender_address: tx.sender_address, max_fee: tx.max_fee, signature: tx.signature, class_hash }
     }
 }

--- a/madara/crates/primitives/transactions/src/lib.rs
+++ b/madara/crates/primitives/transactions/src/lib.rs
@@ -1,10 +1,8 @@
-use mp_class::CompressedLegacyContractClass;
 use mp_convert::hex_serde::{U128AsHex, U64AsHex};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet_api::transaction::TransactionVersion;
 use starknet_types_core::{felt::Felt, hash::StarkHash};
-use std::sync::Arc;
 
 mod from_blockifier;
 mod from_broadcasted_transaction;
@@ -40,15 +38,6 @@ impl TransactionWithHash {
     pub fn new(transaction: Transaction, hash: Felt) -> Self {
         Self { transaction, hash }
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct BroadcastedDeclareTransactionV0 {
-    pub sender_address: Felt,
-    pub max_fee: Felt,
-    pub signature: Vec<Felt>,
-    pub contract_class: Arc<CompressedLegacyContractClass>,
-    pub is_query: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/madara/crates/primitives/transactions/src/lib.rs
+++ b/madara/crates/primitives/transactions/src/lib.rs
@@ -739,10 +739,7 @@ impl From<mp_rpc::DaMode> for DataAvailabilityMode {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
-    use mp_class::{CompressedLegacyContractClass, LegacyEntryPointsByType};
 
     #[test]
     fn test_tx_with_hash() {
@@ -1010,60 +1007,6 @@ mod tests {
         let da_mode_back: DataAvailabilityMode = starknet_da_mode.into();
 
         assert_eq!(da_mode, da_mode_back);
-    }
-
-    #[test]
-    fn test_broadcasted_declare_transaction_v0_serialization() {
-        let contract_class = CompressedLegacyContractClass {
-            program: "".as_bytes().to_vec(),
-            entry_points_by_type: LegacyEntryPointsByType {
-                constructor: Vec::new(),
-                external: Vec::new(),
-                l1_handler: Vec::new(),
-            },
-            abi: None,
-        };
-
-        let tx = BroadcastedDeclareTransactionV0 {
-            sender_address: Felt::from(1),
-            max_fee: Felt::from(1000),
-            signature: vec![Felt::from(2), Felt::from(3)],
-            contract_class: Arc::new(contract_class),
-            is_query: false,
-        };
-
-        let serialized = serde_json::to_string(&tx).unwrap();
-        let deserialized: BroadcastedDeclareTransactionV0 = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(tx, deserialized);
-    }
-
-    #[test]
-    fn test_broadcasted_declare_transaction_v0_deserialization() {
-        let json = r#"
-        {
-            "sender_address": "0x1",
-            "max_fee": "0x3e8",
-            "signature": ["0x2", "0x3"],
-            "contract_class": {
-                "program": [],
-                "entry_points_by_type": {
-                    "CONSTRUCTOR": [],
-                    "EXTERNAL": [],
-                    "L1_HANDLER": []
-                },
-                "abi": null
-            },
-            "is_query": false
-        }
-        "#;
-
-        let deserialized: BroadcastedDeclareTransactionV0 = serde_json::from_str(json).unwrap();
-
-        assert_eq!(deserialized.sender_address, Felt::from(1));
-        assert_eq!(deserialized.max_fee, Felt::from(1000));
-        assert_eq!(deserialized.signature, vec![Felt::from(2), Felt::from(3)]);
-        assert!(!deserialized.is_query);
     }
 
     pub(crate) fn dummy_tx_invoke_v0() -> InvokeTransactionV0 {

--- a/madara/crates/primitives/transactions/src/to_blockifier.rs
+++ b/madara/crates/primitives/transactions/src/to_blockifier.rs
@@ -1,6 +1,6 @@
 use crate::{
-    from_broadcasted_transaction::is_query, into_starknet_api::TransactionApiError, BroadcastedDeclareTransactionV0,
-    L1HandlerTransaction, Transaction, TransactionWithHash,
+    from_broadcasted_transaction::is_query, into_starknet_api::TransactionApiError, L1HandlerTransaction, Transaction,
+    TransactionWithHash,
 };
 use blockifier::{
     execution::contract_class::ClassInfo as BClassInfo, execution::errors::ContractClassError,
@@ -11,7 +11,7 @@ use mp_class::{
     class_hash, compile::ClassCompilationError, CompressedLegacyContractClass, ConvertedClass, FlattenedSierraClass,
     LegacyClassInfo, LegacyConvertedClass, SierraClassInfo, SierraConvertedClass,
 };
-use mp_rpc::{BroadcastedDeclareTxn, BroadcastedTxn};
+use mp_rpc::{admin::BroadcastedDeclareTxnV0, BroadcastedDeclareTxn, BroadcastedTxn};
 use starknet_api::transaction::{Fee, TransactionHash};
 use starknet_types_core::felt::Felt;
 use std::sync::Arc;
@@ -135,13 +135,14 @@ impl L1HandlerTransaction {
     }
 }
 
-impl BroadcastedDeclareTransactionV0 {
-    pub fn into_blockifier(
+impl BroadcastedTransactionExt for BroadcastedDeclareTxnV0 {
+    fn into_blockifier(
         self,
         chain_id: Felt,
         starknet_version: StarknetVersion,
     ) -> Result<(BTransaction, Option<ConvertedClass>), ToBlockifierError> {
-        let (class_info, converted_class, class_hash) = handle_class_legacy(Arc::clone(&self.contract_class))?;
+        let (class_info, converted_class, class_hash) =
+            handle_class_legacy(Arc::new((self.contract_class).clone().try_into()?))?;
 
         let is_query = self.is_query;
         let transaction = Transaction::Declare(crate::DeclareTransaction::from_broadcasted_declare_v0(


### PR DESCRIPTION


## Pull Request type


Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

The RPC endpoint `madara_addDeclareV0Transaction` does not use RPC type CompressedLegacy, which causes issues with the deserialization of class ABIs, as a field should be untagged.

Resolves: #NA
- The `madara_addDeclareV0Transaction` endpoint now uses a new RPC type: `BroadcastedDeclareTxnV0`.
- This type is not perfectly aligned with other RPC transaction types in terms of version, query_only, and type.
- It is now easier to use this endpoint with starknet-rs class types or other external libraries.

## Does this introduce a breaking change?

Yes, for clients using the old RPC admin.

## Other information


