### PR TITLE
E2E: 3 : Anvil Server

### DIFF
--- a/e2e/src/services/anvil/config.rs
+++ b/e2e/src/services/anvil/config.rs
@@ -1,0 +1,163 @@
+use crate::services::server::ServerError;
+use tokio::process::Command;
+
+pub const ANVIL_DEFAULT_DATABASE_NAME: &str = "anvil.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum AnvilError {
+    #[error("Anvil is not installed on the system")]
+    NotInstalled,
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct AnvilConfig {
+    fork_url: Option<String>,
+    load_state: Option<String>,
+    dump_state: Option<String>,
+    block_time: Option<f64>,
+    // Server Configs
+    port: u16,
+    logs: (bool, bool),
+}
+
+impl Default for AnvilConfig {
+    fn default() -> Self {
+        Self {
+            fork_url: None,
+            load_state: None,
+            dump_state: None,
+            block_time: None,
+
+            // Server Config
+            port: 8545,
+            logs: (true, true),
+        }
+    }
+}
+
+impl AnvilConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for AnvilConfig
+    pub fn builder() -> AnvilConfigBuilder {
+        AnvilConfigBuilder::new()
+    }
+
+    /// Get the port
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the logs configuration
+    pub fn logs(&self) -> (bool, bool) {
+        self.logs
+    }
+
+    /// Get the fork URL
+    pub fn fork_url(&self) -> Option<&str> {
+        self.fork_url.as_deref()
+    }
+
+    /// Get the load state path
+    pub fn load_state(&self) -> Option<&str> {
+        self.load_state.as_deref()
+    }
+
+    /// Get the dump state path
+    pub fn dump_state(&self) -> Option<&str> {
+        self.dump_state.as_deref()
+    }
+
+    /// Get the block time in seconds
+    pub fn block_time(&self) -> Option<f64> {
+        self.block_time
+    }
+
+    /// Build the final immutable configuration
+    pub fn to_command(&self) -> Command {
+        let mut command = Command::new("anvil");
+        command.arg("--port").arg(self.port().to_string());
+
+        if let Some(fork_url) = self.fork_url() {
+            command.arg("--fork-url").arg(fork_url);
+        }
+
+        if let Some(load_state) = self.load_state() {
+            command.arg("--load-state").arg(load_state);
+        }
+
+        if let Some(dump_state) = self.dump_state() {
+            command.arg("--dump-state").arg(dump_state);
+        }
+
+        if let Some(block_time) = self.block_time() {
+            command.arg("--block-time").arg(block_time.to_string());
+        }
+
+        command
+    }
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct AnvilConfigBuilder {
+    config: AnvilConfig,
+}
+
+impl AnvilConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: AnvilConfig::default(),
+        }
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> AnvilConfig {
+        self.config
+    }
+
+    /// Set the port (default: 8545)
+    pub fn port(mut self, port: u16) -> Self {
+        self.config.port = port;
+        self
+    }
+
+    /// Set the fork URL for forking from an existing network
+    pub fn fork_url<S: Into<String>>(mut self, url: S) -> Self {
+        self.config.fork_url = Some(url.into());
+        self
+    }
+
+    /// Set the database file to load state from
+    pub fn load_state<S: Into<String>>(mut self, path: S) -> Self {
+        self.config.load_state = Some(path.into());
+        self
+    }
+
+    /// Set the database file to dump state to
+    pub fn dump_state<S: Into<String>>(mut self, path: S) -> Self {
+        self.config.dump_state = Some(path.into());
+        self
+    }
+
+    /// Set the block time in seconds (must be non-negative, can be decimal)
+    pub fn block_time(mut self, seconds: f64) -> Self {
+        if seconds >= 0.0 {
+            self.config.block_time = Some(seconds);
+        }
+        self
+    }
+}
+
+impl Default for AnvilConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/anvil/config.rs
+++ b/e2e/src/services/anvil/config.rs
@@ -1,8 +1,6 @@
 use crate::services::server::ServerError;
 use tokio::process::Command;
 
-pub const ANVIL_DEFAULT_DATABASE_NAME: &str = "anvil.json";
-
 #[derive(Debug, thiserror::Error)]
 pub enum AnvilError {
     #[error("Anvil is not installed on the system")]

--- a/e2e/src/services/anvil/config.rs
+++ b/e2e/src/services/anvil/config.rs
@@ -1,4 +1,4 @@
-use crate::services::server::ServerError;
+use crate::services::{constants::DEFAULT_ANIVL_PORT, server::ServerError};
 use tokio::process::Command;
 
 #[derive(Debug, thiserror::Error)]
@@ -30,7 +30,7 @@ impl Default for AnvilConfig {
             block_time: None,
 
             // Server Config
-            port: 8545,
+            port: DEFAULT_ANIVL_PORT,
             logs: (true, true),
         }
     }

