### PR TITLE
update: new RPC endpoint for block status

### DIFF
--- a/orchestrator/src/cli/queue/aws_sqs.rs
+++ b/orchestrator/src/cli/queue/aws_sqs.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 /// Parameters used to config AWS SQS.
 #[derive(Debug, Clone, Args)]
-#[group(requires_all = ["queue_base_url"])]
+#[group(requires_all = ["queue_identifier"])]
 pub struct AWSSQSCliArgs {
     /// Use the AWS sqs client
     #[arg(long)]

--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -79,4 +79,6 @@ pub trait DatabaseClient: Send + Sync {
     async fn update_batch(&self, batch: &Batch, update: BatchUpdates) -> Result<Batch, DatabaseError>;
     /// create_batch - Create a new batch
     async fn create_batch(&self, batch: Batch) -> Result<Batch, DatabaseError>;
+    /// get_jobs_by_block_number - Get all jobs for a specific block number
+    async fn get_jobs_by_block_number(&self, block_number: u64) -> Result<Vec<JobItem>, DatabaseError>;
 }

--- a/orchestrator/src/core/client/queue/sqs.rs
+++ b/orchestrator/src/core/client/queue/sqs.rs
@@ -195,7 +195,9 @@ impl QueueClient for SQS {
     /// The consumer is used to receive messages from the queue.
     async fn get_consumer(&self, queue: QueueType) -> Result<SqsConsumer, QueueError> {
         let queue_name = self.get_queue_name(&queue)?;
+        tracing::info!("Getting queue url for queue name {}", queue_name);
         let queue_url = self.inner.get_queue_url_from_client(queue_name.as_str()).await?;
+        tracing::info!("Found queue url {}", queue_url);
         let consumer =
             SqsBackend::builder(SqsConfig { queue_dsn: queue_url, override_endpoint: true }).build_consumer().await?;
         Ok(consumer)

--- a/orchestrator/src/tests/server/job_routes.rs
+++ b/orchestrator/src/tests/server/job_routes.rs
@@ -225,7 +225,7 @@ async fn test_get_job_status_by_block_number_found(#[future] setup_trigger: (Soc
         panic!("Unexpected job type");
     }
     let mut state_transition_job_updated = state_transition_job.clone();
-    state_transition_job_updated.metadata.specific = state_transition_job_specific_metadata.into();
+    state_transition_job_updated.metadata.specific = state_transition_job_specific_metadata;
 
     config.database().create_job(snos_job.clone()).await.unwrap();
     config.database().create_job(proving_job.clone()).await.unwrap();

--- a/orchestrator/src/tests/server/job_routes.rs
+++ b/orchestrator/src/tests/server/job_routes.rs
@@ -14,6 +14,7 @@ use crate::core::config::Config;
 use crate::server::types::ApiResponse;
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::build_job_item;
+use crate::types::jobs::metadata::JobSpecificMetadata;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::types::queue::QueueNameForJobType;
 use crate::worker::event_handler::factory::mock_factory::get_job_handler_context;
@@ -203,4 +204,94 @@ async fn test_trigger_retry_job_not_allowed(
     // Verify no message was added to the queue
     let queue_result = config.queue().consume_message_from_queue(job_type.process_queue_name()).await;
     assert!(queue_result.is_err(), "Queue should be empty - no message should be added for non-Failed jobs");
+}
+
+#[tokio::test]
+#[rstest]
+async fn test_get_job_status_by_block_number_found(#[future] setup_trigger: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_trigger.await;
+    let block_number = 123;
+
+    // Create some jobs for the block
+    let snos_job = build_job_item(JobType::SnosRun, JobStatus::Completed, block_number);
+    let proving_job = build_job_item(JobType::ProofCreation, JobStatus::PendingVerification, block_number);
+    let data_submission_job = build_job_item(JobType::DataSubmission, JobStatus::Created, block_number);
+    let state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 0); // internal_id is not block_number for ST
+    let mut state_transition_job_specific_metadata = state_transition_job.metadata.specific.clone();
+
+    if let JobSpecificMetadata::StateUpdate(ref mut x) = state_transition_job_specific_metadata {
+        x.blocks_to_settle = vec![block_number, block_number + 1];
+    } else {
+        panic!("Unexpected job type");
+    }
+    let mut state_transition_job_updated = state_transition_job.clone();
+    state_transition_job_updated.metadata.specific = state_transition_job_specific_metadata.into();
+
+    config.database().create_job(snos_job.clone()).await.unwrap();
+    config.database().create_job(proving_job.clone()).await.unwrap();
+    config.database().create_job(data_submission_job.clone()).await.unwrap();
+    config.database().create_job(state_transition_job_updated.clone()).await.unwrap();
+
+    // Create a job for a different block to ensure it's not returned
+    let other_block_job = build_job_item(JobType::SnosRun, JobStatus::Completed, block_number + 10);
+    config.database().create_job(other_block_job).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/jobs/block/{}/status", addr, block_number))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<crate::server::types::BlockJobStatusResponse> =
+        serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(response_body.success);
+    assert_eq!(response_body.message, Some(format!("Successfully fetched job statuses for block {}", block_number)));
+    let jobs_response = response_body.data.unwrap().jobs;
+    assert_eq!(jobs_response.len(), 4);
+
+    // Check that the correct jobs are returned
+    assert!(jobs_response.iter().any(|j| j.id == snos_job.id && j.status == JobStatus::Completed));
+    assert!(jobs_response.iter().any(|j| j.id == proving_job.id && j.status == JobStatus::PendingVerification));
+    assert!(jobs_response.iter().any(|j| j.id == data_submission_job.id && j.status == JobStatus::Created));
+    assert!(jobs_response.iter().any(|j| j.id == state_transition_job_updated.id && j.status == JobStatus::Completed));
+}
+
+#[tokio::test]
+#[rstest]
+async fn test_get_job_status_by_block_number_not_found(#[future] setup_trigger: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_trigger.await;
+    let block_number = 404;
+
+    // Create a job for a different block to ensure db is not empty
+    let other_block_job = build_job_item(JobType::SnosRun, JobStatus::Completed, block_number + 10);
+    config.database().create_job(other_block_job).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/jobs/block/{}/status", addr, block_number))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200); // Endpoint itself is found, just no data for this block
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<crate::server::types::BlockJobStatusResponse> =
+        serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(response_body.success);
+    assert_eq!(response_body.message, Some(format!("Successfully fetched job statuses for block {}", block_number)));
+    let jobs_response = response_body.data.unwrap().jobs;
+    assert_eq!(jobs_response.len(), 0);
 }


### PR DESCRIPTION
This commit introduces a new GET endpoint `/jobs/block/{block_number}/status` to the orchestrator.

This endpoint retrieves and returns the status of all relevant jobs (SnosRun, Proving, DataSubmission, StateTransition, and ProofRegistration conditionally for L3) associated with the specified block number.

The implementation includes:
- A new MongoDB query function `get_jobs_by_block_number` to fetch jobs based on `metadata.specific.block_number` or, for StateTransition jobs, by checking if the block number is in `metadata.specific.blocks_to_settle`.
- New response types `JobStatusResponseItem` and `BlockJobStatusResponse`.
- Updates to `ApiResponse` and `JobRouteResult` to support generic data payloads.
- Integration tests to verify the endpoint's functionality, including scenarios for found jobs, no jobs found, and correct handling of ProofRegistration jobs based on L2/L3 layer configuration.

## Examples : 

``` 
curl http://localhost:3000/jobs/block/32/status
{"success":true,"data":{"jobs":[]},"message":"Successfully fetched job statuses for block 32"}
```
```
curl http://localhost:3000/jobs/block/0/status
{"success":true,"data":{
"jobs":[
{"job_type":"SnosRun","id":"268f1da6-bcc9-4e96-9e31-c98967a2f7fb","status":"Completed"},
{"job_type":"ProofCreation","id":"2821e914-0cd6-41ef-917b-9f5d0b85c200","status":"Completed"},
{"job_type":"DataSubmission","id":"fbcbc239-59e4-4dc4-ada7-e2d794bfe428","status":"Completed"},
{"job_type":"StateTransition","id":"fb2ace1d-5744-485f-9ddb-8d4062c932ea","status":"Completed"}]}
,"message":"Successfully fetched job statuses for block 0"}
```

```
curl http://localhost:3000/jobs/block/-32/status
Invalid URL: Cannot parse `"-32"` to a `u64`dexterhv@deven:~$ 
```

```
curl http://localhost:3000/jobs/block/asf/status
Invalid URL: Cannot parse `"asf"` to a `u64`
```

```
curl http://localhost:3000/jobs/block/28/status
{"success":true,"data":{"jobs":[
{"job_type":"SnosRun","id":"3f58a7d5-43af-4493-a5f7-558128007cc9","status":"Completed"},
{"job_type":"ProofCreation","id":"571f2a09-260d-4035-88c4be1012ee22a8","status":"LockedForProcessing"}]
},"message":"Successfully fetched job statuses for block 28"}
```
