### PR TITLE
E2E : 4 : Bootstrapper Service

### DIFF
--- a/e2e/src/services/bootstrapper/config.rs
+++ b/e2e/src/services/bootstrapper/config.rs
@@ -1,0 +1,195 @@
+use crate::servers::server::ServerError;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub const DEFAULT_BOOTSTRAPPER_BINARY: &str = "../target/release/bootstrapper";
+pub const DEFAULT_BOOTSTRAPPER_CONFIG: &str = "../bootstrapper/src/configs/devnet.json";
+pub const BOOTSTRAPPER_DEFAULT_ADDRESS_PATH: &str = "addresses.json";
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BootstrapperMode {
+    SetupL1,
+    SetupL2,
+}
+
+impl std::fmt::Display for BootstrapperMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BootstrapperMode::SetupL1 => write!(f, "setup-l1"),
+            BootstrapperMode::SetupL2 => write!(f, "setup-l2"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapperError {
+    #[error("Bootstrapper binary not found: {0}")]
+    BinaryNotFound(String),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+    #[error("Missing required configuration: {0}")]
+    MissingConfig(String),
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+    #[error("Bootstrapper execution failed: {0}")]
+    ExecutionFailed(String),
+    #[error("Setup failed with exit code: {0}")]
+    SetupFailed(i32),
+    #[error("File system error: {0}")]
+    FileSystem(#[from] std::io::Error),
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct BootstrapperConfig {
+    mode: BootstrapperMode,
+    timeout: Duration,
+    config_path: Option<PathBuf>,
+    binary_path: PathBuf,
+    environment_vars: HashMap<String, String>,
+    additional_args: Vec<String>,
+}
+
+impl Default for BootstrapperConfig {
+    fn default() -> Self {
+        Self {
+            mode: BootstrapperMode::SetupL1,
+            timeout: Duration::from_secs(6000),
+            config_path: Some(PathBuf::from(DEFAULT_BOOTSTRAPPER_CONFIG)),
+            binary_path: PathBuf::from(DEFAULT_BOOTSTRAPPER_BINARY),
+            environment_vars: HashMap::new(),
+            additional_args: Vec::new(),
+        }
+    }
+}
+
+impl BootstrapperConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for BootstrapperConfig
+    pub fn builder() -> BootstrapperConfigBuilder {
+        BootstrapperConfigBuilder::new()
+    }
+
+    /// Get the bootstrapper mode
+    pub fn mode(&self) -> &BootstrapperMode {
+        &self.mode
+    }
+
+    /// Get the timeout duration
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Get the configuration file path
+    pub fn config_path(&self) -> Option<&PathBuf> {
+        self.config_path.as_ref()
+    }
+
+    /// Get the binary path
+    pub fn binary_path(&self) -> &PathBuf {
+        &self.binary_path
+    }
+
+    /// Get the environment variables
+    pub fn environment_vars(&self) -> &HashMap<String, String> {
+        &self.environment_vars
+    }
+
+    /// Get the additional arguments
+    pub fn additional_args(&self) -> &[String] {
+        &self.additional_args
+    }
+
+    /// Convert the configuration to a tokio command
+    pub fn to_command(&self) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new(&self.binary_path);
+
+        // Core arguments
+        cmd.arg("--mode").arg(self.mode.to_string());
+
+        if let Some(config_path) = &self.config_path {
+            cmd.arg("--config").arg(config_path);
+        }
+
+        // Additional arguments
+        for arg in &self.additional_args {
+            cmd.arg(arg);
+        }
+
+        // Environment variables
+        for (key, value) in &self.environment_vars {
+            cmd.env(key, value);
+        }
+
+        cmd
+    }
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct BootstrapperConfigBuilder {
+    config: BootstrapperConfig,
+}
+
+impl BootstrapperConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: BootstrapperConfig::default(),
+        }
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> BootstrapperConfig {
+        self.config
+    }
+
+    /// Set the bootstrapper mode
+    pub fn mode(mut self, mode: BootstrapperMode) -> Self {
+        self.config.mode = mode;
+        self
+    }
+
+    /// Set the configuration file path
+    pub fn config_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.config.config_path = Some(path.into());
+        self
+    }
+
+    /// Set the binary path
+    pub fn binary_path<P: Into<PathBuf>>(mut self, path: Option<P>) -> Self {
+        if let Some(p) = path {
+            self.config.binary_path = p.into();
+        }
+        self
+    }
+
+    /// Add an environment variable
+    pub fn env_var(mut self, key: &str, value: &str) -> Self {
+        self.config.environment_vars.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Add an additional argument
+    pub fn arg(mut self, arg: &str) -> Self {
+        self.config.additional_args.push(arg.to_string());
+        self
+    }
+
+    /// Set the timeout duration
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.config.timeout = timeout;
+        self
+    }
+}
+
+impl Default for BootstrapperConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/bootstrapper/config.rs
+++ b/e2e/src/services/bootstrapper/config.rs
@@ -1,4 +1,4 @@
-use crate::servers::server::ServerError;
+use crate::services::server::ServerError;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -1,0 +1,119 @@
+// =============================================================================
+// BOOTSTRAPPER SERVICE - Setup utility for L1/L2 initialization
+// =============================================================================
+
+pub mod config;
+// Re-export common utilities
+pub use config::*;
+
+use crate::servers::server::{Server, ServerConfig};
+use std::process::ExitStatus;
+
+pub struct BootstrapperService {
+    server: Server,
+    config: BootstrapperConfig,
+}
+
+impl BootstrapperService {
+    /// Run the bootstrapper and wait for completion (convenience method)
+    pub async fn run(config: BootstrapperConfig) -> Result<ExitStatus, BootstrapperError> {
+        let mut service = Self::start(config).await?;
+        service.wait_for_completion().await
+    }
+
+    /// Start a new bootstrapper service with the given configuration
+    pub async fn start(config: BootstrapperConfig) -> Result<Self, BootstrapperError> {
+        // Build the bootstrapper command
+        let command = config.to_command();
+
+        // Create server config - bootstrapper doesn't need network port,
+        // but we'll use a dummy port for the generic server interface
+        let server_config = ServerConfig {
+            connection_attempts: 1, // No connection check needed
+            connection_delay_ms: 100,
+            service_name: format!("Bootstrapper-{}", config.mode().to_string()),
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(BootstrapperError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+
+    /// Wait for the bootstrapper to complete execution
+    pub async fn wait_for_completion(&mut self) -> Result<ExitStatus, BootstrapperError> {
+        println!("🚀 Running bootstrapper in {} mode...", self.config.mode());
+
+        // Use timeout to prevent hanging
+        let result = tokio::time::timeout(self.config.timeout(), async {
+            // Keep checking if the process has exited
+            loop {
+                if let Some(exit_status) = self.server.has_exited() {
+                    return Ok::<ExitStatus, BootstrapperError>(exit_status);
+                }
+
+                // Small delay to avoid busy waiting
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match result {
+            Ok(Ok(exit_status)) => {
+                if exit_status.success() {
+                    println!("✅ Bootstrapper {} completed successfully with {}", self.config.mode(), exit_status);
+                    Ok(exit_status)
+                } else {
+                    let exit_code = exit_status.code().unwrap_or(-1);
+                    Err(BootstrapperError::SetupFailed(exit_code))
+                }
+            }
+            Ok(Err(e)) => Err(BootstrapperError::ExecutionFailed(e.to_string())),
+            Err(_) => Err(BootstrapperError::ExecutionFailed(format!(
+                "Bootstrapper timed out after {:?}",
+                self.config.timeout()
+            ))),
+        }
+    }
+
+    /// Get access to the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the mode that was executed
+    pub fn mode(&self) -> &BootstrapperMode {
+        self.config.mode()
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &BootstrapperConfig {
+        &self.config
+    }
+
+    /// Get dependencies
+    pub fn dependencies(&self) -> Option<Vec<String>> {
+        Some(if *self.config().mode() == BootstrapperMode::SetupL1 {
+            vec!["anvil".to_string()]
+        } else {
+            vec!["anvil".to_string(), "madara".to_string(), "bootstrapper_l1".to_string()]
+        })
+    }
+
+    /// Check if bootstrapper binary exists (static method for convenience)
+    pub fn check_binary() -> Result<(), BootstrapperError> {
+        let binary_path = std::path::PathBuf::from(DEFAULT_BOOTSTRAPPER_BINARY);
+        if binary_path.exists() {
+            Ok(())
+        } else {
+            Err(BootstrapperError::BinaryNotFound(format!(
+                "Default binary not found: {}",
+                binary_path.display()
+            )))
+        }
+    }
+}

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -6,7 +6,7 @@ pub mod config;
 // Re-export common utilities
 pub use config::*;
 
-use crate::servers::server::{Server, ServerConfig};
+use crate::services::server::{Server, ServerConfig};
 use std::process::ExitStatus;
 
 pub struct BootstrapperService {

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod server;
 pub mod helpers;
 pub mod anvil;
+pub mod bootstrapper;


### PR DESCRIPTION
# Add Bootstrapper Service for E2E Testing

## Pull Request type

- Feature

## What is the current behavior?

The e2e testing framework lacks a dedicated service for bootstrapping L1 and L2 environments.

## What is the new behavior?

- Adds a new `BootstrapperService` for initializing L1 and L2 environments in e2e tests
- Implements a flexible configuration system with builder pattern for bootstrapper settings
- Provides two operation modes: `SetupL1` and `SetupL2`
- Includes timeout handling, dependency tracking, and proper error management
- Allows customization of binary paths, config files, environment variables, and command arguments

## Does this introduce a breaking change?

No

## Other information

The bootstrapper service integrates with the existing server framework and provides a clean API for test code to initialize environments with proper dependency tracking.