### PR TITLE
refactor: Use type imports for Starknet types

### DIFF
--- a/tests/js_tests/utils.ts
+++ b/tests/js_tests/utils.ts
@@ -1,4 +1,4 @@
-import { CompiledSierra, CompiledSierraCasm, json } from "starknet";
+import { type CompiledSierra, type CompiledSierraCasm, json } from "starknet";
 const fs = require("node:fs");
 const path = require("node:path");
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:


- Refactoring (no functional changes, no API changes)


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?


This PR updates the import statements for `CompiledSierra` and `CompiledSierraCasm` from `starknet` to use `import type`. This change explicitly marks these imports as type-only, improving code clarity and enabling better tree-shaking by bundlers. 





<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
