### PR TITLE
update: updated default values in the presets

### DIFF
--- a/configs/chain_config.example.yaml
+++ b/configs/chain_config.example.yaml
@@ -60,11 +60,11 @@ bouncer_config:
     # Maximum number of steps per block
     n_steps: 40000000
     # Maximum length of message segments
-    message_segment_length: 18446744073709551615
+    message_segment_length: 3700
     # Maximum number of events per block
-    n_events: 18446744073709551615
+    n_events: 5000
     # Maximum size of state differences per block
-    state_diff_size: 131072
+    state_diff_size: 4000
 
 # /!\ Only used for block production.
 # Address of the sequencer (0x0 for a full node).

--- a/configs/presets/devnet.yaml
+++ b/configs/presets/devnet.yaml
@@ -23,9 +23,9 @@ bouncer_config:
       range_check96: 18446744073709551615
     gas: 5000000
     n_steps: 40000000
-    message_segment_length: 18446744073709551615
-    n_events: 18446744073709551615
-    state_diff_size: 131072
+    message_segment_length: 3700
+    n_events: 5000
+    state_diff_size: 4000
 sequencer_address: "0x123"
 eth_core_contract_address: "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
 eth_gps_statement_verifier: "0xf294781D719D2F4169cE54469C28908E6FA752C1"

--- a/configs/presets/integration.yaml
+++ b/configs/presets/integration.yaml
@@ -23,9 +23,9 @@ bouncer_config:
       range_check96: 18446744073709551615
     gas: 5000000
     n_steps: 40000000
-    message_segment_length: 18446744073709551615
-    n_events: 18446744073709551615
-    state_diff_size: 131072
+    message_segment_length: 3700
+    n_events: 5000
+    state_diff_size: 4000
 sequencer_address: "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"
 eth_core_contract_address: "0x4737c0c1B4D5b1A687B42610DdabEE781152359c"
 eth_gps_statement_verifier: "0x2046B966994Adcb88D83f467a41b75d64C2a619F"

--- a/configs/presets/mainnet.yaml
+++ b/configs/presets/mainnet.yaml
@@ -23,9 +23,9 @@ bouncer_config:
       range_check96: 18446744073709551615
     gas: 5000000
     n_steps: 40000000
-    message_segment_length: 18446744073709551615
-    n_events: 18446744073709551615
-    state_diff_size: 131072
+    message_segment_length: 3700
+    n_events: 5000
+    state_diff_size: 4000
 sequencer_address: "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"
 eth_core_contract_address: "0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"
 eth_gps_statement_verifier: "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60"

--- a/configs/presets/sepolia.yaml
+++ b/configs/presets/sepolia.yaml
@@ -23,9 +23,9 @@ bouncer_config:
       range_check96: 18446744073709551615
     gas: 5000000
     n_steps: 40000000
-    message_segment_length: 18446744073709551615
-    n_events: 18446744073709551615
-    state_diff_size: 131072
+    message_segment_length: 3700
+    n_events: 5000
+    state_diff_size: 4000
 sequencer_address: "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8"
 eth_core_contract_address: "0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057"
 eth_gps_statement_verifier: "0xf294781D719D2F4169cE54469C28908E6FA752C1"

--- a/madara/crates/primitives/chain_config/src/chain_config.rs
+++ b/madara/crates/primitives/chain_config/src/chain_config.rs
@@ -538,7 +538,7 @@ mod tests {
         // Check bouncer config
         assert_eq!(chain_config.bouncer_config.block_max_capacity.gas, 5000000);
         assert_eq!(chain_config.bouncer_config.block_max_capacity.n_steps, 40000000);
-        assert_eq!(chain_config.bouncer_config.block_max_capacity.state_diff_size, 131072);
+        assert_eq!(chain_config.bouncer_config.block_max_capacity.state_diff_size, 4000);
         assert_eq!(chain_config.bouncer_config.block_max_capacity.builtin_count.add_mod, 18446744073709551615);
 
         assert_eq!(


### PR DESCRIPTION
we were using wrong values in the default presets, updated those:

1. number of events: 5000
2. max-state-diff size: 4000
3. message segment length: 3700

values are taken from: https://github.com/starkware-libs/sequencer/blob/9ebd907098473236d6470d38ec2b0f13b84d6f2a/config/sequencer/default_config.json#L22