### PR TITLE
Add resource readiness checks with polling mechanism

### DIFF
--- a/orchestrator/crates/orchestrator/src/alerts/mod.rs
+++ b/orchestrator/crates/orchestrator/src/alerts/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use mockall::automock;
+use color_eyre::Result;
 
 pub mod aws_sns;
 
@@ -7,12 +8,17 @@ pub mod aws_sns;
 #[async_trait]
 pub trait Alerts: Send + Sync {
     /// To send an alert message to our alert service
-    async fn send_alert_message(&self, message_body: String) -> color_eyre::Result<()>;
+    async fn send_alert_message(&self, message_body: String) -> Result<()>;
     async fn get_topic_name(&self) -> String;
-    async fn create_alert(&self, topic_name: &str) -> color_eyre::Result<()>;
-    async fn setup(&self) -> color_eyre::Result<()> {
+    async fn create_alert(&self, topic_name: &str) -> Result<()>;
+    async fn exists(&self) -> Result<bool>;
+    async fn setup(&self) -> Result<()> {
         let topic_name = self.get_topic_name().await;
-        self.create_alert(&topic_name).await?;
+        if !self.exists().await? {
+            self.create_alert(&topic_name).await?;
+        } else {
+            self.send_alert_message(format!("Topic {} already exists, skipping", topic_name)).await?;
+        }
         Ok(())
     }
 }

--- a/orchestrator/crates/orchestrator/src/cli/mod.rs
+++ b/orchestrator/crates/orchestrator/src/cli/mod.rs
@@ -272,6 +272,13 @@ pub struct SetupCmd {
     // Cron
     #[clap(flatten)]
     pub aws_event_bridge_args: AWSEventBridgeCliArgs,
+    
+    // Miscellaneous
+    #[arg(env = "MADARA_ORCHESTRATOR_SETUP_TIMEOUT", long)]
+    pub timeout: Option<u64>,
+
+    #[arg(env = "MADARA_ORCHESTRATOR_SETUP_RESOURCE_POLL_INTERVAL", long)]
+    pub poll_interval: Option<u64>,
 }
 
 impl SetupCmd {

--- a/orchestrator/crates/orchestrator/src/cron/event_bridge.rs
+++ b/orchestrator/crates/orchestrator/src/cron/event_bridge.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
+use async_std::task::sleep;
 use aws_config::SdkConfig;
 use aws_sdk_eventbridge::types::{InputTransformer, RuleState, Target as EventBridgeTarget};
 use aws_sdk_scheduler::types::{FlexibleTimeWindow, FlexibleTimeWindowMode, Target};
@@ -102,6 +103,8 @@ impl Cron for AWSEventBridge {
             .assume_role_policy_document(assume_role_policy)
             .send()
             .await?;
+
+        sleep(Duration::from_secs(10)).await;
 
         let role_arn = create_role_resp.role().unwrap().arn();
 

--- a/orchestrator/crates/orchestrator/src/cron/mod.rs
+++ b/orchestrator/crates/orchestrator/src/cron/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use lazy_static::lazy_static;
+use color_eyre::Result;
 
 use crate::queue::job_queue::WorkerTriggerType;
 
@@ -21,13 +22,13 @@ pub struct TriggerArns {
 }
 #[async_trait]
 pub trait Cron {
-    async fn create_cron(&self) -> color_eyre::Result<TriggerArns>;
+    async fn create_cron(&self) -> Result<TriggerArns>;
     async fn add_cron_target_queue(
         &self,
         trigger_type: &WorkerTriggerType,
         trigger_arns: &TriggerArns,
-    ) -> color_eyre::Result<()>;
-    async fn setup(&self) -> color_eyre::Result<()> {
+    ) -> Result<()>;
+    async fn setup(&self) -> Result<()> {
         let trigger_arns = self.create_cron().await?;
         for trigger in WORKER_TRIGGERS.iter() {
             self.add_cron_target_queue(trigger, &trigger_arns).await?;

--- a/orchestrator/crates/orchestrator/src/data_storage/aws_s3/mod.rs
+++ b/orchestrator/crates/orchestrator/src/data_storage/aws_s3/mod.rs
@@ -10,6 +10,7 @@ use color_eyre::eyre::Context;
 use color_eyre::Result;
 
 use crate::data_storage::DataStorage;
+use crate::setup::ResourceStatus;
 
 pub const S3_SETTINGS_NAME: &str = "s3";
 
@@ -128,5 +129,17 @@ impl DataStorage for AWSS3 {
             ))?;
 
         Ok(())
+    }
+
+    async fn exists(&self, bucket_name: &str) -> Result<bool> {
+        Ok(self.client.head_bucket().bucket(bucket_name).send().await.is_ok())
+    }
+}
+
+#[allow(unreachable_patterns)]
+#[async_trait]
+impl ResourceStatus for AWSS3 {
+    async fn are_all_ready(&self) -> bool {
+        self.exists(self.bucket.as_str()).await.is_ok()
     }
 }

--- a/orchestrator/crates/orchestrator/src/queue/mod.rs
+++ b/orchestrator/crates/orchestrator/src/queue/mod.rs
@@ -115,10 +115,15 @@ pub trait QueueProvider: Send + Sync {
         -> EyreResult<()>;
     async fn consume_message_from_queue(&self, queue: QueueType) -> std::result::Result<Delivery, QueueError>;
     async fn create_queue(&self, queue_config: &QueueConfig) -> EyreResult<()>;
+    async fn exists(&self, queue_config: &QueueConfig) -> bool;
     async fn setup(&self) -> EyreResult<()> {
-        // Creating the queues :
+        // Creating the queues
         for queue in QUEUES.iter() {
-            self.create_queue(queue).await?;
+            if !self.exists(queue).await {
+                self.create_queue(queue).await?;
+            } else {
+                println!("Queue {} already exists, skipping", queue.name);
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Introduced methods to verify the existence of resources (queues, data storage, alerts, cron) and added a polling mechanism to ensure readiness during setup. This avoids redundant resource creation and enhances setup reliability by handling resource initialization status effectively.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, there are hardcoded delays before and after creating any resource on cloud

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Now, it polls the cloud services to check if the resource and its dependents are ready

## Does this introduce a breaking change?

NO

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
