### PR TITLE
E2E : 7 : Adding: Pathfinder Service

### DIFF
--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -6,3 +6,4 @@ pub mod docker;
 pub mod localstack;
 pub mod mongodb;
 pub mod madara;
+pub mod pathfinder;

--- a/e2e/src/services/pathfinder/config.rs
+++ b/e2e/src/services/pathfinder/config.rs
@@ -1,0 +1,321 @@
+// Originally implemented with just a struct with public fields. We've refactored
+// to use a builder pattern that ensures immutability after building while providing
+// a clean, fluent API for configuration.
+
+use tokio::process::Command;
+use crate::services::helpers::NodeRpcError;
+
+use crate::services::docker::DockerError;
+
+const DEFAULT_PATHFINDER_PORT: u16 = 9545;
+pub const DEFAULT_PATHFINDER_IMAGE: &str = "prkpandey942/pathfinder:549aa84_2025-05-29_appchain-vers-cons_amd";
+const DEFAULT_PATHFINDER_CONTAINER_NAME: &str = "pathfinder-service";
+
+#[derive(Debug, thiserror::Error)]
+pub enum PathfinderError {
+    #[error("Docker error: {0}")]
+    Docker(#[from] DockerError),
+    #[error("Pathfinder container already running on port {0}")]
+    AlreadyRunning(u16),
+    #[error("Port {0} is already in use")]
+    PortInUse(u16),
+    #[error("Pathfinder connection failed: {0}")]
+    ConnectionFailed(String),
+    #[error("Missing required configuration: {0}")]
+    MissingConfig(String),
+    #[error("Invalid response from Pathfinder")]
+    InvalidResponse,
+    #[error("RPC error: {0}")]
+    RpcError(#[from] NodeRpcError),
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct PathfinderConfig {
+    port: u16,
+    image: String,
+    container_name: String,
+    ethereum_url: String,
+    data_directory: String,
+    rpc_root_version: String,
+    network: String,
+    chain_id: String,
+    gateway_url: Option<String>,
+    feeder_gateway_url: Option<String>,
+    storage_state_tries: String,
+    gateway_request_timeout: u64,
+    data_volume: Option<String>,
+    environment_vars: Vec<(String, String)>,
+}
+
+impl Default for PathfinderConfig {
+    fn default() -> Self {
+        Self {
+            port: DEFAULT_PATHFINDER_PORT,
+            image: DEFAULT_PATHFINDER_IMAGE.to_string(),
+            container_name: DEFAULT_PATHFINDER_CONTAINER_NAME.to_string(),
+            ethereum_url: "https://ethereum-sepolia-rpc.publicnode.com".to_string(),
+            data_directory: "/var/pathfinder".to_string(),
+            rpc_root_version: "v07".to_string(),
+            network: "custom".to_string(),
+            chain_id: "MADARA_DEVNET".to_string(),
+            gateway_url: Some("http://host.docker.internal:8080/feeder".to_string()),
+            feeder_gateway_url: Some("http://host.docker.internal:8080/feeder_gateway".to_string()),
+            storage_state_tries: "archive".to_string(),
+            gateway_request_timeout: 1000,
+            data_volume: None,
+            environment_vars: vec![],
+        }
+    }
+}
+
+impl PathfinderConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for PathfinderConfig
+    pub fn builder() -> PathfinderConfigBuilder {
+        PathfinderConfigBuilder::new()
+    }
+
+    /// Get the RPC port
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the Docker image
+    pub fn image(&self) -> &str {
+        &self.image
+    }
+
+    /// Get the container name
+    pub fn container_name(&self) -> &str {
+        &self.container_name
+    }
+
+    /// Get the Ethereum URL
+    pub fn ethereum_url(&self) -> &str {
+        &self.ethereum_url
+    }
+
+    /// Get the data directory
+    pub fn data_directory(&self) -> &str {
+        &self.data_directory
+    }
+
+    /// Get the RPC root version
+    pub fn rpc_root_version(&self) -> &str {
+        &self.rpc_root_version
+    }
+
+    /// Get the network
+    pub fn network(&self) -> &str {
+        &self.network
+    }
+
+    /// Get the chain ID
+    pub fn chain_id(&self) -> &str {
+        &self.chain_id
+    }
+
+    /// Get the gateway URL
+    pub fn gateway_url(&self) -> Option<&str> {
+        self.gateway_url.as_deref()
+    }
+
+    /// Get the feeder gateway URL
+    pub fn feeder_gateway_url(&self) -> Option<&str> {
+        self.feeder_gateway_url.as_deref()
+    }
+
+    /// Get the storage state tries
+    pub fn storage_state_tries(&self) -> &str {
+        &self.storage_state_tries
+    }
+
+    /// Get the gateway request timeout
+    pub fn gateway_request_timeout(&self) -> u64 {
+        self.gateway_request_timeout
+    }
+
+    /// Get the data volume
+    pub fn data_volume(&self) -> Option<&str> {
+        self.data_volume.as_deref()
+    }
+
+    /// Get the environment variables
+    pub fn environment_vars(&self) -> &[(String, String)] {
+        &self.environment_vars
+    }
+
+    pub fn to_command(&self) -> Command {
+        let mut command = Command::new("docker");
+        command.arg("run");
+        command.arg("--rm"); // Remove container when it stops
+        command.arg("--name").arg(self.container_name());
+
+        // Port mappings
+        command.arg("-p").arg(format!("{}:{}", self.port(), self.port()));
+
+        // Add data volume if specified
+        if let Some(volume) = self.data_volume() {
+            command.arg("-v").arg(format!("{}:{}", volume, self.data_directory()));
+        }
+
+        // Add custom environment variables
+        for (key, value) in self.environment_vars() {
+            command.arg("-e").arg(format!("{}={}", key, value));
+        }
+
+        // Add the image
+        command.arg(self.image());
+
+        // Add pathfinder binary command and arguments
+        command.arg("--ethereum.url").arg(self.ethereum_url());
+        // command.arg("--data-directory").arg(config.data_directory());
+        command.arg("--http-rpc").arg(format!("0.0.0.0:{}", self.port()));
+        command.arg("--rpc.root-version").arg(self.rpc_root_version());
+        command.arg("--network").arg(self.network());
+        command.arg("--chain-id").arg(self.chain_id());
+
+        if let Some(gateway_url) = self.gateway_url() {
+            // command.arg("--add-host");
+            command.arg("--gateway-url").arg(gateway_url);
+        }
+
+        if let Some(feeder_gateway_url) = self.feeder_gateway_url() {
+            // command.arg("--add-host");
+            command.arg("--feeder-gateway-url").arg(feeder_gateway_url);
+        }
+
+        command.arg("--storage.state-tries").arg(self.storage_state_tries());
+        command.arg("--gateway.request-timeout").arg(self.gateway_request_timeout().to_string());
+
+        command
+    }
+
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct PathfinderConfigBuilder {
+    config: PathfinderConfig,
+}
+
+impl PathfinderConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: PathfinderConfig::default(),
+        }
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> PathfinderConfig {
+        self.config
+    }
+
+    /// Set the RPC port (default: 9545)
+    pub fn port(mut self, port: u16) -> Self {
+        self.config.port = port;
+        self
+    }
+
+    /// Set the Docker image
+    pub fn image<S: Into<String>>(mut self, image: S) -> Self {
+        self.config.image = image.into();
+        self
+    }
+
+    /// Set the container name
+    pub fn container_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.config.container_name = name.into();
+        self
+    }
+
+    /// Set the Ethereum URL
+    pub fn ethereum_url<S: Into<String>>(mut self, url: S) -> Self {
+        self.config.ethereum_url = url.into();
+        self
+    }
+
+    /// Set the data directory
+    pub fn data_directory<S: Into<String>>(mut self, directory: S) -> Self {
+        self.config.data_directory = directory.into();
+        self
+    }
+
+    /// Set the RPC root version
+    pub fn rpc_root_version<S: Into<String>>(mut self, version: S) -> Self {
+        self.config.rpc_root_version = version.into();
+        self
+    }
+
+    /// Set the network
+    pub fn network<S: Into<String>>(mut self, network: S) -> Self {
+        self.config.network = network.into();
+        self
+    }
+
+    /// Set the chain ID
+    pub fn chain_id<S: Into<String>>(mut self, chain_id: S) -> Self {
+        self.config.chain_id = chain_id.into();
+        self
+    }
+
+    /// Set the gateway URL
+    pub fn gateway_url<S: Into<String>>(mut self, url: Option<S>) -> Self {
+        self.config.gateway_url = url.map(|u| u.into());
+        self
+    }
+
+    /// Set the feeder gateway URL
+    pub fn feeder_gateway_url<S: Into<String>>(mut self, url: Option<S>) -> Self {
+        self.config.feeder_gateway_url = url.map(|u| u.into());
+        self
+    }
+
+    /// Set the storage state tries
+    pub fn storage_state_tries<S: Into<String>>(mut self, tries: S) -> Self {
+        self.config.storage_state_tries = tries.into();
+        self
+    }
+
+    /// Set the gateway request timeout
+    pub fn gateway_request_timeout(mut self, timeout: u64) -> Self {
+        self.config.gateway_request_timeout = timeout;
+        self
+    }
+
+    /// Set the data volume for persistent storage
+    pub fn data_volume<S: Into<String>>(mut self, volume: Option<S>) -> Self {
+        self.config.data_volume = volume.map(|v| v.into());
+        self
+    }
+
+    /// Add an environment variable
+    pub fn env_var<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+        self.config.environment_vars.push((key.into(), value.into()));
+        self
+    }
+
+    /// Set all environment variables (replaces existing ones)
+    pub fn environment_vars(mut self, vars: Vec<(String, String)>) -> Self {
+        self.config.environment_vars = vars;
+        self
+    }
+
+    /// Clear all environment variables
+    pub fn clear_env_vars(mut self) -> Self {
+        self.config.environment_vars.clear();
+        self
+    }
+}
+
+impl Default for PathfinderConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/pathfinder/mod.rs
+++ b/e2e/src/services/pathfinder/mod.rs
@@ -1,0 +1,158 @@
+// =============================================================================
+// PATHFINDER SERVICE - Using Docker and generic Server
+// =============================================================================
+
+pub mod config;
+
+use crate::services::helpers::NodeRpcMethods;
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::docker::{DockerError, DockerServer};
+use crate::services::server::{Server, ServerConfig};
+use reqwest::Url;
+use tokio::process::Command;
+
+pub struct PathfinderService {
+    server: Server,
+    config: PathfinderConfig,
+}
+
+impl PathfinderService {
+    /// Start a new Pathfinder service
+    /// Will panic if Pathfinder is already running as per pattern
+    pub async fn start(config: PathfinderConfig) -> Result<Self, PathfinderError> {
+        // Validate Docker is running
+        if !DockerServer::is_docker_running() {
+            return Err(PathfinderError::Docker(DockerError::NotRunning));
+        }
+
+        // Validate required configuration
+        Self::validate_config(&config)?;
+
+        // Check if container is already running - PANIC as per pattern
+        if DockerServer::is_container_running(config.container_name())? {
+            panic!(
+                "Pathfinder container '{}' is already running on port {}. Please stop it first.",
+                config.container_name(),
+                config.port()
+            );
+        }
+
+        // Check if ports are in use
+        if DockerServer::is_port_in_use(config.port()) {
+            return Err(PathfinderError::PortInUse(config.port()));
+        }
+
+        // Clean up any existing stopped container with the same name
+        if DockerServer::does_container_exist(config.container_name())? {
+            DockerServer::remove_container(config.container_name())?;
+        }
+
+        // Build the docker command
+        let command = config.to_command();
+
+        // Create server config using the immutable config getters
+        let server_config = ServerConfig {
+            rpc_port: Some(config.port()),
+            service_name: format!("Pathfinder"),
+            connection_attempts: 60, // Pathfinder takes time to sync
+            connection_delay_ms: 2000,
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(|e| PathfinderError::Docker(DockerError::Server(e)))?;
+
+        Ok(Self { server, config })
+    }
+
+    /// Validate the configuration
+    fn validate_config(config: &PathfinderConfig) -> Result<(), PathfinderError> {
+        if config.ethereum_url().contains("YOUR_API_KEY") {
+            return Err(PathfinderError::MissingConfig("ethereum_url must contain a valid API key".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Get the dependencies required by Pathfinder
+    pub fn dependencies(&self) -> Vec<String> {
+        vec!["madara".to_string(), "anvil".to_string()]
+    }
+
+    /// Validate that all required dependencies are available
+    pub async fn validate_dependencies(&self) -> Result<(), PathfinderError> {
+        let dependencies = self.dependencies();
+
+        for dep in dependencies {
+            let result = Command::new(&dep).arg("--version").output().await;
+
+            if result.is_err() {
+                return Err(PathfinderError::MissingConfig(format!("Required dependency '{}' not found", dep)));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate if Pathfinder is ready and responsive
+    pub async fn validate_connection(&self) -> Result<bool, PathfinderError> {
+        // Try to connect to the RPC endpoint
+        let rpc_addr = self.endpoint().to_string();
+        match tokio::net::TcpStream::connect(&rpc_addr).await {
+            Ok(_) => Ok(true),
+            Err(e) => Err(PathfinderError::ConnectionFailed(e.to_string())),
+        }
+    }
+
+    /// Check if Pathfinder is syncing by making an RPC call
+    pub async fn get_sync_status(&self) -> Result<bool, PathfinderError> {
+        // In a real implementation, you would make an RPC call to check sync status
+        // For now, we'll just check if the connection is available
+        self.validate_connection().await
+    }
+
+    /// Get the RPC endpoint URL
+    pub fn endpoint(&self) -> Url {
+        self.server().endpoint()
+            .expect("Failed to get endpoint")
+    }
+
+    /// Get the network name
+    pub fn network(&self) -> &str {
+        self.config.network()
+    }
+
+    /// Get the chain ID
+    pub fn chain_id(&self) -> &str {
+        self.config.chain_id()
+    }
+
+    /// Get the Ethereum URL
+    pub fn ethereum_url(&self) -> &str {
+        self.config.ethereum_url()
+    }
+
+    /// Get the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &PathfinderConfig {
+        &self.config
+    }
+
+    // TODO: dump and load from db fns!
+    // TODO: volume attachment !
+
+}
+
+
+impl NodeRpcMethods for PathfinderService {
+    fn get_endpoint(&self) -> Url {
+        self.endpoint().clone()
+    }
+}


### PR DESCRIPTION
# Add Pathfinder service for e2e testing

## Pull Request type

- Feature

## What is the current behavior?

The e2e testing framework supports various services like Docker, Localstack, MongoDB, and Madara, but lacks support for Pathfinder.

## What is the new behavior?

- Added a new Pathfinder service module for e2e testing
- Implemented a builder pattern for PathfinderConfig with immutable configuration after building
- Created a comprehensive API for configuring and running Pathfinder in Docker containers
- Added validation for dependencies and connection status
- Integrated with the existing NodeRpcMethods trait

## Does this introduce a breaking change?

No

## Other information

The implementation follows the same pattern as other services in the e2e framework, providing a clean API for starting and interacting with Pathfinder nodes during tests.