### PR TITLE
E2E : 2 : Init + Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,6 +4708,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "e2e"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dotenvy",
+ "env_logger",
+ "httpmock",
+ "log",
+ "reqwest 0.12.8",
+ "rstest 0.18.2",
+ "serde",
+ "serde_json",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "testcontainers",
+ "thiserror 2.0.3",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "uuid 1.12.0",
+]
+
+[[package]]
 name = "e2e-tests"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   # "madara",
   "orchestrator",
+  "e2e",
   "e2e-tests",
   "bootstrapper",
   "build-artifacts",

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,2 @@
+data/
+/data.zip

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "e2e"
+version = "0.1.0"
+edition = "2021"
+authors = ["Heemank Verma <heemankv@gmail.com>"]
+
+[lib]
+name = "e2e"
+path = "src/mod.rs"
+
+[dependencies]
+
+async-trait = { workspace = true }
+
+dotenvy = { workspace = true }
+env_logger = { workspace = true }
+httpmock = { version = "0.8.0-alpha.1", features = ["proxy", "remote"] }
+log = { workspace = true }
+thiserror = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+rstest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+testcontainers = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }

--- a/e2e/src/mod.rs
+++ b/e2e/src/mod.rs
@@ -1,0 +1,2 @@
+// We import all the things here!
+pub mod services;

--- a/e2e/src/services/helpers.rs
+++ b/e2e/src/services/helpers.rs
@@ -1,0 +1,70 @@
+use url::Url;
+use serde_json::json;
+use async_trait::async_trait;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NodeRpcError{
+    #[error("Invalid response")]
+    InvalidResponse,
+}
+
+#[async_trait]
+pub trait NodeRpcMethods: Send + Sync {
+    fn get_endpoint(&self) -> Url;
+
+    /// Fetches the latest block number from the Starknet RPC endpoint.
+    ///
+    /// Returns:
+    /// - `Ok(-1)` when no blocks have been mined yet (RPC returns "Block not found" error with code 24)
+    /// - `Ok(block_number)` when blocks exist
+    /// - `Err(NodeRpcError::InvalidResponse)` for other RPC errors or parsing failures
+    ///
+    /// Note: The -1 return value indicates that the blockchain is in an initial state
+    /// with no blocks mined, which is common when first starting a node or testnet.
+    async fn get_latest_block_number(&self) -> Result<i64, NodeRpcError> {
+        let url = self.get_endpoint();
+        let client = reqwest::Client::new();
+        let response = client.post(url)
+            .header("accept", "application/json")
+            .header("content-type", "application/json")
+            .json(&json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "method": "starknet_blockNumber",
+                "params": []
+            }))
+            .send()
+            .await
+            .map_err(|_| NodeRpcError::InvalidResponse)?;
+
+        let json = response.json::<serde_json::Value>().await
+            .map_err(|_| NodeRpcError::InvalidResponse)?;
+
+        // Check if there's an error in the JSON-RPC response
+        if let Some(error) = json.get("error") {
+            // Check for specific "Block not found" error (code 24)
+            if let (Some(code), Some(message)) = (error.get("code"), error.get("message")) {
+                if code.as_u64() == Some(24) &&
+                   message.as_str().map(|s| s.contains("Block not found")).unwrap_or(false) {
+                    println!("No blocks mined yet, returning -1");
+                    return Ok(-1);
+                }
+            }
+
+            println!("RPC Error: {:?}", error);
+            return Err(NodeRpcError::InvalidResponse);
+        }
+
+        // Extract block number directly from result (it's just an integer now)
+        let block_number = json.get("result")
+            .and_then(|v| v.as_u64())
+            .ok_or(NodeRpcError::InvalidResponse)?;
+
+        let block_num_i64 = block_number as i64;
+
+        println!("Madara Block Number: {}", block_num_i64);
+
+        Ok(block_num_i64)
+    }
+
+}

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -1,0 +1,2 @@
+pub mod server;
+pub mod helpers;

