### PR TITLE
fix: trace api match spec

### DIFF
--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/api.rs
@@ -2,12 +2,7 @@ use jsonrpsee::core::RpcResult;
 use m_proc_macros::versioned_rpc;
 use mp_block::BlockId;
 use mp_rpc::{
-    AddInvokeTransactionResult, BlockHashAndNumber, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn,
-    BroadcastedInvokeTxn, BroadcastedTxn, ClassAndTxnHash, ContractAndTxnHash, EventFilterWithPageRequest, EventsChunk,
-    FeeEstimate, FunctionCall, MaybeDeprecatedContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
-    MaybePendingStateUpdate, MsgFromL1, SimulateTransactionsResult, SimulationFlag, SimulationFlagForEstimateFee,
-    StarknetGetBlockWithTxsAndReceiptsResult, SyncingStatus, TraceBlockTransactionsResult,
-    TxnFinalityAndExecutionStatus, TxnReceiptWithBlockInfo, TxnWithHash,
+    AddInvokeTransactionResult, BlockHashAndNumber, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, BroadcastedTxn, ClassAndTxnHash, ContractAndTxnHash, EventFilterWithPageRequest, EventsChunk, FeeEstimate, FunctionCall, MaybeDeprecatedContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingStateUpdate, MsgFromL1, SimulateTransactionsResult, SimulationFlag, SimulationFlagForEstimateFee, StarknetGetBlockWithTxsAndReceiptsResult, SyncingStatus, TraceBlockTransactionsResult, TraceTransactionResult, TxnFinalityAndExecutionStatus, TxnReceiptWithBlockInfo, TxnWithHash
 };
 use starknet_types_core::felt::Felt;
 
@@ -156,5 +151,5 @@ pub trait StarknetTraceRpcApi {
 
     #[method(name = "traceTransaction", and_versions = ["V0_8_0"])]
     /// Returns the execution trace of a transaction
-    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceBlockTransactionsResult>;
+    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceTransactionResult>;
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/api.rs
@@ -2,7 +2,12 @@ use jsonrpsee::core::RpcResult;
 use m_proc_macros::versioned_rpc;
 use mp_block::BlockId;
 use mp_rpc::{
-    AddInvokeTransactionResult, BlockHashAndNumber, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn, BroadcastedTxn, ClassAndTxnHash, ContractAndTxnHash, EventFilterWithPageRequest, EventsChunk, FeeEstimate, FunctionCall, MaybeDeprecatedContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingStateUpdate, MsgFromL1, SimulateTransactionsResult, SimulationFlag, SimulationFlagForEstimateFee, StarknetGetBlockWithTxsAndReceiptsResult, SyncingStatus, TraceBlockTransactionsResult, TraceTransactionResult, TxnFinalityAndExecutionStatus, TxnReceiptWithBlockInfo, TxnWithHash
+    AddInvokeTransactionResult, BlockHashAndNumber, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn,
+    BroadcastedInvokeTxn, BroadcastedTxn, ClassAndTxnHash, ContractAndTxnHash, EventFilterWithPageRequest, EventsChunk,
+    FeeEstimate, FunctionCall, MaybeDeprecatedContractClass, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
+    MaybePendingStateUpdate, MsgFromL1, SimulateTransactionsResult, SimulationFlag, SimulationFlagForEstimateFee,
+    StarknetGetBlockWithTxsAndReceiptsResult, SyncingStatus, TraceBlockTransactionsResult, TraceTransactionResult,
+    TxnFinalityAndExecutionStatus, TxnReceiptWithBlockInfo, TxnWithHash,
 };
 use starknet_types_core::felt::Felt;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/mod.rs
@@ -1,7 +1,9 @@
 use crate::{versions::user::v0_7_1::StarknetTraceRpcApiV0_7_1Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_block::BlockId;
-use mp_rpc::{BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult, TraceTransactionResult};
+use mp_rpc::{
+    BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult, TraceTransactionResult,
+};
 use simulate_transactions::simulate_transactions;
 use starknet_types_core::felt::Felt;
 use trace_block_transactions::trace_block_transactions;

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/mod.rs
@@ -1,7 +1,7 @@
 use crate::{versions::user::v0_7_1::StarknetTraceRpcApiV0_7_1Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
 use mp_block::BlockId;
-use mp_rpc::{BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult};
+use mp_rpc::{BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult, TraceTransactionResult};
 use simulate_transactions::simulate_transactions;
 use starknet_types_core::felt::Felt;
 use trace_block_transactions::trace_block_transactions;
@@ -26,7 +26,7 @@ impl StarknetTraceRpcApiV0_7_1Server for Starknet {
         Ok(trace_block_transactions(self, block_id).await?)
     }
 
-    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceBlockTransactionsResult> {
+    async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceTransactionResult> {
         Ok(trace_transaction(self, transaction_hash).await?)
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/trace_transaction.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/trace_transaction.rs
@@ -6,7 +6,7 @@ use mc_exec::execution_result_to_tx_trace;
 use mc_exec::transaction::to_blockifier_transaction;
 use mc_exec::ExecutionContext;
 use mp_chain_config::StarknetVersion;
-use mp_rpc::TraceBlockTransactionsResult;
+use mp_rpc::TraceTransactionResult;
 use starknet_api::transaction::TransactionHash;
 use starknet_types_core::felt::Felt;
 use std::sync::Arc;
@@ -17,7 +17,7 @@ pub const EXECUTION_UNSUPPORTED_BELOW_VERSION: StarknetVersion = StarknetVersion
 pub async fn trace_transaction(
     starknet: &Starknet,
     transaction_hash: Felt,
-) -> StarknetRpcResult<TraceBlockTransactionsResult> {
+) -> StarknetRpcResult<TraceTransactionResult> {
     let (block, tx_index) = starknet
         .backend
         .find_tx_hash_block(&transaction_hash)
@@ -51,5 +51,5 @@ pub async fn trace_transaction(
     let trace = execution_result_to_tx_trace(&execution_result)
         .or_internal_server_error("Converting execution infos to tx trace")?;
 
-    Ok(TraceBlockTransactionsResult { transaction_hash, trace_root: trace })
+    Ok(TraceTransactionResult { trace })
 }

--- a/madara/crates/primitives/rpc/src/v0_7_1/starknet_trace_api_openrpc.rs
+++ b/madara/crates/primitives/rpc/src/v0_7_1/starknet_trace_api_openrpc.rs
@@ -180,6 +180,13 @@ pub struct TraceBlockTransactionsResult {
     pub transaction_hash: Felt,
 }
 
+/// Trace of a single transaction returned by `starknet_traceTransaction`
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TraceTransactionResult {
+    #[serde(flatten)]
+    pub trace: TransactionTrace,
+}
+
 /// Parameters of the `starknet_traceTransaction` method.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TraceTransactionParams {


### PR DESCRIPTION
Fixes the `traceTransaction` RPC result to match the spec