### PR TITLE
E2E: 5 : Localstack + Mongodb + Docker Service

### DIFF
--- a/e2e/src/services/docker.rs
+++ b/e2e/src/services/docker.rs
@@ -67,7 +67,7 @@ impl DockerServer {
     }
 
     /// Check if a port is in use
-    pub fn is_port_in_use(port: u16) -> bool {
-        std::net::TcpListener::bind(format!("{}:{}", DEFAULT_SERVICE_HOST, port)).is_err()
+    pub async fn is_port_in_use(port: u16) -> bool {
+        tokio::net::TcpListener::bind(format!("{}:{}", DEFAULT_SERVICE_HOST, port)).await.is_err()
     }
 }

--- a/e2e/src/services/docker.rs
+++ b/e2e/src/services/docker.rs
@@ -2,6 +2,7 @@
 // DOCKER SERVER HELPER - For Docker-based services
 // =============================================================================
 
+use crate::services::constants::DEFAULT_SERVICE_HOST;
 use crate::services::server::ServerError;
 use tokio::process::Command;
 
@@ -67,6 +68,6 @@ impl DockerServer {
 
     /// Check if a port is in use
     pub fn is_port_in_use(port: u16) -> bool {
-        std::net::TcpListener::bind(format!("127.0.0.1:{}", port)).is_err()
+        std::net::TcpListener::bind(format!("{}:{}", DEFAULT_SERVICE_HOST, port)).is_err()
     }
 }

--- a/e2e/src/services/docker.rs
+++ b/e2e/src/services/docker.rs
@@ -1,0 +1,72 @@
+// =============================================================================
+// DOCKER SERVER HELPER - For Docker-based services
+// =============================================================================
+
+use crate::services::server::ServerError;
+use tokio::process::Command;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DockerError {
+    #[error("Docker is not running or not installed")]
+    NotRunning,
+    #[error("Container already exists: {0}")]
+    ContainerAlreadyExists(String),
+    #[error("Failed to check container status: {0}")]
+    ContainerStatusFailed(std::io::Error),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+    #[error("Exec error: {0}")]
+    Exec(String),
+}
+
+pub struct DockerServer;
+
+impl DockerServer {
+    /// Check if Docker is running
+    pub async fn is_docker_running() -> bool {
+        let result = Command::new("docker").arg("info").output().await;
+
+        match result {
+            Ok(output) => output.status.success(),
+            Err(_) => false,
+        }
+    }
+
+    /// Check if a container with the given name is already running
+    pub async fn is_container_running(container_name: &str) -> Result<bool, DockerError> {
+        let output = Command::new("docker")
+            .args(["ps", "-q", "-f", &format!("name={}", container_name)])
+            .output()
+            .await
+            .map_err(DockerError::ContainerStatusFailed)?;
+
+        Ok(!output.stdout.is_empty())
+    }
+
+    /// Check if a container with the given name exists (running or stopped)
+    pub async fn does_container_exist(container_name: &str) -> Result<bool, DockerError> {
+        let output = Command::new("docker")
+            .args(["ps", "-a", "-q", "-f", &format!("name={}", container_name)])
+            .output()
+            .await
+            .map_err(DockerError::ContainerStatusFailed)?;
+
+        Ok(!output.stdout.is_empty())
+    }
+
+    /// Remove a container (force remove if running)
+    pub async fn remove_container(container_name: &str) -> Result<(), DockerError> {
+        let _output = Command::new("docker")
+            .args(["rm", "-f", container_name])
+            .output()
+            .await
+            .map_err(DockerError::ContainerStatusFailed)?;
+
+        Ok(())
+    }
+
+    /// Check if a port is in use
+    pub fn is_port_in_use(port: u16) -> bool {
+        std::net::TcpListener::bind(format!("127.0.0.1:{}", port)).is_err()
+    }
+}

--- a/e2e/src/services/localstack/config.rs
+++ b/e2e/src/services/localstack/config.rs
@@ -14,12 +14,7 @@ pub enum LocalstackError {
 }
 
 use crate::services::docker::DockerError;
