### PR TITLE
fix: 🛠️ devcontainers config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,24 @@
-FROM rust:1.75.0-bookworm
+FROM ubuntu:24.04
 
 ARG USERNAME=vscode
 # replace this with your own user id (outside the container)
 # you can retreive your user id with `id -u`
 # this makes it so files created in the container are still owned by the host user (and not root)
-ARG USER_UID=1001 
+ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
 
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+# Check if user with UID 1000 already exists, if not create it
+RUN if ! id -u $USER_UID > /dev/null 2>&1; then \
+        groupadd --gid $USER_GID $USERNAME \
+        && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME; \
+    else \
+        usermod -l $USERNAME $(getent passwd $USER_UID | cut -d: -f1) \
+        && groupmod -n $USERNAME $(getent group $USER_GID | cut -d: -f1); \
+    fi \
     && apt-get update \
-    && apt-get install -y sudo \
+    && apt-get install -y sudo tzdata \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
@@ -27,4 +34,46 @@ RUN sudo apt-get update \
         htop \
         jq \
         tree \
+        curl \
+        git \
+        wget \
+        gnupg \
+        software-properties-common \
+        lsb-release \
+        ca-certificates \
+        # Python dependencies
+        libssl-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libncursesw5-dev \
+        xz-utils \
+        tk-dev \
+        libxml2-dev \
+        libxmlsec1-dev \
+        libffi-dev \
+        liblzma-dev \
     && sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && echo 'source $HOME/.cargo/env' >> $HOME/.zshrc
+
+RUN sudo chsh -s /bin/zsh $USERNAME
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
+    && echo 'export NVM_DIR="$HOME/.nvm"' >> $HOME/.zshrc \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $HOME/.zshrc \
+    && echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"' >> $HOME/.zshrc
+
+RUN curl https://pyenv.run | bash \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $HOME/.zshrc \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> $HOME/.zshrc \
+    && echo 'eval "$(pyenv init -)"' >> $HOME/.zshrc
+
+RUN $HOME/.pyenv/bin/pyenv install 3.9 \
+    && $HOME/.pyenv/bin/pyenv global 3.9
+
+RUN export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
+    nvm install 22

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -15,18 +15,22 @@
    ```
 
 2. **Open in Dev Container:**
-   - In VS Code, click the green button in the bottom-left corner
+   - In VS Code, click the `><` in the bottom-left corner
    - Select "Reopen in Container"
    - VS Code will build and start the dev container with all dependencies pre-installed
 
 ## Features
 
 - Pre-configured Rust development environment
-- All dependencies already installed
+- Python, Node, Rust already installed
 - Consistent development environment across team members
-- No need to install tools on your local machine
 
 ## Troubleshooting
+
+### IDE is stuck on `Installing Server`
+
+Sadly this step takes a long time.
+Be patient and it *should* eventually install the backend into the container to allow it to communicate to VSCode.
 
 ### Dev Container Requires Update
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,45 @@
+# Using Dev Containers with Madara
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/products/docker-desktop/)
+- [VS Code](https://code.visualstudio.com/download) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+## Quick Start
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/madara-alliance/madara.git
+   cd madara
+   ```
+
+2. **Open in Dev Container:**
+   - In VS Code, click the green button in the bottom-left corner
+   - Select "Reopen in Container"
+   - VS Code will build and start the dev container with all dependencies pre-installed
+
+## Features
+
+- Pre-configured Rust development environment
+- All dependencies already installed
+- Consistent development environment across team members
+- No need to install tools on your local machine
+
+## Troubleshooting
+
+### Dev Container Requires Update
+
+If a dependency needs to be added, or an environment version needs to change:
+
+- Update the **Dockerfile** in `<repo>/.devcontainer/Dockerfile`
+- Open CMD Pallet (Ctrl-P) and select `>Dev Containers: Rebuild Container`
+
+### Problems Loading Dev Container
+
+- Open CMD Pallet (Ctrl-P) and select `>Dev Containers: Show Container Log`
+
+## Learn More
+
+- [VSCode Dev Containers documentation](https://code.visualstudio.com/docs/remote/containers)
+- [Dev Containers](https://containers.dev/)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,12 +13,11 @@
         "terminal.integrated.profiles.linux": { "zsh": { "path": "/bin/zsh" } }
       },
       "extensions": [
-        "rust-lang.rust-analyzer",
-        "1YiB.rust-bundle",
-        "tamasfe.even-better-toml",
-        "serayuzgur.crates",
-        "vivaxy.vscode-conventional-commits",
-        "streetsidesoftware.code-spell-checker"
+        //        "1YiB.rust-bundle",
+        //        "tamasfe.even-better-toml",
+        //        "serayuzgur.crates",
+        //        "vivaxy.vscode-conventional-commits",
+        //        "streetsidesoftware.code-spell-checker"
       ]
     }
   },

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,9 +5,9 @@ echo ">> Starting setup.sh script execution."
 # Uncomment this if you want to remove the db on each container start
 # rm -rf /tmp/madara
 
-# Sets up Madara environment
-cargo run -- setup --chain starknet --from-remote --base-path /tmp/madara \
-&& cargo fmt
+rustup show
+node --version
+python --version
 
 # Uncomment this if you want to run madara on container start
 # cargo run -- \

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ frestart: fclean
 
 
 snos:
+	rm -r orchestrator_venv && \
 	python3.9 -m venv orchestrator_venv && \
 	. ./orchestrator_venv/bin/activate && \
 	pip install cairo-lang==0.13.2 "sympy<1.13.0" && \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Madara is a powerful Starknet client written in Rust.
 
 [⬅️ back to top](#-madara-starknet-client)
 
+> [!TIP]  
+> For an easier time setting up machine for local development, consult [Using Dev Containers](.devcontainer/README.md).
+
 ### Run from Source
 
 #### 1. Install dependencies


### PR DESCRIPTION
> [!NOTE]  
> Wait until PR https://github.com/madara-alliance/madara/pull/535 has merged before this is ready.

## Pull Request type

- **DX**:  Dev Tooling

## What is the current behavior?

The previous `.devcontainers` config is broken/outofdate.

## What is the new behaviour?

With this change, a dev can run `make snos` & `cargo build --release` without any extra local deps.

## Does this introduce a breaking change?

No

## Other information 

If we want to support other IDEs that use devcontainers (like rust-rover), we can add that into other PRs which add those client specific config.