### PR TITLE
deps: update snos and prove_block to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,48 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "blockifier"
+version = "0.8.0-rc.3"
+source = "git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73#6624e910c57db9a16f1607c1ed26f7d8f1114e73"
+dependencies = [
+ "anyhow",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-secp256k1",
+ "ark-secp256r1",
+ "cached",
+ "cairo-lang-casm 2.8.4",
+ "cairo-lang-runner",
+ "cairo-lang-starknet-classes 2.8.4",
+ "cairo-lang-utils 2.8.4",
+ "cairo-vm",
+ "derive_more 0.99.18",
+ "indexmap 2.6.0",
+ "itertools 0.10.5",
+ "keccak",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits 0.2.19",
+ "once_cell",
+ "paste",
+ "phf",
+ "rand",
+ "rstest 0.17.0",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3",
+ "starknet-types-core",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.65",
@@ -4891,7 +4932,7 @@ dependencies = [
 [[package]]
 name = "cairo-type-derive"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?branch=madara-monorepo#8acf9741329e240aa3c63be507ea13775735f2f0"
+source = "git+https://github.com/keep-starknet-strange/snos?branch=gm%2Fupdate-cairo-lang-deps#22d9afde1f1a401783b4cc846606821a9a03433c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8795,7 +8836,7 @@ dependencies = [
  "alloy 0.8.3",
  "anyhow",
  "async-trait",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "clap",
  "fdlimit",
  "figment",
@@ -8833,7 +8874,7 @@ dependencies = [
  "serde_yaml",
  "starknet-core 0.12.0",
  "starknet-providers 0.12.0",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tokio",
  "tower 0.4.13",
@@ -9023,7 +9064,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "tempfile",
  "thiserror 2.0.3",
  "tokio",
@@ -9040,7 +9081,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bitvec",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "lazy_static",
  "m-cairo-test-contracts",
  "mc-analytics",
@@ -9072,7 +9113,7 @@ dependencies = [
  "serde_json",
  "starknet-core 0.12.0",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tokio",
  "tracing",
@@ -9087,7 +9128,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "bonsai-trie",
  "lazy_static",
  "librocksdb-sys",
@@ -9110,7 +9151,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "tempfile",
  "thiserror 2.0.3",
  "tokio",
@@ -9126,7 +9167,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "m-cairo-test-contracts",
  "mc-block-import",
  "mc-block-production",
@@ -9154,7 +9195,7 @@ dependencies = [
  "starknet-core 0.12.0",
  "starknet-signers 0.10.0",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "tokio",
  "tracing",
  "tracing-core",
@@ -9187,7 +9228,7 @@ dependencies = [
 name = "mc-exec"
 version = "0.8.0"
 dependencies = [
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "cairo-vm",
  "mc-db",
  "mp-block",
@@ -9205,7 +9246,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rstest 0.18.2",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tokio",
  "tracing",
@@ -9276,7 +9317,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bitvec",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "lazy_static",
  "mc-analytics",
  "mc-block-import",
@@ -9307,7 +9348,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tokio",
  "tokio-util",
@@ -9325,7 +9366,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "bitvec",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "jsonrpsee",
  "m-proc-macros",
  "mc-block-import",
@@ -9347,7 +9388,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tokio",
  "tracing",
@@ -9363,7 +9404,7 @@ dependencies = [
  "async-trait",
  "bigdecimal 0.4.5",
  "bitvec",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "dotenv",
  "futures",
  "httpmock 0.7.0",
@@ -9396,7 +9437,7 @@ dependencies = [
  "starknet-providers 0.12.0",
  "starknet-signers 0.10.0",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "tempfile",
  "thiserror 2.0.3",
  "tokio",
@@ -9439,7 +9480,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde_json",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "tempfile",
  "thiserror 2.0.3",
  "tokio",
@@ -9668,7 +9709,7 @@ dependencies = [
 name = "mp-block"
 version = "0.8.0"
 dependencies = [
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "mp-chain-config",
  "mp-receipt",
  "mp-rpc",
@@ -9694,7 +9735,7 @@ name = "mp-chain-config"
 version = "0.8.0"
 dependencies = [
  "anyhow",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "lazy_static",
  "mp-utils",
  "primitive-types",
@@ -9703,7 +9744,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tracing",
  "url",
@@ -9714,7 +9755,7 @@ name = "mp-class"
 version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "cairo-lang-starknet 1.0.0-alpha.6",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet 1.1.1",
@@ -9751,7 +9792,7 @@ dependencies = [
  "serde_with 3.11.0",
  "starknet-core 0.12.0",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
 ]
 
@@ -9800,7 +9841,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "cairo-vm",
  "mp-rpc",
  "mp-transactions",
@@ -9810,7 +9851,7 @@ dependencies = [
  "sha3",
  "starknet-core 0.12.0",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tracing",
 ]
@@ -9843,7 +9884,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "base64 0.22.1",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "cairo-lang-starknet-classes 2.8.4",
  "cairo-lang-utils 2.8.4",
  "cairo-vm",
@@ -9857,7 +9898,7 @@ dependencies = [
  "serde_with 3.11.0",
  "starknet-core 0.12.0",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo)",
  "thiserror 2.0.3",
  "tracing",
 ]
@@ -11566,10 +11607,10 @@ dependencies = [
 [[package]]
 name = "prove_block"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?branch=madara-monorepo#8acf9741329e240aa3c63be507ea13775735f2f0"
+source = "git+https://github.com/keep-starknet-strange/snos?branch=gm%2Fupdate-cairo-lang-deps#22d9afde1f1a401783b4cc846606821a9a03433c"
 dependencies = [
  "anyhow",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "cairo-lang-starknet-classes 2.8.4",
  "cairo-lang-utils 2.8.4",
  "cairo-vm",
@@ -11587,11 +11628,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.11.0",
- "starknet 0.12.0",
+ "starknet 0.11.0",
  "starknet-os",
  "starknet-os-types",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "thiserror 1.0.65",
  "tokio",
 ]
@@ -12098,13 +12139,13 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?branch=madara-monorepo#8acf9741329e240aa3c63be507ea13775735f2f0"
+source = "git+https://github.com/keep-starknet-strange/snos?branch=gm%2Fupdate-cairo-lang-deps#22d9afde1f1a401783b4cc846606821a9a03433c"
 dependencies = [
  "log",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "starknet 0.12.0",
+ "starknet 0.11.0",
  "starknet-os",
  "starknet-types-core",
  "thiserror 1.0.65",
@@ -12113,16 +12154,16 @@ dependencies = [
 [[package]]
 name = "rpc-replay"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?branch=madara-monorepo#8acf9741329e240aa3c63be507ea13775735f2f0"
+source = "git+https://github.com/keep-starknet-strange/snos?branch=gm%2Fupdate-cairo-lang-deps#22d9afde1f1a401783b4cc846606821a9a03433c"
 dependencies = [
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "cairo-lang-starknet-classes 2.8.4",
  "rpc-client",
  "serde",
  "serde_json",
- "starknet 0.12.0",
+ "starknet 0.11.0",
  "starknet-os-types",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "thiserror 1.0.65",
  "tokio",
 ]
@@ -13816,7 +13857,7 @@ dependencies = [
 [[package]]
 name = "starknet-os"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?branch=madara-monorepo#8acf9741329e240aa3c63be507ea13775735f2f0"
+source = "git+https://github.com/keep-starknet-strange/snos?branch=gm%2Fupdate-cairo-lang-deps#22d9afde1f1a401783b4cc846606821a9a03433c"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -13825,7 +13866,7 @@ dependencies = [
  "ark-secp256r1",
  "base64 0.21.7",
  "bitvec",
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "c-kzg",
  "cairo-lang-casm 2.8.4",
  "cairo-lang-starknet 2.8.4",
@@ -13855,7 +13896,7 @@ dependencies = [
  "starknet-crypto 0.6.2",
  "starknet-gateway-types",
  "starknet-os-types",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "thiserror 1.0.65",
  "tokio",
  "uuid 1.12.0",
@@ -13865,9 +13906,9 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?branch=madara-monorepo#8acf9741329e240aa3c63be507ea13775735f2f0"
+source = "git+https://github.com/keep-starknet-strange/snos?branch=gm%2Fupdate-cairo-lang-deps#22d9afde1f1a401783b4cc846606821a9a03433c"
 dependencies = [
- "blockifier",
+ "blockifier 0.8.0-rc.3 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "cairo-lang-starknet-classes 2.8.4",
  "cairo-vm",
  "flate2",
@@ -13876,11 +13917,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.11.0",
- "starknet-core 0.12.0",
+ "starknet-core 0.11.1",
  "starknet-crypto 0.6.2",
  "starknet-gateway-types",
  "starknet-types-core",
- "starknet_api 0.13.0-rc.1",
+ "starknet_api 0.13.0-rc.1 (git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73)",
  "thiserror 1.0.65",
  "tokio",
 ]
@@ -14029,6 +14070,29 @@ dependencies = [
 name = "starknet_api"
 version = "0.13.0-rc.1"
 source = "git+https://github.com/Moonsong-Labs/sequencer?branch=madara-monorepo#6624e910c57db9a16f1607c1ed26f7d8f1114e73"
+dependencies = [
+ "bitvec",
+ "cairo-lang-starknet-classes 2.8.4",
+ "derive_more 0.99.18",
+ "hex",
+ "indexmap 2.6.0",
+ "itertools 0.12.1",
+ "once_cell",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "sha3",
+ "starknet-crypto 0.5.2",
+ "starknet-types-core",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "starknet_api"
+version = "0.13.0-rc.1"
+source = "git+https://github.com/Moonsong-Labs/sequencer?rev=6624e910c57db9a16f1607c1ed26f7d8f1114e73#6624e910c57db9a16f1607c1ed26f7d8f1114e73"
 dependencies = [
  "bitvec",
  "cairo-lang-starknet-classes 2.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,8 +350,8 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-starknet-os = { git = "https://github.com/keep-starknet-strange/snos", branch = "madara-monorepo" }
-prove_block = { git = "https://github.com/keep-starknet-strange/snos", branch = "madara-monorepo" }
+starknet-os = { git = "https://github.com/keep-starknet-strange/snos", branch = "gm/update-cairo-lang-deps" }
+prove_block = { git = "https://github.com/keep-starknet-strange/snos", branch = "gm/update-cairo-lang-deps" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }


### PR DESCRIPTION
This PR updates the current snos based deps to the latest snos version allowing use of snos v0.13.3

Depends on https://github.com/keep-starknet-strange/snos/pull/480 and will be updated to main when the PR is merged

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Dependency update
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## Does this introduce a breaking change?

No


