### PR TITLE
from microbecode: Add binary target to example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Start the Madara client with a basic set of arguments depending on your chosen m
 Synchronizes the state of the chain from genesis.
 
 ```bash
-cargo run --release --        \
+cargo run --bin madara --release --        \
   --name Madara               \
   --full                      \
   --base-path /var/lib/madara \
@@ -122,7 +122,7 @@ cargo run --release --        \
 Produces new blocks for other nodes to synchronize.
 
 ```bash
-cargo run --release --        \
+cargo run --bin madara --release --        \
   --name Madara               \
   --sequencer                 \
   --base-path /var/lib/madara \
@@ -135,7 +135,7 @@ cargo run --release --        \
 A node in a private local network.
 
 ```bash
- cargo run --release --    \
+ cargo run --bin madara --release --    \
   --name Madara            \
   --devnet                 \
   --base-path ../madara_db \
@@ -152,7 +152,7 @@ You can use cli presets for certain common node configurations, for example
 enabling rpc endpoints:
 
 ```bash
-cargo run --release -- \
+cargo run --bin madara --release -- \
    --name Madara       \
    --full              \
    --preset mainnet    \
@@ -162,7 +162,7 @@ cargo run --release -- \
 ...or the madara [feeder gateway](#feeder-gateway-state-synchronization):
 
 ```bash
-cargo run --release -- \
+cargo run --bin madara --release -- \
    --name Madara       \
    --full              \
    --preset mainnet    \
@@ -600,7 +600,7 @@ already have one, you can use the following command to generate a sample
 database:
 
 ```bash
-cargo run --release --      \
+cargo run --bin madara --release --      \
   --name madara             \
   --network mainnet         \
   --full                    \
@@ -616,7 +616,7 @@ the _source_ of the migration. You can do this with the `--warp-update-sender`
 [preset](#4-presets):
 
 ```bash
-cargo run --release -- \
+cargo run --bin madara --release -- \
   --name Sender        \
   --full               `# This also works with other types of nodes` \
   --network mainnet    \
@@ -637,7 +637,7 @@ You will then need to start a second node to synchronize the state of your
 database:
 
 ```bash
-cargo run --release --            \
+cargo run --bin madara --release --            \
   --name Receiver                 \
   --base-path /tmp/madara_new     `# Where you want the new database to be stored` \
   --full                          \
@@ -662,7 +662,7 @@ environment, you can start your node with the following arguments and achieve
 the same results:
 
 ```bash
-cargo run --release --    \
+cargo run --bin madara --release --    \
   --name Sender           \
   --full                  `# This also works with other types of nodes` \
   --network mainnet       \
@@ -683,7 +683,7 @@ custom ports:
 > examples above, remember to delete its database with `rm -rf /tmp/madara_new`.
 
 ```bash
-cargo run --release --            \
+cargo run --bin madara --release --            \
   --name Receiver                 \
   --base-path /tmp/madara_new     `# Where you want the new database to be stored` \
   --full                          \


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

- Bugfix
- Documentation content changes

## What is the current behavior?

Example commands do not work and give an error.

Resolves: https://github.com/madara-alliance/madara/issues/508 

## What is the new behavior?

Specify the used binary explicitly to make the example commands work again.

## Does this introduce a breaking change?

No

## Other information
