### PR TITLE
feat(`starknet_subscribeTransactionStatus`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9538,6 +9538,7 @@ dependencies = [
  "thiserror 2.0.3",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9513,6 +9513,7 @@ dependencies = [
  "assert_matches",
  "bitvec",
  "blockifier",
+ "futures",
  "jsonrpsee",
  "m-proc-macros",
  "mc-db",
@@ -9605,6 +9606,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "blockifier",
+ "futures",
  "mc-db",
  "mc-exec",
  "mp-class",
@@ -9613,6 +9615,7 @@ dependencies = [
  "mp-transactions",
  "starknet_api 0.13.0-rc.1",
  "thiserror 2.0.3",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9510,6 +9510,7 @@ name = "mc-rpc"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "bitvec",
  "blockifier",
  "jsonrpsee",

--- a/madara/crates/client/db/src/block_db.rs
+++ b/madara/crates/client/db/src/block_db.rs
@@ -243,6 +243,7 @@ impl MadaraBackend {
         let col = self.db.get_column(Column::BlockStorageMeta);
         tracing::debug!("WRITE LAST CONFIRMED l1: {l1_last}");
         self.db.put_cf(&col, ROW_L1_LAST_CONFIRMED_BLOCK, bincode::serialize(&l1_last)?)?;
+        self.watch_blocks.update_last_confirmed_block(l1_last);
         Ok(())
     }
 

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -88,7 +88,7 @@ pub use bonsai_db::GlobalTrie;
 pub use bonsai_trie::{id::BasicId, MultiProof, ProofNode};
 pub use error::{BonsaiStorageError, MadaraStorageError, TrieType};
 pub use rocksdb_options::{RocksDBConfig, StatsLevel};
-pub use watch::{ClosedBlocksReceiver, LastConfirmedBlockReceived, PendingBlockReceiver};
+pub use watch::{ClosedBlocksReceiver, LastConfirmedBlockReceived, PendingBlockReceiver, PendingTxsReceiver};
 pub type DB = DBWithThreadMode<MultiThreaded>;
 pub use rocksdb;
 pub type WriteBatchWithTransaction = rocksdb::WriteBatchWithTransaction<false>;

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -88,7 +88,7 @@ pub use bonsai_db::GlobalTrie;
 pub use bonsai_trie::{id::BasicId, MultiProof, ProofNode};
 pub use error::{BonsaiStorageError, MadaraStorageError, TrieType};
 pub use rocksdb_options::{RocksDBConfig, StatsLevel};
-pub use watch::{ClosedBlocksReceiver, PendingBlockReceiver};
+pub use watch::{ClosedBlocksReceiver, LastConfirmedBlockReceived, PendingBlockReceiver};
 pub type DB = DBWithThreadMode<MultiThreaded>;
 pub use rocksdb;
 pub type WriteBatchWithTransaction = rocksdb::WriteBatchWithTransaction<false>;

--- a/madara/crates/client/devnet/src/lib.rs
+++ b/madara/crates/client/devnet/src/lib.rs
@@ -460,7 +460,8 @@ mod tests {
         Duration::from_secs(500000),
         true
     )]
-    #[case::should_work_across_block_boundary(true, true, None, Duration::from_secs(1), true)]
+    // FIXME: flaky
+    // #[case::should_work_across_block_boundary(true, true, None, Duration::from_secs(1), true)]
     #[ignore = "should_work_across_block_boundary"]
     #[tokio::test]
     async fn test_account_deploy(

--- a/madara/crates/client/gateway/client/src/submit_tx.rs
+++ b/madara/crates/client/gateway/client/src/submit_tx.rs
@@ -119,6 +119,16 @@ impl SubmitTransaction for GatewayProvider {
             .map_err(map_gateway_error)
             .map(|res| AddInvokeTransactionResult { transaction_hash: res.transaction_hash })
     }
+
+    async fn received_transaction(&self, _hash: starknet_types_core::felt::Felt) -> Option<bool> {
+        None
+    }
+
+    async fn subscribe_new_transactions(
+        &self,
+    ) -> Option<tokio::sync::broadcast::Receiver<starknet_types_core::felt::Felt>> {
+        None
+    }
 }
 
 #[async_trait]
@@ -128,5 +138,15 @@ impl mc_submit_tx::SubmitValidatedTransaction for GatewayProvider {
         tx: mp_transactions::validated::ValidatedMempoolTx,
     ) -> Result<(), SubmitTransactionError> {
         self.add_validated_transaction(tx).await.map_err(map_gateway_error)
+    }
+
+    async fn received_transaction(&self, _hash: starknet_types_core::felt::Felt) -> Option<bool> {
+        None
+    }
+
+    async fn subscribe_new_transactions(
+        &self,
+    ) -> Option<tokio::sync::broadcast::Receiver<starknet_types_core::felt::Felt>> {
+        None
     }
 }

--- a/madara/crates/client/gateway/client/src/submit_tx.rs
+++ b/madara/crates/client/gateway/client/src/submit_tx.rs
@@ -121,12 +121,17 @@ impl SubmitTransaction for GatewayProvider {
     }
 
     async fn received_transaction(&self, _hash: starknet_types_core::felt::Felt) -> Option<bool> {
+        // The gateway cannot inform us about the status of transactions it has received since this
+        // is forwarded to a remote node which does not expose any endpoint to query this state. By
+        // default, all transactions which pass through the gateway will be automatically considered
+        // as received.
         None
     }
 
     async fn subscribe_new_transactions(
         &self,
     ) -> Option<tokio::sync::broadcast::Receiver<starknet_types_core::felt::Felt>> {
+        // We cannot subscribe to new transactions from the gateway for the same reasons as above
         None
     }
 }
@@ -141,12 +146,17 @@ impl mc_submit_tx::SubmitValidatedTransaction for GatewayProvider {
     }
 
     async fn received_transaction(&self, _hash: starknet_types_core::felt::Felt) -> Option<bool> {
+        // The gateway cannot inform us about the status of transactions it has received since this
+        // is forwarded to a remote node which does not expose any endpoint to query this state. By
+        // default, all transactions which pass through the gateway will be automatically considered
+        // as received.
         None
     }
 
     async fn subscribe_new_transactions(
         &self,
     ) -> Option<tokio::sync::broadcast::Receiver<starknet_types_core::felt::Felt>> {
+        // We cannot subscribe to new transactions from the gateway for the same reasons as above
         None
     }
 }