--- a/e2e/src/services/anvil/mod.rs
+++ b/e2e/src/services/anvil/mod.rs
@@ -1,0 +1,58 @@
+// =============================================================================
+// ANVIL SERVICE - Spawns a new Anvil service with the given configuration
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+use url::Url;
+
+use crate::services::server::{Server, ServerConfig};
+
+// Anvil service that uses the generic Server
+pub struct AnvilService {
+    server: Server,
+    config: AnvilConfig,
+}
+
+impl AnvilService {
+    /// Start a new Anvil service with the given configuration
+    pub async fn start(config: AnvilConfig) -> Result<Self, AnvilError> {
+
+        // Build the anvil command
+        let command = config.to_command();
+
+        // Create server config using the immutable config getters
+        let server_config = ServerConfig {
+            rpc_port: Some(config.port()),
+            logs: config.logs(),
+            service_name: "Anvil".to_string(),
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(AnvilError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    pub fn stop(&mut self) -> Result<(), AnvilError> {
+        println!("☠️ Stopping Anvil");
+        self.server.stop().map_err(|err| AnvilError::Server(err))
+    }
+
+    pub fn config(&self) -> &AnvilConfig {
+        &self.config
+    }
+
+    pub fn endpoint(&self) -> Url {
+        self.server().endpoint().expect("Anvil should have an endpoint")
+    }
+}

--- a/e2e/src/services/anvil/mod.rs
+++ b/e2e/src/services/anvil/mod.rs
@@ -43,9 +43,9 @@ impl AnvilService {
         &self.server
     }
 
-    pub async fn stop(&mut self) -> Result<(), AnvilError> {
+    pub fn stop(&mut self) -> Result<(), AnvilError> {
         println!("☠️ Stopping Anvil");
-        self.server.stop().await.map_err(|err| AnvilError::Server(err))
+        self.server.stop().map_err(|err| AnvilError::Server(err))
     }
 
     pub fn config(&self) -> &AnvilConfig {

--- a/e2e/src/services/anvil/mod.rs
+++ b/e2e/src/services/anvil/mod.rs
@@ -19,7 +19,6 @@ pub struct AnvilService {
 impl AnvilService {
     /// Start a new Anvil service with the given configuration
     pub async fn start(config: AnvilConfig) -> Result<Self, AnvilError> {
-
         // Build the anvil command
         let command = config.to_command();
 
@@ -32,9 +31,7 @@ impl AnvilService {
         };
 
         // Start the server using the generic Server::start_process
-        let server = Server::start_process(command, server_config)
-            .await
-            .map_err(AnvilError::Server)?;
+        let server = Server::start_process(command, server_config).await.map_err(AnvilError::Server)?;
 
         Ok(Self { server, config })
     }

--- a/e2e/src/services/anvil/mod.rs
+++ b/e2e/src/services/anvil/mod.rs
@@ -42,7 +42,8 @@ impl AnvilService {
 
     pub fn stop(&mut self) -> Result<(), AnvilError> {
         println!("☠️ Stopping Anvil");
-        self.server.stop().map_err(|err| AnvilError::Server(err))
+        self.server.stop().map_err(AnvilError::Server)?;
+        Ok(())
     }
 
     pub fn config(&self) -> &AnvilConfig {

--- a/e2e/src/services/anvil/mod.rs
+++ b/e2e/src/services/anvil/mod.rs
@@ -43,9 +43,9 @@ impl AnvilService {
         &self.server
     }
 
-    pub fn stop(&mut self) -> Result<(), AnvilError> {
+    pub async fn stop(&mut self) -> Result<(), AnvilError> {
         println!("☠️ Stopping Anvil");
-        self.server.stop().map_err(|err| AnvilError::Server(err))
+        self.server.stop().await.map_err(|err| AnvilError::Server(err))
     }
 
     pub fn config(&self) -> &AnvilConfig {

--- a/e2e/src/services/helpers.rs
+++ b/e2e/src/services/helpers.rs
@@ -1,13 +1,10 @@
-use crate::services::constants::DEFAULT_SERVICE_HOST;
+use super::constants::*;
 use async_trait::async_trait;
 use serde_json::json;
 use std::io;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use url::Url;
-
-use super::constants::*;
-
 
 #[derive(Debug, thiserror::Error)]
 pub enum NodeRpcError {

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod anvil;
 pub mod helpers;
 pub mod server;
 pub mod constants;

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -1,4 +1,4 @@
 pub mod anvil;
+pub mod constants;
 pub mod helpers;
 pub mod server;
-pub mod constants;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "madara",
+  "name": "madara_2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
# Add Anvil Service for Ethereum Development Environment

## Pull Request type

- Feature

## What is the current behavior?

The e2e testing framework lacks a dedicated service for running Anvil, a popular Ethereum development environment.

## What is the new behavior?

- Added a new `AnvilService` that can spawn and manage Anvil instances
- Implemented a flexible configuration system with builder pattern for Anvil settings
- Provided methods to control Anvil instances (start, stop) and access their endpoints
- Supported key Anvil features including forking, state loading/dumping, and block time configuration

## Does this introduce a breaking change?

No

## Other information

This implementation allows e2e tests to easily create and manage Anvil instances with customizable configurations, enabling more comprehensive Ethereum-based testing scenarios.