--- a/e2e/src/services/server.rs
+++ b/e2e/src/services/server.rs
@@ -1,0 +1,267 @@
+use std::process::{ ExitStatus, Stdio};
+use std::time::Duration;
+use tokio::net::TcpStream;
+use url::Url;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Command, Child};
+use tokio::task;
+
+pub const DEFAULT_SERVICE_HOST: &str = "127.0.0.1";
+
+// Custom error type
+#[derive(Debug, thiserror::Error)]
+pub enum ServerError {
+    #[error("Failed to start process: {0}")]
+    StartupFailed(std::io::Error),
+    #[error("Process exited early with status: {0}")]
+    ProcessExited(ExitStatus),
+    #[error("Connection timeout after {0} attempts")]
+    ConnectionTimeout(usize),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Process not running")]
+    ProcessNotRunning,
+    #[error("Endpoint not available")]
+    EndpointNotAvailable,
+}
+
+
+// Generic server configuration
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub rpc_port: Option<u16>,
+    pub connection_attempts: usize,
+    pub connection_delay_ms: u64,
+    pub service_name: String,
+    pub enable_stdout: bool,
+    pub enable_stderr: bool,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            service_name: String::from(""),
+            rpc_port: None,
+            connection_attempts: 30,
+            connection_delay_ms: 1000,
+            enable_stdout: true,
+            enable_stderr: true
+        }
+    }
+}
+
+// Generic server struct that can be used by any service
+pub struct Server {
+    config: ServerConfig,
+    process: Child,
+    stdout_task: Option<task::JoinHandle<()>>,
+    stderr_task: Option<task::JoinHandle<()>>,
+}
+
+impl Server {
+    /// Start a process with the given command and wait for it to be ready
+    pub async fn start_process(mut command: Command, config: ServerConfig) -> Result<Self, ServerError> {
+
+        println!("🔔 Starting {} service", config.service_name);
+
+        if config.enable_stderr {
+            command.stderr(Stdio::piped());
+        } else {
+            // Suppress stderr if disabled
+            command.stderr(Stdio::null());
+        }
+
+        if config.enable_stdout {
+            command.stdout(Stdio::piped());
+        } else {
+            // Suppress stdout if disabled
+            command.stdout(Stdio::null());
+        }
+
+        // Start the process
+        let mut process = command.spawn().map_err(ServerError::StartupFailed)?;
+
+        let mut stdout_task = None;
+        let mut stderr_task = None;
+
+        // Extract stdout and stderr for log monitoring
+        if config.enable_stdout {
+            command.stdout(Stdio::piped());
+
+            let stdout = process.stdout.take().ok_or(ServerError::StartupFailed(
+                std::io::Error::new(std::io::ErrorKind::Other, "Failed to capture stdout")
+            ))?;
+
+            let service_name = config.service_name.clone();
+            let stdout_task_inner = task::spawn(async move {
+                // Keeping a large buffer capacity for stdout, to not have buffer overflow
+                let reader = BufReader::with_capacity(65536, stdout);
+                let mut lines = reader.lines();
+
+                while let Ok(Some(line)) = lines.next_line().await {
+                    println!("[STDOUT] [{}] {}", service_name, line);
+
+                    // Flush immediately to prevent backing up
+                    use std::io::Write;
+                    let _ = std::io::stdout().flush();
+                }
+            });
+            stdout_task = Some(stdout_task_inner);
+        }
+
+        if config.enable_stderr {
+            command.stderr(Stdio::piped());
+
+            let stderr = process.stderr.take().ok_or(ServerError::StartupFailed(
+                std::io::Error::new(std::io::ErrorKind::Other, "Failed to capture stderr")
+            ))?;
+
+            let service_name = config.service_name.clone();
+            let stderr_task_inner = task::spawn(async move {
+                let reader = BufReader::new(stderr);
+                let mut lines = reader.lines();
+
+                while let Ok(Some(line)) = lines.next_line().await {
+                    println!("[STDERR] [{}] {}", service_name, line);
+                    // No need for flush, since we stop the service on errors
+                }
+            });
+
+            stderr_task = Some(stderr_task_inner)
+        }
+
+        let service_name = config.service_name.clone();
+        let has_rpc_endpoint = config.rpc_port.is_some();
+
+        let mut server = Self {
+            process,
+            config,
+            stdout_task,
+            stderr_task,
+        };
+
+
+        // We wait & validate only if the service has an API endpoint
+        // e.g : Skips for Bootstrapper and Orchestrator setup
+        if has_rpc_endpoint {
+            println!("🔔 Waiting for {} server to be ready", service_name);
+            server.wait_till_started().await?;
+        }
+
+
+        println!("😁 {} Server is ready", service_name);
+
+        Ok(server)
+    }
+
+    /// Get the endpoint URL
+    pub fn endpoint(&self) -> Option<Url> {
+        if let Some(rpc_port) = &self.config.rpc_port {
+            Url::parse(&format!("http://{}:{}", DEFAULT_SERVICE_HOST, rpc_port)).ok()
+        } else {
+            None
+        }
+    }
+
+    /// Get the process ID if the process is still running
+    pub fn pid(&self) -> Option<u32> {
+        self.process.id()
+    }
+
+    /// Check if the process has exited
+    pub fn has_exited(&mut self) -> Option<ExitStatus> {
+        match self.process.try_wait() {
+            Ok(status) => status,
+            Err(_) => None,
+        }
+
+    }
+
+    /// Check if the process is still running
+    pub fn is_running(&mut self) -> bool {
+       self.has_exited().is_none()
+    }
+
+    /// Get a free port
+    fn get_free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .and_then(|listener| listener.local_addr())
+            .map(|addr| addr.port())
+            .unwrap_or(8080) // Fallback port
+    }
+
+    /// Wait until the server is ready to accept connections
+    async fn wait_till_started(&mut self) -> Result<(), ServerError> {
+        let mut attempts = self.config.connection_attempts;
+        let addr = self.endpoint();
+
+        if let Some(addr) = addr {
+
+            // Extract just the socket address from the URL
+            let socket_addr = if let Some(host) = addr.host_str() {
+                let port = addr.port().unwrap_or(80); // Default to 80 if no port
+                format!("{}:{}", host, port)
+            } else {
+                return Err(ServerError::EndpointNotAvailable);
+            };
+
+            loop {
+                match TcpStream::connect(&socket_addr).await {
+                    Ok(_) => return Ok(()),
+                    Err(e) => {
+                        // Check if process has exited
+                        if let Some(status) = self.has_exited() {
+                            return Err(ServerError::ProcessExited(status));
+                        }
+
+                        if attempts == 0 {
+                            return Err(ServerError::ConnectionTimeout(self.config.connection_attempts));
+                        }
+                    }
+                }
+
+                attempts -= 1;
+                tokio::time::sleep(Duration::from_millis(self.config.connection_delay_ms)).await;
+            }
+        }
+        else {
+            Err(ServerError::EndpointNotAvailable)
+        }
+    }
+    /// Stop the server gracefully
+    pub fn stop(&mut self) -> Result<(), ServerError> {
+        if self.config.rpc_port.is_some() {
+            return Ok(());
+        }
+        if self.has_exited().is_some() {
+            return Ok(());
+        }
+
+        // Try to terminate gracefully first
+        let pid = self.process.id();
+        let kill_result = Command::new("kill").args(["-s", "TERM", &pid.unwrap().to_string()]).spawn();
+
+        match kill_result {
+            Ok(mut kill_process) => {
+                let _ = kill_process.wait();
+            }
+            Err(_) => {
+                // If kill command fails, try to kill the process directly
+                let _ = self.process.kill();
+            }
+        }
+
+        // Wait for the process to actually exit
+        let _ = self.process.wait();
+
+        Ok(())
+    }
+
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}


### PR DESCRIPTION
## Pull Request type

- Feature
- Testing

## What is the current behavior?

Resolves: #NA

## What is the new behavior?

- Created a new `e2e` crate for end-to-end testing infrastructure
- Implemented a generic `Server` struct to manage test service processes
- Added RPC helper methods for interacting with Starknet nodes
- Set up error handling and logging for test services

## Does this introduce a breaking change?

No

## Other information

This PR adds a new e2e testing library that can be used across the project. It includes:

- Process management for starting/stopping test services
- TCP connection validation to ensure services are ready
- Stdout/stderr capture with proper logging
- Starknet RPC methods for block queries
- Proper error handling with custom error types