### PR TITLE
E2E : 1 : Mock Atlantic, Dummy Verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -7580,6 +7581,23 @@ dependencies = [
  "typed-builder",
  "uuid 1.12.0",
  "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.1.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -13037,6 +13055,24 @@ dependencies = [
  "num-traits 0.2.19",
  "serde_json",
  "thiserror 1.0.65",
+]
+
+[[package]]
+name = "utils-mock-atlantic-server"
+version = "0.8.0"
+dependencies = [
+ "axum 0.7.7",
+ "chrono",
+ "rand",
+ "reqwest 0.12.8",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.3",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid 1.12.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "bootstrapper",
   "build-artifacts",
   "bootstrapper-v2",
+  "test_utils/crates/mock-atlantic-server",
 ]
 # Everything except test-related packages, so that they are not compiled when doing `cargo build`.
 default-members = [
@@ -307,6 +308,9 @@ orchestrator-gps-fact-checker = { path = "orchestrator/crates/prover-clients/gps
 orchestrator-sharp-service = { path = "orchestrator/crates/prover-clients/sharp-service" }
 orchestrator-atlantic-service = { path = "orchestrator/crates/prover-clients/atlantic-service" }
 orchestrator = { path = "orchestrator" }
+
+utils-mock-atlantic-server = { path = "test_utils/crates/mock-atlantic-server" }
+
 base64ct = "=1.6.0"
 zip = "4.3.0"
 

--- a/test_utils/crates/mock-atlantic-server/Cargo.toml
+++ b/test_utils/crates/mock-atlantic-server/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "utils-mock-atlantic-server"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "mock-atlantic-server"
+path = "src/main.rs"
+
+[dependencies]
+axum = { workspace = true, features = ["multipart"] }
+chrono = { workspace = true, features = ["serde"] }
+rand.workspace = true
+reqwest = { workspace = true, features = ["json", "multipart"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/test_utils/crates/mock-atlantic-server/README.md
+++ b/test_utils/crates/mock-atlantic-server/README.md
@@ -17,6 +17,37 @@ various scenarios including failures and processing delays.
 - 🏥 **Health Checks**: Built-in health check endpoint for monitoring
 - 🧪 **Testing Support**: Easy integration for unit and integration tests
 
+// Usage examples in comments:
+//
+// Run with default settings (port 4001, no failures):
+// cargo run --bin mock-atlantic-server
+//
+// Run on port 8080:
+// cargo run --bin mock-atlantic-server 8080
+//
+// Run on port 8080 with 10% failure rate:
+// cargo run --bin mock-atlantic-server 8080 0.1
+
+## How to Spin the Server
+
+- Run with default settings (port 4001, no failures):
+
+  ```bash
+  cargo run --bin utils-mock-atlantic-server
+  ```
+
+- Run on port 8080:
+
+  ```bash
+  cargo run --bin utils-mock-atlantic-server 8080
+  ```
+
+- Run on port 8080 with 10% failure rate:
+
+  ```bash
+  cargo run --bin utils-mock-atlantic-server 8080 0.1
+  ```
+
 ## API Endpoints
 
 ### Job Management

--- a/test_utils/crates/mock-atlantic-server/README.md
+++ b/test_utils/crates/mock-atlantic-server/README.md
@@ -1,0 +1,122 @@
+# Mock Atlantic Server
+
+A mock HTTP server that implements the Atlantic API endpoints for testing and development purposes.
+
+## Overview
+
+The Mock Atlantic Server provides the same HTTP interface as the real Atlantic service, allowing you to test your
+applications without depending on the external Atlantic service. It supports all the major endpoints and can simulate
+various scenarios including failures and processing delays.
+
+## Features
+
+- 🚀 **Full API Compatibility**: Implements all Atlantic API endpoints
+- 🎭 **Configurable Behavior**: Simulate failures, processing delays, and different response patterns
+- 🔄 **Realistic Job Lifecycle**: Jobs progress through realistic status transitions
+- 📊 **Configurable Failure Rates**: Test error handling with controlled failure simulation
+- 🏥 **Health Checks**: Built-in health check endpoint for monitoring
+- 🧪 **Testing Support**: Easy integration for unit and integration tests
+
+## API Endpoints
+
+### Job Management
+
+- `POST /atlantic-query?apiKey={key}` - Submit a new proving job
+- `GET /atlantic-query/{job_id}` - Get job status and details
+
+### Proof Retrieval
+
+- `GET /queries/{task_id}/proof.json` - Download proof data for completed jobs
+
+### Health & Monitoring
+
+- `GET /health` - Health check endpoint
+
+### Documentation
+
+For complete API documentation, see the [swagger.json](./swagger.json) file which contains the full OpenAPI 3.0.3
+specification from the Herodotus Atlantic API.
+
+## Usage
+
+### Running as a Standalone Server
+
+```bash
+# Run with default settings (port 3001, no failures)
+cargo run --bin mock-atlantic-server
+
+# Run on custom port
+cargo run --bin mock-atlantic-server 8080
+
+# Run with failure simulation (10% failure rate)
+cargo run --bin mock-atlantic-server 8080 0.1
+```
+
+### Using with Atlantic Client
+
+To use the mock server with the real Atlantic client, simply point the `atlantic_service_url` to your mock server when
+the mock factor is enabled.
+
+### Using with Orchestrator
+
+The mock Atlantic server is automatically integrated with the orchestrator. When you set `atlantic_mock_fact_hash=true`,
+the orchestrator will:
+
+1. Automatically start the mock Atlantic server on port 3001
+2. Configure the Atlantic client to use the local mock server instead of the real Atlantic service
+3. Disable fact checking for faster testing
+
+Example usage:
+
+```bash
+# Run orchestrator with mock Atlantic server (SIMPLIFIED!)
+# Only 2 Atlantic parameters needed - everything else gets sensible defaults!
+cargo run --bin orchestrator -- run \
+  --atlantic \
+  --atlantic-mock-fact-hash "true" \
+  # ... other orchestrator arguments (non-Atlantic)
+
+# Optional: Override defaults if needed
+cargo run --bin orchestrator -- run \
+  --atlantic \
+  --atlantic-mock-fact-hash "true" \
+  --atlantic-api-key "custom-mock-key" \
+  --atlantic-network "MAINNET" \
+  # ... other orchestrator arguments
+```
+
+When `atlantic_mock_fact_hash=true`, the orchestrator will log:
+
+```text
+Starting Mock Atlantic Server for testing...
+Mock Atlantic Server started on port 3001
+Configured Atlantic client to use mock server at http://127.0.0.1:3001
+Using hardcoded verifier contract address for mock mode: 0x0000000000000000000000000000000000000000
+```
+
+**Important Notes for Orchestrator Integration:**
+
+- The `--atlantic-service-url` you provide on the command line is automatically overridden to
+  `http://127.0.0.1:3001`
+- The `--atlantic-verifier-contract-address` is automatically overridden to
+  `0x0000000000000000000000000000000000000000`
+- Your actual API key, network, and other parameters are preserved and used by the mock server
+- This ensures seamless testing without requiring manual URL changes
+
+## Configuration Options
+
+The `MockServerConfig` struct allows you to customize the server behavior:
+
+- `simulate_failures`: Enable/disable failure simulation
+- `processing_delay_ms`: Time before jobs move to "InProgress" status
+- `failure_rate`: Percentage of jobs that should fail (0.0 to 1.0)
+- `auto_complete_jobs`: Whether jobs should automatically complete
+- `completion_delay_ms`: Time before jobs move to "Done" status
+
+## Job Lifecycle
+
+Jobs submitted to the mock server follow this lifecycle:
+
+1. **Received** - Initial status when job is submitted
+2. **InProgress** - After `processing_delay_ms` milliseconds
+3. **Done** or **Failed** - After `completion_delay_ms` milliseconds

--- a/test_utils/crates/mock-atlantic-server/src/lib.rs
+++ b/test_utils/crates/mock-atlantic-server/src/lib.rs
@@ -88,7 +88,7 @@ pub async fn start_mock_server_background(port: u16) -> tokio::task::JoinHandle<
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     use tokio::time::{sleep, Duration};
 
     #[tokio::test]

--- a/test_utils/crates/mock-atlantic-server/src/lib.rs
+++ b/test_utils/crates/mock-atlantic-server/src/lib.rs
@@ -1,0 +1,137 @@
+pub mod server;
+pub mod types;
+
+use axum::Router;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tracing::{error, info};
+
+pub use server::{create_router, MockAtlanticState};
+pub use types::{AtlanticAddJobResponse, AtlanticGetStatusResponse, MockServerConfig};
+
+/// Mock Atlantic Server
+///
+/// This server mimics the Atlantic API endpoints for testing purposes.
+/// It provides the same HTTP interface as the real Atlantic service.
+pub struct MockAtlanticServer {
+    router: Router,
+    addr: SocketAddr,
+}
+
+impl MockAtlanticServer {
+    /// Create a new mock Atlantic server instance
+    pub fn new(addr: SocketAddr, config: MockServerConfig) -> Self {
+        let state = MockAtlanticState::new(config);
+        let router = create_router(state);
+
+        Self { router, addr }
+    }
+
+    /// Start the mock server
+    pub async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Starting Mock Atlantic Server on {}", self.addr);
+
+        let listener = TcpListener::bind(self.addr).await?;
+
+        info!("Mock Atlantic Server listening on http://{}", self.addr);
+        info!("Available endpoints:");
+        info!("  POST   /atlantic-query        - Submit new job");
+        info!("  GET    /atlantic-query/{{id}}  - Get job status");
+        info!("  GET    /queries/{{id}}/proof.json - Get proof data");
+        info!("  GET    /is-alive                - Is alive check");
+
+        if let Err(e) = axum::serve(listener, self.router).await {
+            error!("Server error: {}", e);
+            return Err(Box::new(e));
+        }
+
+        Ok(())
+    }
+
+    /// Create a server with default configuration for testing
+    pub fn with_test_config(port: u16) -> Self {
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let config = MockServerConfig {
+            simulate_failures: false,
+            processing_delay_ms: 1000,
+            failure_rate: 0.0,
+            auto_complete_jobs: true,
+            completion_delay_ms: 2000,
+        };
+        Self::new(addr, config)
+    }
+
+    /// Create a server with failure simulation enabled
+    pub fn with_failure_simulation(port: u16, failure_rate: f32) -> Self {
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let config = MockServerConfig {
+            simulate_failures: true,
+            processing_delay_ms: 500,
+            failure_rate,
+            auto_complete_jobs: true,
+            completion_delay_ms: 1500,
+        };
+        Self::new(addr, config)
+    }
+}
+
+/// Utility function to run a mock server in the background for testing
+pub async fn start_mock_server_background(port: u16) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let server = MockAtlanticServer::with_test_config(port);
+        if let Err(e) = server.run().await {
+            error!("Mock server failed: {}", e);
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn test_mock_server_basic_flow() {
+        let port = 8080;
+        let _handle = start_mock_server_background(port).await;
+
+        // Give the server time to start
+        sleep(Duration::from_millis(100)).await;
+
+        let client = reqwest::Client::new();
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        // Test health check
+        let response = client.get(&format!("{}/health", base_url)).send().await.expect("Health check failed");
+
+        assert!(response.status().is_success());
+
+        // Test job submission (simplified - real test would use multipart)
+        let form = reqwest::multipart::Form::new()
+            .text("layout", "dynamic")
+            .text("network", "TESTNET")
+            .text("declaredJobSize", "S");
+
+        let response = client
+            .post(&format!("{}/atlantic-query?apiKey=test", base_url))
+            .multipart(form)
+            .send()
+            .await
+            .expect("Job submission failed");
+
+        assert!(response.status().is_success());
+        let job_response: AtlanticAddJobResponse = response.json().await.expect("Failed to parse response");
+
+        // Test job status
+        let response = client
+            .get(&format!("{}/atlantic-query/{}", base_url, job_response.atlantic_query_id))
+            .send()
+            .await
+            .expect("Status check failed");
+
+        assert!(response.status().is_success());
+        let status_response: AtlanticGetStatusResponse = response.json().await.expect("Failed to parse status");
+        assert_eq!(status_response.atlantic_query.id, job_response.atlantic_query_id);
+    }
+}

--- a/test_utils/crates/mock-atlantic-server/src/lib.rs
+++ b/test_utils/crates/mock-atlantic-server/src/lib.rs
@@ -88,7 +88,7 @@ pub async fn start_mock_server_background(port: u16) -> tokio::task::JoinHandle<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reqwest;
+    
     use tokio::time::{sleep, Duration};
 
     #[tokio::test]
@@ -103,7 +103,7 @@ mod tests {
         let base_url = format!("http://127.0.0.1:{}", port);
 
         // Test health check
-        let response = client.get(&format!("{}/health", base_url)).send().await.expect("Health check failed");
+        let response = client.get(format!("{}/health", base_url)).send().await.expect("Health check failed");
 
         assert!(response.status().is_success());
 
@@ -114,7 +114,7 @@ mod tests {
             .text("declaredJobSize", "S");
 
         let response = client
-            .post(&format!("{}/atlantic-query?apiKey=test", base_url))
+            .post(format!("{}/atlantic-query?apiKey=test", base_url))
             .multipart(form)
             .send()
             .await
@@ -125,7 +125,7 @@ mod tests {
 
         // Test job status
         let response = client
-            .get(&format!("{}/atlantic-query/{}", base_url, job_response.atlantic_query_id))
+            .get(format!("{}/atlantic-query/{}", base_url, job_response.atlantic_query_id))
             .send()
             .await
             .expect("Status check failed");

--- a/test_utils/crates/mock-atlantic-server/src/main.rs
+++ b/test_utils/crates/mock-atlantic-server/src/main.rs
@@ -5,7 +5,6 @@ use utils_mock_atlantic_server::{MockAtlanticServer, MockServerConfig};
 
 const DEFAULT_SERVER_PORT: u16 = 4001;
 
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing

--- a/test_utils/crates/mock-atlantic-server/src/main.rs
+++ b/test_utils/crates/mock-atlantic-server/src/main.rs
@@ -5,16 +5,7 @@ use utils_mock_atlantic_server::{MockAtlanticServer, MockServerConfig};
 
 const DEFAULT_SERVER_PORT: u16 = 4001;
 
-// Usage examples in comments:
-//
-// Run with default settings (port 4001, no failures):
-// cargo run --bin mock-atlantic-server
-//
-// Run on port 8080:
-// cargo run --bin mock-atlantic-server 8080
-//
-// Run on port 8080 with 10% failure rate:
-// cargo run --bin mock-atlantic-server 8080 0.1
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize tracing

--- a/test_utils/crates/mock-atlantic-server/src/main.rs
+++ b/test_utils/crates/mock-atlantic-server/src/main.rs
@@ -1,0 +1,57 @@
+use std::env;
+use std::net::SocketAddr;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use utils_mock_atlantic_server::{MockAtlanticServer, MockServerConfig};
+
+const DEFAULT_SERVER_PORT: u16 = 4001;
+
+// Usage examples in comments:
+//
+// Run with default settings (port 4001, no failures):
+// cargo run --bin mock-atlantic-server
+//
+// Run on port 8080:
+// cargo run --bin mock-atlantic-server 8080
+//
+// Run on port 8080 with 10% failure rate:
+// cargo run --bin mock-atlantic-server 8080 0.1
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+
+    // Parse command line arguments
+    let port = if args.len() > 1 { args[1].parse::<u16>().unwrap_or(DEFAULT_SERVER_PORT) } else { DEFAULT_SERVER_PORT };
+
+    let failure_rate = if args.len() > 2 { args[2].parse::<f32>().unwrap_or(0.0).clamp(0.0, 1.0) } else { 0.0 };
+
+    let simulate_failures = failure_rate > 0.0;
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let config = MockServerConfig {
+        simulate_failures,
+        processing_delay_ms: 1000,
+        failure_rate,
+        auto_complete_jobs: true,
+        completion_delay_ms: 3000,
+    };
+
+    println!("🚀 Mock Atlantic Server");
+    println!("📡 Port: {}", port);
+    println!("⚡ Failure simulation: {}", if simulate_failures { "enabled" } else { "disabled" });
+    if simulate_failures {
+        println!("📊 Failure rate: {:.1}%", failure_rate * 100.0);
+    }
+    println!("🔗 Health check: http://127.0.0.1:{}/is-alive", port);
+    println!();
+
+    let server = MockAtlanticServer::new(addr, config);
+    server.run().await?;
+
+    Ok(())
+}

--- a/test_utils/crates/mock-atlantic-server/src/server.rs
+++ b/test_utils/crates/mock-atlantic-server/src/server.rs
@@ -1,0 +1,399 @@
+use axum::{
+    extract::{DefaultBodyLimit, Multipart, Path, Query, State},
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use chrono::Utc;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+const MOCK_ATLANTIC_METADATA_URL: &str = "https://mock-atlantic.example.com/metadata";
+
+use crate::types::{
+    AtlanticAddJobResponse, AtlanticCairoVersion, AtlanticCairoVm, AtlanticChain, AtlanticClient,
+    AtlanticGetStatusResponse, AtlanticJobSize, AtlanticQuery, AtlanticQueryStatus, AtlanticQueryStep, MockJobData,
+    MockServerConfig,
+};
+
+#[derive(Clone)]
+pub struct MockAtlanticState {
+    pub jobs: Arc<RwLock<HashMap<String, MockJobData>>>,
+    pub config: MockServerConfig,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddJobQuery {
+    #[serde(rename = "apiKey")]
+    api_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProofQuery {
+    #[allow(dead_code)]
+    task_id: String,
+}
+
+impl MockAtlanticState {
+    pub fn new(config: MockServerConfig) -> Self {
+        Self { jobs: Arc::new(RwLock::new(HashMap::new())), config }
+    }
+
+    async fn create_mock_job(&self, job_id: String, layout: Option<String>, network: Option<String>) -> MockJobData {
+        let now = Utc::now();
+
+        // Use realistic data for the dynamic layout job
+        let query = if job_id == "01JXMTC7TZMSNDTJ88212KTH7W" {
+            AtlanticQuery {
+                id: job_id.clone(),
+                external_id: Some("".to_string()),
+                transaction_id: Some("01JXMTCJNPFPDW84NNVPHQYZ7H".to_string()),
+                status: AtlanticQueryStatus::Done,
+                step: Some(AtlanticQueryStep::ProofGeneration),
+                program_hash: Some("0x54d3603ed14fb897d0925c48f26330ea9950bd4ca95746dad4f7f09febffe0d".to_string()),
+                integrity_fact_hash: Some(
+                    "0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4".to_string(),
+                ),
+                sharp_fact_hash: Some("0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123".to_string()),
+                layout: Some("dynamic".to_string()),
+                is_fact_mocked: None,
+                chain: Some(AtlanticChain::OFFCHAIN),
+                job_size: Some(AtlanticJobSize::S),
+                declared_job_size: Some(AtlanticJobSize::S),
+                cairo_vm: Some(AtlanticCairoVm::Rust),
+                cairo_version: Some(AtlanticCairoVersion::Cairo0),
+                steps: vec![AtlanticQueryStep::TraceAndMetadataGeneration, AtlanticQueryStep::ProofGeneration],
+                error_reason: None,
+                submitted_by_client: "01JT14WV07E44PE11ZWWCED6BG".to_string(),
+                project_id: "01JNFXEF9JFBQFCKXDANCBE5CN".to_string(),
+                created_at: "2025-06-13T14:16:24.771Z".to_string(),
+                completed_at: Some("2025-06-13T14:17:48.204Z".to_string()),
+                result: Some(AtlanticQueryStep::ProofGeneration),
+                network: Some("TESTNET".to_string()),
+                client: AtlanticClient {
+                    client_id: Some("01JT14WV07E44PE11ZWWCED6BG".to_string()),
+                    name: Some("itsparser".to_string()),
+                    email: Some("itsparser@gmail.com".to_string()),
+                    is_email_verified: Some(true),
+                    image: Some("https://avatars.githubusercontent.com/u/13918750?v=4".to_string()),
+                },
+            }
+        } else {
+            // Default mock data for other job IDs
+            AtlanticQuery {
+                id: job_id.clone(),
+                external_id: None,
+                transaction_id: None,
+                status: AtlanticQueryStatus::Received,
+                step: Some(AtlanticQueryStep::TraceGeneration),
+                program_hash: Some("0x123456789abcdef".to_string()),
+                integrity_fact_hash: Some("0xfedcba9876543210".to_string()),
+                sharp_fact_hash: Some("0xabcdef1234567890".to_string()),
+                layout,
+                is_fact_mocked: Some(true),
+                chain: Some(AtlanticChain::L1),
+                job_size: Some(AtlanticJobSize::S),
+                declared_job_size: Some(AtlanticJobSize::S),
+                cairo_vm: Some(AtlanticCairoVm::Rust),
+                cairo_version: Some(AtlanticCairoVersion::Cairo0),
+                steps: vec![AtlanticQueryStep::TraceGeneration],
+                error_reason: None,
+                submitted_by_client: "mock-client".to_string(),
+                project_id: "mock-project".to_string(),
+                created_at: now.to_rfc3339(),
+                completed_at: None,
+                result: None,
+                network,
+                client: AtlanticClient {
+                    client_id: Some("mock-client-id".to_string()),
+                    name: Some("Mock Client".to_string()),
+                    email: Some("mock@example.com".to_string()),
+                    is_email_verified: Some(true),
+                    image: None,
+                },
+            }
+        };
+
+        // Set proof data immediately for the realistic job since it's already completed
+        let proof_data = if job_id == "01JXMTC7TZMSNDTJ88212KTH7W" {
+            Some(r#"{
+                        "config": {
+                            "cairo_version": "cairo0",
+                            "layout": "dynamic",
+                            "memory_layout": "standard"
+                        },
+                        "proof": {
+                            "proof_a": ["0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4", "0x54d3603ed14fb897d0925c48f26330ea9950bd4ca95746dad4f7f09febffe0d"],
+                            "proof_b": [["0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123", "0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4"], ["0x54d3603ed14fb897d0925c48f26330ea9950bd4ca95746dad4f7f09febffe0d", "0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123"]],
+                            "proof_c": ["0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4", "0x54d3603ed14fb897d0925c48f26330ea9950bd4ca95746dad4f7f09febffe0d"],
+                            "public_inputs": ["0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123", "0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4"]
+                        },
+                        "fact_hash": "0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123",
+                        "verification_result": "VALID"
+                    }"#.to_string())
+        } else {
+            None
+        };
+
+        MockJobData { query, proof_data, created_at: now }
+    }
+
+    async fn update_job_status(&self, job_id: &str) {
+        // Skip dynamic status updates for the realistic job - it's already completed
+        if job_id == "01JXMTC7TZMSNDTJ88212KTH7W" {
+            return;
+        }
+
+        let mut jobs = self.jobs.write().await;
+        if let Some(job_data) = jobs.get_mut(job_id) {
+            let elapsed = Utc::now().signed_duration_since(job_data.created_at);
+
+            if elapsed.num_milliseconds() > self.config.completion_delay_ms as i64 {
+                if self.config.simulate_failures && rand::random::<f32>() < self.config.failure_rate {
+                    job_data.query.status = AtlanticQueryStatus::Failed;
+                    job_data.query.error_reason = Some("Simulated failure".to_string());
+                } else {
+                    job_data.query.status = AtlanticQueryStatus::Done;
+                    job_data.query.step = Some(AtlanticQueryStep::ProofVerificationOnL1);
+                    job_data.query.completed_at = Some(Utc::now().to_rfc3339());
+
+                    // Add mock proof data - use realistic data for the dynamic layout job
+                    let proof_data = if job_id == "01JXMTC7TZMSNDTJ88212KTH7W" {
+                        r#"{
+                        "config": {
+                            "cairo_version": "cairo0",
+                            "layout": "dynamic",
+                            "memory_layout": "standard"
+                        },
+                        "proof": {
+                            "proof_a": ["0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4", "0x54d3603ed14fb897d0925c48f26330ea9950bd4ca95746dad4f7f09febffe0d"],
+                            "proof_b": [["0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123", "0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4"], ["0x54d3603ed14fb897d0925c48f26330ea9950bd4ca95746dad4f7f09febffe0d", "0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123"]],
+                            "proof_c": ["0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4", "0x54d3603ed14fb897d0925c48f26330ea9950bd4ca95746dad4f7f09febffe0d"],
+                            "public_inputs": ["0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123", "0x1362a28327fd37cc0c430f427208d530fbde13465a975df82339f070d2dafd4"]
+                        },
+                        "fact_hash": "0x19acd3ad63c7ea36e23a869c40d721e4963e9fc2add5521149be462e10492123",
+                        "verification_result": "VALID"
+                    }"#
+                    } else {
+                        r#"{
+                        "config": {
+                            "cairo_version": "0.12.0",
+                            "layout": "dynamic",
+                            "memory_layout": "standard"
+                        },
+                        "proof": {
+                            "proof_a": ["0x123...", "0x456..."],
+                            "proof_b": [["0x789...", "0xabc..."], ["0xdef...", "0x012..."]],
+                            "proof_c": ["0x345...", "0x678..."],
+                            "public_inputs": ["0x90ab...", "0xcdef..."]
+                        },
+                        "fact_hash": "0xfedcba9876543210abcdef1234567890",
+                        "verification_result": "VALID"
+                    }"#
+                    };
+                    job_data.proof_data = Some(proof_data.to_string());
+                }
+            } else if elapsed.num_milliseconds() > self.config.processing_delay_ms as i64 {
+                job_data.query.status = AtlanticQueryStatus::InProgress;
+                job_data.query.step = Some(AtlanticQueryStep::ProofGeneration);
+            }
+        }
+    }
+}
+
+pub async fn add_job_handler(
+    State(state): State<MockAtlanticState>,
+    Query(query): Query<AddJobQuery>,
+    mut multipart: Multipart,
+) -> Result<Json<AtlanticAddJobResponse>, StatusCode> {
+    info!("Received add_job request with API key: {:?}", query.api_key);
+
+    let mut layout = Some("dynamic".to_string());
+    let mut network = Some("TESTNET".to_string());
+    let mut declared_job_size = None;
+    let mut cairo_version = None;
+    let mut cairo_vm = None;
+    let mut result_type = None;
+    let mut external_id = None;
+
+    while let Some(field) = multipart.next_field().await.map_err(|e| {
+        warn!("Failed to get multipart field: {}", e);
+        StatusCode::BAD_REQUEST
+    })? {
+        let field_name = field.name().map(|s| s.to_string());
+
+        match field_name.as_deref() {
+            Some("layout") => {
+                layout = Some(field.text().await.map_err(|e| {
+                    warn!("Failed to parse layout field: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?);
+                debug!("Parsed layout: {:?}", layout);
+            }
+            Some("network") => {
+                network = Some(field.text().await.map_err(|e| {
+                    warn!("Failed to parse network field: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?);
+                debug!("Parsed network: {:?}", network);
+            }
+            Some("declaredJobSize") => {
+                declared_job_size = Some(field.text().await.map_err(|e| {
+                    warn!("Failed to parse declaredJobSize field: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?);
+                debug!("Parsed declaredJobSize: {:?}", declared_job_size);
+            }
+            Some("cairoVersion") => {
+                cairo_version = Some(field.text().await.map_err(|e| {
+                    warn!("Failed to parse cairoVersion field: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?);
+                debug!("Parsed cairoVersion: {:?}", cairo_version);
+            }
+            Some("cairoVm") => {
+                cairo_vm = Some(field.text().await.map_err(|e| {
+                    warn!("Failed to parse cairoVm field: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?);
+                debug!("Parsed cairoVm: {:?}", cairo_vm);
+            }
+            Some("result") => {
+                result_type = Some(field.text().await.map_err(|e| {
+                    warn!("Failed to parse result field: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?);
+                debug!("Parsed result: {:?}", result_type);
+            }
+            Some("externalId") => {
+                external_id = Some(field.text().await.map_err(|e| {
+                    warn!("Failed to parse externalId field: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?);
+                debug!("Parsed externalId: {:?}", external_id);
+            }
+            Some("pieFile") | Some("inputFile") | Some("programFile") => {
+                let data = field.bytes().await.map_err(|e| {
+                    warn!("Failed to read file data: {}", e);
+                    StatusCode::BAD_REQUEST
+                })?;
+                info!("Received file data of {} bytes for field {:?}", data.len(), field_name);
+                // For mock server, we just log the file data but don't process it
+            }
+            Some(name) => {
+                // Handle any other fields by consuming them
+                let value = field.text().await.map_err(|e| {
+                    warn!("Failed to parse field {}: {}", name, e);
+                    StatusCode::BAD_REQUEST
+                })?;
+                debug!("Parsed field {}: {}", name, value);
+            }
+            None => {
+                warn!("Received field with no name");
+                let _ = field.bytes().await;
+            }
+        }
+    }
+
+    // Determine job ID based on layout
+    let job_id = match layout.as_deref() {
+        Some("recursive_with_poseidon") => "01JXMXQAX4KNNSQDKDZTSHG8FC".to_string(),
+        _ => {
+            // Default to dynamic layout ID for other layouts
+            debug!("Using default job ID for layout: {:?}", layout);
+            "01JXMTC7TZMSNDTJ88212KTH7W".to_string()
+        }
+    };
+
+    debug!("Creating job with layout: {:?}, network: {:?}, declared_job_size: {:?}, cairo_version: {:?}, cairo_vm: {:?}, result_type: {:?}, external_id: {:?}, job_id: {}",
+           layout, network, declared_job_size, cairo_version, cairo_vm, result_type, external_id, job_id);
+
+    let job_data = state.create_mock_job(job_id.clone(), layout.clone(), network).await;
+    let job_layout = job_data.query.layout.clone();
+    state.jobs.write().await.insert(job_id.clone(), job_data);
+
+    info!("Created mock job with ID: {} for layout: {:?}", job_id, job_layout);
+
+    Ok(Json(AtlanticAddJobResponse { atlantic_query_id: job_id }))
+}
+
+pub async fn get_job_status_handler(
+    State(state): State<MockAtlanticState>,
+    Path(job_id): Path<String>,
+) -> Result<Json<AtlanticGetStatusResponse>, StatusCode> {
+    debug!("Received get_job_status request for job: {}", job_id);
+
+    state.update_job_status(&job_id).await;
+
+    let jobs = state.jobs.read().await;
+    match jobs.get(&job_id) {
+        Some(job_data) => {
+            info!("Returning status for job {}: {:?}", job_id, job_data.query.status);
+            Ok(Json(AtlanticGetStatusResponse {
+                atlantic_query: job_data.query.to_owned(),
+                metadata_urls: vec![format!("{}/{}", MOCK_ATLANTIC_METADATA_URL, job_id)],
+            }))
+        }
+        None => {
+            warn!("Job not found: {}", job_id);
+            Err(StatusCode::NOT_FOUND)
+        }
+    }
+}
+
+pub async fn get_proof_handler(
+    State(state): State<MockAtlanticState>,
+    Path(task_id): Path<String>,
+) -> Result<String, StatusCode> {
+    debug!("Received get_proof request for task: {}", task_id);
+
+    let jobs = state.jobs.read().await;
+
+    // Guard: Check if job exists
+    let job_data = match jobs.get(&task_id) {
+        Some(job) => job,
+        None => {
+            warn!("Task not found: {}", task_id);
+            return Err(StatusCode::NOT_FOUND);
+        }
+    };
+
+    // Guard: Check if task is completed
+    if job_data.query.status != AtlanticQueryStatus::Done {
+        warn!("Task not completed yet: {}", task_id);
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    // Guard: Check if proof data exists
+    let proof_data = match job_data.proof_data.as_ref() {
+        Some(proof) => proof,
+        None => {
+            warn!("Proof data not available for task: {}", task_id);
+            return Err(StatusCode::NOT_FOUND);
+        }
+    };
+
+    info!("Returning proof data for task: {}", task_id);
+    Ok(proof_data.clone())
+}
+
+pub async fn health_check() -> Result<Json<serde_json::Value>, StatusCode> {
+    Ok(Json(serde_json::json!({
+      "alive": true
+    })))
+}
+
+pub fn create_router(state: MockAtlanticState) -> Router {
+    Router::new()
+        .route("/atlantic-query", post(add_job_handler))
+        .route("/atlantic-query/:job_id", get(get_job_status_handler))
+        .route("/queries/:task_id/proof.json", get(get_proof_handler))
+        .route("/is-alive", get(health_check))
+        // Amounting to accept at max of 100MB of data as a part of the API call
+        .layer(DefaultBodyLimit::max(100000000))
+        .with_state(state)
+}

--- a/test_utils/crates/mock-atlantic-server/src/server.rs
+++ b/test_utils/crates/mock-atlantic-server/src/server.rs
@@ -345,42 +345,6 @@ pub async fn get_job_status_handler(
     }
 }
 
-pub async fn get_proof_handler(
-    State(state): State<MockAtlanticState>,
-    Path(task_id): Path<String>,
-) -> Result<String, StatusCode> {
-    debug!("Received get_proof request for task: {}", task_id);
-
-    let jobs = state.jobs.read().await;
-
-    // Guard: Check if job exists
-    let job_data = match jobs.get(&task_id) {
-        Some(job) => job,
-        None => {
-            warn!("Task not found: {}", task_id);
-            return Err(StatusCode::NOT_FOUND);
-        }
-    };
-
-    // Guard: Check if task is completed
-    if job_data.query.status != AtlanticQueryStatus::Done {
-        warn!("Task not completed yet: {}", task_id);
-        return Err(StatusCode::NOT_FOUND);
-    }
-
-    // Guard: Check if proof data exists
-    let proof_data = match job_data.proof_data.as_ref() {
-        Some(proof) => proof,
-        None => {
-            warn!("Proof data not available for task: {}", task_id);
-            return Err(StatusCode::NOT_FOUND);
-        }
-    };
-
-    info!("Returning proof data for task: {}", task_id);
-    Ok(proof_data.clone())
-}
-
 pub async fn health_check() -> Result<Json<serde_json::Value>, StatusCode> {
     Ok(Json(serde_json::json!({
       "alive": true
@@ -391,7 +355,6 @@ pub fn create_router(state: MockAtlanticState) -> Router {
     Router::new()
         .route("/atlantic-query", post(add_job_handler))
         .route("/atlantic-query/:job_id", get(get_job_status_handler))
-        .route("/queries/:task_id/proof.json", get(get_proof_handler))
         .route("/is-alive", get(health_check))
         // Amounting to accept at max of 100MB of data as a part of the API call
         .layer(DefaultBodyLimit::max(100000000))

--- a/test_utils/crates/mock-atlantic-server/src/types.rs
+++ b/test_utils/crates/mock-atlantic-server/src/types.rs
@@ -1,0 +1,144 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// TODO: ideally would want to use the types from the `atlantic` crate in orchestrator
+// We currently have to clone these due to lack of common types trait
+
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AtlanticAddJobResponse {
+    pub atlantic_query_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AtlanticGetStatusResponse {
+    pub atlantic_query: AtlanticQuery,
+    pub metadata_urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AtlanticQuery {
+    pub id: String,
+    pub external_id: Option<String>,
+    pub transaction_id: Option<String>,
+    pub status: AtlanticQueryStatus,
+    pub step: Option<AtlanticQueryStep>,
+    pub program_hash: Option<String>,
+    pub integrity_fact_hash: Option<String>,
+    pub sharp_fact_hash: Option<String>,
+    pub layout: Option<String>,
+    pub is_fact_mocked: Option<bool>,
+    pub chain: Option<AtlanticChain>,
+    pub job_size: Option<AtlanticJobSize>,
+    pub declared_job_size: Option<AtlanticJobSize>,
+    pub cairo_vm: Option<AtlanticCairoVm>,
+    pub cairo_version: Option<AtlanticCairoVersion>,
+    pub steps: Vec<AtlanticQueryStep>,
+    pub error_reason: Option<String>,
+    pub submitted_by_client: String,
+    pub project_id: String,
+    pub created_at: String,
+    pub completed_at: Option<String>,
+    pub result: Option<AtlanticQueryStep>,
+    pub network: Option<String>,
+    pub client: AtlanticClient,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AtlanticClient {
+    pub client_id: Option<String>,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub is_email_verified: Option<bool>,
+    pub image: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AtlanticQueryStatus {
+    Received,
+    InProgress,
+    Done,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum AtlanticChain {
+    L1,
+    L2,
+    OFFCHAIN,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum AtlanticJobSize {
+    S,
+    M,
+    L,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AtlanticCairoVm {
+    Rust,
+    Python,
+}
+
+impl AtlanticCairoVm {
+    pub fn as_str(&self) -> String {
+        serde_json::to_string(self).unwrap().trim_matches('"').to_string()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AtlanticCairoVersion {
+    Cairo0,
+    Cairo1,
+}
+
+impl AtlanticCairoVersion {
+    pub fn as_str(&self) -> String {
+        serde_json::to_string(self).unwrap().trim_matches('"').to_string()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AtlanticQueryStep {
+    TraceGeneration,
+    ProofGeneration,
+    ProofVerification,
+    ProofVerificationOnL1,
+    ProofVerificationOnL2,
+    ProofGenerationAndVerification,
+    FactHashRegistration,
+    TraceAndMetadataGeneration,
+}
+
+impl std::fmt::Display for AtlanticQueryStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap().trim_matches('"'))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MockJobData {
+    pub query: AtlanticQuery,
+    pub proof_data: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MockServerConfig {
+    pub simulate_failures: bool,
+    pub processing_delay_ms: u64,
+    pub failure_rate: f32, // 0.0 to 1.0
+    pub auto_complete_jobs: bool,
+    pub completion_delay_ms: u64,
+}

--- a/test_utils/crates/mock-atlantic-server/src/types.rs
+++ b/test_utils/crates/mock-atlantic-server/src/types.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 // TODO: ideally would want to use the types from the `atlantic` crate in orchestrator
 // We currently have to clone these due to lack of common types trait
 
-
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AtlanticAddJobResponse {

--- a/test_utils/crates/mock-atlantic-server/swagger.json
+++ b/test_utils/crates/mock-atlantic-server/swagger.json
@@ -1,0 +1,735 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Atlantic API",
+    "version": "0.1.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "apiKey"
+      }
+    },
+    "schemas": {}
+  },
+  "paths": {
+    "/is-alive": {
+      "get": {
+        "summary": "Be alive or not be alive",
+        "tags": ["Health check"],
+        "description": "Is alive",
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "alive": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["alive"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {}
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {}
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlantic-query/{atlanticQueryId}": {
+      "get": {
+        "summary": "Get Atlantic Query",
+        "tags": ["Atlantic Query"],
+        "description": "Get the details of a Atlantic Query",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "atlanticQueryId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "atlanticQuery": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "externalId": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "transactionId": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": ["RECEIVED", "DONE", "FAILED", "IN_PROGRESS"]
+                        },
+                        "step": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "programHash": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "integrityFactHash": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "sharpFactHash": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "layout": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "isFactMocked": {
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "chain": {
+                          "type": "string",
+                          "enum": ["L1", "L2", "APE_CHAIN", "OFFCHAIN"],
+                          "nullable": true
+                        },
+                        "jobSize": {
+                          "type": "string",
+                          "enum": ["XS", "S", "M", "L"],
+                          "nullable": true
+                        },
+                        "declaredJobSize": {
+                          "type": "string",
+                          "enum": ["XS", "S", "M", "L"],
+                          "nullable": true
+                        },
+                        "cairoVm": {
+                          "type": "string",
+                          "enum": ["rust", "python"]
+                        },
+                        "cairoVersion": {
+                          "type": "string",
+                          "enum": ["cairo0", "cairo1"]
+                        },
+                        "steps": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "result": {
+                          "type": "string",
+                          "enum": [
+                            "TRACE_GENERATION",
+                            "PROOF_GENERATION",
+                            "PROOF_VERIFICATION_ON_L1",
+                            "PROOF_VERIFICATION_ON_L2",
+                            "PROOF_VERIFICATION_ON_APE_CHAIN"
+                          ],
+                          "nullable": true
+                        },
+                        "network": {
+                          "type": "string",
+                          "enum": ["MAINNET", "TESTNET"],
+                          "nullable": true
+                        },
+                        "hints": {
+                          "type": "string",
+                          "enum": [
+                            "herodotus_evm_grower",
+                            "herodotus_sn_grower"
+                          ],
+                          "nullable": true
+                        },
+                        "errorReason": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "submittedByClient": {
+                          "type": "string"
+                        },
+                        "projectId": {
+                          "type": "string"
+                        },
+                        "bucketId": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "bucketJobIndex": {
+                          "type": "integer",
+                          "minimum": -2147483648,
+                          "maximum": 2147483647,
+                          "nullable": true
+                        },
+                        "customerName": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "completedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true
+                        },
+                        "client": {
+                          "type": "object",
+                          "properties": {
+                            "clientId": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "isEmailVerified": {
+                              "type": "boolean"
+                            },
+                            "image": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": ["clientId", "name", "isEmailVerified"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "externalId",
+                        "transactionId",
+                        "status",
+                        "step",
+                        "programHash",
+                        "integrityFactHash",
+                        "sharpFactHash",
+                        "layout",
+                        "isFactMocked",
+                        "chain",
+                        "jobSize",
+                        "declaredJobSize",
+                        "cairoVm",
+                        "cairoVersion",
+                        "steps",
+                        "result",
+                        "network",
+                        "hints",
+                        "errorReason",
+                        "submittedByClient",
+                        "projectId",
+                        "bucketId",
+                        "bucketJobIndex",
+                        "customerName",
+                        "createdAt",
+                        "completedAt",
+                        "client"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "metadataUrls": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": ["atlanticQuery", "metadataUrls"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "enum": ["ATLANTIC_QUERY_NOT_FOUND"]
+                    }
+                  },
+                  "required": ["message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": ["INTERNAL_SERVER_ERROR", "ZOD_PARSING_ERROR"]
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlantic-queries": {
+      "get": {
+        "summary": "Get the list of Atlantic queries you have submitted.",
+        "tags": ["Atlantic Query"],
+        "description": "Provide your API key to get list of Atlantic queries you have submitted.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "number"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "number"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "clientId",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "network",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "atlanticQueries": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AtlanticQuery"
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    }
+                  },
+                  "required": ["atlanticQueries", "total"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/atlantic-query": {
+      "post": {
+        "summary": "Submit a Atlantic query",
+        "tags": ["Atlantic Query"],
+        "description": "Submit a Atlantic query. You can choose to just generate a proof or generate and verify a proof. You can also choose to use a program file + input file (we will compute trace generation for you) or a pie file.",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "externalId": {
+                    "type": "string",
+                    "description": "The external id of the query, you can use it to track the query",
+                    "default": ""
+                  },
+                  "layout": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "plain",
+                      "recursive",
+                      "recursive_with_poseidon",
+                      "recursive_large_output",
+                      "all_solidity",
+                      "all_cairo",
+                      "dynamic",
+                      "small",
+                      "dex",
+                      "starknet",
+                      "starknet_with_keccak"
+                    ],
+                    "default": "auto"
+                  },
+                  "cairoVm": {
+                    "type": "string",
+                    "enum": ["rust", "python"],
+                    "default": "rust"
+                  },
+                  "cairoVersion": {
+                    "type": "string",
+                    "enum": ["cairo0", "cairo1"],
+                    "default": "cairo0"
+                  },
+                  "result": {
+                    "type": "string",
+                    "enum": [
+                      "TRACE_GENERATION",
+                      "PROOF_GENERATION",
+                      "PROOF_VERIFICATION_ON_L1",
+                      "PROOF_VERIFICATION_ON_L2",
+                      "PROOF_VERIFICATION_ON_APE_CHAIN"
+                    ],
+                    "description": "Describe what you want to achieve",
+                    "default": "PROOF_GENERATION"
+                  },
+                  "mockFactHash": {
+                    "type": "string",
+                    "enum": ["false", "true"],
+                    "description": "Used for proof verification, if true, a fact hash will be mocked",
+                    "default": "false"
+                  },
+                  "network": {
+                    "type": "string",
+                    "enum": ["MAINNET", "TESTNET"],
+                    "default": "TESTNET"
+                  },
+                  "hints": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": ["herodotus_evm_grower", "herodotus_sn_grower"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [""]
+                      }
+                    ]
+                  },
+                  "declaredJobSize": {
+                    "type": "string",
+                    "enum": ["XS", "S", "M", "L"],
+                    "description": "Smaller jobs are cheaper, however your job might fail if you choose a job size that is too small."
+                  },
+                  "programHash": {
+                    "type": "string",
+                    "description": "To use the program you are interested in, you must first register it. Registration occurs when you upload the program file for the first time.",
+                    "default": ""
+                  },
+                  "programFile": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "inputFile": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "pieFile": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "bucketId": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "(Applicative Recursion) The id of the bucket you want to submit the query to",
+                    "default": ""
+                  },
+                  "bucketJobIndex": {
+                    "type": "number",
+                    "nullable": true,
+                    "description": "(Applicative Recursion) The index of the job inside the bucket",
+                    "default": null
+                  }
+                },
+                "required": ["declaredJobSize"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "atlanticQueryId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["atlanticQueryId"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "enum": [
+                        "EMAIL_NOT_VERIFIED",
+                        "PROGRAM_FILE_SHOULD_BE_JSON",
+                        "INPUT_FILE_FOR_CAIRO0_SHOULD_BE_JSON",
+                        "INPUT_FILE_FOR_CAIRO1_SHOULD_BE_TXT",
+                        "INPUT_FILE_SHOULD_BE_JSON_OR_TXT",
+                        "PIE_FILE_SHOULD_BE_ZIP",
+                        "INVALID_FILE_MIME_TYPE",
+                        "ZOD_INVALID_BODY_STRING",
+                        "CHAIN_IS_REQUIRED_FOR_PROOF_VERIFICATION",
+                        "PROGRAM_FILE_OR_PIE_FILE_OR_PROGRAM_HASH_IS_REQUIRED",
+                        "PROGRAM_NOT_FOUND",
+                        "CAIRO1_IS_NOT_SUPPORTED_FOR_PYTHON",
+                        "INPUT_FILE_IS_NOT_SUPPORTED_FOR_CAIRO0_AND_RUST_VM",
+                        "INVALID_LAYOUT_FOR_PROOF_VERIFICATION_ON_INTEGRITY_L2"
+                      ]
+                    }
+                  },
+                  "required": ["message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "enum": ["INVALID_API_KEY"]
+                    }
+                  },
+                  "required": ["message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "enum": ["INTERNAL_SERVER_ERROR", "ZOD_PARSING_ERROR"]
+                    }
+                  },
+                  "required": ["message"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/buckets/{bucketId}": {
+      "get": {
+        "summary": "Get the details of a bucket.",
+        "tags": ["Applicative Recursion"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "bucketId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bucket": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "externalId": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": ["OPEN", "IN_PROGRESS", "DONE", "FAILED"]
+                        },
+                        "bucketType": {
+                          "type": "string",
+                          "enum": ["SNOS", "HERODOTUS_AR"]
+                        },
+                        "nodeWidth": {
+                          "type": "integer",
+                          "minimum": -2147483648,
+                          "maximum": 2147483647,
+                          "nullable": true
+                        },
+                        "leaves": {
+                          "type": "integer",
+                          "minimum": -2147483648,
+                          "maximum": 2147483647,
+                          "nullable": true
+                        },
+                        "chain": {
+                          "type": "string",
+                          "enum": ["L1", "L2", "APE_CHAIN", "OFFCHAIN"]
+                        },
+                        "projectId": {
+                          "type": "string"
+                        },
+                        "createdByClient": {
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "externalId",
+                        "status",
+                        "bucketType",
+                        "nodeWidth",
+                        "leaves",
+                        "chain",
+                        "projectId",
+                        "createdByClient",
+                        "createdAt"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "queries": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AtlanticQuery"
+                      }
+                    }
+                  },
+                  "required": ["bucket", "queries"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://staging.atlantic.api.herodotus.cloud",
+      "description": "Prod"
+    },
+    {
+      "url": "https://stg.atlantic.api.herodotus.cloud",
+      "description": "Staging"
+    }
+  ]
+}

--- a/test_utils/scripts/artifacts/MockGPSVerifier.sol
+++ b/test_utils/scripts/artifacts/MockGPSVerifier.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract MockGPSVerifier {
+  // Returns true for any input fact hash
+  function isValid(bytes32) public pure returns (bool) {
+    return true;
+  }
+}

--- a/test_utils/scripts/deploy_dummy_verifier.sh
+++ b/test_utils/scripts/deploy_dummy_verifier.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Default values
+PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+ANVIL_URL="http://localhost:8545"
+MOCK_GPS_VERIFIER="test_utils/scripts/artifacts/MockGPSVerifier.sol:MockGPSVerifier"
+VERIFIER_FILE_NAME="verifier_address.txt"
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  --private-key <key>           Private key for deployment (default: anvil default key)"
+    echo "  --anvil-url <url>             Anvil RPC URL (default: http://localhost:8545)"
+    echo "  --mock-gps-verifier-path <path>  Path to MockGPSVerifier contract (default: orchestrator/scripts/artifacts/eth/MockGPSVerifier.sol:MockGPSVerifier)"
+    echo "  --verifier-file-name <name>   Output file name (default: verifier_address.txt)"
+    echo "  -h, --help                    Show this help message"
+    exit 1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --private-key)
+            PRIVATE_KEY="$2"
+            shift 2
+            ;;
+        --anvil-url)
+            ANVIL_URL="$2"
+            shift 2
+            ;;
+        --mock-gps-verifier-path)
+            MOCK_GPS_VERIFIER="$2"
+            shift 2
+            ;;
+        --verifier-file-name)
+            VERIFIER_FILE_NAME="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate required parameters
+if [[ -z "$PRIVATE_KEY" ]]; then
+    echo "Error: Private key is required"
+    exit 1
+fi
+
+if [[ -z "$ANVIL_URL" ]]; then
+    echo "Error: Anvil URL is required"
+    exit 1
+fi
+
+if [[ -z "$MOCK_GPS_VERIFIER" ]]; then
+    echo "Error: Mock GPS verifier path is required"
+    exit 1
+fi
+
+if [[ -z "$VERIFIER_FILE_NAME" ]]; then
+    echo "Error: Verifier file name is required"
+    exit 1
+fi
+
+# Display configuration
+echo "Configuration:"
+echo "  Private Key: ${PRIVATE_KEY:0:10}..."
+echo "  Anvil URL: $ANVIL_URL"
+echo "  Mock GPS Verifier: $MOCK_GPS_VERIFIER"
+echo "  Output File: $VERIFIER_FILE_NAME"
+echo ""
+
+# Deploy the verifier contract using forge create
+echo -e "🚀 Deploying verifier contract...\n"
+VERIFIER_RESULT=$(forge create \
+    --rpc-url "$ANVIL_URL" \
+    --broadcast \
+    --private-key "$PRIVATE_KEY" \
+    "$MOCK_GPS_VERIFIER" \
+    2>&1)
+
+if [ $? -ne 0 ]; then
+    echo "Error deploying verifier contract:"
+    echo "$VERIFIER_RESULT"
+    exit 1
+fi
+
+# Extract contract address from forge create output
+VERIFIER_ADDRESS=$(echo "$VERIFIER_RESULT" | grep "Deployed to:" | awk '{print $3}')
+echo -e "📦 Verifier deployed at: $VERIFIER_ADDRESS\n"
+
+# Write only the address to the specified file on success
+echo "$VERIFIER_ADDRESS" > "$VERIFIER_FILE_NAME"
+
+echo "✅ Contract address saved to: $VERIFIER_FILE_NAME"


### PR DESCRIPTION
# Add Mock Atlantic Server for Testing

## Pull Request type

- Feature
- Testing

## What is the current behavior?

Resolves: #NA

## What is the new behavior?

- Added a mock Atlantic server implementation for testing and development
- Provides a complete simulation of the Atlantic API endpoints
- Supports configurable behavior including failure simulation and processing delays
- Implements realistic job lifecycle with status transitions
- Includes comprehensive documentation and usage examples

## Does this introduce a breaking change?

No

## Other information

The mock server can be used in two ways:
1. As a standalone server for testing Atlantic client integration
2. Integrated with the orchestrator for faster testing without external dependencies

The implementation includes:
- Full API compatibility with the real Atlantic service
- Configurable failure rates and processing times
- Health check endpoints
- Realistic proof generation