### PR TITLE
E2E : 5 : Adding: Localstack + Mongodb + Docker Service

### DIFF
--- a/e2e/src/services/docker.rs
+++ b/e2e/src/services/docker.rs
@@ -1,0 +1,67 @@
+// =============================================================================
+// DOCKER SERVER HELPER - For Docker-based services
+// =============================================================================
+
+use crate::services::server::ServerError;
+use std::process::Command;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DockerError {
+    #[error("Docker is not running or not installed")]
+    NotRunning,
+    #[error("Container already exists: {0}")]
+    ContainerAlreadyExists(String),
+    #[error("Failed to check container status: {0}")]
+    ContainerStatusFailed(std::io::Error),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+}
+
+pub struct DockerServer;
+
+impl DockerServer {
+    /// Check if Docker is running
+    pub fn is_docker_running() -> bool {
+        let result = Command::new("docker").arg("info").output();
+
+        match result {
+            Ok(output) => output.status.success(),
+            Err(_) => false,
+        }
+    }
+
+    /// Check if a container with the given name is already running
+    pub fn is_container_running(container_name: &str) -> Result<bool, DockerError> {
+        let output = Command::new("docker")
+            .args(["ps", "-q", "-f", &format!("name={}", container_name)])
+            .output()
+            .map_err(DockerError::ContainerStatusFailed)?;
+
+        Ok(!output.stdout.is_empty())
+    }
+
+    /// Check if a container with the given name exists (running or stopped)
+    pub fn does_container_exist(container_name: &str) -> Result<bool, DockerError> {
+        let output = Command::new("docker")
+            .args(["ps", "-a", "-q", "-f", &format!("name={}", container_name)])
+            .output()
+            .map_err(DockerError::ContainerStatusFailed)?;
+
+        Ok(!output.stdout.is_empty())
+    }
+
+    /// Remove a container (force remove if running)
+    pub fn remove_container(container_name: &str) -> Result<(), DockerError> {
+        let _output = Command::new("docker")
+            .args(["rm", "-f", container_name])
+            .output()
+            .map_err(DockerError::ContainerStatusFailed)?;
+
+        Ok(())
+    }
+
+    /// Check if a port is in use
+    pub fn is_port_in_use(port: u16) -> bool {
+        std::net::TcpListener::bind(format!("127.0.0.1:{}", port)).is_err()
+    }
+}

