### PR TITLE
E2E : 8 : Adding: Orchestrator

### DIFF
--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -7,3 +7,4 @@ pub mod localstack;
 pub mod mongodb;
 pub mod madara;
 pub mod pathfinder;
+pub mod orchestrator;

--- a/e2e/src/services/orchestrator/config.rs
+++ b/e2e/src/services/orchestrator/config.rs
@@ -1,0 +1,433 @@
+use crate::services::server::ServerError;
+use std::path::PathBuf;
+use strum_macros::Display;
+use tokio::process::Command;
+
+pub const DEFAULT_ORCHESTRATOR_BINARY: &str = "../target/release/orchestrator";
+
+
+// TODO: options are currently limited to per-usages bases
+
+// TODO: might want to re-use these from orchestrator only and not re-write it here!
+// Will have to make orchestrator a dependency of e2e then, unsure, ask
+#[derive(Display, Debug, Clone, PartialEq, Eq)]
+#[strum(serialize_all = "lowercase")]
+pub enum OrchestratorMode {
+    Run,
+    Setup,
+}
+
+#[derive(Debug, Clone, PartialEq, Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum Layer {
+    L2,
+    L3,
+}
+
+#[derive(Debug, Clone, PartialEq, Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum AWSEventBridgeType {
+    Rule,
+    Schedule,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OrchestratorError {
+    #[error("Repository root not found")]
+    RepositoryRootNotFound,
+    #[error("Failed to change working directory: {0}")]
+    WorkingDirectoryFailed(std::io::Error),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+    #[error("Setup mode failed with exit code: {0}")]
+    SetupFailed(i32),
+    #[error("Missing required dependency: {0}")]
+    MissingDependency(String),
+    #[error("Orchestrator execution failed: {0}")]
+    ExecutionFailed(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct OrchestratorConfig {
+    // Runner Config
+    binary_path: PathBuf,
+
+    // Orchestrator Config
+    mode: OrchestratorMode,
+    layer: Layer,
+    port: Option<u16>,
+
+    // External Service
+    // Database
+    mongodb: bool,
+
+    // AWS Configuration
+    aws: bool,
+    event_bridge_type: AWSEventBridgeType,
+
+    // Layer-specific options
+
+    // Settlement (exclusive)
+    settle_on_ethereum: bool,
+    settle_on_starknet: bool,
+
+    // Data Availability (exclusive)
+    da_on_ethereum: bool,
+    da_on_starknet: bool,
+
+    // Prover (exclusive)
+    sharp: bool,
+    atlantic: bool,
+
+    environment_vars: Vec<(String, String)>,
+    additional_args: Vec<String>,
+}
+
+impl Default for OrchestratorConfig {
+    fn default() -> Self {
+        Self {
+            binary_path: PathBuf::from(DEFAULT_ORCHESTRATOR_BINARY),
+            mode: OrchestratorMode::Run,
+            layer: Layer::L2,
+            port: None,
+            additional_args: vec![],
+            environment_vars: vec![],
+            mongodb: true,
+            aws: true,
+            event_bridge_type: AWSEventBridgeType::Rule,
+
+            settle_on_ethereum: false,
+            settle_on_starknet: false,
+            da_on_ethereum: false,
+            da_on_starknet: false,
+            sharp: false,
+            atlantic: false,
+        }
+    }
+}
+
+impl OrchestratorConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for OrchestratorConfig
+    pub fn builder() -> OrchestratorConfigBuilder {
+        OrchestratorConfigBuilder::new()
+    }
+
+    // Getter methods (immutable access)
+
+    /// Get the orchestrator mode
+    pub fn mode(&self) -> &OrchestratorMode {
+        &self.mode
+    }
+
+    /// Get the layer
+    pub fn layer(&self) -> &Layer {
+        &self.layer
+    }
+
+    /// Get the port
+    pub fn port(&self) -> Option<u16> {
+        self.port
+    }
+
+    /// Get the environment variables
+    pub fn environment_vars(&self) -> &[(String, String)] {
+        &self.environment_vars
+    }
+
+    /// Get additional arguments
+    pub fn additional_args(&self) -> &[String] {
+        &self.additional_args
+    }
+
+    /// Check if AWS is enabled
+    pub fn is_aws_enabled(&self) -> bool {
+        self.aws
+    }
+
+    /// Get the EventBridge type
+    pub fn event_bridge_type(&self) -> &AWSEventBridgeType {
+        &self.event_bridge_type
+    }
+
+    /// Check if settlement on Ethereum is enabled
+    pub fn is_settle_on_ethereum_enabled(&self) -> bool {
+        self.settle_on_ethereum
+    }
+
+    /// Check if settlement on Starknet is enabled
+    pub fn is_settle_on_starknet_enabled(&self) -> bool {
+        self.settle_on_starknet
+    }
+
+    /// Check if data availability on Ethereum is enabled
+    pub fn is_da_on_ethereum_enabled(&self) -> bool {
+        self.da_on_ethereum
+    }
+
+    /// Check if data availability on Starknet is enabled
+    pub fn is_da_on_starknet_enabled(&self) -> bool {
+        self.da_on_starknet
+    }
+
+    /// Check if SHARP is enabled
+    pub fn is_sharp_enabled(&self) -> bool {
+        self.sharp
+    }
+
+    /// Check if MongoDB is enabled
+    pub fn is_mongodb_enabled(&self) -> bool {
+        self.mongodb
+    }
+
+    /// Check if Atlantic is enabled
+    pub fn is_atlantic_enabled(&self) -> bool {
+        self.atlantic
+    }
+
+    /// Get the binary path
+    pub fn binary_path(&self) -> &PathBuf {
+        &self.binary_path
+    }
+
+    pub fn to_command(&self) -> Command {
+        let mut command = Command::new(&self.binary_path);
+        command.arg(self.mode.to_string());
+        command.arg("--layer").arg(self.layer.to_string());
+
+        // Add AWS flags (Needed in both)
+        if self.aws {
+            command.arg("--aws");
+            command.arg("--aws-s3");
+            command.arg("--aws-sqs");
+            command.arg("--aws-sns");
+        }
+
+        if *self.mode() == OrchestratorMode::Run {
+            command = self.to_command_run(command);
+        } else {
+            command = self.to_command_setup(command);
+        }
+
+        command
+    }
+
+    pub fn to_command_setup(&self, mut command: Command) -> Command {
+        command.arg("--aws-event-bridge");
+        command.arg("--event-bridge-type").arg(self.event_bridge_type.to_string());
+
+        command
+    }
+
+    pub fn to_command_run(&self, mut command: Command) -> Command {
+        if let Some(port) = self.port {
+            command.arg("--port").arg(port.to_string());
+        }
+
+        // TODO: might wanna remove it ?
+        if self.mongodb {
+            command.arg("--mongodb");
+        }
+
+        // Add settlement flags
+        if self.settle_on_ethereum {
+            command.arg("--settle-on-ethereum");
+        }
+        if self.settle_on_starknet {
+            command.arg("--settle-on-starknet");
+        }
+
+        // Add data availability flags
+        if self.da_on_ethereum {
+            command.arg("--da-on-ethereum");
+        }
+        if self.da_on_starknet {
+            command.arg("--da-on-starknet");
+        }
+
+        // Add prover flags
+        if self.sharp {
+            command.arg("--sharp");
+        }
+        if self.atlantic {
+            command.arg("--atlantic");
+        }
+
+        // Add environment variables
+        for (key, value) in &self.environment_vars {
+            command.env(key, value);
+        }
+
+        // Add additional arguments
+        for arg in &self.additional_args {
+            command.arg(arg);
+        }
+
+        command
+    }
+}
+
+/// Builder for OrchestratorConfig
+#[derive(Debug, Clone)]
+pub struct OrchestratorConfigBuilder {
+    config: OrchestratorConfig,
+}
+
+impl OrchestratorConfigBuilder {
+    /// Create a new builder with default configuration
+    pub fn new() -> Self {
+        Self {
+            config: OrchestratorConfig::default(),
+        }
+    }
+
+    /// Build the final configuration
+    pub fn build(self) -> OrchestratorConfig {
+        self.config
+    }
+
+    // Convenience factory methods for common configurations - now return builder for chaining
+    pub fn run_l2() -> Self {
+        Self::new()
+            .layer(Layer::L2)
+            .mode(OrchestratorMode::Run)
+            .atlantic(true)
+            .event_bridge_type(AWSEventBridgeType::Rule)
+            .settle_on_ethereum(true)
+            .da_on_ethereum(true)
+    }
+
+    pub fn setup_l2() -> Self {
+        Self::new()
+            .layer(Layer::L2)
+            .mode(OrchestratorMode::Setup)
+    }
+
+    pub fn run_l3() -> Self {
+        Self::new()
+            .layer(Layer::L3)
+            .mode(OrchestratorMode::Run)
+            .atlantic(true)
+            .event_bridge_type(AWSEventBridgeType::Rule)
+            .settle_on_starknet(true)
+            .da_on_starknet(true)
+    }
+
+    pub fn setup_l3() -> Self {
+        Self::new()
+            .layer(Layer::L3)
+            .mode(OrchestratorMode::Setup)
+    }
+
+    /// Set the binary path
+    pub fn binary_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.config.binary_path = path.into();
+        self
+    }
+
+    /// Set the orchestrator mode
+    pub fn mode(mut self, mode: OrchestratorMode) -> Self {
+        self.config.mode = mode;
+        self
+    }
+
+    /// Set the layer (L2 or L3)
+    pub fn layer(mut self, layer: Layer) -> Self {
+        self.config.layer = layer;
+        self
+    }
+
+    /// Set the port
+    pub fn port(mut self, port: u16) -> Self {
+        self.config.port = Some(port);
+        self
+    }
+
+    /// Add an environment variable
+    pub fn env_var<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+        self.config.environment_vars.push((key.into(), value.into()));
+        self
+    }
+
+    /// Set all environment variables (replaces existing ones)
+    pub fn environment_vars(mut self, vars: Vec<(String, String)>) -> Self {
+        self.config.environment_vars = vars;
+        self
+    }
+
+    /// Add an additional argument
+    pub fn arg<S: Into<String>>(mut self, arg: S) -> Self {
+        self.config.additional_args.push(arg.into());
+        self
+    }
+
+    /// Set all additional arguments (replaces existing ones)
+    pub fn additional_args(mut self, args: Vec<String>) -> Self {
+        self.config.additional_args = args;
+        self
+    }
+
+    /// Enable/disable MongoDB
+    pub fn mongodb(mut self, enabled: bool) -> Self {
+        self.config.mongodb = enabled;
+        self
+    }
+
+    /// Enable/disable AWS integration
+    pub fn aws(mut self, enabled: bool) -> Self {
+        self.config.aws = enabled;
+        self
+    }
+
+    /// Set the EventBridge type
+    pub fn event_bridge_type(mut self, event_bridge_type: AWSEventBridgeType) -> Self {
+        self.config.event_bridge_type = event_bridge_type;
+        self
+    }
+
+    /// Enable/disable settlement on Ethereum
+    pub fn settle_on_ethereum(mut self, enabled: bool) -> Self {
+        self.config.settle_on_ethereum = enabled;
+        self
+    }
+
+    /// Enable/disable settlement on Starknet
+    pub fn settle_on_starknet(mut self, enabled: bool) -> Self {
+        self.config.settle_on_starknet = enabled;
+        self
+    }
+
+    /// Enable/disable data availability on Ethereum
+    pub fn da_on_ethereum(mut self, enabled: bool) -> Self {
+        self.config.da_on_ethereum = enabled;
+        self
+    }
+
+    /// Enable/disable data availability on Starknet
+    pub fn da_on_starknet(mut self, enabled: bool) -> Self {
+        self.config.da_on_starknet = enabled;
+        self
+    }
+
+    /// Enable/disable SHARP prover
+    pub fn sharp(mut self, enabled: bool) -> Self {
+        self.config.sharp = enabled;
+        self
+    }
+
+    /// Enable/disable Atlantic prover
+    pub fn atlantic(mut self, enabled: bool) -> Self {
+        self.config.atlantic = enabled;
+        self
+    }
+}
+
+impl Default for OrchestratorConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/orchestrator/mod.rs
+++ b/e2e/src/services/orchestrator/mod.rs
@@ -1,0 +1,162 @@
+// =============================================================================
+// ORCHESTRATOR SERVICE - Using generic Server
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::server::{Server, ServerConfig};
+use std::process::ExitStatus;
+
+use std::time::Duration;
+
+pub struct OrchestratorService {
+    server: Server, // None for setup mode
+    config: OrchestratorConfig,
+}
+
+impl OrchestratorService {
+
+    pub async fn start(config: OrchestratorConfig) -> Result<Self, OrchestratorError> {
+        // TODO: config mode should only be run
+
+        let command = config.to_command();
+
+        println!("Running orchestrator in run mode with command : {:?}", command);
+
+        let port = config.port().unwrap();
+
+        // Create server config
+        let server_config = ServerConfig {
+            rpc_port: Some(port),
+            service_name: format!("Orchestrator-{}", config.mode().to_string()),
+            connection_attempts: 60, // Orchestrator might take time to start
+            connection_delay_ms: 2000,
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(OrchestratorError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+    pub async fn setup(config: OrchestratorConfig) -> Result<ExitStatus, OrchestratorError> {
+        // TODO: config mode should only be setup
+
+        let mut service = Self::start_setup_mode(config).await?;
+        service.wait_for_completion().await
+    }
+
+
+    /// Wait for the bootstrapper to complete execution
+    pub async fn wait_for_completion(&mut self) -> Result<ExitStatus, OrchestratorError> {
+        println!("🚀 Running orchestrator in {} mode...", self.config.mode());
+
+        // Use timeout to prevent hanging
+        let result = tokio::time::timeout(Duration::from_secs(360), async {
+            // Keep checking if the process has exited
+            loop {
+                if let Some(exit_status) = self.server.has_exited() {
+                    return Ok::<ExitStatus, OrchestratorError>(exit_status);
+                }
+
+                // Small delay to avoid busy waiting
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match result {
+            Ok(Ok(exit_status)) => {
+                if exit_status.success() {
+                    println!("✅ Orchestrator {} completed successfully with {}", self.config.mode(), exit_status);
+                    Ok(exit_status)
+                } else {
+                    let exit_code = exit_status.code().unwrap_or(-1);
+                    Err(OrchestratorError::SetupFailed(exit_code))
+                }
+            }
+            Ok(Err(e)) => Err(OrchestratorError::ExecutionFailed(e.to_string())),
+            Err(_) => Err(OrchestratorError::ExecutionFailed(format!(
+                "Orchestrator timed out after {:?}",
+                Duration::from_secs(360)
+            ))),
+        }
+    }
+
+
+    /// Run in setup mode (blocking, returns when complete)
+    async fn start_setup_mode(config: OrchestratorConfig) -> Result<Self, OrchestratorError> {
+        let command = config.to_command();
+
+        println!("Running orchestrator in setup mode with command : {:?}", command);
+
+        let server_config = ServerConfig {
+            service_name: format!("Orchestrator-{}", config.mode().to_string()),
+            ..Default::default()
+
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(OrchestratorError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+
+    // TODO: these dependencies should be typed and not a Vec<String>
+
+    /// Get the dependencies required by the orchestrator
+    pub fn dependencies(&self) -> Vec<String> {
+        vec![
+            // internal
+            "anvil".to_string(),
+            "madara".to_string(),
+            "pathfinder".to_string(),
+            // TODO: Actually bootstrapper is not a direct dep of orchestrator
+            // we can remove this
+            "bootstrapper_l1".to_string(),
+            "bootstrapper_l2".to_string(),
+            // external
+            "atlantic".to_string(),
+            "localstack".to_string(),
+            "mongodb".to_string(),
+        ]
+    }
+
+    // TODO: Will need a endpoint() fn here
+
+    // TODO: A mongodb respective fn that dumps and loads the db
+
+    /// Get the current mode
+    pub fn mode(&self) -> &OrchestratorMode {
+        self.config.mode()
+    }
+
+    /// Get the port number (run mode only)
+    pub fn port(&self) -> Option<u16> {
+        self.config.port()
+    }
+
+    /// Get the layer
+    pub fn layer(&self) -> &Layer {
+        self.config.layer()
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &OrchestratorConfig {
+        &self.config
+    }
+
+    /// Get the underlying server (run mode only)
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+}


### PR DESCRIPTION
# Add Orchestrator Service for E2E Testing

## Pull Request type

- Feature

## What is the current behavior?

The e2e testing framework lacks support for the Orchestrator service, which is needed for comprehensive testing of the system.

## What is the new behavior?

- Added a new `orchestrator` module to the e2e testing services
- Implemented `OrchestratorConfig` and `OrchestratorConfigBuilder` for flexible configuration
- Created `OrchestratorService` with support for both run and setup modes
- Added support for L2/L3 layer configurations
- Implemented AWS integration options (EventBridge, S3, SQS, SNS)
- Added configuration options for settlement and data availability on Ethereum/Starknet
- Included support for SHARP and Atlantic provers

## Does this introduce a breaking change?

No

## Other information

The implementation follows the pattern of other e2e services, using the generic Server implementation for process management and providing a builder pattern for easy configuration.