-
-
-const DEFAULT_LOCALSTACK_PORT: u16 = 4566;
-pub const DEFAULT_LOCALSTACK_IMAGE: &str =
-    "localstack/localstack@sha256:763947722c6c8d33d5fbf7e8d52b4bddec5be35274a0998fdc6176d733375314";
-const DEFAULT_LOCALSTACK_CONTAINER_NAME: &str = "localstack-service";
+use crate::services::constants::*;
 
 // Final immutable configuration
 #[derive(Debug, Clone)]

--- a/e2e/src/services/localstack/config.rs
+++ b/e2e/src/services/localstack/config.rs
@@ -1,0 +1,161 @@
+use tokio::process::Command;
+use crate::services::server::ServerError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LocalstackError {
+    #[error("Docker error: {0}")]
+    Docker(#[from] DockerError),
+    #[error("Localstack container already running on port {0}")]
+    AlreadyRunning(u16),
+    #[error("Port {0} is already in use")]
+    PortInUse(u16),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+}
+
+use crate::services::docker::DockerError;
+
+
+const DEFAULT_LOCALSTACK_PORT: u16 = 4566;
+pub const DEFAULT_LOCALSTACK_IMAGE: &str =
+    "localstack/localstack@sha256:763947722c6c8d33d5fbf7e8d52b4bddec5be35274a0998fdc6176d733375314";
+const DEFAULT_LOCALSTACK_CONTAINER_NAME: &str = "localstack-service";
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct LocalstackConfig {
+    image: String,
+    container_name: String,
+    environment_vars: Vec<(String, String)>,
+
+    // Server Configs
+    port: u16,
+    logs: (bool, bool),
+}
+
+impl Default for LocalstackConfig {
+    fn default() -> Self {
+        Self {
+            image: DEFAULT_LOCALSTACK_IMAGE.to_string(),
+            container_name: format!("{}-{}", DEFAULT_LOCALSTACK_CONTAINER_NAME, uuid::Uuid::new_v4()),
+            environment_vars: vec![
+                ("DEBUG".to_string(), "1".to_string()),
+                ("SERVICES".to_string(), "iam,s3,eventbridge,events,sqs,sns".to_string()),
+            ],
+
+            port: DEFAULT_LOCALSTACK_PORT,
+            logs: (false, true),
+        }
+    }
+}
+
+impl LocalstackConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for LocalstackConfig
+    pub fn builder() -> LocalstackConfigBuilder {
+        LocalstackConfigBuilder::new()
+    }
+
+    /// Get the port
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the logs
+    pub fn logs(&self) -> (bool, bool) {
+        self.logs
+    }
+
+    /// Get the Docker image
+    pub fn image(&self) -> &str {
+        &self.image
+    }
+
+    /// Get the container name
+    pub fn container_name(&self) -> &str {
+        &self.container_name
+    }
+
+    /// Get the environment variables
+    pub fn environment_vars(&self) -> &[(String, String)] {
+        &self.environment_vars
+    }
+
+    /// Build the Docker command for Localstack
+    pub fn to_command(&self) -> Command {
+        let mut command = Command::new("docker");
+        command.arg("run");
+        command.arg("--rm"); // Remove container when it stops
+        command.arg("--name").arg(self.container_name());
+        command.arg("-p").arg(format!("{}:{}", self.port(), self.port()));
+
+        // Add environment variables
+        for (key, value) in self.environment_vars() {
+            command.arg("-e").arg(format!("{}={}", key, value));
+        }
+
+        command.arg(self.image());
+
+        command
+    }
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct LocalstackConfigBuilder {
+    config: LocalstackConfig,
+}
+
+impl LocalstackConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: LocalstackConfig::default(),
+        }
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> LocalstackConfig {
+        self.config
+    }
+
+    /// Set the port (default: 4566)
+    pub fn port(mut self, port: u16) -> Self {
+        self.config.port = port;
+        self
+    }
+
+    /// Set the Docker image
+    pub fn image<S: Into<String>>(mut self, image: S) -> Self {
+        self.config.image = image.into();
+        self
+    }
+
+    /// Set the container name
+    pub fn container_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.config.container_name = name.into();
+        self
+    }
+
+    /// Add an environment variable
+    pub fn env_var<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+        self.config.environment_vars.push((key.into(), value.into()));
+        self
+    }
+
+    /// Set all environment variables (replaces existing ones)
+    pub fn environment_vars(mut self, vars: Vec<(String, String)>) -> Self {
+        self.config.environment_vars = vars;
+        self
+    }
+}
+
+impl Default for LocalstackConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/localstack/mod.rs
+++ b/e2e/src/services/localstack/mod.rs
@@ -1,0 +1,117 @@
+// =============================================================================
+// LOCALSTACK SERVICE - Using Docker and generic Server
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::server::{Server, ServerConfig};
+use crate::services::docker::{DockerError, DockerServer};
+use url::Url;
+
+pub struct LocalstackService {
+    server: Server,
+    config: LocalstackConfig,
+}
+
+impl LocalstackService {
+    /// Start a new Localstack service
+    /// Will panic if Localstack is already running as per your requirement
+    pub async fn start(config: LocalstackConfig) -> Result<Self, LocalstackError> {
+        // Validate Docker is running
+        if !DockerServer::is_docker_running().await {
+            return Err(LocalstackError::Docker(DockerError::NotRunning));
+        }
+
+        // Check if container is already running - PANIC as requested
+        if DockerServer::is_container_running(config.container_name()).await? {
+            panic!(
+                "Localstack container '{}' is already running on port {}. Please stop it first.",
+                config.container_name(),
+                config.port()
+            );
+        }
+
+        // Check if port is in use
+        if DockerServer::is_port_in_use(config.port()) {
+            return Err(LocalstackError::PortInUse(config.port()));
+        }
+
+        // Clean up any existing stopped container with the same name
+        if DockerServer::does_container_exist(config.container_name()).await? {
+            DockerServer::remove_container(config.container_name()).await?;
+        }
+
+        // Build the docker command
+        let command = config.to_command();
+
+        // Create server config using the immutable config getters
+        let server_config = ServerConfig {
+            rpc_port: Some(config.port()),
+            service_name: "Localstack".to_string(),
+            connection_attempts: 60, // Localstack takes longer to start
+            connection_delay_ms: 2000,
+            logs: config.logs(),
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(|e| LocalstackError::Docker(DockerError::Server(e)))?;
+
+        Ok(Self { server, config })
+    }
+
+
+    /// Validate if AWS resources with the given prefix are available
+    /// This helps determine if the scenario setup is ready
+    pub async fn validate_resources(&self, aws_prefix: &str) -> Result<bool, LocalstackError> {
+        // This is a basic implementation - you might want to extend this
+        // to check specific resources like S3 buckets, DynamoDB tables, etc.
+
+        // Example: Check if we can connect to Localstack's health endpoint
+        let health_url = format!("{}/health", self.endpoint());
+
+        match reqwest::get(&health_url).await {
+            Ok(response) => {
+                if response.status().is_success() {
+                    // You can add more specific validation here
+                    // For example, check if specific AWS resources exist
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Err(_) => Ok(false),
+        }
+    }
+
+    /// Get the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &LocalstackConfig {
+        &self.config
+    }
+
+    pub fn stop(&mut self) -> Result<(), LocalstackError> {
+        println!("☠️ Stopping Localstack");
+        self.server.stop().map_err(|err| LocalstackError::Server(err))
+    }
+
+
+    /// Get the endpoint URL for the Localstack server
+    pub fn endpoint(&self) -> Url {
+        self.server().endpoint().expect("Localstack server endpoint not found!")
+    }
+
+    /// Get dependencies (Docker is required)
+    pub fn dependencies(&self) -> Vec<String> {
+        vec!["docker".to_string()]
+    }
+}

--- a/e2e/src/services/localstack/mod.rs
+++ b/e2e/src/services/localstack/mod.rs
@@ -110,8 +110,4 @@ impl LocalstackService {
         self.server().endpoint().expect("Localstack server endpoint not found!")
     }
 
-    /// Get dependencies (Docker is required)
-    pub fn dependencies(&self) -> Vec<String> {
-        vec!["docker".to_string()]
-    }
 }

--- a/e2e/src/services/localstack/mod.rs
+++ b/e2e/src/services/localstack/mod.rs
@@ -99,9 +99,9 @@ impl LocalstackService {
         &self.config
     }
 
-    pub async fn stop(&mut self) -> Result<(), LocalstackError> {
+    pub fn stop(&mut self) -> Result<(), LocalstackError> {
         println!("☠️ Stopping Localstack");
-        self.server.stop().await.map_err(|err| LocalstackError::Server(err))
+        self.server.stop().map_err(|err| LocalstackError::Server(err))
     }
 
 

--- a/e2e/src/services/localstack/mod.rs
+++ b/e2e/src/services/localstack/mod.rs
@@ -35,7 +35,7 @@ impl LocalstackService {
         }
 
         // Check if port is in use
-        if DockerServer::is_port_in_use(config.port()) {
+        if DockerServer::is_port_in_use(config.port()).await {
             return Err(LocalstackError::PortInUse(config.port()));
         }
 

--- a/e2e/src/services/localstack/mod.rs
+++ b/e2e/src/services/localstack/mod.rs
@@ -7,8 +7,8 @@ pub mod config;
 // Re-export common utilities
 pub use config::*;
 
-use crate::services::server::{Server, ServerConfig};
 use crate::services::docker::{DockerError, DockerServer};
+use crate::services::server::{Server, ServerConfig};
 use url::Url;
 
 pub struct LocalstackService {
@@ -65,30 +65,6 @@ impl LocalstackService {
         Ok(Self { server, config })
     }
 
-
-    /// Validate if AWS resources with the given prefix are available
-    /// This helps determine if the scenario setup is ready
-    pub async fn validate_resources(&self, aws_prefix: &str) -> Result<bool, LocalstackError> {
-        // This is a basic implementation - you might want to extend this
-        // to check specific resources like S3 buckets, DynamoDB tables, etc.
-
-        // Example: Check if we can connect to Localstack's health endpoint
-        let health_url = format!("{}/health", self.endpoint());
-
-        match reqwest::get(&health_url).await {
-            Ok(response) => {
-                if response.status().is_success() {
-                    // You can add more specific validation here
-                    // For example, check if specific AWS resources exist
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            Err(_) => Ok(false),
-        }
-    }
-
     /// Get the underlying server
     pub fn server(&self) -> &Server {
         &self.server
@@ -104,10 +80,8 @@ impl LocalstackService {
         self.server.stop().map_err(|err| LocalstackError::Server(err))
     }
 
-
     /// Get the endpoint URL for the Localstack server
     pub fn endpoint(&self) -> Url {
         self.server().endpoint().expect("Localstack server endpoint not found!")
     }
-
 }

--- a/e2e/src/services/localstack/mod.rs
+++ b/e2e/src/services/localstack/mod.rs
@@ -99,9 +99,9 @@ impl LocalstackService {
         &self.config
     }
 
-    pub fn stop(&mut self) -> Result<(), LocalstackError> {
+    pub async fn stop(&mut self) -> Result<(), LocalstackError> {
         println!("☠️ Stopping Localstack");
-        self.server.stop().map_err(|err| LocalstackError::Server(err))
+        self.server.stop().await.map_err(|err| LocalstackError::Server(err))
     }
 
 

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -1,5 +1,8 @@
 pub mod anvil;
 pub mod constants;
 pub mod bootstrapper;
+pub mod docker;
 pub mod helpers;
+pub mod localstack;
+pub mod mongodb;
 pub mod server;

--- a/e2e/src/services/mongodb/config.rs
+++ b/e2e/src/services/mongodb/config.rs
@@ -1,13 +1,9 @@
 use crate::services::docker::DockerError;
 use crate::services::server::ServerError;
 
-use crate::services::helpers::DEFAULT_DATA_DIR;
+use crate::services::constants::*;
 use tokio::process::Command;
 
-const DEFAULT_MONGO_PORT: u16 = 27017;
-pub const DEFAULT_MONGO_IMAGE: &str = "mongo:latest";
-const DEFAULT_MONGO_CONTAINER_NAME: &str = "mongodb-service";
-pub const MONGO_DEFAULT_DATABASE_PATH: &str = "mongodb_dump.json";
 
 #[derive(Debug, thiserror::Error)]
 pub enum MongoError {

--- a/e2e/src/services/mongodb/config.rs
+++ b/e2e/src/services/mongodb/config.rs
@@ -24,6 +24,7 @@ pub enum MongoError {
 pub struct MongoConfig {
     image: String,
     container_name: String,
+    environment_vars: Vec<(String, String)>,
 
     // Server configs
     port: u16,
@@ -35,6 +36,8 @@ impl Default for MongoConfig {
         Self {
             image: DEFAULT_MONGO_IMAGE.to_string(),
             container_name: format!("{}-{}", DEFAULT_MONGO_CONTAINER_NAME, uuid::Uuid::new_v4()),
+            environment_vars: vec![],
+
             port: DEFAULT_MONGO_PORT,
             logs: (false, false),
         }
@@ -67,6 +70,11 @@ impl MongoConfig {
         &self.image
     }
 
+    /// Get the environment variables
+    pub fn environment_vars(&self) -> &[(String, String)] {
+        &self.environment_vars
+    }
+
     /// Get the container name
     pub fn container_name(&self) -> &str {
         &self.container_name
@@ -79,6 +87,12 @@ impl MongoConfig {
         command.arg("--rm"); // Remove container when it stops
         command.arg("--name").arg(self.container_name());
         command.arg("-p").arg(format!("{}:27017", self.port()));
+
+        // Add environment variables
+        for (key, value) in self.environment_vars() {
+            command.arg("-e").arg(format!("{}={}", key, value));
+        }
+
         command.arg(self.image());
 
         command

--- a/e2e/src/services/mongodb/config.rs
+++ b/e2e/src/services/mongodb/config.rs
@@ -1,0 +1,132 @@
+use crate::services::docker::DockerError;
+use crate::services::server::ServerError;
+
+use crate::services::helpers::DEFAULT_DATA_DIR;
+use tokio::process::Command;
+
+const DEFAULT_MONGO_PORT: u16 = 27017;
+pub const DEFAULT_MONGO_IMAGE: &str = "mongo:latest";
+const DEFAULT_MONGO_CONTAINER_NAME: &str = "mongodb-service";
+pub const MONGO_DEFAULT_DATABASE_PATH: &str = "mongodb_dump.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum MongoError {
+    #[error("Docker error: {0}")]
+    Docker(#[from] DockerError),
+    #[error("MongoDB container already running on port {0}")]
+    AlreadyRunning(u16),
+    #[error("Port {0} is already in use")]
+    PortInUse(u16),
+    #[error("MongoDB connection failed: {0}")]
+    ConnectionFailed(String),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct MongoConfig {
+    image: String,
+    container_name: String,
+
+    // Server configs
+    port: u16,
+    logs: (bool, bool),
+}
+
+impl Default for MongoConfig {
+    fn default() -> Self {
+        Self {
+            image: DEFAULT_MONGO_IMAGE.to_string(),
+            container_name: format!("{}-{}", DEFAULT_MONGO_CONTAINER_NAME, uuid::Uuid::new_v4()),
+            port: DEFAULT_MONGO_PORT,
+            logs: (false, false),
+        }
+    }
+}
+
+impl MongoConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for MongoConfig
+    pub fn builder() -> MongoConfigBuilder {
+        MongoConfigBuilder::new()
+    }
+
+    /// Get the port
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Get the logs
+    pub fn logs(&self) -> (bool, bool) {
+        self.logs
+    }
+
+    /// Get the Docker image
+    pub fn image(&self) -> &str {
+        &self.image
+    }
+
+    /// Get the container name
+    pub fn container_name(&self) -> &str {
+        &self.container_name
+    }
+
+    /// Build the Docker command for MongoDB
+    pub fn to_command(&self) -> Command {
+        let mut command = Command::new("docker");
+        command.arg("run");
+        command.arg("--rm"); // Remove container when it stops
+        command.arg("--name").arg(self.container_name());
+        command.arg("-p").arg(format!("{}:27017", self.port()));
+        command.arg(self.image());
+
+        command
+    }
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct MongoConfigBuilder {
+    config: MongoConfig,
+}
+
+impl MongoConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self { config: MongoConfig::default() }
+    }
+
+    /// Set the port (default: 27017)
+    pub fn port(mut self, port: u16) -> Self {
+        self.config.port = port;
+        self
+    }
+
+    /// Set the Docker image
+    pub fn image<S: Into<String>>(mut self, image: S) -> Self {
+        self.config.image = image.into();
+        self
+    }
+
+    /// Set the container name
+    pub fn container_name<S: Into<String>>(mut self, name: S) -> Self {
+        self.config.container_name = name.into();
+        self
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> MongoConfig {
+        self.config
+    }
+}
+
+impl Default for MongoConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/mongodb/config.rs
+++ b/e2e/src/services/mongodb/config.rs
@@ -1,9 +1,10 @@
 use crate::services::docker::DockerError;
+use crate::services::helpers::get_container_name;
 use crate::services::server::ServerError;
 
 use crate::services::constants::*;
 use tokio::process::Command;
-
+use url::Url;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MongoError {
@@ -34,11 +35,11 @@ pub struct MongoConfig {
 impl Default for MongoConfig {
     fn default() -> Self {
         Self {
-            image: DEFAULT_MONGO_IMAGE.to_string(),
-            container_name: format!("{}-{}", DEFAULT_MONGO_CONTAINER_NAME, uuid::Uuid::new_v4()),
+            image: MONGODB_IMAGE.to_string(),
+            container_name: get_container_name(MONGODB_CONTAINER),
             environment_vars: vec![],
 
-            port: DEFAULT_MONGO_PORT,
+            port: MONGODB_PORT,
             logs: (false, false),
         }
     }
@@ -78,6 +79,11 @@ impl MongoConfig {
     /// Get the container name
     pub fn container_name(&self) -> &str {
         &self.container_name
+    }
+
+    /// Get the endpoint
+    pub fn endpoint(&self) -> Url {
+        Url::parse(format!("mongodb://{}:{}", DEFAULT_SERVICE_HOST, self.port()).as_str()).unwrap()
     }
 
     /// Build the Docker command for MongoDB
@@ -126,6 +132,12 @@ impl MongoConfigBuilder {
     /// Set the container name
     pub fn container_name<S: Into<String>>(mut self, name: S) -> Self {
         self.config.container_name = name.into();
+        self
+    }
+
+    /// Set the logs
+    pub fn logs(mut self, logs: (bool, bool)) -> Self {
+        self.config.logs = logs;
         self
     }
 

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -1,0 +1,185 @@
+// =============================================================================
+// MONGODB SERVICE - Using Docker and generic Server
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::docker::{DockerError, DockerServer};
+use crate::services::server::{Server, ServerConfig};
+use reqwest::Url;
+
+use crate::services::helpers::DEFAULT_DATA_DIR;
+use crate::services::server::DEFAULT_MONGODB_DIR;
+use crate::services::server::DEFAULT_SERVICE_HOST;
+use tokio::process::Command;
+
+pub struct MongoService {
+    server: Server,
+    config: MongoConfig,
+}
+
+impl MongoService {
+    /// Start a new MongoDB service
+    /// Will panic if MongoDB is already running as per pattern
+    pub async fn start(config: MongoConfig) -> Result<Self, MongoError> {
+        // Validate Docker is running
+        if !DockerServer::is_docker_running().await {
+            return Err(MongoError::Docker(DockerError::NotRunning));
+        }
+
+        // Check if container is already running - PANIC as per pattern
+        if DockerServer::is_container_running(config.container_name()).await? {
+            panic!(
+                "MongoDB container '{}' is already running on port {}. Please stop it first.",
+                config.container_name(),
+                config.port()
+            );
+        }
+
+        // Check if port is in use
+        if DockerServer::is_port_in_use(config.port()) {
+            return Err(MongoError::PortInUse(config.port()));
+        }
+
+        // Clean up any existing stopped container with the same name
+        if DockerServer::does_container_exist(config.container_name()).await? {
+            DockerServer::remove_container(config.container_name()).await?;
+        }
+
+        // Build the docker command
+        let command = config.to_command();
+
+        // Create server config using the immutable config getters
+        let server_config = ServerConfig {
+            rpc_port: Some(config.port()),
+            service_name: "MongoDB".to_string(),
+            connection_attempts: 30, // MongoDB usually starts quickly
+            connection_delay_ms: 1000,
+            logs: config.logs(),
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(|e| MongoError::Docker(DockerError::Server(e)))?;
+
+        Ok(Self { server, config })
+    }
+
+    /// Get the endpoint URL for the MongoDB service
+    pub fn endpoint(&self) -> Url {
+        // MongoDB doesn't use HTTP, but we'll return the TCP endpoint
+        Url::parse(&format!("mongodb://{}:{}", DEFAULT_SERVICE_HOST, self.config().port())).unwrap()
+    }
+
+    /// Get the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the configuration used
+    pub fn config(&self) -> &MongoConfig {
+        &self.config
+    }
+
+    pub fn stop(&mut self) -> Result<(), MongoError> {
+        println!("☠️ Stopping MongoDB");
+        self.server.stop().map_err(|err| MongoError::Server(err))
+    }
+
+    /// Get dependencies (Docker is required)
+    pub fn dependencies(&self) -> Vec<String> {
+        vec!["docker".to_string()]
+    }
+}
+
+// MongoDump and MongoRestore impl from within the docker container
+impl MongoService {
+    /// MongoDump
+    /// docker exec <container_name> mongodump --host "localhost:27017" --db orchestrator_3 --out /backup
+    pub async fn dump_db(&self, database_name: &str) -> Result<(), MongoError> {
+        let command = format!(
+            "docker exec {} mongodump --host \"{}:{}\" --db {} --out {}",
+            self.config().container_name(),
+            DEFAULT_SERVICE_HOST,
+            self.config().port(),
+            database_name,
+            DEFAULT_MONGODB_DIR
+        );
+        println!("Command : {}", command);
+        let _ = Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .status()
+            .await
+            .map_err(|e| MongoError::Docker(DockerError::Exec(e.to_string())))?;
+
+        // Copy the dump to the host machine
+        // docker cp <container_name>:/backup ./backup
+        let command = format!(
+            "docker cp {}:/{}/{} {}/{}",
+            self.config().container_name(),
+            DEFAULT_MONGODB_DIR,
+            database_name,
+            DEFAULT_DATA_DIR,
+            database_name
+        );
+        println!("Command : {}", command);
+        Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .status()
+            .await
+            .map_err(|e| MongoError::Docker(DockerError::Exec(e.to_string())))?;
+
+        Ok(())
+    }
+
+    /// MongoRestore
+    /// First copy backup from host to container, then restore
+    pub async fn restore_db(&self, database_name: &str) -> Result<(), MongoError> {
+        // Copy the backup from host machine to docker container
+        // docker cp ./backup <container_name>:/backup
+        let command = format!(
+            "docker cp {}/{} {}:/{}/{}",
+            DEFAULT_DATA_DIR,
+            database_name,
+            self.config().container_name(),
+            DEFAULT_MONGODB_DIR,
+            database_name
+        );
+        println!("Command : {}", command);
+        Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .status()
+            .await
+            .map_err(|e| MongoError::Docker(DockerError::Exec(e.to_string())))?;
+
+        // Now restore the database inside the container
+        // docker exec <container_name> mongorestore --host "localhost:27017" --db orchestrator_3 /backup/database_name
+        let command = format!(
+            "docker exec {} mongorestore --host \"{}:{}\" --db {} {}/{}",
+            self.config().container_name(),
+            DEFAULT_SERVICE_HOST,
+            self.config().port(),
+            database_name,
+            DEFAULT_MONGODB_DIR,
+            database_name
+        );
+        println!("Command : {}", command);
+
+        Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .status()
+            .await
+            .map_err(|e| MongoError::Docker(DockerError::Exec(e.to_string())))?;
+
+        Ok(())
+    }
+}

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -90,9 +90,14 @@ impl MongoService {
 
 // MongoDump and MongoRestore impl from within the docker container
 impl MongoService {
-    /// MongoDump
-    /// docker exec <container_name> mongodump --host "localhost:27017" --db orchestrator --out /tmp
-    /// docker cp <container_name>:/tmp/orchestrator <host_path>
+    /// Creates a backup of the specified MongoDB database.
+    /// 
+    /// Executes `mongodump` inside the Docker container to create a backup in `/tmp`,
+    /// then copies the dump to the host machine at the specified path.
+    /// 
+    /// # Arguments
+    /// * `database_path` - Host directory path where the backup will be stored
+    /// * `database_name` - Name of the database to backup
     pub async fn dump_db(&self, database_path: &str, database_name: &str) -> Result<(), MongoError> {
         // Step 1: Dump database inside container to /tmp
         let command = format!(
@@ -130,9 +135,14 @@ impl MongoService {
         Ok(())
     }
 
-    /// MongoRestore
-    /// docker cp <host_path>/database_name <container_name>:/tmp
-    /// docker exec <container_name> mongorestore --host "localhost:27017" --db database_name --dir /tmp/database_name
+    /// Restores a MongoDB database from a backup.
+    /// 
+    /// Copies backup files from the host machine to the Docker container's `/tmp` directory,
+    /// then executes `mongorestore` to restore the database.
+    /// 
+    /// # Arguments
+    /// * `database_path` - Host directory path where the backup is stored
+    /// * `database_name` - Name of the database to restore
     pub async fn restore_db(&self, database_path: &str, database_name: &str) -> Result<(), MongoError> {
         // Get system's db storage directory
         let database_dir_path = get_file_path(database_path).to_string_lossy().into_owned();

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -83,9 +83,9 @@ impl MongoService {
         &self.config
     }
 
-    pub async fn stop(&mut self) -> Result<(), MongoError> {
+    pub fn stop(&mut self) -> Result<(), MongoError> {
         println!("☠️ Stopping MongoDB");
-        self.server.stop().await.map_err(|err| MongoError::Server(err))
+        self.server.stop().map_err(|err| MongoError::Server(err))
     }
 
 }

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -83,9 +83,9 @@ impl MongoService {
         &self.config
     }
 
-    pub fn stop(&mut self) -> Result<(), MongoError> {
+    pub async fn stop(&mut self) -> Result<(), MongoError> {
         println!("☠️ Stopping MongoDB");
-        self.server.stop().map_err(|err| MongoError::Server(err))
+        self.server.stop().await.map_err(|err| MongoError::Server(err))
     }
 
 }

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -6,14 +6,11 @@ pub mod config;
 
 // Re-export common utilities
 pub use config::*;
-
+use crate::services::constants::*;
 use crate::services::docker::{DockerError, DockerServer};
 use crate::services::server::{Server, ServerConfig};
 use reqwest::Url;
 
-use crate::services::helpers::DEFAULT_DATA_DIR;
-use crate::services::server::DEFAULT_MONGODB_DIR;
-use crate::services::server::DEFAULT_SERVICE_HOST;
 use tokio::process::Command;
 
 pub struct MongoService {

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -38,7 +38,7 @@ impl MongoService {
         }
 
         // Check if port is in use
-        if DockerServer::is_port_in_use(config.port()) {
+        if DockerServer::is_port_in_use(config.port()).await {
             return Err(MongoError::PortInUse(config.port()));
         }
 
@@ -91,10 +91,10 @@ impl MongoService {
 // MongoDump and MongoRestore impl from within the docker container
 impl MongoService {
     /// Creates a backup of the specified MongoDB database.
-    /// 
+    ///
     /// Executes `mongodump` inside the Docker container to create a backup in `/tmp`,
     /// then copies the dump to the host machine at the specified path.
-    /// 
+    ///
     /// # Arguments
     /// * `database_path` - Host directory path where the backup will be stored
     /// * `database_name` - Name of the database to backup
@@ -136,10 +136,10 @@ impl MongoService {
     }
 
     /// Restores a MongoDB database from a backup.
-    /// 
+    ///
     /// Copies backup files from the host machine to the Docker container's `/tmp` directory,
     /// then executes `mongorestore` to restore the database.
-    /// 
+    ///
     /// # Arguments
     /// * `database_path` - Host directory path where the backup is stored
     /// * `database_name` - Name of the database to restore

--- a/e2e/src/services/mongodb/mod.rs
+++ b/e2e/src/services/mongodb/mod.rs
@@ -88,10 +88,6 @@ impl MongoService {
         self.server.stop().map_err(|err| MongoError::Server(err))
     }
 
-    /// Get dependencies (Docker is required)
-    pub fn dependencies(&self) -> Vec<String> {
-        vec!["docker".to_string()]
-    }
 }
 
 // MongoDump and MongoRestore impl from within the docker container


### PR DESCRIPTION
# Add Docker-based services for E2E testing

## Pull Request type

- Feature
- Refactoring (no functional changes, no API changes)

## What is the current behavior?

The E2E testing framework lacks support for Docker-based services like MongoDB and Localstack, which are needed for comprehensive integration testing.

Resolves: #NA

## What is the new behavior?

- Added a Docker server helper module for managing Docker containers
- Implemented MongoDB service with configuration and database dump/restore capabilities
- Added Localstack service for AWS resource emulation
- Defined consistent configuration patterns with builder support for both services
- Integrated with the existing server framework for process management

## Does this introduce a breaking change?

No

## Other information

These services will enable more comprehensive E2E testing scenarios that require database persistence or AWS service interactions.