### PR TITLE
E2E: 4 : Bootstrapper Service

### DIFF
--- a/e2e/src/services/bootstrapper/config.rs
+++ b/e2e/src/services/bootstrapper/config.rs
@@ -32,10 +32,12 @@ pub enum BootstrapperError {
     InvalidConfig(String),
     #[error("Bootstrapper execution failed: {0}")]
     ExecutionFailed(String),
-    #[error("Setup failed with exit code: {0}")]
-    SetupFailed(i32),
-    #[error("Other Error : {0}")]
-    OtherError(String),
+    #[error("Setup failed with exit message: {0}")]
+    SetupFailed(String),
+    #[error("Config read error: {0}")]
+    ConfigReadWriteError(#[from] std::io::Error),
+    #[error("Config parse error: {0}")]
+    ConfigParseError(#[from] serde_json::Error),
 }
 
 // Final immutable configuration

--- a/e2e/src/services/bootstrapper/config.rs
+++ b/e2e/src/services/bootstrapper/config.rs
@@ -1,3 +1,4 @@
+use crate::services::helpers::{get_binary_path, get_file_path};
 use crate::services::server::ServerError;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -56,9 +57,9 @@ impl Default for BootstrapperConfig {
     fn default() -> Self {
         Self {
             mode: BootstrapperMode::SetupL1,
-            timeout: Duration::from_secs(6000),
-            config_path: Some(PathBuf::from(DEFAULT_BOOTSTRAPPER_CONFIG)),
-            binary_path: PathBuf::from(DEFAULT_BOOTSTRAPPER_BINARY),
+            timeout: BOOTSTRAPPER_SETUP_L1_TIMEOUT.clone(),
+            config_path: None,
+            binary_path: get_binary_path(BOOTSTRAPPER_BINARY),
             logs: (true, true),
             environment_vars: HashMap::new(),
             additional_args: Vec::new(),
@@ -146,9 +147,7 @@ pub struct BootstrapperConfigBuilder {
 impl BootstrapperConfigBuilder {
     /// Create a new configuration builder with default values
     pub fn new() -> Self {
-        Self {
-            config: BootstrapperConfig::default(),
-        }
+        Self { config: BootstrapperConfig::default() }
     }
 
     /// Build the final immutable configuration
@@ -163,22 +162,26 @@ impl BootstrapperConfigBuilder {
     }
 
     /// Set the configuration file path
-    pub fn config_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
-        self.config.config_path = Some(path.into());
+    pub fn config_path(mut self, path: &str) -> Self {
+        self.config.config_path = Some(get_file_path(path));
         self
     }
 
     /// Set the binary path
-    pub fn binary_path<P: Into<PathBuf>>(mut self, path: Option<P>) -> Self {
-        if let Some(p) = path {
-            self.config.binary_path = p.into();
-        }
+    pub fn binary_path(mut self, path: &str) -> Self {
+        self.config.binary_path = get_binary_path(path);
         self
     }
 
     /// Add an environment variable
     pub fn env_var(mut self, key: &str, value: &str) -> Self {
         self.config.environment_vars.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Set the logs
+    pub fn logs(mut self, logs: (bool, bool)) -> Self {
+        self.config.logs = logs;
         self
     }
 

--- a/e2e/src/services/bootstrapper/config.rs
+++ b/e2e/src/services/bootstrapper/config.rs
@@ -3,9 +3,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
-pub const DEFAULT_BOOTSTRAPPER_BINARY: &str = "../target/release/bootstrapper";
-pub const DEFAULT_BOOTSTRAPPER_CONFIG: &str = "./config/bootstrapper.json";
-pub const BOOTSTRAPPER_DEFAULT_ADDRESS_PATH: &str = "addresses.json";
+use crate::services::constants::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum BootstrapperMode {

--- a/e2e/src/services/bootstrapper/config.rs
+++ b/e2e/src/services/bootstrapper/config.rs
@@ -1,0 +1,202 @@
+use crate::services::server::ServerError;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub const DEFAULT_BOOTSTRAPPER_BINARY: &str = "../target/release/bootstrapper";
+pub const DEFAULT_BOOTSTRAPPER_CONFIG: &str = "./config/bootstrapper.json";
+pub const BOOTSTRAPPER_DEFAULT_ADDRESS_PATH: &str = "addresses.json";
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BootstrapperMode {
+    SetupL1,
+    SetupL2,
+}
+
+impl std::fmt::Display for BootstrapperMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BootstrapperMode::SetupL1 => write!(f, "setup-l1"),
+            BootstrapperMode::SetupL2 => write!(f, "setup-l2"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapperError {
+    #[error("Bootstrapper binary not found: {0}")]
+    BinaryNotFound(String),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+    #[error("Missing required configuration: {0}")]
+    MissingConfig(String),
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+    #[error("Bootstrapper execution failed: {0}")]
+    ExecutionFailed(String),
+    #[error("Setup failed with exit code: {0}")]
+    SetupFailed(i32),
+    #[error("Other Error : {0}")]
+    OtherError(String),
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct BootstrapperConfig {
+    mode: BootstrapperMode,
+    timeout: Duration,
+    config_path: Option<PathBuf>,
+    binary_path: PathBuf,
+    logs: (bool, bool),
+    environment_vars: HashMap<String, String>,
+    additional_args: Vec<String>,
+}
+
+impl Default for BootstrapperConfig {
+    fn default() -> Self {
+        Self {
+            mode: BootstrapperMode::SetupL1,
+            timeout: Duration::from_secs(6000),
+            config_path: Some(PathBuf::from(DEFAULT_BOOTSTRAPPER_CONFIG)),
+            binary_path: PathBuf::from(DEFAULT_BOOTSTRAPPER_BINARY),
+            logs: (true, true),
+            environment_vars: HashMap::new(),
+            additional_args: Vec::new(),
+        }
+    }
+}
+
+impl BootstrapperConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for BootstrapperConfig
+    pub fn builder() -> BootstrapperConfigBuilder {
+        BootstrapperConfigBuilder::new()
+    }
+
+    /// Get the bootstrapper mode
+    pub fn mode(&self) -> &BootstrapperMode {
+        &self.mode
+    }
+
+    /// Get the timeout duration
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Get the logs
+    pub fn logs(&self) -> (bool, bool) {
+        self.logs
+    }
+
+    /// Get the configuration file path
+    pub fn config_path(&self) -> Option<&PathBuf> {
+        self.config_path.as_ref()
+    }
+
+    /// Get the binary path
+    pub fn binary_path(&self) -> &PathBuf {
+        &self.binary_path
+    }
+
+    /// Get the environment variables
+    pub fn environment_vars(&self) -> &HashMap<String, String> {
+        &self.environment_vars
+    }
+
+    /// Get the additional arguments
+    pub fn additional_args(&self) -> &[String] {
+        &self.additional_args
+    }
+
+    /// Convert the configuration to a tokio command
+    pub fn to_command(&self) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new(&self.binary_path);
+
+        // Core arguments
+        cmd.arg("--mode").arg(self.mode.to_string());
+
+        if let Some(config_path) = &self.config_path {
+            cmd.arg("--config").arg(config_path);
+        }
+
+        // Additional arguments
+        for arg in &self.additional_args {
+            cmd.arg(arg);
+        }
+
+        // Environment variables
+        for (key, value) in &self.environment_vars {
+            cmd.env(key, value);
+        }
+
+        cmd
+    }
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct BootstrapperConfigBuilder {
+    config: BootstrapperConfig,
+}
+
+impl BootstrapperConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: BootstrapperConfig::default(),
+        }
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> BootstrapperConfig {
+        self.config
+    }
+
+    /// Set the bootstrapper mode
+    pub fn mode(mut self, mode: BootstrapperMode) -> Self {
+        self.config.mode = mode;
+        self
+    }
+
+    /// Set the configuration file path
+    pub fn config_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.config.config_path = Some(path.into());
+        self
+    }
+
+    /// Set the binary path
+    pub fn binary_path<P: Into<PathBuf>>(mut self, path: Option<P>) -> Self {
+        if let Some(p) = path {
+            self.config.binary_path = p.into();
+        }
+        self
+    }
+
+    /// Add an environment variable
+    pub fn env_var(mut self, key: &str, value: &str) -> Self {
+        self.config.environment_vars.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    /// Add an additional argument
+    pub fn arg(mut self, arg: &str) -> Self {
+        self.config.additional_args.push(arg.to_string());
+        self
+    }
+
+    /// Set the timeout duration
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.config.timeout = timeout;
+        self
+    }
+}
+
+impl Default for BootstrapperConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/bootstrapper/config.rs
+++ b/e2e/src/services/bootstrapper/config.rs
@@ -33,8 +33,12 @@ pub enum BootstrapperError {
     InvalidConfig(String),
     #[error("Bootstrapper execution failed: {0}")]
     ExecutionFailed(String),
-    #[error("Setup failed with exit message: {0}")]
-    SetupFailed(String),
+    #[error("Bootstrapper execution timed out after {0:?}")]
+    ExecutionTimedOut(Duration),
+    #[error("Setup failed with exit code: {0}")]
+    SetupFailedWithCode(i32),
+    #[error("Setup failed - process terminated by signal: {0}")]
+    SetupFailedWithSignal(String),
     #[error("Config read error: {0}")]
     ConfigReadWriteError(#[from] std::io::Error),
     #[error("Config parse error: {0}")]

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -95,9 +95,9 @@ impl BootstrapperService {
         &self.config
     }
 
-    pub fn stop(&mut self) -> Result<(), BootstrapperError> {
+    pub async fn stop(&mut self) -> Result<(), BootstrapperError> {
         println!("☠️ Stopping Bootstrapper");
-        self.server.stop().map_err(|err| BootstrapperError::Server(err))
+        self.server.stop().await.map_err(|err| BootstrapperError::Server(err))
     }
 
     /// Get logs

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -54,7 +54,7 @@ impl BootstrapperService {
         let result = tokio::time::timeout(self.config.timeout(), async {
             // Keep checking if the process has exited
             loop {
-                if let Some(exit_status) = self.server.has_exited() {
+                if let Some(exit_status) = self.server.has_exited()? {
                     return Ok::<ExitStatus, BootstrapperError>(exit_status);
                 }
 

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -88,9 +88,9 @@ impl BootstrapperService {
         &self.config
     }
 
-    pub async fn stop(&mut self) -> Result<(), BootstrapperError> {
+    pub fn stop(&mut self) -> Result<(), BootstrapperError> {
         println!("☠️ Stopping Bootstrapper");
-        self.server.stop().await.map_err(|err| BootstrapperError::Server(err))
+        self.server.stop().map_err(|err| BootstrapperError::Server(err))
     }
 
     /// Get logs

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -70,19 +70,16 @@ impl BootstrapperService {
                     println!("✅ Bootstrapper {} completed successfully with {}", self.config.mode(), exit_status);
                     Ok(exit_status)
                 } else {
-                    let error_msg = if let Some(code) = exit_status.code() {
-                        format!("Process exited with code: {}", code)
+                    let error = if let Some(code) = exit_status.code() {
+                        BootstrapperError::SetupFailedWithCode(code)
                     } else {
-                        format!("Process terminated by signal: {}", exit_status)
+                        BootstrapperError::SetupFailedWithSignal(exit_status.to_string())
                     };
-                    Err(BootstrapperError::SetupFailed(error_msg))
+                    Err(error)
                 }
             }
             Ok(Err(e)) => Err(BootstrapperError::ExecutionFailed(e.to_string())),
-            Err(_) => Err(BootstrapperError::ExecutionFailed(format!(
-                "Bootstrapper timed out after {:?}",
-                self.config.timeout()
-            ))),
+            Err(_) => Err(BootstrapperError::ExecutionTimedOut(self.config.timeout())),
         }
     }
 

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -5,6 +5,7 @@
 pub mod config;
 // Re-export common utilities
 pub use config::*;
+use crate::services::constants::*;
 
 use crate::services::server::{Server, ServerConfig};
 use std::process::ExitStatus;

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -98,14 +98,6 @@ impl BootstrapperService {
         self.config.logs()
     }
 
-    /// Get dependencies
-    pub fn dependencies(&self) -> Option<Vec<String>> {
-        Some(if *self.config().mode() == BootstrapperMode::SetupL1 {
-            vec!["anvil".to_string()]
-        } else {
-            vec!["anvil".to_string(), "madara".to_string(), "bootstrapper_l1".to_string()]
-        })
-    }
 
     /// Check if bootstrapper binary exists (static method for convenience)
     pub fn check_binary() -> Result<(), BootstrapperError> {

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -88,9 +88,9 @@ impl BootstrapperService {
         &self.config
     }
 
-    pub fn stop(&mut self) -> Result<(), BootstrapperError> {
+    pub async fn stop(&mut self) -> Result<(), BootstrapperError> {
         println!("☠️ Stopping Bootstrapper");
-        self.server.stop().map_err(|err| BootstrapperError::Server(err))
+        self.server.stop().await.map_err(|err| BootstrapperError::Server(err))
     }
 
     /// Get logs

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -10,6 +10,9 @@ use crate::services::constants::*;
 use crate::services::server::{Server, ServerConfig};
 use std::process::ExitStatus;
 
+const CONNECTION_ATTEMPTS: usize = 1;
+const CONNECTION_DELAY_MS: u64 = 100;
+
 pub struct BootstrapperService {
     server: Server,
     config: BootstrapperConfig,
@@ -30,8 +33,8 @@ impl BootstrapperService {
         // Create server config - bootstrapper doesn't need network port,
         // but we'll use a dummy port for the generic server interface
         let server_config = ServerConfig {
-            connection_attempts: 1, // No connection check needed
-            connection_delay_ms: 100,
+            connection_attempts: CONNECTION_ATTEMPTS, // No connection check needed
+            connection_delay_ms: CONNECTION_DELAY_MS,
             service_name: format!("Bootstrapper-{}", config.mode().to_string()),
             ..Default::default()
         };

--- a/e2e/src/services/bootstrapper/mod.rs
+++ b/e2e/src/services/bootstrapper/mod.rs
@@ -1,0 +1,140 @@
+// =============================================================================
+// BOOTSTRAPPER SERVICE - Setup utility for L1/L2 initialization
+// =============================================================================
+
+pub mod config;
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::server::{Server, ServerConfig};
+use std::process::ExitStatus;
+
+pub struct BootstrapperService {
+    server: Server,
+    config: BootstrapperConfig,
+}
+
+impl BootstrapperService {
+    /// Run the bootstrapper and wait for completion (convenience method)
+    pub async fn run(config: BootstrapperConfig) -> Result<ExitStatus, BootstrapperError> {
+        let mut service = Self::start(config).await?;
+        service.wait_for_completion().await
+    }
+
+    /// Start a new bootstrapper service with the given configuration
+    pub async fn start(config: BootstrapperConfig) -> Result<Self, BootstrapperError> {
+        // Build the bootstrapper command
+        let command = config.to_command();
+
+        // Create server config - bootstrapper doesn't need network port,
+        // but we'll use a dummy port for the generic server interface
+        let server_config = ServerConfig {
+            connection_attempts: 1, // No connection check needed
+            connection_delay_ms: 100,
+            service_name: format!("Bootstrapper-{}", config.mode().to_string()),
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config).await.map_err(BootstrapperError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+    /// Wait for the bootstrapper to complete execution
+    pub async fn wait_for_completion(&mut self) -> Result<ExitStatus, BootstrapperError> {
+        println!("🚀 Running bootstrapper in {} mode...", self.config.mode());
+
+        // Use timeout to prevent hanging
+        let result = tokio::time::timeout(self.config.timeout(), async {
+            // Keep checking if the process has exited
+            loop {
+                if let Some(exit_status) = self.server.has_exited() {
+                    return Ok::<ExitStatus, BootstrapperError>(exit_status);
+                }
+
+                // Small delay to avoid busy waiting
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match result {
+            Ok(Ok(exit_status)) => {
+                if exit_status.success() {
+                    println!("✅ Bootstrapper {} completed successfully with {}", self.config.mode(), exit_status);
+                    Ok(exit_status)
+                } else {
+                    let exit_code = exit_status.code().unwrap_or(-1);
+                    Err(BootstrapperError::SetupFailed(exit_code))
+                }
+            }
+            Ok(Err(e)) => Err(BootstrapperError::ExecutionFailed(e.to_string())),
+            Err(_) => Err(BootstrapperError::ExecutionFailed(format!(
+                "Bootstrapper timed out after {:?}",
+                self.config.timeout()
+            ))),
+        }
+    }
+
+    /// Get the mode that was executed
+    pub fn mode(&self) -> &BootstrapperMode {
+        self.config.mode()
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &BootstrapperConfig {
+        &self.config
+    }
+
+    pub fn stop(&mut self) -> Result<(), BootstrapperError> {
+        println!("☠️ Stopping Bootstrapper");
+        self.server.stop().map_err(|err| BootstrapperError::Server(err))
+    }
+
+    /// Get logs
+    pub fn logs(&self) -> (bool, bool) {
+        self.config.logs()
+    }
+
+    /// Get dependencies
+    pub fn dependencies(&self) -> Option<Vec<String>> {
+        Some(if *self.config().mode() == BootstrapperMode::SetupL1 {
+            vec!["anvil".to_string()]
+        } else {
+            vec!["anvil".to_string(), "madara".to_string(), "bootstrapper_l1".to_string()]
+        })
+    }
+
+    /// Check if bootstrapper binary exists (static method for convenience)
+    pub fn check_binary() -> Result<(), BootstrapperError> {
+        let binary_path = std::path::PathBuf::from(DEFAULT_BOOTSTRAPPER_BINARY);
+        if binary_path.exists() {
+            Ok(())
+        } else {
+            Err(BootstrapperError::BinaryNotFound(format!("Default binary not found: {}", binary_path.display())))
+        }
+    }
+
+    // update values in the config file
+    pub fn update_config_file(key: &str, value: &str) -> Result<(), BootstrapperError> {
+        // Update bootstrapper config
+        let mut config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(DEFAULT_BOOTSTRAPPER_CONFIG)
+                .map_err(|e| BootstrapperError::OtherError(format!("Failed to read bootstrapper config: {}", e)))?,
+        )
+        .map_err(|e| BootstrapperError::OtherError(format!("Failed to parse bootstrapper config JSON: {}", e)))?;
+
+        config[key] = serde_json::Value::String(value.to_string());
+
+        std::fs::write(
+            DEFAULT_BOOTSTRAPPER_CONFIG,
+            serde_json::to_string_pretty(&config)
+                .map_err(|e| BootstrapperError::OtherError(format!("Failed to serialize config: {}", e)))?,
+        )
+        .map_err(|e| BootstrapperError::OtherError(format!("Failed to write bootstrapper config: {}", e)))?;
+
+        println!("✅ Updated bootstrapper config with {} value: {}", key, value);
+        Ok(())
+    }
+}

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod anvil;
 pub mod constants;
+pub mod bootstrapper;
 pub mod helpers;
 pub mod server;


### PR DESCRIPTION
# Add Bootstrapper Service for L1/L2 Setup in E2E Tests

## Pull Request type

- Feature

## What is the current behavior?

The e2e test framework lacks a dedicated service for bootstrapping L1 and L2 environments.

## What is the new behavior?

- Added a new bootstrapper service module for e2e tests that can initialize L1 and L2 environments
- Implemented two bootstrapper modes: `SetupL1` and `SetupL2`
- Created a flexible configuration system with builder pattern for easy bootstrapper setup
- Added utility methods to run, wait for completion, and manage bootstrapper processes
- Integrated with the existing server framework for process management

## Does this introduce a breaking change?

No

## Other information

The bootstrapper service provides a clean interface for initializing test environments with proper timeout handling, dependency tracking, and configuration management. It supports both synchronous execution and asynchronous operation with proper process lifecycle management.