### PR TITLE
refactor: `PendingFullBlock` construction for clarity

### DIFF
--- a/madara/crates/client/block_production/src/close_block.rs
+++ b/madara/crates/client/block_production/src/close_block.rs
@@ -14,32 +14,39 @@ pub async fn close_and_save_block(
     block_number: u64,
     declared_classes: Vec<ConvertedClass>,
 ) -> anyhow::Result<Felt> {
-    let block = PendingFullBlock {
+    let events: Vec<EventWithTransactionHash> = block
+        .inner
+        .receipts
+        .iter()
+        .flat_map(|receipt| {
+            receipt
+                .events()
+                .iter()
+                .cloned()
+                .map(|event| EventWithTransactionHash {
+                    transaction_hash: receipt.transaction_hash(),
+                    event,
+                })
+        })
+        .collect();
+
+    let transactions: Vec<TransactionWithReceipt> = block
+        .inner
+        .transactions
+        .into_iter()
+        .zip(block.inner.receipts)
+        .map(|(transaction, receipt)| TransactionWithReceipt { receipt, transaction })
+        .collect();
+
+    let full_block = PendingFullBlock {
         header: block.info.header,
         state_diff,
-        events: block
-            .inner
-            .receipts
-            .iter()
-            .flat_map(|receipt| {
-                receipt
-                    .events()
-                    .iter()
-                    .cloned()
-                    .map(|event| EventWithTransactionHash { transaction_hash: receipt.transaction_hash(), event })
-            })
-            .collect(),
-        transactions: block
-            .inner
-            .transactions
-            .into_iter()
-            .zip(block.inner.receipts)
-            .map(|(transaction, receipt)| TransactionWithReceipt { receipt, transaction })
-            .collect(),
+        events,
+        transactions,
     };
 
     let block_hash = backend
-        .add_full_block_with_classes(block, block_number, &declared_classes, /* pre_v0_13_2_hash_override */ true)
+        .add_full_block_with_classes(full_block, block_number, &declared_classes, /* pre_v0_13_2_hash_override */ true)
         .await?;
 
     Ok(block_hash)


### PR DESCRIPTION
## Pull Request type

Refactoring (no functional changes, no API changes)

## What is the current behavior?
`events` and `transactions` are built inline inside the `PendingFullBlock` structure using nested `.collect()` calls, making the code harder to read and maintain.

## What is the new behavior?
`events` and `transactions` are built beforehand and then passed to `PendingFullBlock`, resulting in a cleaner, more readable, and more compact structure. No changes were made to how `block` is handled.


## Does this introduce a breaking change?

no