--- a/madara/crates/client/mempool/src/inner/mod.rs
+++ b/madara/crates/client/mempool/src/inner/mod.rs
@@ -576,7 +576,7 @@ impl MempoolInner {
             let limits = TransactionCheckedLimits::limits_for(nonce_mapping_entry.get());
             if self.limiter.tx_age_exceeded(&limits) {
                 let mempool_tx = nonce_mapping_entry.remove();
-                assert!(
+                debug_assert!(
                     self.tx_received.remove(&mempool_tx.tx_hash()),
                     "Tried to remove a ready transaction which had not already been marked as received"
                 );
@@ -637,7 +637,7 @@ impl MempoolInner {
                 // tx_intent_queue_pending_by_timestamp
 
                 let mempool_tx = nonce_mapping_entry.remove(); // *- snip -*
-                assert!(
+                debug_assert!(
                     self.tx_received.remove(&mempool_tx.tx_hash()),
                     "Tried to remove a pending transaction which had not already been marked as received"
                 );
@@ -743,7 +743,7 @@ impl MempoolInner {
         #[cfg(any(test, feature = "testing"))]
         self.nonce_cache_inner.insert(tx_mempool.contract_address(), tx_mempool.nonce_next);
         self.limiter.mark_removed(&TransactionCheckedLimits::limits_for(&tx_mempool));
-        assert!(
+        debug_assert!(
             self.tx_received.remove(&tx_mempool.tx_hash()),
             "Tried to remove a ready transaction which had not already been marked as received"
         );

--- a/madara/crates/client/mempool/src/inner/property_testing.rs
+++ b/madara/crates/client/mempool/src/inner/property_testing.rs
@@ -68,6 +68,11 @@ pub enum TxTy {
 
 impl TxTy {
     fn tx(self, contract_address: Felt) -> blockifier::transaction::transaction_execution::Transaction {
+        static HASH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+        let ordering = std::sync::atomic::Ordering::AcqRel;
+        let tx_hash = starknet_api::transaction::TransactionHash(HASH.fetch_add(1, ordering).into());
+
         match self {
             Self::Declare => blockifier::transaction::transaction_execution::Transaction::AccountTransaction(
                 blockifier::transaction::account_transaction::AccountTransaction::Declare(
@@ -78,7 +83,7 @@ impl TxTy {
                                 ..Default::default()
                             },
                         ),
-                        starknet_api::transaction::TransactionHash::default(),
+                        tx_hash,
                         blockifier::execution::contract_class::ClassInfo::new(
                             &blockifier::execution::contract_class::ContractClass::V0(
                                 blockifier::execution::contract_class::ContractClassV0::default(),
@@ -97,7 +102,7 @@ impl TxTy {
                         tx: starknet_api::transaction::DeployAccountTransaction::V1(
                             starknet_api::transaction::DeployAccountTransactionV1::default(),
                         ),
-                        tx_hash: starknet_api::transaction::TransactionHash::default(),
+                        tx_hash,
                         contract_address: ContractAddress::try_from(contract_address).unwrap(),
                         only_query: false,
                     },
@@ -112,7 +117,7 @@ impl TxTy {
                                 ..Default::default()
                             },
                         ),
-                        tx_hash: starknet_api::transaction::TransactionHash::default(),
+                        tx_hash,
                         only_query: false,
                     },
                 ),
@@ -123,7 +128,7 @@ impl TxTy {
                         contract_address: ContractAddress::try_from(contract_address).unwrap(),
                         ..Default::default()
                     },
-                    tx_hash: starknet_api::transaction::TransactionHash::default(),
+                    tx_hash,
                     paid_fee_on_l1: starknet_api::transaction::Fee::default(),
                 },
             ),

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -19,6 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rstest = { workspace = true }
 mc-db = { workspace = true, features = ["testing"] }
 mp-utils = { workspace = true, features = ["testing"] }
+mc-mempool = { workspace = true, features = ["testing"] }
 
 [dependencies]
 
@@ -59,3 +60,4 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -51,6 +51,7 @@ starknet_api = { workspace = true, default-features = true }
 # Others
 anyhow = { workspace = true }
 bitvec = { workspace = true }
+futures = { workspace = true }
 jsonrpsee = { workspace = true, default-features = true, features = [
   "macros",
   "server",
@@ -59,6 +60,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-futures = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -57,4 +57,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
 tracing = { workspace = true }

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -20,6 +20,7 @@ rstest = { workspace = true }
 mc-db = { workspace = true, features = ["testing"] }
 mp-utils = { workspace = true, features = ["testing"] }
 mc-mempool = { workspace = true, features = ["testing"] }
+assert_matches = { workspace = true }
 
 [dependencies]
 

--- a/madara/crates/client/rpc/src/test_utils.rs
+++ b/madara/crates/client/rpc/src/test_utils.rs
@@ -58,7 +58,7 @@ impl SubmitTransaction for TestTransactionProvider {
     async fn received_transaction(&self, _hash: mp_convert::Felt) -> Option<bool> {
         unimplemented!()
     }
-    async fn subscribe_new_transactions(&self) -> tokio::sync::broadcast::Receiver<Option<mp_convert::Felt>> {
+    async fn subscribe_new_transactions(&self) -> Option<tokio::sync::broadcast::Receiver<mp_convert::Felt>> {
         unimplemented!()
     }
 }

--- a/madara/crates/client/rpc/src/test_utils.rs
+++ b/madara/crates/client/rpc/src/test_utils.rs
@@ -7,7 +7,7 @@ use mp_block::{
     Header, MadaraBlockInfo, MadaraBlockInner, MadaraMaybePendingBlock, MadaraMaybePendingBlockInfo,
     MadaraPendingBlockInfo,
 };
-use mp_chain_config::{ChainConfig, L1DataAvailabilityMode, StarknetVersion};
+use mp_chain_config::{L1DataAvailabilityMode, StarknetVersion};
 use mp_receipt::{
     ExecutionResources, ExecutionResult, FeePayment, InvokeTransactionReceipt, PriceUnit, TransactionReceipt,
 };
@@ -20,7 +20,6 @@ use mp_state_update::{
     StorageEntry,
 };
 use mp_transactions::{InvokeTransaction, InvokeTransactionV0, Transaction};
-use mp_utils::service::ServiceContext;
 use rstest::fixture;
 use starknet_types_core::felt::Felt;
 use std::sync::Arc;
@@ -65,14 +64,21 @@ impl SubmitTransaction for TestTransactionProvider {
 
 #[fixture]
 pub fn rpc_test_setup() -> (Arc<MadaraBackend>, Starknet) {
-    let chain_config = Arc::new(ChainConfig::madara_test());
-    let backend = MadaraBackend::open_for_testing(chain_config.clone());
-    let rpc = Starknet::new(
-        backend.clone(),
-        Arc::new(TestTransactionProvider),
-        Default::default(),
-        ServiceContext::new_for_testing(),
-    );
+    let chain_config = std::sync::Arc::new(mp_chain_config::ChainConfig::madara_test());
+    let backend = mc_db::MadaraBackend::open_for_testing(chain_config);
+    let validation = mc_submit_tx::TransactionValidatorConfig { disable_validation: true };
+    let mempool = std::sync::Arc::new(mc_mempool::Mempool::new(
+        std::sync::Arc::clone(&backend),
+        mc_mempool::MempoolConfig::for_testing(),
+    ));
+    let mempool_validator = std::sync::Arc::new(mc_submit_tx::TransactionValidator::new(
+        mempool,
+        std::sync::Arc::clone(&backend),
+        validation,
+    ));
+    let context = mp_utils::service::ServiceContext::new_for_testing();
+    let rpc = Starknet::new(Arc::clone(&backend), mempool_validator, Default::default(), context);
+
     (backend, rpc)
 }
 

--- a/madara/crates/client/rpc/src/test_utils.rs
+++ b/madara/crates/client/rpc/src/test_utils.rs
@@ -55,6 +55,12 @@ impl SubmitTransaction for TestTransactionProvider {
     ) -> Result<AddInvokeTransactionResult, SubmitTransactionError> {
         unimplemented!()
     }
+    async fn received_transaction(&self, _hash: mp_convert::Felt) -> Option<bool> {
+        unimplemented!()
+    }
+    async fn subscribe_new_transactions(&self) -> tokio::sync::broadcast::Receiver<Option<mp_convert::Felt>> {
+        unimplemented!()
+    }
 }
 
 #[fixture]

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/api.rs
@@ -128,7 +128,7 @@ pub trait StarknetReadRpcApi {
 
     /// Gets the Transaction Status, Including Mempool Status and Execution Details
     #[method(name = "getTransactionStatus", and_versions = ["V0_8_0"])]
-    fn get_transaction_status(&self, transaction_hash: Felt) -> RpcResult<TxnFinalityAndExecutionStatus>;
+    async fn get_transaction_status(&self, transaction_hash: Felt) -> RpcResult<TxnFinalityAndExecutionStatus>;
 
     /// Get an object about the sync status, or false if the node is not syncing
     #[method(name = "syncing", and_versions = ["V0_8_0"])]

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_status.rs
@@ -7,70 +7,79 @@ use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::utils::ResultExt;
 use crate::Starknet;
 
-/// Gets the Transaction Status, Including Mempool Status and Execution Details
+/// Gets the status of a transaction. ([specs])
 ///
-/// This method retrieves the status of a specified transaction. It provides information on
-/// whether the transaction is still in the mempool, has been executed, or dropped from the
-/// mempool. The status includes both finality status and execution status of the
-/// transaction.
+/// Supported statuses are:
 ///
-/// ### Arguments
+/// - [`Received`]: tx has been inserted into the mempool.
+/// - [`AcceptedOnL2`]: tx has been saved to a closed block.
+/// - [`AcceptedOnL1`]: tx has been finalized on L1.
 ///
-/// * `transaction_hash` - The hash of the transaction for which the status is requested.
+/// We do not count a transaction as being accepted on L2 if it is included in the pending block.
+/// This is because the pending block is not a reliable storage of information: it is not persisted
+/// between restarts and as such can be lost in case of a node shutdown, and in the future it could
+/// be dropped in case of consensus disagreements. A transaction being included in the pending block
+/// therefore is _not_ a guarantee that it will necessarily be accepted on L1.
 ///
-/// ### Returns
+/// We do not currently support the **Rejected** transaction status.
 ///
-/// * `transaction_status` - An object containing the transaction status details:
-///   - `finality_status`: The finality status of the transaction, indicating whether it is
-///     confirmed, pending, or rejected.
-///   - `execution_status`: The execution status of the transaction, providing details on the
-///     execution outcome if the transaction has been processed.
-pub fn get_transaction_status(
+/// [specs]: https://github.com/starkware-libs/starknet-specs/blob/a2d10fc6cbaddbe2d3cf6ace5174dd0a306f4885/api/starknet_api_openrpc.json#L224C5-L250C7
+/// [`Received`]: mp_rpc::v0_7_1::TxnStatus::Received
+/// [`AcceptedOnL2`]: mp_rpc::v0_7_1::TxnStatus::AcceptedOnL2
+/// [`AcceptedOnL1`]: mp_rpc::v0_7_1::TxnStatus::AcceptedOnL1
+pub async fn get_transaction_status(
     starknet: &Starknet,
     transaction_hash: Felt,
 ) -> StarknetRpcResult<TxnFinalityAndExecutionStatus> {
-    let (block, tx_index) = starknet
-        .backend
-        .find_tx_hash_block(&transaction_hash)
-        .or_internal_server_error("Error find tx hash block info from db")?
-        .ok_or(StarknetRpcApiError::TxnHashNotFound)?;
+    let (finality_status, execution_status) =
+        if starknet.add_transaction_provider.received_transaction(transaction_hash).await.is_some_and(|b| b) {
+            (TxnStatus::Received, None)
+        } else {
+            let (block, tx_index) = starknet
+                .backend
+                .find_tx_hash_block(&transaction_hash)
+                .or_else_internal_server_error(|| {
+                    format!("GetTransactionStatus failed to retrieve block for tx {transaction_hash:#x}")
+                })?
+                .ok_or(StarknetRpcApiError::TxnHashNotFound)?;
 
-    // Note: we don't support TransactionStatus::Received and TransactionStatus::Rejected yet.
+            let tx_receipt =
+                block.inner.receipts.get(tx_index.0 as usize).ok_or(StarknetRpcApiError::TxnHashNotFound)?;
 
-    let tx_receipt = block.inner.receipts.get(tx_index.0 as usize).ok_or(StarknetRpcApiError::TxnHashNotFound)?;
+            let execution_status = match tx_receipt.execution_result() {
+                ExecutionResult::Reverted { .. } => Some(TxnExecutionStatus::Reverted),
+                ExecutionResult::Succeeded => Some(TxnExecutionStatus::Succeeded),
+            };
 
-    let tx_execution_status = match tx_receipt.execution_result() {
-        ExecutionResult::Reverted { .. } => TxnExecutionStatus::Reverted,
-        ExecutionResult::Succeeded => TxnExecutionStatus::Succeeded,
-    };
+            let finality_status = match block.info {
+                MadaraMaybePendingBlockInfo::Pending(_) => TxnStatus::Received,
+                MadaraMaybePendingBlockInfo::NotPending(block) => {
+                    if block.header.block_number <= starknet.get_l1_last_confirmed_block()? {
+                        TxnStatus::AcceptedOnL1
+                    } else {
+                        TxnStatus::AcceptedOnL2
+                    }
+                }
+            };
+            (finality_status, execution_status)
+        };
 
-    let finality_status = match block.info {
-        MadaraMaybePendingBlockInfo::Pending(_) => TxnStatus::AcceptedOnL2,
-        MadaraMaybePendingBlockInfo::NotPending(block) => {
-            if block.header.block_number <= starknet.get_l1_last_confirmed_block()? {
-                TxnStatus::AcceptedOnL1
-            } else {
-                TxnStatus::AcceptedOnL2
-            }
-        }
-    };
-
-    Ok(TxnFinalityAndExecutionStatus { finality_status, execution_status: Some(tx_execution_status) })
+    Ok(TxnFinalityAndExecutionStatus { finality_status, execution_status })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_utils::{sample_chain_for_block_getters, SampleChainForBlockGetters};
-    use rstest::rstest;
 
-    #[rstest]
-    fn test_get_transaction_status(sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet)) {
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn test_get_transaction_status(sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet)) {
         let (SampleChainForBlockGetters { tx_hashes, .. }, rpc) = sample_chain_for_block_getters;
 
         // Block 0
         assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[0]).unwrap(),
+            get_transaction_status(&rpc, tx_hashes[0]).await.unwrap(),
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL1,
                 execution_status: Some(TxnExecutionStatus::Succeeded)
@@ -81,14 +90,14 @@ mod tests {
 
         // Block 2
         assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[1]).unwrap(),
+            get_transaction_status(&rpc, tx_hashes[1]).await.unwrap(),
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL2,
                 execution_status: Some(TxnExecutionStatus::Succeeded)
             }
         );
         assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[2]).unwrap(),
+            get_transaction_status(&rpc, tx_hashes[2]).await.unwrap(),
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL2,
                 execution_status: Some(TxnExecutionStatus::Reverted)
@@ -97,19 +106,22 @@ mod tests {
 
         // Pending
         assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[3]).unwrap(),
+            get_transaction_status(&rpc, tx_hashes[3]).await.unwrap(),
             TxnFinalityAndExecutionStatus {
-                finality_status: TxnStatus::AcceptedOnL2,
+                finality_status: TxnStatus::Received,
                 execution_status: Some(TxnExecutionStatus::Succeeded)
             }
         );
     }
 
-    #[rstest]
-    fn test_get_transaction_status_not_found(sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet)) {
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn test_get_transaction_status_not_found(
+        sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet),
+    ) {
         let (SampleChainForBlockGetters { .. }, rpc) = sample_chain_for_block_getters;
 
         let does_not_exist = Felt::from_hex_unchecked("0x7128638126378");
-        assert_eq!(get_transaction_status(&rpc, does_not_exist), Err(StarknetRpcApiError::TxnHashNotFound));
+        assert_eq!(get_transaction_status(&rpc, does_not_exist).await, Err(StarknetRpcApiError::TxnHashNotFound));
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_transaction_status.rs
@@ -12,14 +12,8 @@ use crate::Starknet;
 /// Supported statuses are:
 ///
 /// - [`Received`]: tx has been inserted into the mempool.
-/// - [`AcceptedOnL2`]: tx has been saved to a closed block.
+/// - [`AcceptedOnL2`]: tx has been saved to the pending block.
 /// - [`AcceptedOnL1`]: tx has been finalized on L1.
-///
-/// We do not count a transaction as being accepted on L2 if it is included in the pending block.
-/// This is because the pending block is not a reliable storage of information: it is not persisted
-/// between restarts and as such can be lost in case of a node shutdown, and in the future it could
-/// be dropped in case of consensus disagreements. A transaction being included in the pending block
-/// therefore is _not_ a guarantee that it will necessarily be accepted on L1.
 ///
 /// We do not currently support the **Rejected** transaction status.
 ///
@@ -31,97 +25,186 @@ pub async fn get_transaction_status(
     starknet: &Starknet,
     transaction_hash: Felt,
 ) -> StarknetRpcResult<TxnFinalityAndExecutionStatus> {
-    let (finality_status, execution_status) =
-        if starknet.add_transaction_provider.received_transaction(transaction_hash).await.is_some_and(|b| b) {
-            (TxnStatus::Received, None)
-        } else {
-            let (block, tx_index) = starknet
-                .backend
-                .find_tx_hash_block(&transaction_hash)
-                .or_else_internal_server_error(|| {
-                    format!("GetTransactionStatus failed to retrieve block for tx {transaction_hash:#x}")
-                })?
-                .ok_or(StarknetRpcApiError::TxnHashNotFound)?;
+    if starknet.add_transaction_provider.received_transaction(transaction_hash).await.is_some_and(|b| b) {
+        Ok(TxnFinalityAndExecutionStatus { finality_status: TxnStatus::Received, execution_status: None })
+    } else {
+        let (block, tx_index) = starknet
+            .backend
+            .find_tx_hash_block(&transaction_hash)
+            .or_else_internal_server_error(|| {
+                format!("GetTransactionStatus failed to retrieve block for tx {transaction_hash:#x}")
+            })?
+            .ok_or(StarknetRpcApiError::TxnHashNotFound)?;
 
-            let tx_receipt =
-                block.inner.receipts.get(tx_index.0 as usize).ok_or(StarknetRpcApiError::TxnHashNotFound)?;
+        let tx_receipt = block.inner.receipts.get(tx_index.0 as usize).ok_or(StarknetRpcApiError::TxnHashNotFound)?;
 
-            let execution_status = match tx_receipt.execution_result() {
-                ExecutionResult::Reverted { .. } => Some(TxnExecutionStatus::Reverted),
-                ExecutionResult::Succeeded => Some(TxnExecutionStatus::Succeeded),
-            };
-
-            let finality_status = match block.info {
-                MadaraMaybePendingBlockInfo::Pending(_) => TxnStatus::Received,
-                MadaraMaybePendingBlockInfo::NotPending(block) => {
-                    if block.header.block_number <= starknet.get_l1_last_confirmed_block()? {
-                        TxnStatus::AcceptedOnL1
-                    } else {
-                        TxnStatus::AcceptedOnL2
-                    }
-                }
-            };
-            (finality_status, execution_status)
+        let execution_status = match tx_receipt.execution_result() {
+            ExecutionResult::Reverted { .. } => Some(TxnExecutionStatus::Reverted),
+            ExecutionResult::Succeeded => Some(TxnExecutionStatus::Succeeded),
         };
 
-    Ok(TxnFinalityAndExecutionStatus { finality_status, execution_status })
+        let finality_status = match block.info {
+            MadaraMaybePendingBlockInfo::Pending(_) => TxnStatus::AcceptedOnL2,
+            MadaraMaybePendingBlockInfo::NotPending(block) => {
+                if block.header.block_number <= starknet.get_l1_last_confirmed_block()? {
+                    TxnStatus::AcceptedOnL1
+                } else {
+                    TxnStatus::AcceptedOnL2
+                }
+            }
+        };
+
+        Ok(TxnFinalityAndExecutionStatus { finality_status, execution_status })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{sample_chain_for_block_getters, SampleChainForBlockGetters};
+
+    const TX_HASH: starknet_types_core::felt::Felt = starknet_types_core::felt::Felt::from_hex_unchecked(
+        "0x3ccaabf599097d1965e1ef8317b830e76eb681016722c9364ed6e59f3252908",
+    );
+
+    #[rstest::fixture]
+    fn logs() {
+        let debug = tracing_subscriber::filter::LevelFilter::DEBUG;
+        let env = tracing_subscriber::EnvFilter::builder().with_default_directive(debug.into()).from_env_lossy();
+        let timer = tracing_subscriber::fmt::time::Uptime::default();
+        let _ = tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_env_filter(env)
+            .with_file(true)
+            .with_line_number(true)
+            .with_target(false)
+            .with_timer(timer)
+            .try_init();
+    }
+
+    #[rstest::fixture]
+    fn tx() -> mp_rpc::BroadcastedInvokeTxn {
+        mp_rpc::BroadcastedInvokeTxn::V0(mp_rpc::InvokeTxnV0 {
+            calldata: Default::default(),
+            contract_address: Default::default(),
+            entry_point_selector: Default::default(),
+            max_fee: Default::default(),
+            signature: Default::default(),
+        })
+    }
+
+    #[rstest::fixture]
+    fn tx_with_receipt(tx: mp_rpc::BroadcastedInvokeTxn) -> mp_block::TransactionWithReceipt {
+        mp_block::TransactionWithReceipt {
+            transaction: mp_transactions::Transaction::Invoke(tx.into()),
+            receipt: mp_receipt::TransactionReceipt::Invoke(mp_receipt::InvokeTransactionReceipt {
+                transaction_hash: TX_HASH,
+                execution_result: mp_receipt::ExecutionResult::Succeeded,
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[rstest::fixture]
+    fn pending(tx_with_receipt: mp_block::TransactionWithReceipt) -> mp_block::PendingFullBlock {
+        mp_block::PendingFullBlock {
+            header: Default::default(),
+            state_diff: Default::default(),
+            transactions: vec![tx_with_receipt],
+            events: Default::default(),
+        }
+    }
+
+    #[rstest::fixture]
+    fn block(tx_with_receipt: mp_block::TransactionWithReceipt) -> mp_block::MadaraMaybePendingBlock {
+        mp_block::MadaraMaybePendingBlock {
+            info: mp_block::MadaraMaybePendingBlockInfo::NotPending(mp_block::MadaraBlockInfo {
+                tx_hashes: vec![TX_HASH],
+                ..Default::default()
+            }),
+            inner: mp_block::MadaraBlockInner {
+                transactions: vec![tx_with_receipt.transaction],
+                receipts: vec![tx_with_receipt.receipt],
+            },
+        }
+    }
+
+    #[rstest::fixture]
+    fn starknet() -> Starknet {
+        let chain_config = std::sync::Arc::new(mp_chain_config::ChainConfig::madara_test());
+        let backend = mc_db::MadaraBackend::open_for_testing(chain_config);
+        let validation = mc_submit_tx::TransactionValidatorConfig { disable_validation: true };
+        let mempool = std::sync::Arc::new(mc_mempool::Mempool::new(
+            std::sync::Arc::clone(&backend),
+            mc_mempool::MempoolConfig::for_testing(),
+        ));
+        let mempool_validator = std::sync::Arc::new(mc_submit_tx::TransactionValidator::new(
+            mempool,
+            std::sync::Arc::clone(&backend),
+            validation,
+        ));
+        let context = mp_utils::service::ServiceContext::new_for_testing();
+
+        Starknet::new(backend, mempool_validator, Default::default(), context)
+    }
 
     #[tokio::test]
     #[rstest::rstest]
-    async fn test_get_transaction_status(sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet)) {
-        let (SampleChainForBlockGetters { tx_hashes, .. }, rpc) = sample_chain_for_block_getters;
+    async fn get_transaction_status_received(_logs: (), starknet: Starknet, tx: mp_rpc::BroadcastedInvokeTxn) {
+        let provider = std::sync::Arc::clone(&starknet.add_transaction_provider);
+        provider.submit_invoke_transaction(tx).await.expect("Failed to submit invoke transaction");
 
-        // Block 0
+        let status = get_transaction_status(&starknet, TX_HASH).await.expect("Failed to retrieve transaction status");
+
         assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[0]).await.unwrap(),
-            TxnFinalityAndExecutionStatus {
-                finality_status: TxnStatus::AcceptedOnL1,
-                execution_status: Some(TxnExecutionStatus::Succeeded)
-            }
+            status,
+            TxnFinalityAndExecutionStatus { finality_status: TxnStatus::Received, execution_status: None }
         );
+    }
 
-        // Block 1
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_transaction_status_accepted_on_l2(_logs: (), starknet: Starknet, pending: mp_block::PendingFullBlock) {
+        let backend = std::sync::Arc::clone(&starknet.backend);
+        backend.store_pending_block(pending).expect("Failed to store pending block");
 
-        // Block 2
+        let status = get_transaction_status(&starknet, TX_HASH).await.expect("Failed to retrieve transaction status");
+
         assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[1]).await.unwrap(),
+            status,
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL2,
-                execution_status: Some(TxnExecutionStatus::Succeeded)
-            }
-        );
-        assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[2]).await.unwrap(),
-            TxnFinalityAndExecutionStatus {
-                finality_status: TxnStatus::AcceptedOnL2,
-                execution_status: Some(TxnExecutionStatus::Reverted)
-            }
-        );
-
-        // Pending
-        assert_eq!(
-            get_transaction_status(&rpc, tx_hashes[3]).await.unwrap(),
-            TxnFinalityAndExecutionStatus {
-                finality_status: TxnStatus::Received,
-                execution_status: Some(TxnExecutionStatus::Succeeded)
+                execution_status: Some(mp_rpc::v0_7_1::TxnExecutionStatus::Succeeded)
             }
         );
     }
 
     #[tokio::test]
     #[rstest::rstest]
-    async fn test_get_transaction_status_not_found(
-        sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet),
+    async fn get_transaction_status_accepted_on_l1(
+        _logs: (),
+        starknet: Starknet,
+        block: mp_block::MadaraMaybePendingBlock,
     ) {
-        let (SampleChainForBlockGetters { .. }, rpc) = sample_chain_for_block_getters;
+        let backend = std::sync::Arc::clone(&starknet.backend);
+        let state_diff = Default::default();
+        let converted_classes = Default::default();
+        backend.store_block(block, state_diff, converted_classes).expect("Failed to store block");
+        backend.write_last_confirmed_block(0).expect("Failed to update last confirmed block");
 
-        let does_not_exist = Felt::from_hex_unchecked("0x7128638126378");
-        assert_eq!(get_transaction_status(&rpc, does_not_exist).await, Err(StarknetRpcApiError::TxnHashNotFound));
+        let status = get_transaction_status(&starknet, TX_HASH).await.expect("Failed to retrieve transaction status");
+
+        assert_eq!(
+            status,
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL1,
+                execution_status: Some(mp_rpc::v0_7_1::TxnExecutionStatus::Succeeded)
+            }
+        );
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_transaction_status_err_not_found(_logs: (), starknet: Starknet) {
+        assert_eq!(get_transaction_status(&starknet, TX_HASH).await, Err(StarknetRpcApiError::TxnHashNotFound));
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/lib.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/lib.rs
@@ -121,8 +121,8 @@ impl StarknetReadRpcApiV0_7_1Server for Starknet {
         Ok(get_transaction_receipt(self, transaction_hash)?)
     }
 
-    fn get_transaction_status(&self, transaction_hash: Felt) -> RpcResult<TxnFinalityAndExecutionStatus> {
-        Ok(get_transaction_status(self, transaction_hash)?)
+    async fn get_transaction_status(&self, transaction_hash: Felt) -> RpcResult<TxnFinalityAndExecutionStatus> {
+        Ok(get_transaction_status(self, transaction_hash).await?)
     }
 
     async fn syncing(&self) -> RpcResult<SyncingStatus> {

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
@@ -66,6 +66,9 @@ pub trait StarknetWsRpcApi {
         keys: Option<Vec<Vec<Felt>>>,
         block: Option<BlockId>,
     ) -> jsonrpsee::core::SubscriptionResult;
+
+    #[subscription(name = "subscribeTransactionStatus", unsubscribe = "unsubscribeTransactionStatus", item = mp_rpc::TxnStatus, param_kind = map)]
+    async fn subscribe_transaction_status(&self, transaction_hash: Felt) -> jsonrpsee::core::SubscriptionResult;
 }
 
 #[versioned_rpc("V0_8_0", "starknet")]

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
@@ -67,7 +67,12 @@ pub trait StarknetWsRpcApi {
         block: Option<BlockId>,
     ) -> jsonrpsee::core::SubscriptionResult;
 
-    #[subscription(name = "subscribeTransactionStatus", unsubscribe = "unsubscribeTransactionStatus", item = mp_rpc::TxnStatus, param_kind = map)]
+    #[subscription(
+        name = "subscribeTransactionStatus",
+        unsubscribe = "unsubscribeTransactionStatus",
+        item = mp_rpc::v0_8_1::TxnStatus,
+        param_kind = map
+    )]
     async fn subscribe_transaction_status(&self, transaction_hash: Felt) -> jsonrpsee::core::SubscriptionResult;
 }
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/lib.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/lib.rs
@@ -5,6 +5,7 @@ use crate::versions::user::v0_8_0::StarknetWsRpcApiV0_8_0Server;
 
 use super::subscribe_events::*;
 use super::subscribe_new_heads::*;
+use super::subscribe_transaction_status::*;
 
 #[jsonrpsee::core::async_trait]
 impl StarknetWsRpcApiV0_8_0Server for crate::Starknet {
@@ -24,5 +25,13 @@ impl StarknetWsRpcApiV0_8_0Server for crate::Starknet {
         block: Option<BlockId>,
     ) -> jsonrpsee::core::SubscriptionResult {
         Ok(subscribe_events(self, subscription_sink, from_address, keys, block).await?)
+    }
+
+    async fn subscribe_transaction_status(
+        &self,
+        subscription_sink: jsonrpsee::PendingSubscriptionSink,
+        transaction_hash: Felt,
+    ) -> jsonrpsee::core::SubscriptionResult {
+        Ok(subscribe_transaction_status(self, subscription_sink, transaction_hash).await?)
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/mod.rs
@@ -1,5 +1,6 @@
 pub mod lib;
 pub mod subscribe_events;
 pub mod subscribe_new_heads;
+pub mod subscribe_transaction_status;
 
 const BLOCK_PAST_LIMIT: u64 = 1024;

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -498,6 +498,8 @@ mod test {
                 });
             }
         );
+
+        assert!(sub.next().await.is_none());
     }
 
     #[tokio::test]
@@ -533,6 +535,8 @@ mod test {
                 });
             }
         );
+
+        assert!(sub.next().await.is_none());
     }
 
     #[tokio::test]
@@ -568,6 +572,8 @@ mod test {
                 });
             }
         );
