### PR TITLE
Add l1_da_mode in tests/chain_config

### DIFF
--- a/madara/crates/tests/test_devnet.yaml
+++ b/madara/crates/tests/test_devnet.yaml
@@ -1,5 +1,6 @@
 chain_name: "Test devnet"
 chain_id: "MADARA_DEVNET"
+l1_da_mode: "Calldata"
 feeder_gateway_url: "http://localhost:8080/feeder_gateway/"
 gateway_url: "http://localhost:8080/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"

--- a/orchestrator/crates/settlement-clients/starknet/src/tests/preset.yml
+++ b/orchestrator/crates/settlement-clients/starknet/src/tests/preset.yml
@@ -1,5 +1,6 @@
 chain_name: "Madara"
 chain_id: "MADARA_DEVNET"
+l1_da_mode: "Calldata"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 parent_fee_token_address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
 versioned_constants:


### PR DESCRIPTION
This is a addition to #657.
Adding `l1_da_mode` to 
`test_devnet.yaml` and `preset.yml`