### PR TITLE
fix: task test orch was missing orchestrator crate

### DIFF
--- a/.github/workflows/task-test-orchestrator.yml
+++ b/.github/workflows/task-test-orchestrator.yml
@@ -111,7 +111,7 @@ jobs:
             --lcov \
             --output-path lcov.info \
             --test-threads=1 \
-            --package "orchestrator-*" \
+            --package "orchestrator*" \
             --no-fail-fast
 
       - name: Upload coverage to Coveralls


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix


## What is the current behavior?

while running the orchestrator test in the CI, because we are doing `orchestrator-*` it misses the `orchestrator` crate

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

changed the package from `orchestrator-*` to `orchestrator*` and it would pickup every test now


## Does this introduce a breaking change?
No
<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