+
+        assert!(sub.next().await.is_none());
     }
 
     #[tokio::test]
@@ -603,6 +609,8 @@ mod test {
                 });
             }
         );
+
+        assert!(sub.next().await.is_none());
     }
 
     #[tokio::test]
@@ -696,7 +704,7 @@ mod test {
 
     #[tokio::test]
     #[rstest::rstest]
-    #[timeout(super::TIMEOUT * 10)]
+    #[timeout(super::TIMEOUT * 2)]
     async fn subscribe_transaction_status_timeout(_logs: (), starknet: Starknet) {
         let builder = jsonrpsee::server::Server::builder();
         let server = builder.build(SERVER_ADDR).await.expect("Failed to start jsonprsee server");

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -1,0 +1,147 @@
+use crate::errors::ErrorExtWs;
+
+/// Notifies the subscriber of updates to a transaction's status. ([specs])
+///
+/// Supported statuses are:
+///
+/// - **Received**: tx has been inserted into the mempool.
+/// - **Accepted on L2**: tx has been inserted into the pending block.
+/// - **Accepted on L1**: tx has been finalized on L1.
+///
+/// Note that it is possible to call this method on a transaction which has not yet been received by
+/// the node and this endpoint will send an update as soon as the tx is received.
+///
+/// ## DOS mitigation
+///
+/// To avoid a malicious attacker keeping connections open indefinitely on an nonexistent
+/// transaction hash, this endpoint will terminate the connection after a global timeout period.
+///
+/// This subscription will also automatically close once a transaction has reached `ACCEPTED_ON_L1`.
+///
+/// [specs]: https://github.com/starkware-libs/starknet-specs/blob/a2d10fc6cbaddbe2d3cf6ace5174dd0a306f4885/api/starknet_ws_api.json#L127C5-L168C7
+pub async fn subscribe_transaction_status(
+    starknet: &crate::Starknet,
+    subscription_sink: jsonrpsee::PendingSubscriptionSink,
+    transaction_hash: mp_convert::Felt,
+) -> Result<(), crate::errors::StarknetWsApiError> {
+    let sink = subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
+    let mut state = SubscriptionState::new(starknet, &sink, transaction_hash);
+
+    // TODO: timeout should be based off a constant in chain config
+    let timeout = tokio::time::timeout(std::time::Duration::from_secs(300), state.drive());
+
+    tokio::select! {
+        res = timeout => res.or_internal_server_error("Failed to timeout on transaction status")?,
+        _ = sink.closed() => Ok(())
+    }
+}
+
+enum SubscriptionState<'a> {
+    Received(StateTransitionReceived<'a>),
+    AcceptedOnL2(StateTransitionAcceptedOnL2<'a>),
+    AcceptedOnL1(StateTransitionAcceptedOnL1<'a>),
+}
+
+impl<'a> SubscriptionState<'a> {
+    fn new(
+        starknet: &'a crate::Starknet,
+        subscription_sink: &'a jsonrpsee::core::server::SubscriptionSink,
+        transaction_hash: mp_convert::Felt,
+    ) -> Self {
+        todo!()
+    }
+
+    async fn drive(&mut self) -> Result<(), crate::errors::StarknetWsApiError> {
+        loop {
+            match self {
+                SubscriptionState::Received(state) => {
+                    if let Some(state) = state.transition().await? {
+                        state.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::Received).await?;
+                        *self = Self::AcceptedOnL2(state);
+                    }
+                }
+                SubscriptionState::AcceptedOnL2(state) => {
+                    if let Some(state) = state.transition().await? {
+                        state.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::AcceptedOnL2).await?;
+                        *self = Self::AcceptedOnL1(state);
+                    }
+                }
+                SubscriptionState::AcceptedOnL1(state) => {
+                    if let Some(state) = state.transition().await? {
+                        state.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::AcceptedOnL1).await?;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct StateTransitionCommon<'a> {
+    starknet: &'a crate::Starknet,
+    subscription_sink: &'a jsonrpsee::core::server::SubscriptionSink,
+    transaction_hash: mp_convert::Felt,
+}
+struct StateTransitionReceived<'a> {
+    common: StateTransitionCommon<'a>,
+    channel: tokio::sync::broadcast::Receiver<mp_convert::Felt>,
+}
+struct StateTransitionAcceptedOnL2<'a> {
+    common: StateTransitionCommon<'a>,
+    channel: tokio::sync::watch::Receiver<mp_convert::Felt>,
+}
+struct StateTransitionAcceptedOnL1<'a> {
+    common: StateTransitionCommon<'a>,
+}
+
+impl<'a> StateTransitionCommon<'a> {
+    fn new(
+        starknet: &'a crate::Starknet,
+        subscription_sink: &'a jsonrpsee::core::server::SubscriptionSink,
+        transaction_hash: mp_convert::Felt,
+    ) -> Self {
+        Self { starknet, subscription_sink, transaction_hash }
+    }
+
+    async fn send_txn_status(
+        &self,
+        status: mp_rpc::v0_7_1::TxnStatus,
+    ) -> Result<(), crate::errors::StarknetWsApiError> {
+        let txn_status = mp_rpc::v0_8_1::TxnStatus { transaction_hash: self.transaction_hash, status };
+        let msg = jsonrpsee::SubscriptionMessage::from_json(&txn_status).or_else_internal_server_error(|| {
+            format!("Failed to create response message for status update at tx hash {:#x}", self.transaction_hash)
+        })?;
+
+        self.subscription_sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")
+    }
+}
+
+trait StateTransition {
+    type TransitionTo: StateTransition;
+
+    async fn transition(&mut self) -> Result<Option<Self::TransitionTo>, crate::errors::StarknetWsApiError>;
+}
+
+impl<'a> StateTransition for StateTransitionReceived<'a> {
+    type TransitionTo = StateTransitionAcceptedOnL2<'a>;
+
+    async fn transition(&mut self) -> Result<Option<Self::TransitionTo>, crate::errors::StarknetWsApiError> {
+        todo!()
+    }
+}
+
+impl<'a> StateTransition for StateTransitionAcceptedOnL2<'a> {
+    type TransitionTo = StateTransitionAcceptedOnL1<'a>;
+
+    async fn transition(&mut self) -> Result<Option<Self::TransitionTo>, crate::errors::StarknetWsApiError> {
+        todo!()
+    }
+}
+
+impl<'a> StateTransition for StateTransitionAcceptedOnL1<'a> {
+    type TransitionTo = StateTransitionAcceptedOnL1<'a>;
+
+    async fn transition(&mut self) -> Result<Option<Self::TransitionTo>, crate::errors::StarknetWsApiError> {
+        todo!()
+    }
+}

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -10,7 +10,7 @@ const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300); // 5mi
 /// Supported statuses are:
 ///
 /// - [`Received`]: tx has been inserted into the mempool.
-/// - [`AcceptedOnL2`]: tx has been inserted into a closed block.
+/// - [`AcceptedOnL2`]: tx has been saved to a closed block.
 /// - [`AcceptedOnL1`]: tx has been finalized on L1.
 ///
 /// We do not count a transaction as being accepted on L2 if it is included in the pending block.

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -452,13 +452,16 @@ mod test {
     }
 
     #[rstest::fixture]
-    fn block() -> mp_block::MadaraMaybePendingBlock {
+    fn block(tx_with_receipt: mp_block::TransactionWithReceipt) -> mp_block::MadaraMaybePendingBlock {
         mp_block::MadaraMaybePendingBlock {
             info: mp_block::MadaraMaybePendingBlockInfo::NotPending(mp_block::MadaraBlockInfo {
                 tx_hashes: vec![TX_HASH],
                 ..Default::default()
             }),
-            inner: mp_block::MadaraBlockInner::default(),
+            inner: mp_block::MadaraBlockInner {
+                transactions: vec![tx_with_receipt.transaction],
+                receipts: vec![tx_with_receipt.receipt],
+            },
         }
     }
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -1,13 +1,15 @@
 use crate::errors::ErrorExtWs;
+use futures::StreamExt;
 
 /// Notifies the subscriber of updates to a transaction's status. ([specs])
 ///
 /// Supported statuses are:
 ///
 /// - **Received**: tx has been inserted into the mempool.
-/// - **Rejected**: tx was included into a block but failed execution.
 /// - **Accepted on L2**: tx has been inserted into the pending block.
 /// - **Accepted on L1**: tx has been finalized on L1.
+///
+/// We do not currently support the **Rejected** transaction status.
 ///
 /// Note that it is possible to call this method on a transaction which has not yet been received by
 /// the node and this endpoint will send an update as soon as the tx is received.
@@ -27,9 +29,7 @@ pub async fn subscribe_transaction_status(
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     let sink = subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
     let mut state = SubscriptionState::new(starknet, &sink, transaction_hash).await?;
-
-    // TODO: timeout should be based off a constant in chain config
-    let timeout = tokio::time::timeout(std::time::Duration::from_secs(300), state.drive());
+    let timeout = tokio::time::timeout(std::time::Duration::from_secs(300 /* 5min */), state.drive());
 
     tokio::select! {
         res = timeout => res.or_else_internal_server_error(|| {
@@ -39,6 +39,11 @@ pub async fn subscribe_transaction_status(
     }
 }
 
+/// State-machine-based transactions status discovery.
+///
+/// The state machine progresses through a series of legals states and transitions as defined by
+/// implementors of the [`StateTransition`] trait. Each state is responsible for checking the status
+/// of a single transaction state and moving on to the next state check once this has completed.
 #[derive(Default)]
 enum SubscriptionState<'a> {
     #[default]
@@ -49,6 +54,10 @@ enum SubscriptionState<'a> {
 }
 
 impl<'a> SubscriptionState<'a> {
+    /// This function is responsible for initializing the state machine.
+    ///
+    /// It does so by determining the initial state of the transaction, which in turn determines in
+    /// which state the state machine starts.
     async fn new(
         starknet: &'a crate::Starknet,
         subscription_sink: &'a jsonrpsee::core::server::SubscriptionSink,
@@ -62,15 +71,10 @@ impl<'a> SubscriptionState<'a> {
 
         if let Some((block_info, _idx)) = block_info {
             match block_info {
+                // Tx has been accepted in the pending block, hence it is marked as accepted on L2.
+                // We wait for it to be accepted on L1
                 mp_block::MadaraMaybePendingBlockInfo::Pending(block_info) => {
-                    let parent_hash = block_info.header.parent_block_hash;
-                    let block_number = common
-                        .starknet
-                        .backend
-                        .get_block_n(&mp_block::BlockId::Hash(parent_hash))
-                        .or_internal_server_error("Failed to get parent block number")?
-                        .unwrap_or_default()
-                        .saturating_add(1);
+                    let block_number = block_number_from_pending(common.starknet, &block_info)?;
                     common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::AcceptedOnL2).await?;
                     let channel = common.starknet.backend.subscribe_last_confirmed_block();
                     Ok(Self::WaitAcceptedOnL1(StateTransitionAcceptedOnL1 { common, block_number, channel }))
@@ -82,10 +86,16 @@ impl<'a> SubscriptionState<'a> {
                         .backend
                         .get_l1_last_confirmed_block()
                         .or_internal_server_error("Error retrieving last confirmed block")?;
+
+                    // Tx has been accepted on L1, hence it is marked as such. This is the final
+                    // stage of the transaction so the state machine is put in its end state.
                     if confirmed.is_some_and(|n| block_number <= n) {
                         common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::AcceptedOnL1).await?;
                         Ok(Self::None)
-                    } else {
+                    }
+                    // Tx has not yet been accepted on L1 but is included on L2, hence it is marked
+                    // as accepted on L2. We wait for it to be accepted on L1
+                    else {
                         common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::AcceptedOnL2).await?;
                         let channel = common.starknet.backend.subscribe_last_confirmed_block();
                         Ok(Self::WaitAcceptedOnL1(StateTransitionAcceptedOnL1 { common, block_number, channel }))
@@ -93,23 +103,43 @@ impl<'a> SubscriptionState<'a> {
                 }
             }
         } else {
-            Ok(Self::WaitReceived(StateTransitionReceived { common, channel: todo!() }))
+            // Local mempool is the only AddTransactionProvider which allows us to inspect the state
+            // of received transactions. For other providers (such as when forwarding to a remote
+            // gateway), we default to assuming that the transaction has been received and wait for
+            // it to be accepted on L2.
+            match common.starknet.add_transaction_provider.subscribe_new_transactions().await {
+                // We wait for the tx to be received
+                Some(channel) => Ok(Self::WaitReceived(StateTransitionReceived { common, channel })),
+                // We assume the tx has been received and wait for the tx to be accepted on L2
+                None => {
+                    common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::Received).await?;
+                    let channel = common.starknet.backend.subscribe_pending_block();
+                    Ok(Self::WaitAcceptedOnL2(StateTransitionAcceptedOnL2 { common, channel }))
+                }
+            }
         }
     }
 
+    /// This function is responsible for driving the state machine to completion. It is also
+    /// responsible for sending status updates back to the client. Status updates are not the
+    /// responsibility of the [`StateTransition`] implementors and are instead centralized here.
+    ///
+    /// ## Legal state transitions
+    ///
     /// ```text
     ///
     ///             ┌────┐
-    ///          ┌─►│None├────────────────────────────────────────────────────────┐
+    ///          ┌─►│None├─────────────────────►──────────────────────────────────┐
     ///          │  └────┘                                                        │
     ///          │                                                                │
-    ///          │             ┌──┐                   ┌──┐                   ┌──┐ │
-    /// ┌─────┐  │  ┌──────────▼─┐│    ┌──────────────▼─┐│    ┌──────────────▼─┐│ │  ┌───┐
-    /// │START├──┴─►│WaitReceived├┴───►│WaitAcceptedOnL2├┴─┬─►│WaitAcceptedOnL1├┴─┼─►│END│
-    /// └─────┘     └────────────┘     └────────────────┘  │  └────────────────┘  │  └───┘
-    ///                                                    │  ┌────────┐          │
-    ///                                                    └─►│Rejected├──────────┘
-    ///                                                       └────────┘
+    ///          │             ┌──┐                                          ┌──┐ │
+    /// ┌─────┐  │  ┌──────────▼─┐│                           ┌──────────────▼─┐│ └─►┌───┐
+    /// │START├──┼─►│WaitReceived├┼───────────────────────┬──►│WaitAcceptedOnL1├┴───►│END│
+    /// └─────┘  │  └────────────┘│                       │   └────────────────┘     └───┘
+    ///          │                │                       ▲
+    ///          │                └───►┌────────────────┐ │
+    ///          └────────────────────►│WaitAcceptedOnL2├─┘
+    ///                                └────────────────┘
     ///
     /// ```
     async fn drive(&mut self) -> Result<(), crate::errors::StarknetWsApiError> {
@@ -118,23 +148,23 @@ impl<'a> SubscriptionState<'a> {
                 Self::None => return Ok(()),
                 Self::WaitReceived(state) => match state.transition().await? {
                     StateTransitionResult::State(s) => *self = Self::WaitReceived(s),
-                    StateTransitionResult::Transition(s) => {
-                        s.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::Received).await?;
-                        *self = Self::WaitAcceptedOnL2(s);
-                    }
-                },
-                Self::WaitAcceptedOnL2(state) => match state.transition().await? {
-                    StateTransitionResult::State(s) => *self = Self::WaitAcceptedOnL2(s),
                     StateTransitionResult::Transition(s) => match s {
-                        StateMatrixAcceptedOnL2::Rejected(s) => {
-                            s.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::Rejected).await?;
-                            return Ok(());
+                        TransitionMatrixReceived::WaitAcceptedOnL2(s) => {
+                            s.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::Received).await?;
+                            *self = Self::WaitAcceptedOnL2(s);
                         }
-                        StateMatrixAcceptedOnL2::WaitAcceptedOnL1(s) => {
+                        TransitionMatrixReceived::WaitAcceptedOnL1(s) => {
                             s.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::AcceptedOnL2).await?;
                             *self = Self::WaitAcceptedOnL1(s);
                         }
                     },
+                },
+                Self::WaitAcceptedOnL2(state) => match state.transition().await? {
+                    StateTransitionResult::State(s) => *self = Self::WaitAcceptedOnL2(s),
+                    StateTransitionResult::Transition(s) => {
+                        s.common.send_txn_status(mp_rpc::v0_7_1::TxnStatus::AcceptedOnL2).await?;
+                        *self = Self::WaitAcceptedOnL1(s);
+                    }
                 },
                 Self::WaitAcceptedOnL1(state) => match state.transition().await? {
                     StateTransitionResult::State(s) => *self = Self::WaitAcceptedOnL1(s),
@@ -157,9 +187,6 @@ struct StateTransitionReceived<'a> {
     common: StateTransitionCommon<'a>,
     channel: tokio::sync::broadcast::Receiver<mp_convert::Felt>,
 }
-struct StateTransitionRejected<'a> {
-    common: StateTransitionCommon<'a>,
-}
 struct StateTransitionAcceptedOnL2<'a> {
     common: StateTransitionCommon<'a>,
     channel: mc_db::PendingBlockReceiver,
@@ -172,21 +199,12 @@ struct StateTransitionAcceptedOnL1<'a> {
 struct StateTransitionEnd<'a> {
     common: StateTransitionCommon<'a>,
 }
-
-enum StateMatrixAcceptedOnL2<'a> {
+enum TransitionMatrixReceived<'a> {
+    WaitAcceptedOnL2(StateTransitionAcceptedOnL2<'a>),
     WaitAcceptedOnL1(StateTransitionAcceptedOnL1<'a>),
-    Rejected(StateTransitionRejected<'a>),
 }
 
 impl<'a> StateTransitionCommon<'a> {
-    fn new(
-        starknet: &'a crate::Starknet,
-        subscription_sink: &'a jsonrpsee::core::server::SubscriptionSink,
-        transaction_hash: mp_convert::Felt,
-    ) -> Self {
-        Self { starknet, subscription_sink, transaction_hash }
-    }
-
     async fn send_txn_status(
         &self,
         status: mp_rpc::v0_7_1::TxnStatus,
@@ -212,20 +230,68 @@ trait StateTransition: Sized {
     ) -> Result<StateTransitionResult<Self, Self::TransitionTo>, crate::errors::StarknetWsApiError>;
 }
 impl<'a> StateTransition for StateTransitionReceived<'a> {
-    type TransitionTo = StateTransitionAcceptedOnL2<'a>;
+    type TransitionTo = TransitionMatrixReceived<'a>;
 
     async fn transition(
         self,
     ) -> Result<StateTransitionResult<Self, Self::TransitionTo>, crate::errors::StarknetWsApiError> {
-        let Self { common, channel } = self;
-        Ok(StateTransitionResult::Transition(Self::TransitionTo {
-            channel: common.starknet.backend.subscribe_pending_block(),
-            common,
-        }))
+        let Self { common, mut channel } = self;
+
+        let stream = futures::stream::unfold(&mut channel, |channel| async move {
+            match channel.recv().await {
+                Ok(felt) => Some((felt, channel)),
+                Err(_error) => None, // The stream will end if the channel lags or is closed.
+            }
+        });
+
+        // We only check 100 transactions at a time and if that fails we check against the
+        // transaction provider directly and if that fails we check against the db to make sure we
+        // have not missed the transaction.
+        let received = stream.take(100).any(|hash| async move { hash == common.transaction_hash }).await
+            || common
+                .starknet
+                .add_transaction_provider
+                .received_transaction(common.transaction_hash)
+                .await
+                .unwrap_or(false);
+
+        if received {
+            let channel = common.starknet.backend.subscribe_pending_block();
+            let transition = StateTransitionAcceptedOnL2 { channel, common };
+            let transition = Self::TransitionTo::WaitAcceptedOnL2(transition);
+            Ok(StateTransitionResult::Transition(transition))
+        } else {
+            let block_info = common
+                .starknet
+                .backend
+                .find_tx_hash_block_info(&common.transaction_hash)
+                .or_else_internal_server_error(|| {
+                    format!("Error looking for block info associated to tx {:#x}", common.transaction_hash)
+                })?;
+
+            if let Some((block_info, _idx)) = block_info {
+                let block_number = match block_info {
+                    mp_block::MadaraMaybePendingBlockInfo::Pending(block_info) => {
+                        block_number_from_pending(common.starknet, &block_info)?
+                    }
+                    mp_block::MadaraMaybePendingBlockInfo::NotPending(block_info) => block_info.header.block_number,
+                };
+
+                // We assume that the time to settle on L1 is great enough that we do not bother to
+                // check if a transaction went directly from received to accepted on L1.
+                let channel = common.starknet.backend.subscribe_last_confirmed_block();
+                let transition = StateTransitionAcceptedOnL1 { common, block_number, channel };
+                let transition = Self::TransitionTo::WaitAcceptedOnL1(transition);
+
+                Ok(StateTransitionResult::Transition(transition))
+            } else {
+                Ok(StateTransitionResult::State(Self { common, channel }))
+            }
+        }
     }
 }
 impl<'a> StateTransition for StateTransitionAcceptedOnL2<'a> {
-    type TransitionTo = StateMatrixAcceptedOnL2<'a>;
+    type TransitionTo = StateTransitionAcceptedOnL1<'a>;
 
     async fn transition(
         self,
@@ -237,16 +303,9 @@ impl<'a> StateTransition for StateTransitionAcceptedOnL2<'a> {
         let block_info = std::sync::Arc::clone(&channel.borrow_and_update());
         if block_info.tx_hashes.iter().find(|hash| *hash == &common.transaction_hash).is_some() {
             let channel = common.starknet.backend.subscribe_last_confirmed_block();
-            let parent_hash = block_info.header.parent_block_hash;
-            let block_number = common
-                .starknet
-                .backend
-                .get_block_n(&mp_block::BlockId::Hash(parent_hash))
-                .or_internal_server_error("Failed to get parent block number")?
-                .unwrap_or_default()
-                .saturating_add(1);
-            let transition = StateTransitionAcceptedOnL1 { common, block_number, channel };
-            Ok(StateTransitionResult::Transition(Self::TransitionTo::WaitAcceptedOnL1(transition)))
+            let block_number = block_number_from_pending(common.starknet, block_info.as_ref())?;
+            let transition = Self::TransitionTo { common, block_number, channel };
+            Ok(StateTransitionResult::Transition(transition))
         } else {
             let block_info = common
                 .starknet
@@ -259,25 +318,14 @@ impl<'a> StateTransition for StateTransitionAcceptedOnL2<'a> {
             match block_info {
                 Some((mp_block::MadaraMaybePendingBlockInfo::Pending(block_info), _idx)) => {
                     let channel = common.starknet.backend.subscribe_last_confirmed_block();
-                    let parent_hash = block_info.header.parent_block_hash;
-                    let block_number = common
-                        .starknet
-                        .backend
-                        .get_block_n(&mp_block::BlockId::Hash(parent_hash))
-                        .or_internal_server_error("Failed to get parent block number")?
-                        .unwrap_or_default()
-                        .saturating_add(1);
-                    let transition = StateTransitionAcceptedOnL1 { common, block_number, channel };
-                    Ok(StateTransitionResult::Transition(Self::TransitionTo::WaitAcceptedOnL1(transition)))
+                    let block_number = block_number_from_pending(common.starknet, &block_info)?;
+                    let transition = Self::TransitionTo { common, block_number, channel };
+                    Ok(StateTransitionResult::Transition(transition))
                 }
                 Some((mp_block::MadaraMaybePendingBlockInfo::NotPending(block_info), _idx)) => {
                     let channel = common.starknet.backend.subscribe_last_confirmed_block();
                     let block_number = block_info.header.block_number;
-                    let transition = Self::TransitionTo::WaitAcceptedOnL1(StateTransitionAcceptedOnL1 {
-                        common,
-                        block_number,
-                        channel,
-                    });
+                    let transition = Self::TransitionTo { common, block_number, channel };
                     Ok(StateTransitionResult::Transition(transition))
                 }
                 None => Ok(StateTransitionResult::State(Self { common, channel })),
@@ -302,4 +350,16 @@ impl<'a> StateTransition for StateTransitionAcceptedOnL1<'a> {
             Ok(StateTransitionResult::State(Self { common, block_number, channel }))
         }
     }
+}
+
+fn block_number_from_pending<'a, 'b>(
+    starknet: &'a crate::Starknet,
+    block_info: &'b mp_block::MadaraPendingBlockInfo,
+) -> Result<u64, crate::errors::StarknetWsApiError> {
+    Ok(starknet
+        .backend
+        .get_block_n(&mp_block::BlockId::Hash(block_info.header.parent_block_hash))
+        .or_internal_server_error("Failed to get parent block number")?
+        .unwrap_or_default()
+        .saturating_add(1))
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -316,15 +316,9 @@ impl<'a> StateTransition for StateTransitionAcceptedOnL2<'a> {
         let tx_hash = &common.tx_hash;
 
         // Step 1: we wait for the tx to be ACCEPTED in the pending block
-        loop {
-            match channel_pending_tx.recv().await {
-                Ok(tx) => {
-                    if tx.receipt.transaction_hash() == common.tx_hash {
-                        break;
-                    }
-                }
-                // This happens if the channel lags behind block prod
-                Err(_) => break,
+        while let Ok(tx) = channel_pending_tx.recv().await {
+            if tx.receipt.transaction_hash() == common.tx_hash {
+                break;
             }
         }
 

--- a/madara/crates/client/submit_tx/Cargo.toml
+++ b/madara/crates/client/submit_tx/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+futures.workspace = true
 
 blockifier.workspace = true
 starknet_api.workspace = true
@@ -29,3 +30,5 @@ mp-class.workspace = true
 mp-convert.workspace = true
 mp-rpc.workspace = true
 mp-transactions.workspace = true
+
+tokio.workspace = true

--- a/madara/crates/client/submit_tx/Cargo.toml
+++ b/madara/crates/client/submit_tx/Cargo.toml
@@ -17,9 +17,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+futures.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-futures.workspace = true
 
 blockifier.workspace = true
 starknet_api.workspace = true

--- a/madara/crates/client/submit_tx/src/lib.rs
+++ b/madara/crates/client/submit_tx/src/lib.rs
@@ -39,6 +39,10 @@ pub trait SubmitTransaction: Send + Sync {
         &self,
         tx: BroadcastedInvokeTxn,
     ) -> Result<AddInvokeTransactionResult, SubmitTransactionError>;
+
+    async fn received_transaction(&self, hash: mp_convert::Felt) -> Option<bool>;
+
+    async fn subscribe_new_transactions(&self) -> Option<tokio::sync::broadcast::Receiver<mp_convert::Felt>>;
 }
 
 /// Submit an L1HandlerTransaction.
@@ -56,4 +60,8 @@ pub trait SubmitL1HandlerTransaction: Send + Sync {
 #[async_trait]
 pub trait SubmitValidatedTransaction: Send + Sync {
     async fn submit_validated_transaction(&self, tx: ValidatedMempoolTx) -> Result<(), SubmitTransactionError>;
+
+    async fn received_transaction(&self, hash: mp_convert::Felt) -> Option<bool>;
+
+    async fn subscribe_new_transactions(&self) -> Option<tokio::sync::broadcast::Receiver<mp_convert::Felt>>;
 }

--- a/madara/crates/client/submit_tx/src/validation.rs
+++ b/madara/crates/client/submit_tx/src/validation.rs
@@ -299,4 +299,12 @@ impl SubmitTransaction for TransactionValidator {
         self.accept_tx(btx, class, arrived_at).await?;
         Ok(res)
     }
+
+    async fn received_transaction(&self, hash: mp_convert::Felt) -> Option<bool> {
+        self.inner.received_transaction(hash).await
+    }
+
+    async fn subscribe_new_transactions(&self) -> Option<tokio::sync::broadcast::Receiver<mp_convert::Felt>> {
+        self.inner.subscribe_new_transactions().await
+    }
 }

--- a/madara/crates/node/Cargo.toml
+++ b/madara/crates/node/Cargo.toml
@@ -35,11 +35,11 @@ mc-sync.workspace = true
 mc-telemetry.workspace = true
 mp-block.workspace = true
 mp-chain-config.workspace = true
+mp-convert.workspace = true
 mp-oracle.workspace = true
 mp-rpc.workspace = true
 mp-transactions.workspace = true
 mp-utils.workspace = true
-mp-convert.workspace = true
 
 # Starknet
 blockifier.workspace = true

--- a/madara/crates/node/Cargo.toml
+++ b/madara/crates/node/Cargo.toml
@@ -1,0 +1,87 @@
+[package]
+name = "madara"
+description = "Madara node"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+homepage.workspace = true
+build = "build.rs"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "madara"
+
+[dependencies]
+
+# Madara
+mc-analytics.workspace = true
+mc-block-production.workspace = true
+mc-db.workspace = true
+mc-devnet.workspace = true
+mc-gateway-client.workspace = true
+mc-gateway-server.workspace = true
+mc-mempool.workspace = true
+mc-rpc.workspace = true
+mc-settlement-client.workspace = true
+mc-submit-tx.workspace = true
+mc-sync.workspace = true
+mc-telemetry.workspace = true
+mp-block.workspace = true
+mp-chain-config.workspace = true
+mp-oracle.workspace = true
+mp-rpc.workspace = true
+mp-transactions.workspace = true
+mp-utils.workspace = true
+mp-convert.workspace = true
+
+# Starknet
+blockifier.workspace = true
+starknet_api.workspace = true
+
+# Other
+alloy.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+fdlimit.workspace = true
+figment = { workspace = true, features = ["toml", "json", "yaml"] }
+futures = { workspace = true, features = ["thread-pool"] }
+http.workspace = true
+hyper = { version = "0.14", features = ["server"] }
+jsonrpsee.workspace = true
+rand.workspace = true
+rayon.workspace = true
+reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_yaml.workspace = true
+starknet-core.workspace = true
+starknet-providers.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+url.workspace = true
+
+#Instrumentation
+opentelemetry = { workspace = true, features = ["metrics", "logs"] }
+opentelemetry-appender-tracing = { workspace = true, default-features = false }
+opentelemetry-otlp = { workspace = true, features = [
+  "tonic",
+  "metrics",
+  "logs",
+] }
+opentelemetry-semantic-conventions.workspace = true
+opentelemetry-stdout.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "logs"] }
+tracing.workspace = true
+tracing-core = { workspace = true, default-features = false }
+tracing-opentelemetry.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/madara/crates/primitives/rpc/src/lib.rs
+++ b/madara/crates/primitives/rpc/src/lib.rs
@@ -3,5 +3,6 @@ mod custom_serde;
 
 pub mod admin;
 pub mod v0_7_1;
+pub mod v0_8_1;
 
 pub use self::v0_7_1::*;

--- a/madara/crates/primitives/rpc/src/v0_7_1/starknet_api_openrpc.rs
+++ b/madara/crates/primitives/rpc/src/v0_7_1/starknet_api_openrpc.rs
@@ -668,7 +668,7 @@ pub struct InvokeTxnReceipt {
     pub common_receipt_properties: CommonReceiptProperties,
 }
 
-/// invokes a specific function in the desired contract (not necessarily an account)
+/// Invokes a specific function in the desired contract (not necessarily an account)
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct InvokeTxnV0 {
     /// The parameters passed to the function

--- a/madara/crates/primitives/rpc/src/v0_8_1/mod.rs
+++ b/madara/crates/primitives/rpc/src/v0_8_1/mod.rs
@@ -1,0 +1,3 @@
+mod starknet_ws_api;
+
+pub use self::starknet_ws_api::*;

--- a/madara/crates/primitives/rpc/src/v0_8_1/starknet_ws_api.rs
+++ b/madara/crates/primitives/rpc/src/v0_8_1/starknet_ws_api.rs
@@ -1,0 +1,5 @@
+#[derive(Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct TxnStatus {
+    pub transaction_hash: starknet_types_core::felt::Felt,
+    pub status: crate::v0_7_1::TxnStatus,
+}

--- a/madara/src/submit_tx.rs
+++ b/madara/src/submit_tx.rs
@@ -69,6 +69,20 @@ impl SubmitTransaction for SubmitTransactionSwitch {
     ) -> Result<AddInvokeTransactionResult, SubmitTransactionError> {
         self.provider()?.submit_invoke_transaction(tx).await
     }
+
+    async fn received_transaction(&self, hash: mp_convert::Felt) -> Option<bool> {
+        match self.provider().ok() {
+            Some(provider) => provider.received_transaction(hash).await,
+            None => None,
+        }
+    }
+
+    async fn subscribe_new_transactions(&self) -> Option<tokio::sync::broadcast::Receiver<mp_convert::Felt>> {
+        match self.provider().ok() {
+            Some(provider) => provider.subscribe_new_transactions().await,
+            None => None,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -94,6 +108,20 @@ impl SubmitValidatedTransactionSwitch {
 impl SubmitValidatedTransaction for SubmitValidatedTransactionSwitch {
     async fn submit_validated_transaction(&self, tx: ValidatedMempoolTx) -> Result<(), SubmitTransactionError> {
         self.validated_provider()?.submit_validated_transaction(tx).await
+    }
+
+    async fn received_transaction(&self, hash: mp_convert::Felt) -> Option<bool> {
+        match self.validated_provider().ok() {
+            Some(provider) => provider.received_transaction(hash).await,
+            None => None,
+        }
+    }
+
+    async fn subscribe_new_transactions(&self) -> Option<tokio::sync::broadcast::Receiver<mp_convert::Felt>> {
+        match self.validated_provider().ok() {
+            Some(provider) => provider.subscribe_new_transactions().await,
+            None => None,
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Madara currently does not support the `starknet_subscribeTransactionStatus` ws endpoint.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added support for `starknet_subscribeTransactionStatus`.
- Added update channels to follow the state of pending transactions and the latest confirmed block on L1.

## Implementation details

Supported transaction statuses are:

### `Received`

Transaction has been received in the inner mempool. **This status is not supported when forwarding to a remote gateway.**

### `AcceptedOnL2`

Transaction has been inserted into a _closed_ block. **Pending block inclusion does not count towards** `AcceptedOnL2`.

### `AcceptedOnL1`

Transaction has been finalized on L1.

> [!WARNING]
> Transaction status `Rejected` is not supported as of now.

The set of legal state transitions are

```                                                                            
            ┌────┐                                                                  
         ┌─►│None├─────────────────────────────────────────────────────────┐        
         │  └────┘                                                         │        
         │                                                                 │        
         │                                                                 │        
┌─────┐  │  ┌────────────┐                             ┌────────────────┐  └─►┌───┐ 
│START├──┼─►│WaitReceived│┬────────────────────────┬──►│WaitAcceptedOnL1│────►│END│ 
└─────┘  │  └────────────┘│                        │   └────────────────┘     └───┘ 
         │                │                        ▲                                
         │                └───►┌────────────────┐  │                                
         └────────────────────►│WaitAcceptedOnL2│──┘                                
                               └────────────────┘                                   
```

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

No.
