### PR TITLE
Chain Config : L1DataAvailabilityMode added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9716,6 +9716,7 @@ dependencies = [
  "anyhow",
  "blockifier",
  "lazy_static",
+ "mp-rpc",
  "mp-utils",
  "primitive-types",
  "rstest 0.18.2",

--- a/configs/chain_config.example.yaml
+++ b/configs/chain_config.example.yaml
@@ -3,6 +3,10 @@ chain_name: "Starknet Mainnet"
 
 chain_id: "SN_MAIN"
 
+# The DA mode used by L1.
+# "Calldata" or "Blob"
+l1_da_mode: "Calldata"
+
 # The URL of the gateway and Feeder Gateway your nodes should sync from.
 feeder_gateway_url: "http://localhost:8080/feeder_gateway/"
 gateway_url: "http://localhost:8080/gateway/"

--- a/configs/chain_config.template.yml
+++ b/configs/chain_config.template.yml
@@ -1,5 +1,6 @@
 chain_name: ""
 chain_id: ""
+l1_da_mode: ""
 feeder_gateway_url: ""
 gateway_url: ""
 native_fee_token_address: ""

--- a/configs/presets/devnet.yaml
+++ b/configs/presets/devnet.yaml
@@ -1,5 +1,6 @@
 chain_name: "Madara"
 chain_id: "MADARA_DEVNET"
+l1_da_mode: "Calldata"
 feeder_gateway_url: "http://localhost:8080/feeder_gateway/"
 gateway_url: "http://localhost:8080/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"

--- a/configs/presets/integration.yaml
+++ b/configs/presets/integration.yaml
@@ -1,5 +1,6 @@
 chain_name: "Starknet Sepolia"
 chain_id: "SN_INTEGRATION_SEPOLIA"
+l1_da_mode: "Calldata"
 feeder_gateway_url: "https://integration-sepolia.starknet.io/feeder_gateway/"
 gateway_url: "https://integration-sepolia.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"

--- a/configs/presets/mainnet.yaml
+++ b/configs/presets/mainnet.yaml
@@ -1,5 +1,6 @@
 chain_name: "Starknet Mainnet"
 chain_id: "SN_MAIN"
+l1_da_mode: "Blob"
 feeder_gateway_url: "https://alpha-mainnet.starknet.io/feeder_gateway/"
 gateway_url: "https://alpha-mainnet.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"

--- a/configs/presets/sepolia.yaml
+++ b/configs/presets/sepolia.yaml
@@ -1,5 +1,6 @@
 chain_name: "Starknet Sepolia"
 chain_id: "SN_SEPOLIA"
+l1_da_mode: "Blob"
 feeder_gateway_url: "https://alpha-sepolia.starknet.io/feeder_gateway/"
 gateway_url: "https://alpha-sepolia.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -699,7 +699,6 @@ mod tests {
         genesis.build_and_store(&backend).await.unwrap();
 
         let mut l1_data_provider = MockL1DataProvider::new();
-        l1_data_provider.expect_get_da_mode().return_const(L1DataAvailabilityMode::Blob);
         l1_data_provider.expect_get_gas_prices().return_const(GasPrices {
             eth_l1_gas_price: 128,
             strk_l1_gas_price: 128,

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -600,11 +600,9 @@ mod tests {
     use mc_exec::execution::TxInfo;
     use mc_mempool::{Mempool, MempoolConfig, MockL1DataProvider};
     use mc_submit_tx::{SubmitTransaction, TransactionValidator, TransactionValidatorConfig};
-    use mp_block::{
-        header::{GasPrices, L1DataAvailabilityMode},
-        MadaraPendingBlock,
-    };
+    use mp_block::{header::GasPrices, MadaraPendingBlock};
     use mp_chain_config::ChainConfig;
+    use mp_chain_config::L1DataAvailabilityMode;
     use mp_convert::ToFelt;
     use mp_rpc::{
         BroadcastedDeclareTxn, BroadcastedDeclareTxnV3, BroadcastedInvokeTxn, BroadcastedTxn, DaMode, InvokeTxnV3,

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -602,7 +602,6 @@ mod tests {
     use mc_submit_tx::{SubmitTransaction, TransactionValidator, TransactionValidatorConfig};
     use mp_block::{header::GasPrices, MadaraPendingBlock};
     use mp_chain_config::ChainConfig;
-    use mp_chain_config::L1DataAvailabilityMode;
     use mp_convert::ToFelt;
     use mp_rpc::{
         BroadcastedDeclareTxn, BroadcastedDeclareTxnV3, BroadcastedInvokeTxn, BroadcastedTxn, DaMode, InvokeTxnV3,

--- a/madara/crates/client/db/src/block_db.rs
+++ b/madara/crates/client/db/src/block_db.rs
@@ -148,7 +148,7 @@ impl MadaraBackend {
                             eth_l1_data_gas_price: 1,
                             strk_l1_data_gas_price: 1,
                         },
-                        l1_da_mode: mp_block::header::L1DataAvailabilityMode::Blob,
+                        l1_da_mode: self.chain_config.l1_da_mode,
                     },
                     tx_hashes: vec![],
                 });

--- a/madara/crates/client/devnet/src/lib.rs
+++ b/madara/crates/client/devnet/src/lib.rs
@@ -175,7 +175,7 @@ impl ChainGenesisDescription {
                         eth_l1_data_gas_price: 5,
                         strk_l1_data_gas_price: 5,
                     },
-                    l1_da_mode: mp_block::header::L1DataAvailabilityMode::Blob,
+                    l1_da_mode: chain_config.l1_da_mode,
                 },
                 state_diff: StateDiff {
                     storage_diffs: self.initial_storage.as_state_diff(),
@@ -217,7 +217,6 @@ mod tests {
     use mc_mempool::{L1DataProvider, Mempool, MempoolConfig, MempoolLimits, MockL1DataProvider};
 
     use mc_submit_tx::{SubmitTransaction, SubmitTransactionError, TransactionValidator, TransactionValidatorConfig};
-    use mp_block::header::L1DataAvailabilityMode;
     use mp_block::{BlockId, BlockTag};
     use mp_class::{ClassInfo, FlattenedSierraClass};
     use mp_receipt::{Event, ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, TransactionReceipt};
@@ -333,7 +332,7 @@ mod tests {
         tracing::debug!("block imported {:?}", backend.get_block_info(&BlockId::Tag(BlockTag::Latest)));
 
         let mut l1_data_provider = MockL1DataProvider::new();
-        l1_data_provider.expect_get_da_mode().return_const(L1DataAvailabilityMode::Blob);
+        l1_data_provider.expect_get_da_mode().return_const(backend.chain_config().l1_da_mode);
         l1_data_provider.expect_get_gas_prices().return_const(GasPrices {
             eth_l1_gas_price: 128,
             strk_l1_gas_price: 128,

--- a/madara/crates/client/devnet/src/lib.rs
+++ b/madara/crates/client/devnet/src/lib.rs
@@ -332,7 +332,6 @@ mod tests {
         tracing::debug!("block imported {:?}", backend.get_block_info(&BlockId::Tag(BlockTag::Latest)));
 
         let mut l1_data_provider = MockL1DataProvider::new();
-        l1_data_provider.expect_get_da_mode().return_const(backend.chain_config().l1_da_mode);
         l1_data_provider.expect_get_gas_prices().return_const(GasPrices {
             eth_l1_gas_price: 128,
             strk_l1_gas_price: 128,

--- a/madara/crates/client/exec/src/block_context.rs
+++ b/madara/crates/client/exec/src/block_context.rs
@@ -8,7 +8,8 @@ use blockifier::{
     state::cached_state::CachedState,
 };
 use mc_db::{db_block_id::DbBlockId, MadaraBackend};
-use mp_block::{header::L1DataAvailabilityMode, MadaraMaybePendingBlockInfo};
+use mp_block::MadaraMaybePendingBlockInfo;
+
 use starknet_api::block::{BlockNumber, BlockTimestamp};
 use std::sync::Arc;
 
@@ -118,7 +119,7 @@ impl ExecutionContext {
                         .try_into()
                         .map_err(|_| Error::InvalidSequencerAddress(pending_block.header.sequencer_address))?,
                     gas_prices: (&pending_block.header.l1_gas_price).into(),
-                    use_kzg_da: pending_block.header.l1_da_mode == L1DataAvailabilityMode::Blob,
+                    use_kzg_da: pending_block.header.l1_da_mode == backend.chain_config().l1_da_mode,
                 },
                 chain_info,
                 versioned_constants,
@@ -167,7 +168,7 @@ impl ExecutionContext {
                 .try_into()
                 .map_err(|_| Error::InvalidSequencerAddress(sequencer_address))?,
             gas_prices: (&l1_gas_price).into(),
-            use_kzg_da: l1_da_mode == L1DataAvailabilityMode::Blob,
+            use_kzg_da: l1_da_mode == backend.chain_config().l1_da_mode,
         };
 
         Ok(ExecutionContext {

--- a/madara/crates/client/mempool/src/header.rs
+++ b/madara/crates/client/mempool/src/header.rs
@@ -14,6 +14,6 @@ pub fn make_pending_header(
         block_timestamp: BlockTimestamp::now(),
         protocol_version: chain_config.latest_protocol_version,
         l1_gas_price: l1_info.get_gas_prices(),
-        l1_da_mode: l1_info.get_da_mode(),
+        l1_da_mode: chain_config.l1_da_mode,
     }
 }

--- a/madara/crates/client/mempool/src/l1.rs
+++ b/madara/crates/client/mempool/src/l1.rs
@@ -1,5 +1,5 @@
 //! TODO: this should be in the backend
-use mp_block::header::{GasPrices, L1DataAvailabilityMode};
+use mp_block::header::GasPrices;
 use mp_oracle::Oracle;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -118,7 +118,6 @@ impl Default for GasPriceProvider {
 pub trait L1DataProvider: Send + Sync {
     fn get_gas_prices(&self) -> GasPrices;
     fn get_gas_prices_last_update(&self) -> SystemTime;
-    fn get_da_mode(&self) -> L1DataAvailabilityMode;
 }
 
 /// This trait enables the block production task to fill in the L1 info.
@@ -130,9 +129,5 @@ impl L1DataProvider for GasPriceProvider {
 
     fn get_gas_prices_last_update(&self) -> SystemTime {
         *self.last_update.lock().expect("Failed to acquire lock")
-    }
-
-    fn get_da_mode(&self) -> L1DataAvailabilityMode {
-        L1DataAvailabilityMode::Blob
     }
 }

--- a/madara/crates/client/rpc/src/test_utils.rs
+++ b/madara/crates/client/rpc/src/test_utils.rs
@@ -3,11 +3,11 @@ use jsonrpsee::core::async_trait;
 use mc_db::MadaraBackend;
 use mc_submit_tx::{SubmitTransaction, SubmitTransactionError};
 use mp_block::{
-    header::{BlockTimestamp, GasPrices, L1DataAvailabilityMode, PendingHeader},
+    header::{BlockTimestamp, GasPrices, PendingHeader},
     Header, MadaraBlockInfo, MadaraBlockInner, MadaraMaybePendingBlock, MadaraMaybePendingBlockInfo,
     MadaraPendingBlockInfo,
 };
-use mp_chain_config::{ChainConfig, StarknetVersion};
+use mp_chain_config::{ChainConfig, L1DataAvailabilityMode, StarknetVersion};
 use mp_receipt::{
     ExecutionResources, ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, TransactionReceipt,
 };

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_receipts.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_block_with_receipts.rs
@@ -226,7 +226,7 @@ mod tests {
                                 eth_l1_data_gas_price: 44,
                                 strk_l1_data_gas_price: 52,
                             },
-                            l1_da_mode: mp_block::header::L1DataAvailabilityMode::Blob,
+                            l1_da_mode: mp_chain_config::L1DataAvailabilityMode::Blob,
                         },
                         block_hash: Felt::from_hex_unchecked("0x1777177171"),
                         tx_hashes: vec![Felt::from_hex_unchecked("0x8888888")],

--- a/madara/crates/node/src/cli/chain_config_overrides.rs
+++ b/madara/crates/node/src/cli/chain_config_overrides.rs
@@ -9,7 +9,7 @@ use starknet_api::core::{ChainId, ContractAddress};
 
 use mp_chain_config::{
     deserialize_bouncer_config, deserialize_starknet_version, serialize_bouncer_config, serialize_starknet_version,
-    ChainConfig, StarknetVersion,
+    ChainConfig, L1DataAvailabilityMode, StarknetVersion,
 };
 use mp_utils::parsers::parse_key_value_yaml;
 use mp_utils::serde::{
@@ -84,6 +84,7 @@ pub struct ChainConfigOverrideParams {
 pub struct ChainConfigOverridesInner {
     pub chain_name: String,
     pub chain_id: ChainId,
+    pub l1_da_mode: L1DataAvailabilityMode,
     pub feeder_gateway_url: Url,
     pub gateway_url: Url,
     pub native_fee_token_address: ContractAddress,
@@ -113,6 +114,7 @@ impl ChainConfigOverrideParams {
         let mut chain_config_overrides = serde_yaml::to_value(ChainConfigOverridesInner {
             chain_name: chain_config.chain_name,
             chain_id: chain_config.chain_id,
+            l1_da_mode: chain_config.l1_da_mode,
             native_fee_token_address: chain_config.native_fee_token_address,
             parent_fee_token_address: chain_config.parent_fee_token_address,
             latest_protocol_version: chain_config.latest_protocol_version,
@@ -163,6 +165,7 @@ impl ChainConfigOverrideParams {
         Ok(ChainConfig {
             chain_name: chain_config_overrides.chain_name,
             chain_id: chain_config_overrides.chain_id,
+            l1_da_mode: chain_config_overrides.l1_da_mode,
             feeder_gateway_url: chain_config_overrides.feeder_gateway_url,
             gateway_url: chain_config_overrides.gateway_url,
             native_fee_token_address: chain_config_overrides.native_fee_token_address,

--- a/madara/crates/primitives/block/src/commitments.rs
+++ b/madara/crates/primitives/block/src/commitments.rs
@@ -189,7 +189,9 @@ pub fn compute_merkle_root<H: StarkHash + Send + Sync>(values: impl IntoIterator
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::header::{BlockTimestamp, GasPrices, L1DataAvailabilityMode};
+    use crate::header::{BlockTimestamp, GasPrices};
+    use mp_chain_config::L1DataAvailabilityMode;
+
     use mp_convert::ToFelt;
     use rstest::*;
     use starknet_api::{core::ChainId, felt};

--- a/madara/crates/primitives/block/src/header.rs
+++ b/madara/crates/primitives/block/src/header.rs
@@ -1,4 +1,5 @@
 use core::num::NonZeroU128;
+use mp_chain_config::L1DataAvailabilityMode;
 use mp_chain_config::StarknetVersion;
 use serde::Deserialize;
 use serde::Serialize;
@@ -134,25 +135,6 @@ impl GasPrices {
         mp_rpc::ResourcePrice {
             price_in_fri: self.strk_l1_data_gas_price.into(),
             price_in_wei: self.eth_l1_data_gas_price.into(),
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum L1DataAvailabilityMode {
-    #[serde(alias = "Calldata")]
-    Calldata,
-    #[serde(alias = "Blob")]
-    #[default]
-    Blob,
-}
-
-impl From<L1DataAvailabilityMode> for mp_rpc::L1DaMode {
-    fn from(value: L1DataAvailabilityMode) -> Self {
-        match value {
-            L1DataAvailabilityMode::Calldata => Self::Calldata,
-            L1DataAvailabilityMode::Blob => Self::Blob,
         }
     }
 }

--- a/madara/crates/primitives/block/src/lib.rs
+++ b/madara/crates/primitives/block/src/lib.rs
@@ -2,7 +2,9 @@
 
 use crate::header::GasPrices;
 use commitments::{BlockCommitments, CommitmentComputationContext};
-use header::{BlockTimestamp, L1DataAvailabilityMode, PendingHeader};
+use header::{BlockTimestamp, PendingHeader};
+use mp_chain_config::L1DataAvailabilityMode;
+
 use mp_chain_config::StarknetVersion;
 use mp_receipt::{EventWithTransactionHash, TransactionReceipt};
 use mp_state_update::StateDiff;

--- a/madara/crates/primitives/chain_config/Cargo.toml
+++ b/madara/crates/primitives/chain_config/Cargo.toml
@@ -22,6 +22,7 @@ starknet_api.workspace = true
 
 # Madara
 mp-utils.workspace = true
+mp-rpc = { workspace = true }
 
 # Other
 anyhow.workspace = true

--- a/madara/crates/primitives/chain_config/Cargo.toml
+++ b/madara/crates/primitives/chain_config/Cargo.toml
@@ -21,8 +21,8 @@ starknet-types-core.workspace = true
 starknet_api.workspace = true
 
 # Madara
-mp-utils.workspace = true
 mp-rpc = { workspace = true }
+mp-utils.workspace = true
 
 # Other
 anyhow.workspace = true

--- a/madara/crates/primitives/chain_config/src/chain_config.rs
+++ b/madara/crates/primitives/chain_config/src/chain_config.rs
@@ -26,7 +26,7 @@ use url::Url;
 
 use mp_utils::serde::{deserialize_duration, deserialize_optional_duration};
 
-use crate::StarknetVersion;
+use crate::{L1DataAvailabilityMode, StarknetVersion};
 
 pub mod eth_core_contract_address {
     pub const MAINNET: &str = "0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4";
@@ -72,6 +72,9 @@ pub struct ChainConfig {
     /// Human readable chain name, for displaying to the console.
     pub chain_name: String,
     pub chain_id: ChainId,
+
+    /// The DA mode supported by L1.
+    pub l1_da_mode: L1DataAvailabilityMode,
 
     // The Gateway URLs are the URLs of the endpoint that the node will use to sync blocks in full mode.
     pub feeder_gateway_url: Url,
@@ -185,6 +188,8 @@ impl ChainConfig {
         Self {
             chain_name: "Starknet Mainnet".into(),
             chain_id: ChainId::Mainnet,
+            // Since L1 here is Ethereum, that supports Blob.
+            l1_da_mode: L1DataAvailabilityMode::Blob,
             feeder_gateway_url: Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/").unwrap(),
             gateway_url: Url::parse("https://alpha-mainnet.starknet.io/gateway/").unwrap(),
             native_fee_token_address: ContractAddress(

--- a/madara/crates/primitives/chain_config/src/l1_da_mode.rs
+++ b/madara/crates/primitives/chain_config/src/l1_da_mode.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum L1DataAvailabilityMode {
+    #[serde(alias = "Calldata")]
+    Calldata,
+    #[serde(alias = "Blob")]
+    #[default]
+    Blob,
+}
+
+impl From<L1DataAvailabilityMode> for mp_rpc::L1DaMode {
+    fn from(value: L1DataAvailabilityMode) -> Self {
+        match value {
+            L1DataAvailabilityMode::Calldata => Self::Calldata,
+            L1DataAvailabilityMode::Blob => Self::Blob,
+        }
+    }
+}

--- a/madara/crates/primitives/chain_config/src/lib.rs
+++ b/madara/crates/primitives/chain_config/src/lib.rs
@@ -1,7 +1,9 @@
 mod chain_config;
+mod l1_da_mode;
 mod rpc_version;
 mod starknet_version;
 
 pub use chain_config::*;
+pub use l1_da_mode::*;
 pub use rpc_version::*;
 pub use starknet_version::*;

--- a/madara/crates/primitives/gateway/src/block.rs
+++ b/madara/crates/primitives/gateway/src/block.rs
@@ -1,8 +1,6 @@
 use super::{receipt::ConfirmedReceipt, transaction::Transaction};
-use mp_block::{
-    header::{L1DataAvailabilityMode, PendingHeader},
-    FullBlock, PendingFullBlock, TransactionWithReceipt,
-};
+use mp_block::{header::PendingHeader, FullBlock, PendingFullBlock, TransactionWithReceipt};
+use mp_chain_config::L1DataAvailabilityMode;
 use mp_chain_config::{StarknetVersion, StarknetVersionError};
 use mp_convert::hex_serde::U128AsHex;
 use mp_receipt::EventWithTransactionHash;


### PR DESCRIPTION
This PR allows to configure the `L1DataAvailabilityMode` by providing it inside the chain config.


## What is the current behavior?
Currently the code as is returning `L1DataAvailabilityMode::Blob` by default, which works for `L2s` that want to settle using `Ethereum Blobs`. 



## What is the new behavior?
This PR allows the user to choose between `L1DataAvailabilityMode::Blob` and `L1DataAvailabilityMode::Calldata` based on which ever they want to use. 
For eg. 
The most common setting right now would follow : 
L2s : `L1DataAvailabilityMode::Blob` for settlement on `Ethereum`
L3s: `L1DataAvailabilityMode::Calldata` for settlement on `Starknet`

Note: 
This PR moves `L1DataAvailabilityMode` from `mp_block` to `mp_chain_config` due to a cyclic dependency that gets created when we try add `mp_block` as a dependency for `mp_chain_config` :
- `mp_chain_config` requires `L1DataAvailabilityMode`.
-  but `mp_block` is already using `StarknetVersion` from `mp_chain_config`.
Hence we took the decision to move `L1DataAvailabilityMode`  as a part of `mp_chain_config`.

Please use this in your chain config file : 
```
l1_da_mode : "Calldata" or "Blob" 
```
