### PR TITLE
Fix: introduce deterministic hasher interface for bloom-filter

### DIFF
--- a/.db-versions.yml
+++ b/.db-versions.yml
@@ -1,5 +1,7 @@
-current_version: 3
+current_version: 4
 versions:
+  - version: 4
+    pr: 692
   - version: 3
     pr: 473
   - version: 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7570,6 +7570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "highway"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9040319a6910b901d5d49cbada4a99db52836a1b63228a05f7e2b7f8feef89b1"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9270,7 +9276,6 @@ dependencies = [
 name = "mc-db"
 version = "0.8.0"
 dependencies = [
- "ahash 0.8.11",
  "anyhow",
  "bincode 1.3.3",
  "bitvec",
@@ -9303,6 +9308,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
+ "siphasher 1.0.1",
  "starknet-types-core",
  "starknet_api 0.13.0-rc.1",
  "tempfile",
@@ -9920,13 +9926,16 @@ dependencies = [
  "ahash 0.8.11",
  "bincode 1.3.3",
  "criterion",
+ "highway",
  "mp-receipt",
  "proptest",
  "rand",
  "rayon",
  "rstest 0.18.2",
+ "rustc-hash 2.1.0",
  "serde",
  "serde_json",
+ "siphasher 1.0.1",
  "starknet-types-core",
  "thiserror 2.0.3",
  "twox-hash 2.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,9 @@ crypto-bigint = "0.5.5"
 zeroize = "1.8"
 ahash = "0.8"
 twox-hash = "2.1"
+rustc-hash = "2.1"
+highway = "1.3"
+siphasher = "1.0"
 
 # Std extensions
 lazy_static = { version = "1.4", default-features = false }

--- a/madara/crates/client/db/Cargo.toml
+++ b/madara/crates/client/db/Cargo.toml
@@ -76,7 +76,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [dev-dependencies]
 proptest = { workspace = true }
 serde_json = { workspace = true }
-starknet_api = { workspace = true, features = ["testing"]}
 tempfile = "3.10"
 lazy_static = { workspace = true }
 mp-transactions = { workspace = true }

--- a/madara/crates/client/db/Cargo.toml
+++ b/madara/crates/client/db/Cargo.toml
@@ -38,7 +38,6 @@ starknet-types-core = { workspace = true }
 starknet_api = { workspace = true }
 
 # Other
-ahash.workspace = true
 anyhow.workspace = true
 bincode = { workspace = true }
 bitvec = { workspace = true }
@@ -47,6 +46,7 @@ librocksdb-sys = { workspace = true }
 rayon = { workspace = true }
 rocksdb.workspace = true
 serde = { workspace = true }
+siphasher.workspace = true
 tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [

--- a/madara/crates/client/db/Cargo.toml
+++ b/madara/crates/client/db/Cargo.toml
@@ -76,6 +76,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [dev-dependencies]
 proptest = { workspace = true }
 serde_json = { workspace = true }
+starknet_api = { workspace = true, features = ["testing"]}
 tempfile = "3.10"
 lazy_static = { workspace = true }
 mp-transactions = { workspace = true }

--- a/madara/crates/client/db/src/events_bloom_filter.rs
+++ b/madara/crates/client/db/src/events_bloom_filter.rs
@@ -51,7 +51,7 @@ pub struct EventBloomWriter {
 
 impl fmt::Debug for EventBloomWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "EventBloomWriter {{ size: {}, hash_count: {} }}", self.size(), HASH_COUNT)
+        f.debug_struct("EventBloomWriter").field("size", &self.size()).field("hash_count", &HASH_COUNT).finish()
     }
 }
 
@@ -180,7 +180,7 @@ impl EventBloomSearcher {
     ///
     /// * `from_address` - Optional Felt value to match against event from_address
     /// * `keys` - Optional array of key arrays. Each inner array represents a set of alternatives
-    ///           (OR semantics), while the outer array elements are combined with AND semantics.
+    ///   (OR semantics), while the outer array elements are combined with AND semantics.
     ///
     /// # Returns
     ///

--- a/madara/crates/client/db/src/events_bloom_filter.rs
+++ b/madara/crates/client/db/src/events_bloom_filter.rs
@@ -1,6 +1,6 @@
-use ahash::AHasher;
 use mp_receipt::Event;
 use serde::{Deserialize, Deserializer, Serialize};
+use siphasher::sip::SipHasher;
 use starknet_types_core::felt::Felt;
 use std::{collections::HashSet, fmt};
 
@@ -25,7 +25,7 @@ const HASH_COUNT: u8 = 7;
 /// - p is the desired false positive rate (0.01)
 const BITS_PER_ELEMENT: f64 = 9.6;
 
-type BloomHasher = AHasher;
+type BloomHasher = SipHasher;
 
 /// Writer component for creating event-based Bloom filters.
 ///

--- a/madara/crates/client/db/src/events_bloom_filter.rs
+++ b/madara/crates/client/db/src/events_bloom_filter.rs
@@ -51,7 +51,7 @@ pub struct EventBloomWriter {
 
 impl fmt::Debug for EventBloomWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EventBloomWriter").field("size", &self.size()).field("hash_count", &HASH_COUNT).finish()
+        write!(f, "EventBloomWriter {{ size: {}, hash_count: {} }}", self.size(), HASH_COUNT)
     }
 }
 
@@ -180,7 +180,7 @@ impl EventBloomSearcher {
     ///
     /// * `from_address` - Optional Felt value to match against event from_address
     /// * `keys` - Optional array of key arrays. Each inner array represents a set of alternatives
-    ///   (OR semantics), while the outer array elements are combined with AND semantics.
+    ///           (OR semantics), while the outer array elements are combined with AND semantics.
     ///
     /// # Returns
     ///

--- a/madara/crates/client/gateway/client/src/request_builder.rs
+++ b/madara/crates/client/gateway/client/src/request_builder.rs
@@ -16,7 +16,7 @@ use tower::Service;
 use url::Url;
 
 pub(crate) fn url_join_segment(url: &mut Url, segment: &str) {
-    if url.path_segments().expect("Invalid base URL").last().is_some_and(|e| e.is_empty()) {
+    if url.path_segments().expect("Invalid base URL").next_back().is_some_and(|e| e.is_empty()) {
         url.path_segments_mut().expect("Invalid base URL").pop();
     }
     url.path_segments_mut().expect("Invalid base URL").extend(&[segment]);

--- a/madara/crates/client/submit_tx/src/validation.rs
+++ b/madara/crates/client/submit_tx/src/validation.rs
@@ -101,7 +101,7 @@ impl From<TransactionExecutionError> for SubmitTransactionError {
             | E::TransactionFeeError(_)
             | E::TransactionPreValidationError(_)
             | E::TryFromIntError(_)
-            | E::TransactionTooLarge { .. }) => rejected(ValidateFailure, format!("{err:#}")),
+            | E::TransactionTooLarge) => rejected(ValidateFailure, format!("{err:#}")),
             err @ E::InvalidVersion { .. } => rejected(InvalidTransactionVersion, format!("{err:#}")),
             err @ E::InvalidSegmentStructure(_, _) => rejected(InvalidProgram, format!("{err:#}")),
             E::StateError(err) => err.into(),

--- a/madara/crates/primitives/bloom_filter/Cargo.toml
+++ b/madara/crates/primitives/bloom_filter/Cargo.toml
@@ -29,6 +29,9 @@ rayon.workspace = true
 bincode.workspace = true
 proptest.workspace = true
 rstest.workspace = true
+rustc-hash.workspace = true
+highway.workspace = true
+siphasher.workspace = true
 serde_json.workspace = true
 
 [[bench]]

--- a/madara/crates/primitives/bloom_filter/benches/bloom_benchmark.rs
+++ b/madara/crates/primitives/bloom_filter/benches/bloom_benchmark.rs
@@ -6,9 +6,13 @@ use rayon::prelude::*;
 use mp_bloom_filter::{AtomicBitStore, BitStore, BloomFilter};
 
 use ahash::AHasher;
+use siphasher::sip::SipHasher;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 use twox_hash::XxHash64;
+use rustc_hash::FxHasher;
+use highway::HighwayHasher;
+
 
 /// Configuration constants for benchmarks
 const KEY_SIZE: usize = 32;
@@ -160,6 +164,9 @@ fn bench_bloom_filters(c: &mut Criterion) {
         get_hasher_benchmarks::<DefaultHasher>("DefaultHasher"),
         get_hasher_benchmarks::<AHasher>("AHasher"),
         get_hasher_benchmarks::<XxHash64>("XxHash64"),
+        get_hasher_benchmarks::<FxHasher>("FxHasher"),
+        get_hasher_benchmarks::<HighwayHasher>("HighwayHasher"),
+        get_hasher_benchmarks::<SipHasher>("SipHasher"),
     ];
 
     for hasher in &hashers {

--- a/madara/crates/primitives/bloom_filter/benches/bloom_benchmark.rs
+++ b/madara/crates/primitives/bloom_filter/benches/bloom_benchmark.rs
@@ -6,13 +6,12 @@ use rayon::prelude::*;
 use mp_bloom_filter::{AtomicBitStore, BitStore, BloomFilter};
 
 use ahash::AHasher;
+use highway::HighwayHasher;
+use rustc_hash::FxHasher;
 use siphasher::sip::SipHasher;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 use twox_hash::XxHash64;
-use rustc_hash::FxHasher;
-use highway::HighwayHasher;
-
 
 /// Configuration constants for benchmarks
 const KEY_SIZE: usize = 32;

--- a/madara/crates/primitives/bloom_filter/src/filter.rs
+++ b/madara/crates/primitives/bloom_filter/src/filter.rs
@@ -13,45 +13,8 @@
 
 use crate::storage::{AtomicBitStore, BitStore};
 use serde::{Deserialize, Serialize};
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-
-/// A trait for constructing deterministic hashers suitable for reproducible Bloom filters.
-///
-/// # Overview
-///
-/// `DeterministicBuildHasher` defines a minimal interface for generating hashers that produce stable and reproducible hash values across program runs, platforms, and environments.
-pub trait DeterministicBuildHasher {
-    /// The hasher type to be constructed.
-    type H: Hasher;
-
-    /// Builds a new deterministic hasher instance.
-    ///
-    /// # Returns
-    /// A fresh `Hasher` instance whose behavior is fully deterministic.
-    ///
-    /// # Guarantees
-    /// The returned hasher must produce the same output for the same input, independent of execution environment or runtime state.
-    fn build_hasher() -> Self::H;
-}
-
-impl DeterministicBuildHasher for ahash::AHasher {
-    type H = ahash::AHasher;
-
-    fn build_hasher() -> Self::H {
-        ahash::RandomState::with_seeds(0x03d04773fad45387, 0x39d4e9b0f45e97cc, 0x63a175b11b94edaf, 0x075c02fb32039c72)
-            .build_hasher()
-    }
-}
-
-impl DeterministicBuildHasher for std::collections::hash_map::DefaultHasher {
-    type H = std::collections::hash_map::DefaultHasher;
-
-    fn build_hasher() -> Self::H {
-        std::collections::hash_map::DefaultHasher::new()
-    }
-}
-
 /// A cache of computed hash positions that can be reused across different filter sizes.
 ///
 /// This structure stores the raw hash values generated for an item, allowing them to be
@@ -89,7 +52,7 @@ impl PreCalculatedHashes {
     /// # Returns
     ///
     /// A new `PreCalculatedHashes` instance containing the computed hash values
-    pub fn new<H: Hasher + DeterministicBuildHasher, T: Hash>(hash_count: u8, item: &T) -> Self {
+    pub fn new<H: Hasher + Default, T: Hash>(hash_count: u8, item: &T) -> Self {
         Self { raw_hashes: calculate_hashes::<H, T>(hash_count, item).collect(), hash_count }
     }
 
@@ -151,7 +114,7 @@ impl PreCalculatedHashes {
 /// * `hash_count`: The number of hash functions used
 /// * `_hasher`: Phantom data for the hasher type
 #[derive(Serialize, Deserialize, Clone)]
-pub struct BloomFilter<H: Hasher + DeterministicBuildHasher, B> {
+pub struct BloomFilter<H: Hasher + Default, B> {
     storage: B,
     bit_size: u64,
     hash_count: u8,
@@ -159,7 +122,7 @@ pub struct BloomFilter<H: Hasher + DeterministicBuildHasher, B> {
     _hasher: PhantomData<H>,
 }
 
-impl<H: Hasher + DeterministicBuildHasher> BloomFilter<H, AtomicBitStore> {
+impl<H: Hasher + Default> BloomFilter<H, AtomicBitStore> {
     /// Creates a new Bloom filter with the specified size and number of hash functions.
     ///
     /// The actual size will be aligned to the next multiple of 64 bits for efficient storage.
@@ -203,7 +166,7 @@ impl<H: Hasher + DeterministicBuildHasher> BloomFilter<H, AtomicBitStore> {
     }
 }
 
-impl<H: Hasher + DeterministicBuildHasher, B> BloomFilter<H, B> {
+impl<H: Hasher + Default, B> BloomFilter<H, B> {
     /// Returns the size of the Bloom filter in bits.
     pub fn size(&self) -> u64 {
         self.bit_size
@@ -219,7 +182,7 @@ impl<H: Hasher + DeterministicBuildHasher, B> BloomFilter<H, B> {
     }
 }
 
-impl<H: Hasher + DeterministicBuildHasher> BloomFilter<H, BitStore> {
+impl<H: Hasher + Default> BloomFilter<H, BitStore> {
     /// Creates a new immutable Bloom filter from a bit storage backend.
     pub fn from_storage(storage: BitStore, hash_count: u8) -> Self {
         let bit_size = storage.len() as _;
@@ -293,7 +256,7 @@ impl<H: Hasher + DeterministicBuildHasher> BloomFilter<H, BitStore> {
 ///
 /// # Type Parameters
 ///
-/// * `H`: A hasher type that implements `Hasher` + `DeterministicBuildHasher`
+/// * `H`: A hasher type that implements `Hasher` + `Default`
 /// * `T`: The type of item being hashed, must implement `Hash`
 ///
 /// # Returns
@@ -305,11 +268,8 @@ impl<H: Hasher + DeterministicBuildHasher> BloomFilter<H, BitStore> {
 /// Note: The actual bit positions should be computed by the caller by applying
 /// modulo with the bit array size to the returned hash values.
 #[inline]
-fn calculate_hashes<H: Hasher + DeterministicBuildHasher, T: Hash>(
-    hash_count: u8,
-    item: &T,
-) -> impl Iterator<Item = u64> + '_ {
-    let mut hasher1 = H::build_hasher();
+fn calculate_hashes<H: Hasher + Default, T: Hash>(hash_count: u8, item: &T) -> impl Iterator<Item = u64> + '_ {
+    let mut hasher1 = H::default();
     item.hash(&mut hasher1);
     let h1 = hasher1.finish();
 

--- a/madara/crates/primitives/bloom_filter/src/tests/filter_tests.rs
+++ b/madara/crates/primitives/bloom_filter/src/tests/filter_tests.rs
@@ -61,7 +61,8 @@ fn test_parallel() {
     let ro_filter = filter.finalize();
 
     // Test parallel lookup for false negatives
-    let false_negatives: Vec<_> = elements.par_iter().filter(|&&item| !ro_filter.might_contain(&item.to_be_bytes())).collect();
+    let false_negatives: Vec<_> =
+        elements.par_iter().filter(|&&item| !ro_filter.might_contain(&item.to_be_bytes())).collect();
 
     assert!(false_negatives.is_empty(), "Found {} false negatives which should be impossible", false_negatives.len());
 }

--- a/madara/crates/primitives/bloom_filter/src/tests/filter_tests.rs
+++ b/madara/crates/primitives/bloom_filter/src/tests/filter_tests.rs
@@ -31,7 +31,7 @@ fn test_false_positive_rate() {
 
     // Add elements
     for i in 0..NB_ELEM {
-        filter.add(&i);
+        filter.add(&i.to_be_bytes());
     }
 
     let read_only_filter = filter.finalize();
@@ -55,13 +55,13 @@ fn test_parallel() {
 
     // Test parallel insertion
     elements.par_iter().for_each(|item| {
-        filter.add(item);
+        filter.add(&item.to_be_bytes());
     });
 
     let ro_filter = filter.finalize();
 
     // Test parallel lookup for false negatives
-    let false_negatives: Vec<_> = elements.par_iter().filter(|&&item| !ro_filter.might_contain(&item)).collect();
+    let false_negatives: Vec<_> = elements.par_iter().filter(|&&item| !ro_filter.might_contain(&item.to_be_bytes())).collect();
 
     assert!(false_negatives.is_empty(), "Found {} false negatives which should be impossible", false_negatives.len());
 }
@@ -99,7 +99,7 @@ fn test_actual_false_positive_rate() {
     for _ in 0..NB_ELEM {
         let value: u64 = rng.gen();
         known_elements.insert(value);
-        filter.add(&value);
+        filter.add(&value.to_be_bytes());
     }
 
     let ro_filter = filter.finalize();
@@ -108,7 +108,7 @@ fn test_actual_false_positive_rate() {
     let mut false_positives = 0;
     for _ in 0..TEST_SAMPLES {
         let test_value: u64 = rng.gen();
-        if !known_elements.contains(&test_value) && ro_filter.might_contain(&test_value) {
+        if !known_elements.contains(&test_value) && ro_filter.might_contain(&test_value.to_be_bytes()) {
             false_positives += 1;
         }
     }
@@ -136,10 +136,9 @@ fn test_empty_filter() {
     let ro_filter = filter.finalize();
 
     // Test various types with empty filter
-    assert!(!ro_filter.might_contain(&42u64));
+    assert!(!ro_filter.might_contain(&42u64.to_be_bytes()));
     assert!(!ro_filter.might_contain(&"test"));
     assert!(!ro_filter.might_contain(&vec![1, 2, 3]));
-    assert!(!ro_filter.might_contain(&(21, "tuple")));
 }
 
 #[test]
@@ -147,17 +146,15 @@ fn test_different_types() {
     let filter = create_filter::<DefaultHasher>(10);
 
     // Test adding different types
-    filter.add(&42u64);
+    filter.add(&42u64.to_be_bytes());
     filter.add(&"string");
     filter.add(&vec![1, 2, 3]);
-    filter.add(&(21, "tuple"));
 
     let ro_filter = filter.finalize();
 
-    assert!(ro_filter.might_contain(&42u64));
+    assert!(ro_filter.might_contain(&42u64.to_be_bytes()));
     assert!(ro_filter.might_contain(&"string"));
     assert!(ro_filter.might_contain(&vec![1, 2, 3]));
-    assert!(ro_filter.might_contain(&(21, "tuple")));
 }
 
 #[test]

--- a/madara/crates/primitives/bloom_filter/src/tests/proptest.rs
+++ b/madara/crates/primitives/bloom_filter/src/tests/proptest.rs
@@ -13,13 +13,13 @@ proptest! {
         let input_set: HashSet<u64> = input_set.iter().cloned().collect();
 
         input_set.par_iter().for_each(|item| {
-            filter.add(item);
+            filter.add(&item.to_be_bytes());
         });
 
         let ro_filter = filter.finalize();
 
         let false_negatives: Vec<_> = input_set.par_iter()
-            .filter(|&&item| !ro_filter.might_contain(&item))
+            .filter(|&&item| !ro_filter.might_contain(&item.to_be_bytes()))
             .collect();
 
         prop_assert!(false_negatives.is_empty(), "Found {} false negatives!", false_negatives.len());

--- a/madara/crates/primitives/bloom_filter/src/tests/utils.rs
+++ b/madara/crates/primitives/bloom_filter/src/tests/utils.rs
@@ -1,6 +1,6 @@
 use std::hash::Hasher;
 
-use crate::{filter::DeterministicBuildHasher, AtomicBitStore, BloomFilter};
+use crate::{AtomicBitStore, BloomFilter};
 
 // Constants for Bloom filter configuration
 // Number of hash functions used in the Bloom filter.
@@ -14,7 +14,7 @@ const BITS_PER_ELEMENT: f64 = 9.6;
 pub const FALSE_POSITIF_RATE: f64 = 0.01;
 
 /// Helper function to create a Bloom filter with the given number of elements
-pub fn create_filter<H: Hasher + DeterministicBuildHasher>(nb_elem: u64) -> BloomFilter<H, AtomicBitStore> {
+pub fn create_filter<H: Hasher + Default>(nb_elem: u64) -> BloomFilter<H, AtomicBitStore> {
     let size = (nb_elem as f64 * BITS_PER_ELEMENT).ceil() as u64;
     BloomFilter::new(size, HASH_COUNT)
 }

--- a/madara/crates/primitives/bloom_filter/src/tests/utils.rs
+++ b/madara/crates/primitives/bloom_filter/src/tests/utils.rs
@@ -1,6 +1,6 @@
 use std::hash::Hasher;
 
-use crate::{AtomicBitStore, BloomFilter};
+use crate::{filter::DeterministicBuildHasher, AtomicBitStore, BloomFilter};
 
 // Constants for Bloom filter configuration
 // Number of hash functions used in the Bloom filter.
@@ -14,7 +14,7 @@ const BITS_PER_ELEMENT: f64 = 9.6;
 pub const FALSE_POSITIF_RATE: f64 = 0.01;
 
 /// Helper function to create a Bloom filter with the given number of elements
-pub fn create_filter<H: Hasher + Default>(nb_elem: u64) -> BloomFilter<H, AtomicBitStore> {
+pub fn create_filter<H: Hasher + DeterministicBuildHasher>(nb_elem: u64) -> BloomFilter<H, AtomicBitStore> {
     let size = (nb_elem as f64 * BITS_PER_ELEMENT).ceil() as u64;
     BloomFilter::new(size, HASH_COUNT)
 }

--- a/madara/crates/proc-macros/src/lib.rs
+++ b/madara/crates/proc-macros/src/lib.rs
@@ -38,8 +38,8 @@
 //! **Arguments:**
 //! - `name`: rpc method name, must not be a duplicate in the current namespace.
 //! - `and_versions`: implementations of this method will also work for the
-//!     supplied versions. Note that these versions must not already contain
-//!     a method with the same name.
+//!   supplied versions. Note that these versions must not already contain
+//!   a method with the same name.
 //!
 //! # Example:
 //!

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -45,7 +45,7 @@ where
         write!(writer, "{}{:<5}{} ", level_color, *meta.level(), reset)?;
 
         if let (Some(file), Some(line)) = (meta.file(), meta.line()) {
-            let file_name = file.split('/').last().unwrap_or(file);
+            let file_name = file.split('/').next_back().unwrap_or(file);
             let module_path = meta.module_path().unwrap_or("");
             let last_module = module_path.split("::").last().unwrap_or(module_path);
 


### PR DESCRIPTION
This PR introduces a deterministic hashing abstraction to ensure reproducible and stable hash values across Bloom filter instances.

## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

Bloom filters are persisted in the database. Therefore, the hashing logic must be deterministic across executions and environments to maintain filter integrity. Without this, deserialization or lookups on previously stored filters may behave incorrectly due to mismatched hash calculations.

- added `DeterministicBuildHashe`r trait for constructing reproducible hashers
- provided implementations for `AHasher` (with fixed seeds) and `DefaultHasher`
- fix linter warnings


## Does this introduce a breaking change?

yes, DB written with non-deterministic hashers prior to this change may no longer be valid or function as expected

## Other information

