### PR TITLE
E2E: 9 : Adding: mock verifier + deployer

### DIFF
--- a/e2e/src/services/mock_prover/config.rs
+++ b/e2e/src/services/mock_prover/config.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+use tokio::process::Command;
+
+pub const DEFAULT_MOCK_PROVER_BINARY: &str = "../target/release/mock-atlantic-server";
+
+#[derive(Debug, thiserror::Error)]
+pub enum MockProverError {
+    #[error("Server error: {0}")]
+    Server(#[from] crate::services::server::ServerError),
+    #[error("Mock prover execution failed: {0}")]
+    ExecutionFailed(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct MockProverConfig {
+    binary_path: PathBuf,
+    port: u16,
+}
+
+impl MockProverConfig {
+    /// Create a new configuration with the specified port
+    pub fn new(port: u16) -> Self {
+        Self {
+            binary_path: PathBuf::from(DEFAULT_MOCK_PROVER_BINARY),
+            port,
+        }
+    }
+
+    /// Create a builder for MockProverConfig
+    pub fn builder() -> MockProverConfigBuilder {
+        MockProverConfigBuilder::new()
+    }
+
+    /// Get the port
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the binary path
+    pub fn binary_path(&self) -> &PathBuf {
+        &self.binary_path
+    }
+
+    /// Convert configuration to tokio Command
+    pub fn to_command(&self) -> Command {
+        let mut command = Command::new(&self.binary_path);
+        command.arg(self.port.to_string());
+        command
+    }
+}
+
+/// Builder for MockProverConfig
+#[derive(Debug, Clone)]
+pub struct MockProverConfigBuilder {
+    binary_path: PathBuf,
+    port: Option<u16>,
+}
+
+impl MockProverConfigBuilder {
+    /// Create a new builder
+    pub fn new() -> Self {
+        Self {
+            binary_path: PathBuf::from(DEFAULT_MOCK_PROVER_BINARY),
+            port: None,
+        }
+    }
+
+    /// Set the binary path
+    pub fn binary_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.binary_path = path.into();
+        self
+    }
+
+    /// Set the port
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    /// Build the final configuration
+    pub fn build(self) -> Result<MockProverConfig, MockProverError> {
+        let port = self.port.ok_or_else(|| {
+            MockProverError::ExecutionFailed("Port must be specified".to_string())
+        })?;
+
+        Ok(MockProverConfig {
+            binary_path: self.binary_path,
+            port,
+        })
+    }
+}
+
+impl Default for MockProverConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/mock_prover/mod.rs
+++ b/e2e/src/services/mock_prover/mod.rs
@@ -1,0 +1,64 @@
+// =============================================================================
+// MOCK PROVER SERVICE - Using generic Server
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::server::{Server, ServerConfig};
+
+pub struct MockProverService {
+    server: Server,
+    config: MockProverConfig,
+}
+
+impl MockProverService {
+    /// Start the mock prover service
+    pub async fn start(config: MockProverConfig) -> Result<Self, MockProverError> {
+        let command = config.to_command();
+        let port = config.port();
+
+        println!("Running mock prover with command: {:?}", command);
+
+        // Create server config
+        let server_config = ServerConfig {
+            rpc_port: Some(port),
+            service_name: "MockProver".to_string(),
+            connection_attempts: 30,
+            connection_delay_ms: 1000,
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(MockProverError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+    /// Get the dependencies required by the mock prover
+    pub fn dependencies(&self) -> Vec<String> {
+        vec![
+            // Mock prover typically has minimal dependencies
+            // Add any external dependencies here if needed
+        ]
+    }
+
+    /// Get the port number
+    pub fn port(&self) -> u16 {
+        self.config.port()
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &MockProverConfig {
+        &self.config
+    }
+
+    /// Get the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+}

--- a/e2e/src/services/mock_verifier/config.rs
+++ b/e2e/src/services/mock_verifier/config.rs
@@ -1,0 +1,214 @@
+use crate::services::server::ServerError;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub const DEFAULT_SCRIPT_PATH: &str = "../test_utils/scripts/deploy_dummy_verifier.sh";
+pub const DEFAULT_PRIVATE_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+pub const DEFAULT_ANVIL_URL: &str = "http://localhost:8545";
+pub const DEFAULT_MOCK_GPS_VERIFIER_PATH: &str = "test_utils/scripts/artifacts/MockGPSVerifier.sol:MockGPSVerifier";
+pub const DEFAULT_VERIFIER_FILE_NAME: &str = "verifier_address.txt";
+
+#[derive(Debug, thiserror::Error)]
+pub enum MockVerifierDeployerError {
+    #[error("Script not found: {0}")]
+    ScriptNotFound(String),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+    #[error("Missing required configuration: {0}")]
+    MissingConfig(String),
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+    #[error("Deployment script execution failed: {0}")]
+    ExecutionFailed(String),
+    #[error("Deployment failed with exit code: {0}")]
+    DeploymentFailed(i32),
+    #[error("File system error: {0}")]
+    FileSystem(#[from] std::io::Error),
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct MockVerifierDeployerConfig {
+    timeout: Duration,
+    script_path: PathBuf,
+    private_key: String,
+    anvil_url: String,
+    mock_gps_verifier_path: String,
+    verifier_file_name: String,
+    environment_vars: HashMap<String, String>,
+    additional_args: Vec<String>,
+}
+
+impl Default for MockVerifierDeployerConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(300), // 5 minutes should be enough for deployment
+            script_path: PathBuf::from(DEFAULT_SCRIPT_PATH),
+            private_key: DEFAULT_PRIVATE_KEY.to_string(),
+            anvil_url: DEFAULT_ANVIL_URL.to_string(),
+            mock_gps_verifier_path: DEFAULT_MOCK_GPS_VERIFIER_PATH.to_string(),
+            verifier_file_name: DEFAULT_VERIFIER_FILE_NAME.to_string(),
+            environment_vars: HashMap::new(),
+            additional_args: Vec::new(),
+        }
+    }
+}
+
+impl MockVerifierDeployerConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for MockVerifierDeployerConfig
+    pub fn builder() -> MockVerifierDeployerConfigBuilder {
+        MockVerifierDeployerConfigBuilder::new()
+    }
+
+    /// Get the timeout duration
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Get the script path
+    pub fn script_path(&self) -> &PathBuf {
+        &self.script_path
+    }
+
+    /// Get the private key
+    pub fn private_key(&self) -> &str {
+        &self.private_key
+    }
+
+    /// Get the anvil URL
+    pub fn anvil_url(&self) -> &str {
+        &self.anvil_url
+    }
+
+    /// Get the mock GPS verifier path
+    pub fn mock_gps_verifier_path(&self) -> &str {
+        &self.mock_gps_verifier_path
+    }
+
+    /// Get the verifier file name
+    pub fn verifier_file_name(&self) -> &str {
+        &self.verifier_file_name
+    }
+
+    /// Get the environment variables
+    pub fn environment_vars(&self) -> &HashMap<String, String> {
+        &self.environment_vars
+    }
+
+    /// Get the additional arguments
+    pub fn additional_args(&self) -> &[String] {
+        &self.additional_args
+    }
+
+    /// Convert the configuration to a tokio command
+    pub fn to_command(&self) -> tokio::process::Command {
+        let script_path_str = self.script_path.to_string_lossy();
+
+        // Create command that first makes the script executable, then runs it
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c");
+
+        // Build the command string: chmod +x script && script args
+        let mut command_string = format!("chmod +x {} && {}", script_path_str, script_path_str);
+
+        // Add script arguments
+        command_string.push_str(&format!(" --private-key '{}'", self.private_key));
+        command_string.push_str(&format!(" --anvil-url '{}'", self.anvil_url));
+        command_string.push_str(&format!(" --mock-gps-verifier-path '{}'", self.mock_gps_verifier_path));
+        command_string.push_str(&format!(" --verifier-file-name '{}'", self.verifier_file_name));
+
+        // Additional arguments
+        for arg in &self.additional_args {
+            command_string.push_str(&format!(" '{}'", arg));
+        }
+
+        cmd.arg(command_string);
+
+        // Environment variables
+        for (key, value) in &self.environment_vars {
+            cmd.env(key, value);
+        }
+
+        cmd
+    }
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct MockVerifierDeployerConfigBuilder {
+    config: MockVerifierDeployerConfig,
+}
+
+impl MockVerifierDeployerConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: MockVerifierDeployerConfig::default(),
+        }
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> MockVerifierDeployerConfig {
+        self.config
+    }
+
+    /// Set the script path
+    pub fn script_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.config.script_path = path.into();
+        self
+    }
+
+    /// Set the private key
+    pub fn private_key<S: Into<String>>(mut self, key: S) -> Self {
+        self.config.private_key = key.into();
+        self
+    }
+
+    /// Set the anvil URL
+    pub fn anvil_url<S: Into<String>>(mut self, url: S) -> Self {
+        self.config.anvil_url = url.into();
+        self
+    }
+
+    /// Set the mock GPS verifier path
+    pub fn mock_gps_verifier_path<S: Into<String>>(mut self, path: S) -> Self {
+        self.config.mock_gps_verifier_path = path.into();
+        self
+    }
+
+    /// Set the verifier file name
+    pub fn verifier_file_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.config.verifier_file_name = name.into();
+        self
+    }
+
+    /// Add an environment variable
+    pub fn env_var(mut self, key: &str, value: &str) -> Self {
+        self.config.environment_vars.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Add an additional argument
+    pub fn arg(mut self, arg: &str) -> Self {
+        self.config.additional_args.push(arg.to_string());
+        self
+    }
+
+    /// Set the timeout duration
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.config.timeout = timeout;
+        self
+    }
+}
+
+impl Default for MockVerifierDeployerConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/mock_verifier/mod.rs
+++ b/e2e/src/services/mock_verifier/mod.rs
@@ -1,0 +1,137 @@
+// =============================================================================
+// MOCK VERIFIER DEPLOYER SERVICE - Deployment utility for mock GPS verifier contract
+// =============================================================================
+
+pub mod config;
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::server::{Server, ServerConfig};
+use std::process::ExitStatus;
+
+pub struct MockVerifierDeployerService {
+    server: Server,
+    config: MockVerifierDeployerConfig,
+}
+
+impl MockVerifierDeployerService {
+    /// Run the mock verifier deployment and wait for completion (convenience method)
+    pub async fn run(config: MockVerifierDeployerConfig) -> Result<ExitStatus, MockVerifierDeployerError> {
+        let mut service = Self::start(config).await?;
+        service.wait_for_completion().await
+    }
+
+    /// Start a new mock verifier service with the given configuration
+    pub async fn start(config: MockVerifierDeployerConfig) -> Result<Self, MockVerifierDeployerError> {
+        // Build the deployment script command
+        let command = config.to_command();
+
+        // Create server config - mock verifier doesn't need network port,
+        // but we'll use the generic server interface
+        let server_config = ServerConfig {
+            connection_attempts: 1, // No connection check needed
+            connection_delay_ms: 100,
+            service_name: "MockVerifierDeployerDeployer".to_string(),
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(MockVerifierDeployerError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+    /// Wait for the mock verifier deployment to complete execution
+    pub async fn wait_for_completion(&mut self) -> Result<ExitStatus, MockVerifierDeployerError> {
+        println!("🚀 Deploying mock verifier contract...");
+
+        // Use timeout to prevent hanging
+        let result = tokio::time::timeout(self.config.timeout(), async {
+            // Keep checking if the process has exited
+            loop {
+                if let Some(exit_status) = self.server.has_exited() {
+                    return Ok::<ExitStatus, MockVerifierDeployerError>(exit_status);
+                }
+
+                // Small delay to avoid busy waiting
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match result {
+            Ok(Ok(exit_status)) => {
+                if exit_status.success() {
+                    println!("✅ Mock verifier deployed successfully with {}", exit_status);
+
+                    // Try to read the deployed address from the output file
+                    if let Ok(address) = std::fs::read_to_string(&self.config.verifier_file_name()) {
+                        println!("📦 Verifier contract deployed at: {}", address.trim());
+                    }
+
+                    Ok(exit_status)
+                } else {
+                    let exit_code = exit_status.code().unwrap_or(-1);
+                    Err(MockVerifierDeployerError::DeploymentFailed(exit_code))
+                }
+            }
+            Ok(Err(e)) => Err(MockVerifierDeployerError::ExecutionFailed(e.to_string())),
+            Err(_) => Err(MockVerifierDeployerError::ExecutionFailed(format!(
+                "Mock verifier deployment timed out after {:?}",
+                self.config.timeout()
+            ))),
+        }
+    }
+
+    /// Get access to the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &MockVerifierDeployerConfig {
+        &self.config
+    }
+
+    /// Get the deployed verifier address from the output file
+    pub fn get_verifier_address(&self) -> Result<String, MockVerifierDeployerError> {
+        std::fs::read_to_string(&self.config.verifier_file_name())
+            .map(|s| s.trim().to_string())
+            .map_err(|e| MockVerifierDeployerError::FileSystem(e))
+    }
+
+    /// Get dependencies
+    pub fn dependencies(&self) -> Option<Vec<String>> {
+        Some(vec![
+            "anvil".to_string(),
+            "forge".to_string(),
+        ])
+    }
+
+    /// Check if deployment script exists (static method for convenience)
+    pub fn check_script() -> Result<(), MockVerifierDeployerError> {
+        let script_path = std::path::PathBuf::from(DEFAULT_SCRIPT_PATH);
+        if script_path.exists() {
+            Ok(())
+        } else {
+            Err(MockVerifierDeployerError::ScriptNotFound(format!(
+                "Default script not found: {}",
+                script_path.display()
+            )))
+        }
+    }
+
+    /// Check if deployment script exists for a specific path
+    pub fn check_script_path(path: &std::path::Path) -> Result<(), MockVerifierDeployerError> {
+        if path.exists() {
+            Ok(())
+        } else {
+            Err(MockVerifierDeployerError::ScriptNotFound(format!(
+                "Script not found: {}",
+                path.display()
+            )))
+        }
+    }
+}

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -8,3 +8,5 @@ pub mod mongodb;
 pub mod madara;
 pub mod pathfinder;
 pub mod orchestrator;
+pub mod mock_verifier;
+pub mod mock_prover;


### PR DESCRIPTION
# Add Mock Prover and Mock Verifier Services for E2E Testing

## Pull Request type

- Feature
- Testing

## What is the current behavior?

The e2e testing framework lacks mock implementations for prover and verifier services, which are needed for comprehensive testing without relying on actual production services.

## What is the new behavior?

- Added `MockProverService` for simulating prover functionality in tests
- Added `MockVerifierDeployerService` for deploying mock GPS verifier contracts
- Implemented configuration builders with sensible defaults for both services
- Integrated both services with the existing server framework

## Does this introduce a breaking change?

No

## Other information

These mock services will allow for faster and more reliable testing by eliminating dependencies on actual proving systems and blockchain networks during development and CI testing.