--- a/e2e/src/services/localstack/mod.rs
+++ b/e2e/src/services/localstack/mod.rs
@@ -1,0 +1,111 @@
+// =============================================================================
+// LOCALSTACK SERVICE - Using Docker and generic Server
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::server::{Server, ServerConfig};
+use crate::services::docker::{DockerError, DockerServer};
+use url::Url;
+
+pub struct LocalstackService {
+    server: Server,
+    config: LocalstackConfig,
+}
+
+impl LocalstackService {
+    /// Start a new Localstack service
+    /// Will panic if Localstack is already running as per your requirement
+    pub async fn start(config: LocalstackConfig) -> Result<Self, LocalstackError> {
+        // Validate Docker is running
+        if !DockerServer::is_docker_running() {
+            return Err(LocalstackError::Docker(DockerError::NotRunning));
+        }
+
+        // Check if container is already running - PANIC as requested
+        if DockerServer::is_container_running(config.container_name())? {
+            panic!(
+                "Localstack container '{}' is already running on port {}. Please stop it first.",
+                config.container_name(),
+                config.port()
+            );
+        }
+
+        // Check if port is in use
+        if DockerServer::is_port_in_use(config.port()) {
+            return Err(LocalstackError::PortInUse(config.port()));
+        }
+
+        // Clean up any existing stopped container with the same name
+        if DockerServer::does_container_exist(config.container_name())? {
+            DockerServer::remove_container(config.container_name())?;
+        }
+
+        // Build the docker command
+        let command = config.to_command();
+
+        // Create server config using the immutable config getters
+        let server_config = ServerConfig {
+            rpc_port: Some(config.port()),
+            service_name: "Localstack".to_string(),
+            connection_attempts: 60, // Localstack takes longer to start
+            connection_delay_ms: 2000,
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(|e| LocalstackError::Docker(DockerError::Server(e)))?;
+
+        Ok(Self { server, config })
+    }
+
+
+    /// Validate if AWS resources with the given prefix are available
+    /// This helps determine if the scenario setup is ready
+    pub async fn validate_resources(&self, aws_prefix: &str) -> Result<bool, LocalstackError> {
+        // This is a basic implementation - you might want to extend this
+        // to check specific resources like S3 buckets, DynamoDB tables, etc.
+
+        // Example: Check if we can connect to Localstack's health endpoint
+        let health_url = format!("{}/health", self.endpoint());
+
+        match reqwest::get(&health_url).await {
+            Ok(response) => {
+                if response.status().is_success() {
+                    // You can add more specific validation here
+                    // For example, check if specific AWS resources exist
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Err(_) => Ok(false),
+        }
+    }
+
+    /// Get the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &LocalstackConfig {
+        &self.config
+    }
+
+
+    /// Get the endpoint URL for the Localstack server
+    pub fn endpoint(&self) -> Url {
+        self.server().endpoint().expect("Localstack server endpoint not found!")
+    }
+
+    /// Get dependencies (Docker is required)
+    pub fn dependencies(&self) -> Vec<String> {
+        vec!["docker".to_string()]
+    }
+}

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -2,3 +2,6 @@ pub mod server;
 pub mod helpers;
 pub mod anvil;
 pub mod bootstrapper;
+pub mod docker;
+pub mod localstack;
+pub mod mongodb;

--- a/e2e/src/services/mongodb/config.rs
+++ b/e2e/src/services/mongodb/config.rs
@@ -1,0 +1,124 @@
+use crate::services::docker::DockerError;
+use tokio::process::Command;
+
+const DEFAULT_MONGO_PORT: u16 = 27017;
+pub const DEFAULT_MONGO_IMAGE: &str = "mongo:latest";
+const DEFAULT_MONGO_CONTAINER_NAME: &str = "mongodb-service";
+pub const MONGO_DEFAULT_DATABASE_PATH: &str = "mongodb_dump.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum MongoError {
+    #[error("Docker error: {0}")]
+    Docker(#[from] DockerError),
+    #[error("MongoDB container already running on port {0}")]
+    AlreadyRunning(u16),
+    #[error("Port {0} is already in use")]
+    PortInUse(u16),
+    #[error("MongoDB connection failed: {0}")]
+    ConnectionFailed(String),
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct MongoConfig {
+    port: u16,
+    image: String,
+    container_name: String,
+}
+
+impl Default for MongoConfig {
+    fn default() -> Self {
+        Self {
+            port: DEFAULT_MONGO_PORT,
+            image: DEFAULT_MONGO_IMAGE.to_string(),
+            container_name: DEFAULT_MONGO_CONTAINER_NAME.to_string(),
+        }
+    }
+}
+
+impl MongoConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for MongoConfig
+    pub fn builder() -> MongoConfigBuilder {
+        MongoConfigBuilder::new()
+    }
+
+    /// Get the port
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the Docker image
+    pub fn image(&self) -> &str {
+        &self.image
+    }
+
+    /// Get the container name
+    pub fn container_name(&self) -> &str {
+        &self.container_name
+    }
+
+
+    /// Build the Docker command for MongoDB
+    pub fn to_command(&self) -> Command {
+        let mut command = Command::new("docker");
+        command.arg("run");
+        command.arg("--rm"); // Remove container when it stops
+        command.arg("--name").arg(self.container_name());
+        command.arg("-p").arg(format!("{}:27017", self.port()));
+        command.arg(self.image());
+
+        command
+    }
+
+
+
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct MongoConfigBuilder {
+    config: MongoConfig,
+}
+
+impl MongoConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: MongoConfig::default(),
+        }
+    }
+
+    /// Set the port (default: 27017)
+    pub fn port(mut self, port: u16) -> Self {
+        self.config.port = port;
+        self
+    }
+
+    /// Set the Docker image
+    pub fn image<S: Into<String>>(mut self, image: S) -> Self {
+        self.config.image = image.into();
+        self
+    }
+
+    /// Set the container name
+    pub fn container_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.config.container_name = name.into();
+        self
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> MongoConfig {
+        self.config
+    }
+}
+
+impl Default for MongoConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -1,0 +1,90 @@
+// =============================================================================
+// MONGODB SERVICE - Using Docker and generic Server
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::docker::{DockerError, DockerServer};
+use crate::services::server::{Server, ServerConfig};
+use reqwest::Url;
+
+use super::server::DEFAULT_SERVICE_HOST;
+
+pub struct MongoService {
+    server: Server,
+    config: MongoConfig,
+}
+
+impl MongoService {
+    /// Start a new MongoDB service
+    /// Will panic if MongoDB is already running as per pattern
+    pub async fn start(config: MongoConfig) -> Result<Self, MongoError> {
+        // Validate Docker is running
+        if !DockerServer::is_docker_running() {
+            return Err(MongoError::Docker(DockerError::NotRunning));
+        }
+
+        // Check if container is already running - PANIC as per pattern
+        if DockerServer::is_container_running(config.container_name())? {
+            panic!(
+                "MongoDB container '{}' is already running on port {}. Please stop it first.",
+                config.container_name(),
+                config.port()
+            );
+        }
+
+        // Check if port is in use
+        if DockerServer::is_port_in_use(config.port()) {
+            return Err(MongoError::PortInUse(config.port()));
+        }
+
+        // Clean up any existing stopped container with the same name
+        if DockerServer::does_container_exist(config.container_name())? {
+            DockerServer::remove_container(config.container_name())?;
+        }
+
+        // Build the docker command
+        let command = config.to_command();
+
+        // Create server config using the immutable config getters
+        let server_config = ServerConfig {
+            rpc_port: Some(config.port()),
+            service_name: "MongoDB".to_string(),
+            connection_attempts: 30, // MongoDB usually starts quickly
+            connection_delay_ms: 1000,
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(|e| MongoError::Docker(DockerError::Server(e)))?;
+
+        Ok(Self { server, config })
+    }
+
+
+    /// Get the endpoint URL for the MongoDB service
+    pub fn endpoint(&self) -> Url {
+        // MongoDB doesn't use HTTP, but we'll return the TCP endpoint
+        Url::parse(&format!("mongodb://{}:{}", DEFAULT_SERVICE_HOST, self.config().port())).unwrap()
+    }
+
+    /// Get the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &MongoConfig {
+        &self.config
+    }
+
+    /// Get dependencies (Docker is required)
+    pub fn dependencies(&self) -> Vec<String> {
+        vec!["docker".to_string()]
+    }
+}


### PR DESCRIPTION
# Add Docker-based services for E2E testing

## Pull Request type

- Feature
- Refactoring (no functional changes, no API changes)

## What is the current behavior?

The E2E testing framework lacks support for Docker-based services like Localstack and MongoDB.

Resolves: #NA

## What is the new behavior?

- Added a Docker server helper to manage Docker containers for E2E tests
- Implemented Localstack service with configurable options for AWS service testing
- Added MongoDB service with configurable options for database testing
- Both services follow a consistent pattern with builder-style configuration

## Does this introduce a breaking change?

No

## Other information

These new services allow E2E tests to spin up isolated Docker containers for testing against AWS services (via Localstack) and MongoDB databases. The implementation follows a consistent pattern with immutable configurations and builder patterns for flexibility.