### PR TITLE
fix(`starknet_unsubscribe`)

### DIFF
--- a/madara/Cargo.lock
+++ b/madara/Cargo.lock
@@ -6846,6 +6846,7 @@ dependencies = [
  "assert_matches",
  "bitvec",
  "blockifier",
+ "dashmap",
  "futures",
  "jsonrpsee",
  "m-proc-macros",

--- a/madara/Cargo.toml
+++ b/madara/Cargo.toml
@@ -191,6 +191,7 @@ tokio-util = "0.7.12"
 rayon = "1.10"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 async-trait = "0.1"
+dashmap = "6.1.0"
 
 # Serialization
 derive_more = "2.0.1"

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -60,3 +60,4 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+dashmap = { workspace = true }

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -49,6 +49,7 @@ starknet_api = { workspace = true, default-features = true }
 # Others
 anyhow = { workspace = true }
 bitvec = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 jsonrpsee = { workspace = true, default-features = true, features = [
   "macros",
@@ -60,4 +61,3 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-dashmap = { workspace = true }

--- a/madara/crates/client/rpc/src/errors.rs
+++ b/madara/crates/client/rpc/src/errors.rs
@@ -77,6 +77,8 @@ pub enum StarknetRpcApiError {
     ClassAlreadyDeclared { error: Cow<'static, str> },
     #[error("Invalid transaction nonce")]
     InvalidTxnNonce { error: Cow<'static, str> },
+    #[error("Invalid subscription id")]
+    InvalidSubscriptionId,
     #[error("Max fee is smaller than the minimal transaction cost (validation plus fee transfer)")]
     InsufficientMaxFee { error: Cow<'static, str> },
     #[error("Account balance is smaller than the transaction's max_fee")]
@@ -166,6 +168,7 @@ impl From<&StarknetRpcApiError> for i32 {
             StarknetRpcApiError::InvalidContractClass { .. } => 50,
             StarknetRpcApiError::ClassAlreadyDeclared { .. } => 51,
             StarknetRpcApiError::InvalidTxnNonce { .. } => 52,
+            StarknetRpcApiError::InvalidSubscriptionId => 66,
             StarknetRpcApiError::InsufficientMaxFee { .. } => 53,
             StarknetRpcApiError::InsufficientAccountBalance { .. } => 54,
             StarknetRpcApiError::ValidationFailure { .. } => 55,
@@ -222,6 +225,7 @@ impl StarknetRpcApiError {
             | StarknetRpcApiError::InvalidTxnHash
             | StarknetRpcApiError::InvalidBlockHash
             | StarknetRpcApiError::InvalidTxnIndex
+            | StarknetRpcApiError::InvalidSubscriptionId
             | StarknetRpcApiError::TxnHashNotFound
             | StarknetRpcApiError::PageSizeTooBig
             | StarknetRpcApiError::NoBlocks

--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -192,17 +192,6 @@ impl WsSubscribeHandles {
 pub(crate) struct WsSubscribeContext(std::sync::Arc<tokio::sync::Notify>);
 
 impl WsSubscribeContext {
-    pub async fn run_until_cancelled<T, F>(&self, f: F) -> Option<T>
-    where
-        T: Sized,
-        F: std::future::Future<Output = T>,
-    {
-        tokio::select! {
-            res = f => Some(res),
-            _ = self.0.notified() => None
-        }
-    }
-
     pub async fn cancelled(&self) {
         self.0.notified().await
     }

--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -202,4 +202,8 @@ impl WsSubscribeContext {
             _ = self.0.notified() => None
         }
     }
+
+    pub async fn cancelled(&self) {
+        self.0.notified().await
+    }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
 pub(crate) type NewHead = mp_rpc::BlockHeader;
-pub(crate) type EmittedEvent = mp_rpc::EmittedEvent;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContractStorageKeysItem {
@@ -55,13 +54,19 @@ pub struct GetStorageProofResult {
 }
 
 type SubscriptionItemPendingTxs = super::methods::ws::SubscriptionItem<mp_rpc::v0_8_1::PendingTxnInfo>;
+type SubscriptionItemEvents = super::methods::ws::SubscriptionItem<mp_rpc::v0_7_1::EmittedEvent>;
 
 #[versioned_rpc("V0_8_0", "starknet")]
 pub trait StarknetWsRpcApi {
     #[subscription(name = "subscribeNewHeads", unsubscribe = "unsubscribeNewHeads", item = NewHead, param_kind = map)]
     async fn subscribe_new_heads(&self, block: BlockId) -> jsonrpsee::core::SubscriptionResult;
 
-    #[subscription(name = "subscribeEvents", unsubscribe = "unsubscribeEvents", item = EmittedEvent, param_kind = map)]
+    #[subscription(
+        name = "subscribeEvents",
+        unsubscribe = "unsubscribeEvents",
+        item = SubscriptionItemEvents,
+        param_kind = map
+    )]
     async fn subscribe_events(
         &self,
         from_address: Option<Felt>,

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
@@ -54,6 +54,8 @@ pub struct GetStorageProofResult {
     pub global_roots: GlobalRoots,
 }
 
+type SubscriptionItemPendingTxs = super::methods::ws::SubscriptionItem<mp_rpc::v0_8_1::PendingTxnInfo>;
+
 #[versioned_rpc("V0_8_0", "starknet")]
 pub trait StarknetWsRpcApi {
     #[subscription(name = "subscribeNewHeads", unsubscribe = "unsubscribeNewHeads", item = NewHead, param_kind = map)]
@@ -78,7 +80,7 @@ pub trait StarknetWsRpcApi {
     #[subscription(
         name = "subscribePendingTransactions",
         unsubscribe = "unsubscribePendingTransactions",
-        item = mp_rpc::v0_8_1::PendingTxnInfo,
+        item = SubscriptionItemPendingTxs,
         param_kind = map
     )]
     async fn subscribe_pending_transactions(
@@ -86,6 +88,8 @@ pub trait StarknetWsRpcApi {
         transaction_details: bool,
         sender_address: Vec<starknet_types_core::felt::Felt>,
     ) -> jsonrpsee::core::SubscriptionResult;
+    #[method(name = "unsubscribe")]
+    async fn starknet_unsubscribe(&self, subscription_id: u64) -> RpcResult<bool>;
 }
 
 #[versioned_rpc("V0_8_0", "starknet")]

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
@@ -4,8 +4,6 @@ use mp_block::BlockId;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-pub(crate) type NewHead = mp_rpc::BlockHeader;
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContractStorageKeysItem {
     pub contract_address: Felt,
@@ -55,10 +53,16 @@ pub struct GetStorageProofResult {
 
 type SubscriptionItemPendingTxs = super::methods::ws::SubscriptionItem<mp_rpc::v0_8_1::PendingTxnInfo>;
 type SubscriptionItemEvents = super::methods::ws::SubscriptionItem<mp_rpc::v0_7_1::EmittedEvent>;
+type SubscriptionItemNewHeads = super::methods::ws::SubscriptionItem<mp_rpc::v0_7_1::BlockHeader>;
 
 #[versioned_rpc("V0_8_0", "starknet")]
 pub trait StarknetWsRpcApi {
-    #[subscription(name = "subscribeNewHeads", unsubscribe = "unsubscribeNewHeads", item = NewHead, param_kind = map)]
+    #[subscription(
+        name = "subscribeNewHeads",
+        unsubscribe = "unsubscribeNewHeads",
+        item = SubscriptionItemNewHeads,
+        param_kind = map
+    )]
     async fn subscribe_new_heads(&self, block: BlockId) -> jsonrpsee::core::SubscriptionResult;
 
     #[subscription(

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/api.rs
@@ -54,6 +54,7 @@ pub struct GetStorageProofResult {
 type SubscriptionItemPendingTxs = super::methods::ws::SubscriptionItem<mp_rpc::v0_8_1::PendingTxnInfo>;
 type SubscriptionItemEvents = super::methods::ws::SubscriptionItem<mp_rpc::v0_7_1::EmittedEvent>;
 type SubscriptionItemNewHeads = super::methods::ws::SubscriptionItem<mp_rpc::v0_7_1::BlockHeader>;
+type SubscriptionItemTransactionStatus = super::methods::ws::SubscriptionItem<mp_rpc::v0_8_1::TxnStatus>;
 
 #[versioned_rpc("V0_8_0", "starknet")]
 pub trait StarknetWsRpcApi {
@@ -81,7 +82,7 @@ pub trait StarknetWsRpcApi {
     #[subscription(
         name = "subscribeTransactionStatus",
         unsubscribe = "unsubscribeTransactionStatus",
-        item = mp_rpc::v0_8_1::TxnStatus,
+        item = SubscriptionItemTransactionStatus,
         param_kind = map
     )]
     async fn subscribe_transaction_status(&self, transaction_hash: Felt) -> jsonrpsee::core::SubscriptionResult;

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/lib.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/lib.rs
@@ -3,6 +3,7 @@ use starknet_types_core::felt::Felt;
 
 use crate::versions::user::v0_8_0::StarknetWsRpcApiV0_8_0Server;
 
+use super::starknet_unsubscribe::*;
 use super::subscribe_events::*;
 use super::subscribe_new_heads::*;
 use super::subscribe_pending_transactions::*;
@@ -43,5 +44,9 @@ impl StarknetWsRpcApiV0_8_0Server for crate::Starknet {
         sender_address: Vec<starknet_types_core::felt::Felt>,
     ) -> jsonrpsee::core::SubscriptionResult {
         Ok(subscribe_pending_transactions(self, subscription_sink, transaction_details, sender_address).await?)
+    }
+
+    async fn starknet_unsubscribe(&self, subscription_id: u64) -> jsonrpsee::core::RpcResult<bool> {
+        Ok(starknet_unsubscribe(self, subscription_id).await?)
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/mod.rs
@@ -1,4 +1,5 @@
 pub mod lib;
+pub mod starknet_unsubscribe;
 pub mod subscribe_events;
 pub mod subscribe_new_heads;
 pub mod subscribe_pending_transactions;
@@ -6,3 +7,22 @@ pub mod subscribe_transaction_status;
 
 const BLOCK_PAST_LIMIT: u64 = 1024;
 const ADDRESS_FILTER_LIMIT: u64 = 128;
+
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SubscriptionItem<T> {
+    subscription_id: u64,
+    result: T,
+}
+
+impl<T> SubscriptionItem<T> {
+    pub fn new(subscription_id: jsonrpsee::types::SubscriptionId, result: T) -> Self {
+        let subscription_id = match subscription_id {
+            jsonrpsee::types::SubscriptionId::Num(id) => id,
+            jsonrpsee::types::SubscriptionId::Str(_) => {
+                unreachable!("Jsonrpsee middleware has been configured to use u64 subscription ids")
+            }
+        };
+
+        Self { subscription_id, result }
+    }
+}

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
@@ -1,0 +1,45 @@
+pub async fn starknet_unsubscribe(starknet: &crate::Starknet, subscription_id: u64) -> crate::StarknetRpcResult<bool> {
+    if starknet.ws_handles.subscription_close(subscription_id).await {
+        Ok(true)
+    } else {
+        Err(crate::StarknetRpcApiError::InvalidSubscriptionId.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[rstest::fixture]
+    fn logs() {
+        let debug = tracing_subscriber::filter::LevelFilter::DEBUG;
+        let env = tracing_subscriber::EnvFilter::builder().with_default_directive(debug.into()).from_env_lossy();
+        let _ = tracing_subscriber::fmt().with_test_writer().with_env_filter(env).with_line_number(true).try_init();
+    }
+
+    #[rstest::fixture]
+    fn starknet() -> crate::Starknet {
+        let chain_config = std::sync::Arc::new(mp_chain_config::ChainConfig::madara_test());
+        let backend = mc_db::MadaraBackend::open_for_testing(chain_config);
+        let validation = mc_submit_tx::TransactionValidatorConfig { disable_validation: true };
+        let mempool = std::sync::Arc::new(mc_mempool::Mempool::new(
+            std::sync::Arc::clone(&backend),
+            mc_mempool::MempoolConfig::for_testing(),
+        ));
+        let mempool_validator = std::sync::Arc::new(mc_submit_tx::TransactionValidator::new(
+            mempool,
+            std::sync::Arc::clone(&backend),
+            validation,
+        ));
+        let context = mp_utils::service::ServiceContext::new_for_testing();
+
+        crate::Starknet::new(backend, mempool_validator, Default::default(), context)
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn starknet_unsubscribe_err(_logs: (), starknet: crate::Starknet) {
+        assert_eq!(
+            super::starknet_unsubscribe(&starknet, 0).await,
+            Err(crate::StarknetRpcApiError::InvalidSubscriptionId)
+        )
+    }
+}

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
@@ -2,7 +2,7 @@ pub async fn starknet_unsubscribe(starknet: &crate::Starknet, subscription_id: u
     if starknet.ws_handles.subscription_close(subscription_id).await {
         Ok(true)
     } else {
-        Err(crate::StarknetRpcApiError::InvalidSubscriptionId.into())
+        Err(crate::StarknetRpcApiError::InvalidSubscriptionId)
     }
 }
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
@@ -19,7 +19,7 @@ mod test {
     fn starknet() -> crate::Starknet {
         let chain_config = std::sync::Arc::new(mp_chain_config::ChainConfig::madara_test());
         let backend = mc_db::MadaraBackend::open_for_testing(chain_config);
-        let validation = mc_submit_tx::TransactionValidatorConfig { disable_validation: true };
+        let validation = mc_submit_tx::TransactionValidatorConfig { disable_validation: true, disable_fee: true };
         let mempool = std::sync::Arc::new(mc_mempool::Mempool::new(
             std::sync::Arc::clone(&backend),
             mc_mempool::MempoolConfig::for_testing(),
@@ -31,7 +31,7 @@ mod test {
         ));
         let context = mp_utils::service::ServiceContext::new_for_testing();
 
-        crate::Starknet::new(backend, mempool_validator, Default::default(), context)
+        crate::Starknet::new(backend, mempool_validator, Default::default(), None, context)
     }
 
     #[tokio::test]

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/starknet_unsubscribe.rs
@@ -1,3 +1,14 @@
+/// # Caution
+///
+/// This is a temporary workaround due to limitations in the way in which [jsonrpsee] works. If
+/// possible at all, clients should prefer to use the unsubscribe methods defined in [api.rs]. These
+/// follow the structure `starknet_unsubscribeMethodName`, so for example
+/// `starknet_unsubscribeNewHeads`.
+///
+/// Use these if you encounter any strange edge cases such as 500 error codes on unsubscribe.
+///
+/// [api.rs]: super::super::super::api
+
 pub async fn starknet_unsubscribe(starknet: &crate::Starknet, subscription_id: u64) -> crate::StarknetRpcResult<bool> {
     if starknet.ws_handles.subscription_close(subscription_id).await {
         Ok(true)

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_events.rs
@@ -17,6 +17,19 @@ pub async fn subscribe_events(
 ) -> Result<(), StarknetWsApiError> {
     let sink = subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
 
+    let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
+    ctx.run_until_cancelled(subscribe_events_impl(starknet, sink, from_address, keys, block_id))
+        .await
+        .unwrap_or(Err(StarknetWsApiError::Internal))
+}
+
+async fn subscribe_events_impl(
+    starknet: &crate::Starknet,
+    sink: jsonrpsee::server::SubscriptionSink,
+    from_address: Option<Felt>,
+    keys: Option<Vec<Vec<Felt>>>,
+    block_id: Option<BlockId>,
+) -> Result<(), StarknetWsApiError> {
     let mut rx = starknet.backend.subscribe_events(from_address);
 
     if let Some(block_id) = block_id {
@@ -44,9 +57,7 @@ pub async fn subscribe_events(
             for event in drain_block_events(block)
                 .filter(|event| event_match_filter(&event.event, from_address.as_ref(), keys.as_deref()))
             {
-                let msg = jsonrpsee::SubscriptionMessage::from_json(&EmittedEvent::from(event))
-                    .or_internal_server_error("Failed to create response message")?;
-                sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")?;
+                send_event(event, &sink).await?;
             }
         }
     }
@@ -56,9 +67,7 @@ pub async fn subscribe_events(
             event = rx.recv() => {
                 let event = event.or_internal_server_error("Failed to retrieve event")?;
                 if event_match_filter(&event.event, from_address.as_ref(), keys.as_deref()) {
-                    let msg = jsonrpsee::SubscriptionMessage::from_json(&EmittedEvent::from(event))
-                        .or_internal_server_error("Failed to create response message")?;
-                    sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")?;
+                    send_event(event, &sink).await?;
                 }
             },
             _ = sink.closed() => {
@@ -66,6 +75,17 @@ pub async fn subscribe_events(
             }
         }
     }
+}
+
+async fn send_event(
+    event: mp_block::EventWithInfo,
+    sink: &jsonrpsee::server::SubscriptionSink,
+) -> Result<(), StarknetWsApiError> {
+    let event = EmittedEvent::from(event);
+    let item = super::SubscriptionItem::new(sink.subscription_id(), event);
+    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+        .or_internal_server_error("Failed to create response message")?;
+    sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")
 }
 
 #[cfg(test)]
@@ -192,7 +212,7 @@ mod test {
             let events = generator.next().expect("Retrieving block");
             for event in events {
                 let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-                assert_eq!(received, event);
+                assert_eq!(received.result, event);
                 nb_events += 1;
             }
         }
@@ -224,7 +244,7 @@ mod test {
             for event in events {
                 if event.event.from_address == from_address {
                     let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-                    assert_eq!(received, event);
+                    assert_eq!(received.result, event);
                     nb_events += 1;
                 }
             }
@@ -287,7 +307,7 @@ mod test {
 
         for event in expected_events {
             let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-            assert_eq!(received, event);
+            assert_eq!(received.result, event);
         }
     }
 
@@ -327,7 +347,35 @@ mod test {
 
         for event in expected_events {
             let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-            assert_eq!(received, event);
+            assert_eq!(received.result, event);
         }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn subscribe_events_unsubscribe(rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, Starknet)) {
+        let (backend, starknet) = rpc_test_setup;
+        let server = jsonrpsee::server::Server::builder().build("127.0.0.1:0").await.expect("Starting server");
+        let server_url = format!("ws://{}", server.local_addr().expect("Retrieving server local address"));
+        let _server_handle = server.start(StarknetWsRpcApiV0_8_0Server::into_rpc(starknet));
+        let client = WsClientBuilder::default().build(&server_url).await.expect("Building client");
+
+        let mut generator = block_generator(&backend);
+
+        let mut sub = client.subscribe_events(None, None, None).await.expect("Subscribing to events");
+
+        let events = generator.next().expect("Retrieving block");
+        let subscription_id = sub.next().await.unwrap().unwrap().subscription_id;
+        client.starknet_unsubscribe(subscription_id).await.expect("Failed to close subscription");
+
+        let mut nb_events = 0;
+        for event in events.into_iter().skip(1) {
+            let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
+            assert_eq!(received.result, event);
+            nb_events += 1;
+        }
+        assert_eq!(nb_events, 2);
+
+        assert!(sub.next().await.is_none());
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_pending_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_pending_transactions.rs
@@ -98,7 +98,9 @@ pub async fn subscribe_pending_transactions(
 #[cfg(test)]
 mod test {
     use crate::{
-        versions::user::v0_8_0::{StarknetWsRpcApiV0_8_0Client, StarknetWsRpcApiV0_8_0Server},
+        versions::user::v0_8_0::{
+            methods::ws::SubscriptionItem, StarknetWsRpcApiV0_8_0Client, StarknetWsRpcApiV0_8_0Server,
+        },
         Starknet,
     };
 
@@ -245,7 +247,7 @@ mod test {
         backend.on_new_pending_tx(tx_2.clone());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(hash)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: hash, .. })) => {
                 assert_matches::assert_matches!(
                     hash, mp_rpc::v0_8_1::PendingTxnInfo::Hash(hash) => {
                         assert_eq!(hash, tx_1.receipt.transaction_hash());
@@ -257,7 +259,7 @@ mod test {
         tracing::debug!("Received {:#x}", tx_1.receipt.transaction_hash());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(hash)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: hash, .. })) => {
                 assert_matches::assert_matches!(
                     hash, mp_rpc::v0_8_1::PendingTxnInfo::Hash(hash) => {
                         assert_eq!(hash, tx_2.receipt.transaction_hash());
@@ -310,7 +312,7 @@ mod test {
         backend.on_new_pending_tx(tx_2.clone());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(tx)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: tx, .. })) => {
                 assert_matches::assert_matches!(
                     tx, mp_rpc::v0_8_1::PendingTxnInfo::Full(tx) => {
                         assert_eq!(tx, tx_1.transaction.into());
@@ -322,7 +324,7 @@ mod test {
         tracing::debug!("Received {:#x}", tx_1.receipt.transaction_hash());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(tx)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: tx, .. })) => {
                 assert_matches::assert_matches!(
                     tx, mp_rpc::v0_8_1::PendingTxnInfo::Full(tx) => {
                         assert_eq!(tx, tx_2.transaction.into());
@@ -373,7 +375,7 @@ mod test {
         backend.on_new_pending_tx(invoke.clone());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(hash)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: hash, .. })) => {
                 assert_matches::assert_matches!(
                     hash, mp_rpc::v0_8_1::PendingTxnInfo::Hash(hash) => {
                         assert_eq!(hash, deploy_account.receipt.transaction_hash());
@@ -385,7 +387,7 @@ mod test {
         tracing::debug!("Received {:#x}", deploy_account.receipt.transaction_hash());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(hash)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: hash, .. })) => {
                 assert_matches::assert_matches!(
                     hash, mp_rpc::v0_8_1::PendingTxnInfo::Hash(hash) => {
                         assert_eq!(hash, deploy.receipt.transaction_hash());
@@ -397,7 +399,7 @@ mod test {
         tracing::debug!("Received {:#x}", deploy.receipt.transaction_hash());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(hash)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: hash, .. })) => {
                 assert_matches::assert_matches!(
                     hash, mp_rpc::v0_8_1::PendingTxnInfo::Hash(hash) => {
                         assert_eq!(hash, declare.receipt.transaction_hash());
@@ -409,7 +411,7 @@ mod test {
         tracing::debug!("Received {:#x}", declare.receipt.transaction_hash());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(hash)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: hash, .. })) => {
                 assert_matches::assert_matches!(
                     hash, mp_rpc::v0_8_1::PendingTxnInfo::Hash(hash) => {
                         assert_eq!(hash, l1_handler.receipt.transaction_hash());
@@ -421,7 +423,7 @@ mod test {
         tracing::debug!("Received {:#x}", l1_handler.receipt.transaction_hash());
 
         assert_matches::assert_matches!(
-            sub.next().await, Some(Ok(hash)) => {
+            sub.next().await, Some(Ok(SubscriptionItem { result: hash, .. })) => {
                 assert_matches::assert_matches!(
                     hash, mp_rpc::v0_8_1::PendingTxnInfo::Hash(hash) => {
                         assert_eq!(hash, invoke.receipt.transaction_hash());

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_pending_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_pending_transactions.rs
@@ -89,7 +89,8 @@ pub async fn subscribe_pending_transactions(
             mp_rpc::v0_8_1::PendingTxnInfo::Hash(tx_hash)
         };
 
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&tx_info).or_else_internal_server_error(|| {
+        let item = super::SubscriptionItem::new(sink.subscription_id(), tx_info);
+        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
             format!("SubscribePendingTransactions failed to create response message at tx {tx_hash:#x}")
         })?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -250,7 +250,7 @@ impl StateTransitionCommon<'_> {
         let txn_status = mp_rpc::v0_8_1::TxnStatus { transaction_hash: self.tx_hash, status };
         let item = super::SubscriptionItem::new(self.subscription_sink.subscription_id(), txn_status);
         let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
-            format!("SubscribeTransactionStatus failed to create response for tx hash {:#x}", self.transaction_hash)
+            format!("SubscribeTransactionStatus failed to create response for tx hash {:#x}", self.tx_hash)
         })?;
 
         self.sink

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -69,7 +69,7 @@ impl<'a> SubscriptionState<'a> {
     async fn new(
         starknet: &'a crate::Starknet,
         sink: &'a jsonrpsee::core::server::SubscriptionSink,
-        ctx: &'a crate::WsSubscriptionGuard<'a>,
+        ctx: &'a crate::WsSubscriptionGuard,
         tx_hash: mp_convert::Felt,
     ) -> Result<Self, crate::errors::StarknetWsApiError> {
         let common = StateTransitionCommon { starknet, sink, ctx, tx_hash };
@@ -224,7 +224,7 @@ impl<'a> SubscriptionState<'a> {
 struct StateTransitionCommon<'a> {
     starknet: &'a crate::Starknet,
     sink: &'a jsonrpsee::core::server::SubscriptionSink,
-    ctx: &'a crate::WsSubscriptionGuard<'a>,
+    ctx: &'a crate::WsSubscriptionGuard,
     tx_hash: mp_convert::Felt,
 }
 struct StateTransitionReceived<'a> {

--- a/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_0/methods/ws/subscribe_transaction_status.rs
@@ -69,7 +69,7 @@ impl<'a> SubscriptionState<'a> {
     async fn new(
         starknet: &'a crate::Starknet,
         sink: &'a jsonrpsee::core::server::SubscriptionSink,
-        ctx: &'a crate::WsSubscribeContext,
+        ctx: &'a crate::WsSubscriptionGuard<'a>,
         tx_hash: mp_convert::Felt,
     ) -> Result<Self, crate::errors::StarknetWsApiError> {
         let common = StateTransitionCommon { starknet, sink, ctx, tx_hash };
@@ -224,7 +224,7 @@ impl<'a> SubscriptionState<'a> {
 struct StateTransitionCommon<'a> {
     starknet: &'a crate::Starknet,
     sink: &'a jsonrpsee::core::server::SubscriptionSink,
-    ctx: &'a crate::WsSubscribeContext,
+    ctx: &'a crate::WsSubscriptionGuard<'a>,
     tx_hash: mp_convert::Felt,
 }
 struct StateTransitionReceived<'a> {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the madara ws API does not adhere to the specs by not allowing ws subscriptions to be terminated via `starknet_unsubscribe`. This is a limitation in the way in which `jsonrpsee` works which makes it impossible to have different ws methods with the same unsubscribe name.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Manual handling of ws method unsubscribe via a new `starknet_unsubscribe` endpoint. This works by tracking ws subscription ids for active subscriptions and notifying them they have been unsubscribed when this method is called, resulting in a cancel.

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

Yes. Ws RPC method items were not conforming to specs and did not return the subscription id number. This has been fixed but marks a breaking change in the format of ws responses.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

> [!NOTE]
> The way this works is a bit janky: jsonrpsee does not let a ws method close itself, and strangely even the method exiting will not close the sink. The only way to close a ws subscription this way is to return an error. In the future, I would really like us to move _away_ from jsonrpsee in favor of our own Json-RPC middleware which would give us much more flexibility in scenarios such as these
