### PR TITLE
E2E: 6 : Madara Service

### DIFF
--- a/e2e/src/services/constants.rs
+++ b/e2e/src/services/constants.rs
@@ -66,6 +66,7 @@ pub const MADARA_CONFIG: &str = "e2e/config/madara.yaml";
 pub const MADARA_RPC_PORT: u16 = 9944;
 pub const MADARA_RPC_ADMIN_PORT: u16 = 9943;
 pub const MADARA_GATEWAY_PORT: u16 = 8080;
+pub static MADARA_WAITING_DURATION: LazyLock<Duration> = LazyLock::new(|| Duration::from_secs(1));
 
 // =============================================================================
 // MOCK PROVER SERVICE

--- a/e2e/src/services/madara/config.rs
+++ b/e2e/src/services/madara/config.rs
@@ -249,7 +249,7 @@ impl MadaraConfig {
 
     /// Get the feeder gateway endpoint
     pub fn feeder_gateway_endpoint(&self) -> Url {
-        Url::parse(&format!("http://{}:{}/{}", DEFAULT_SERVICE_HOST, self.gateway_port(), "feeder-gateway")).unwrap()
+        Url::parse(&format!("http://{}:{}/{}", DEFAULT_SERVICE_HOST, self.gateway_port(), "feeder_gateway")).unwrap()
     }
 
     /// Convert the configuration to a command

--- a/e2e/src/services/madara/config.rs
+++ b/e2e/src/services/madara/config.rs
@@ -256,7 +256,7 @@ impl MadaraConfig {
         cmd.arg("--gateway-port").arg(self.gateway_port.to_string());
 
         // Gas prices
-        cmd.arg("---l1-gas-price").arg(self.l1_gas_price.to_string());
+        cmd.arg("--l1-gas-price").arg(self.l1_gas_price.to_string());
         cmd.arg("--blob-gas-price").arg(self.blob_gas_price.to_string());
         cmd.arg("--strk-per-eth").arg(self.strk_per_eth.to_string());
 

--- a/e2e/src/services/madara/config.rs
+++ b/e2e/src/services/madara/config.rs
@@ -61,10 +61,9 @@ pub struct MadaraConfig {
     gateway_port: u16,
     charge_fee: bool,
     l1_endpoint: Option<Url>,
-    strk_gas_price: u64,
-    strk_blob_gas_price: u64,
-    gas_price: u64,
+    l1_gas_price: u64,
     blob_gas_price: u64,
+    strk_per_eth: u64,
     environment_vars: HashMap<String, String>,
     additional_args: Vec<String>,
     logs: (bool, bool),
@@ -90,10 +89,9 @@ impl Default for MadaraConfig {
             charge_fee: false,
             block_time: None,
             l1_endpoint: None,
-            strk_gas_price: 0,
-            strk_blob_gas_price: 0,
-            gas_price: 0,
+            l1_gas_price: 0,
             blob_gas_price: 0,
+            strk_per_eth: 1,
             environment_vars: HashMap::new(),
             additional_args: Vec::new(),
             logs: (true, true),
@@ -198,19 +196,10 @@ impl MadaraConfig {
     }
 
     /// Get STRK gas price
-    pub fn strk_gas_price(&self) -> u64 {
-        self.strk_gas_price
+    pub fn l1_gas_price(&self) -> u64 {
+        self.l1_gas_price
     }
 
-    /// Get STRK blob gas price
-    pub fn strk_blob_gas_price(&self) -> u64 {
-        self.strk_blob_gas_price
-    }
-
-    /// Get gas price
-    pub fn gas_price(&self) -> u64 {
-        self.gas_price
-    }
 
     /// Get blob gas price
     pub fn blob_gas_price(&self) -> u64 {
@@ -267,10 +256,9 @@ impl MadaraConfig {
         cmd.arg("--gateway-port").arg(self.gateway_port.to_string());
 
         // Gas prices
-        cmd.arg("--strk-gas-price").arg(self.strk_gas_price.to_string());
-        cmd.arg("--strk-blob-gas-price").arg(self.strk_blob_gas_price.to_string());
-        cmd.arg("--gas-price").arg(self.gas_price.to_string());
+        cmd.arg("---l1-gas-price").arg(self.l1_gas_price.to_string());
         cmd.arg("--blob-gas-price").arg(self.blob_gas_price.to_string());
+        cmd.arg("--strk-per-eth").arg(self.strk_per_eth.to_string());
 
         // Charge fee flag (inverted logic)
         if !self.charge_fee {
@@ -437,23 +425,18 @@ impl MadaraConfigBuilder {
         self
     }
 
-    pub fn strk_gas_price(mut self, price: u64) -> Self {
-        self.config.strk_gas_price = price;
-        self
-    }
-
-    pub fn strk_blob_gas_price(mut self, price: u64) -> Self {
-        self.config.strk_blob_gas_price = price;
-        self
-    }
-
-    pub fn gas_price(mut self, price: u64) -> Self {
-        self.config.gas_price = price;
+    pub fn l1_gas_price(mut self, price: u64) -> Self {
+        self.config.l1_gas_price = price;
         self
     }
 
     pub fn blob_gas_price(mut self, price: u64) -> Self {
         self.config.blob_gas_price = price;
+        self
+    }
+
+    pub fn strk_per_eth(mut self, price: u64) -> Self {
+        self.config.strk_per_eth = price;
         self
     }
 

--- a/e2e/src/services/madara/config.rs
+++ b/e2e/src/services/madara/config.rs
@@ -300,7 +300,7 @@ impl MadaraConfig {
                 cmd.arg("--sequencer");
             }
             MadaraMode::FullNode => {
-                cmd.arg("--full-node");
+                cmd.arg("--full");
             }
         }
 

--- a/e2e/src/services/madara/config.rs
+++ b/e2e/src/services/madara/config.rs
@@ -5,13 +5,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::process::Command;
 use crate::services::helpers::NodeRpcError;
-
-const DEFAULT_MADARA_RPC_PORT: u16 = 9944;
-const DEFAULT_MADARA_GATEWAY_PORT: u16 = 8080;
-const DEFAULT_MADARA_NAME: &str = "madara";
-pub const MADARA_DEFAULT_DATABASE_NAME: &str = "madara-db";
-pub const DEFAULT_MADARA_BINARY_PATH: &str = "../target/release/madara";
-pub const DEFAULT_MADARA_CONFIG_PATH: &str = "./config/madara.yaml";
+use crate::services::constants::*;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MadaraError {

--- a/e2e/src/services/madara/config.rs
+++ b/e2e/src/services/madara/config.rs
@@ -1,0 +1,451 @@
+// Can be extened to support all the args present in configs/args/config.json
+
+use crate::services::server::ServerError;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio::process::Command;
+use crate::services::helpers::NodeRpcError;
+
+const DEFAULT_MADARA_RPC_PORT: u16 = 9944;
+const DEFAULT_MADARA_GATEWAY_PORT: u16 = 8080;
+const DEFAULT_MADARA_NAME: &str = "madara";
+pub const MADARA_DEFAULT_DATABASE_NAME: &str = "madara-db";
+pub const DEFAULT_MADARA_BINARY_PATH: &str = "../target/release/madara";
+pub const DEFAULT_MADARA_CONFIG_PATH: &str = "./config/madara.yaml";
+
+#[derive(Debug, thiserror::Error)]
+pub enum MadaraError {
+    #[error("Binary not found: {0}")]
+    BinaryNotFound(String),
+    #[error("Server error: {0}")]
+    Server(#[from] ServerError),
+    #[error("Missing required configuration: {0}")]
+    MissingConfig(String),
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+    #[error("Madara connection failed: {0}")]
+    ConnectionFailed(String),
+    #[error("File system error: {0}")]
+    FileSystem(#[from] std::io::Error),
+    #[error("RPC error: {0}")]
+    RpcError(#[from] NodeRpcError),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MadaraMode {
+    FullNode,
+    Sequencer,
+}
+
+impl std::fmt::Display for MadaraMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MadaraMode::FullNode => write!(f, "full-node"),
+            MadaraMode::Sequencer => write!(f, "sequencer"),
+        }
+    }
+}
+
+// Final immutable configuration
+#[derive(Debug, Clone)]
+pub struct MadaraConfig {
+    binary_path: Option<PathBuf>,
+    name: String,
+    database_path: PathBuf,
+    rpc_port: u16,
+    rpc_cors: String,
+    rpc_external: bool,
+    rpc_admin: bool,
+    mode: MadaraMode,
+    chain_config_path: Option<PathBuf>,
+    block_time: Option<String>,
+    feeder_gateway_enable: bool,
+    gateway_enable: bool,
+    gateway_external: bool,
+    gateway_port: u16,
+    charge_fee: bool,
+    l1_endpoint: Option<String>,
+    strk_gas_price: u64,
+    strk_blob_gas_price: u64,
+    gas_price: u64,
+    blob_gas_price: u64,
+    environment_vars: HashMap<String, String>,
+    additional_args: Vec<String>,
+    logs: (bool, bool),
+}
+
+impl Default for MadaraConfig {
+    fn default() -> Self {
+        Self {
+            binary_path: Some(PathBuf::from(DEFAULT_MADARA_BINARY_PATH)),
+            name: DEFAULT_MADARA_NAME.to_string(),
+            database_path: PathBuf::from("./data/madara-db"),
+            rpc_port: DEFAULT_MADARA_RPC_PORT,
+            rpc_cors: "*".to_string(),
+            rpc_external: true,
+            rpc_admin: true,
+            mode: MadaraMode::Sequencer,
+            chain_config_path: Some(PathBuf::from(DEFAULT_MADARA_CONFIG_PATH)),
+            feeder_gateway_enable: true,
+            gateway_enable: true,
+            gateway_external: true,
+            gateway_port: DEFAULT_MADARA_GATEWAY_PORT,
+            charge_fee: false,
+            block_time: None,
+            // l1_endpoint: Some("http://127.0.0.1:8545".to_string()),
+            l1_endpoint: None,
+            strk_gas_price: 0,
+            strk_blob_gas_price: 0,
+            gas_price: 0,
+            blob_gas_price: 0,
+            environment_vars: HashMap::new(),
+            additional_args: Vec::new(),
+            logs: (true, true),
+        }
+    }
+}
+
+impl MadaraConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a builder for MadaraConfig
+    pub fn builder() -> MadaraConfigBuilder {
+        MadaraConfigBuilder::new()
+    }
+
+    /// Get the binary path
+    pub fn binary_path(&self) -> Option<&PathBuf> {
+        self.binary_path.as_ref()
+    }
+
+    /// Get the name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the block time
+    pub fn block_time(&self) -> Option<String> {
+        self.block_time.clone()
+    }
+
+    /// Get the database path
+    pub fn database_path(&self) -> &PathBuf {
+        &self.database_path
+    }
+
+    /// Get the RPC port
+    pub fn rpc_port(&self) -> u16 {
+        self.rpc_port
+    }
+
+    /// Get the RPC CORS
+    pub fn rpc_cors(&self) -> &str {
+        &self.rpc_cors
+    }
+
+    /// Get RPC external setting
+    pub fn rpc_external(&self) -> bool {
+        self.rpc_external
+    }
+
+    /// Get RPC admin setting
+    pub fn rpc_admin(&self) -> bool {
+        self.rpc_admin
+    }
+
+    /// Get the mode
+    pub fn mode(&self) -> &MadaraMode {
+        &self.mode
+    }
+
+    /// Get the chain config path
+    pub fn chain_config_path(&self) -> Option<&PathBuf> {
+        self.chain_config_path.as_ref()
+    }
+
+    /// Get feeder gateway enable setting
+    pub fn feeder_gateway_enable(&self) -> bool {
+        self.feeder_gateway_enable
+    }
+
+    /// Get gateway enable setting
+    pub fn gateway_enable(&self) -> bool {
+        self.gateway_enable
+    }
+
+    /// Get gateway external setting
+    pub fn gateway_external(&self) -> bool {
+        self.gateway_external
+    }
+
+    /// Get the gateway port
+    pub fn gateway_port(&self) -> u16 {
+        self.gateway_port
+    }
+
+    /// Get charge fee setting
+    pub fn charge_fee(&self) -> bool {
+        self.charge_fee
+    }
+
+    /// Get the L1 endpoint
+    pub fn l1_endpoint(&self) -> Option<&str> {
+        self.l1_endpoint.as_deref()
+    }
+
+    /// Get STRK gas price
+    pub fn strk_gas_price(&self) -> u64 {
+        self.strk_gas_price
+    }
+
+    /// Get STRK blob gas price
+    pub fn strk_blob_gas_price(&self) -> u64 {
+        self.strk_blob_gas_price
+    }
+
+    /// Get gas price
+    pub fn gas_price(&self) -> u64 {
+        self.gas_price
+    }
+
+    /// Get blob gas price
+    pub fn blob_gas_price(&self) -> u64 {
+        self.blob_gas_price
+    }
+
+    /// Get environment variables
+    pub fn environment_vars(&self) -> &HashMap<String, String> {
+        &self.environment_vars
+    }
+
+    /// Get additional arguments
+    pub fn additional_args(&self) -> &[String] {
+        &self.additional_args
+    }
+
+    /// Get logs
+    pub fn logs(&self) -> (bool, bool) {
+        self.logs
+    }
+
+    /// Convert the configuration to a command
+    pub fn to_command(&self) -> Command {
+        let binary_path = self.binary_path.as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| DEFAULT_MADARA_BINARY_PATH.to_string());
+
+        let mut cmd = Command::new(binary_path);
+
+        // Core arguments
+        cmd.arg("--name").arg(&self.name);
+        cmd.arg("--base-path").arg(&self.database_path);
+        cmd.arg("--rpc-port").arg(self.rpc_port.to_string());
+        cmd.arg("--rpc-cors").arg(&self.rpc_cors);
+        cmd.arg("--gateway-port").arg(self.gateway_port.to_string());
+
+        // Gas prices
+        cmd.arg("--strk-gas-price").arg(self.strk_gas_price.to_string());
+        cmd.arg("--strk-blob-gas-price").arg(self.strk_blob_gas_price.to_string());
+        cmd.arg("--gas-price").arg(self.gas_price.to_string());
+        cmd.arg("--blob-gas-price").arg(self.blob_gas_price.to_string());
+
+        // Charge fee flag (inverted logic)
+        if !self.charge_fee {
+            cmd.arg("--no-charge-fee");
+        }
+
+        // Boolean flags
+        if self.rpc_external {
+            cmd.arg("--rpc-external");
+        }
+        if self.rpc_admin {
+            cmd.arg("--rpc-admin");
+        }
+        if self.feeder_gateway_enable {
+            cmd.arg("--feeder-gateway-enable");
+        }
+        if self.gateway_enable {
+            cmd.arg("--gateway-enable");
+        }
+        if self.gateway_external {
+            cmd.arg("--gateway-external");
+        }
+
+        // Mode-specific flags
+        match self.mode {
+            MadaraMode::Sequencer => {
+                cmd.arg("--sequencer");
+            }
+            MadaraMode::FullNode => {
+                cmd.arg("--full-node");
+            }
+        }
+
+        if let Some(ref l1_endpoint) = self.l1_endpoint {
+            cmd.arg("--l1-endpoint").arg(l1_endpoint);
+        } else {
+            cmd.arg("--no-l1-sync");
+        }
+
+        // Optional arguments
+        if let Some(ref chain_config) = self.chain_config_path {
+            cmd.arg("--chain-config-path").arg(chain_config);
+        }
+
+        // --chain-config-override block_time=3s
+        if let Some(ref block_time) = self.block_time {
+            cmd.arg("--chain-config-override").arg(format!("block_time={}", block_time));
+        }
+
+        // Additional arguments
+        for arg in &self.additional_args {
+            cmd.arg(arg);
+        }
+
+        // Environment variables
+        for (key, value) in &self.environment_vars {
+            cmd.env(key, value);
+        }
+
+        cmd
+    }
+}
+
+// Builder type that allows configuration
+#[derive(Debug, Clone)]
+pub struct MadaraConfigBuilder {
+    config: MadaraConfig,
+}
+
+impl MadaraConfigBuilder {
+    /// Create a new configuration builder with default values
+    pub fn new() -> Self {
+        Self {
+            config: MadaraConfig::default(),
+        }
+    }
+
+    /// Build the final immutable configuration
+    pub fn build(self) -> MadaraConfig {
+        self.config
+    }
+
+    pub fn binary_path<P: Into<PathBuf>>(mut self, path: Option<P>) -> Self {
+        self.config.binary_path = path.map(|p| p.into());
+        self
+    }
+
+    pub fn name(mut self, name: &str) -> Self {
+        self.config.name = name.to_string();
+        self
+    }
+
+    pub fn block_time(mut self, block_time: Option<String>) -> Self {
+        self.config.block_time = block_time;
+        self
+    }
+
+    pub fn database_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.config.database_path = path.into();
+        self
+    }
+
+    pub fn rpc_port(mut self, port: u16) -> Self {
+        self.config.rpc_port = port;
+        self
+    }
+
+    pub fn rpc_cors(mut self, cors: &str) -> Self {
+        self.config.rpc_cors = cors.to_string();
+        self
+    }
+
+    pub fn rpc_external(mut self, external: bool) -> Self {
+        self.config.rpc_external = external;
+        self
+    }
+
+    pub fn rpc_admin(mut self, admin: bool) -> Self {
+        self.config.rpc_admin = admin;
+        self
+    }
+
+    pub fn mode(mut self, mode: MadaraMode) -> Self {
+        self.config.mode = mode;
+        self
+    }
+
+    pub fn chain_config_path<P: Into<PathBuf>>(mut self, path: Option<P>) -> Self {
+        self.config.chain_config_path = path.map(|p| p.into());
+        self
+    }
+
+    pub fn feeder_gateway_enable(mut self, enable: bool) -> Self {
+        self.config.feeder_gateway_enable = enable;
+        self
+    }
+
+    pub fn gateway_enable(mut self, enable: bool) -> Self {
+        self.config.gateway_enable = enable;
+        self
+    }
+
+    pub fn gateway_external(mut self, external: bool) -> Self {
+        self.config.gateway_external = external;
+        self
+    }
+
+    pub fn gateway_port(mut self, port: u16) -> Self {
+        self.config.gateway_port = port;
+        self
+    }
+
+    pub fn charge_fee(mut self, charge_fee: bool) -> Self {
+        self.config.charge_fee = charge_fee;
+        self
+    }
+
+    pub fn l1_endpoint(mut self, endpoint: Option<&str>) -> Self {
+        self.config.l1_endpoint = endpoint.map(|v| v.to_string());
+        self
+    }
+
+    pub fn strk_gas_price(mut self, price: u64) -> Self {
+        self.config.strk_gas_price = price;
+        self
+    }
+
+    pub fn strk_blob_gas_price(mut self, price: u64) -> Self {
+        self.config.strk_blob_gas_price = price;
+        self
+    }
+
+    pub fn gas_price(mut self, price: u64) -> Self {
+        self.config.gas_price = price;
+        self
+    }
+
+    pub fn blob_gas_price(mut self, price: u64) -> Self {
+        self.config.blob_gas_price = price;
+        self
+    }
+
+    pub fn env_var(mut self, key: &str, value: &str) -> Self {
+        self.config.environment_vars.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    pub fn arg(mut self, arg: &str) -> Self {
+        self.config.additional_args.push(arg.to_string());
+        self
+    }
+}
+
+impl Default for MadaraConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/e2e/src/services/madara/config.rs
+++ b/e2e/src/services/madara/config.rs
@@ -244,12 +244,12 @@ impl MadaraConfig {
 
     /// Get the gateway endpoint
     pub fn gateway_endpoint(&self) -> Url {
-        Url::parse(&format!("http://{}:{}/{}", DEFAULT_SERVICE_HOST, self.gateway_port(), "feeder")).unwrap()
+        Url::parse(&format!("http://{}:{}/{}", DEFAULT_SERVICE_HOST, self.gateway_port(), "gateway")).unwrap()
     }
 
     /// Get the feeder gateway endpoint
     pub fn feeder_gateway_endpoint(&self) -> Url {
-        Url::parse(&format!("http://{}:{}/{}", DEFAULT_SERVICE_HOST, self.gateway_port(), "feeder_gateway")).unwrap()
+        Url::parse(&format!("http://{}:{}/{}", DEFAULT_SERVICE_HOST, self.gateway_port(), "feeder-gateway")).unwrap()
     }
 
     /// Convert the configuration to a command

--- a/e2e/src/services/madara/mod.rs
+++ b/e2e/src/services/madara/mod.rs
@@ -52,13 +52,6 @@ impl MadaraService {
         vec!["anvil".to_string()] // L1 endpoint dependency
     }
 
-    // TODO: ideally validating deps should be done inside setup coz it has the deps listed within itself as Option
-    /// Validate that all required dependencies are available
-    pub fn validate_dependencies(&self) -> Result<(), MadaraError> {
-        //  need to move to setup
-        Ok(())
-    }
-
     /// Get the RPC endpoint URL
     pub fn rpc_endpoint(&self) -> Url {
         Url::parse(&format!("http://{}:{}", DEFAULT_SERVICE_HOST, self.config().rpc_port())).unwrap()
@@ -124,10 +117,6 @@ impl MadaraService {
         self.server.pid()
     }
 
-    /// Check if the process has exited
-    // pub fn has_exited(&mut self) -> Option<ExitStatus> {
-    //     self.server.has_exited().unwrap()
-    // }
 
     /// Check if the service is running
     pub fn is_running(&mut self) -> bool {
@@ -146,75 +135,6 @@ impl MadaraService {
 
         Ok(())
     }
-
-    // Stop the Madara service
-    // pub async fn stop(&mut self) -> Result<(), MadaraError> {
-    //     self.server.stop().await.map_err(MadaraError::Server)
-    // }
-
-    // Restart the Madara service (useful after bootstrapper setup)
-    // pub async fn restart(&mut self) -> Result<(), MadaraError> {
-    //     println!("🔄 Restarting Madara service...");
-
-    //     // Stop current instance
-    //     self.stop().await?;
-
-    //     // Wait a moment for clean shutdown
-    //     tokio::time::sleep(Duration::from_secs(10)).await;
-
-    //     // Build new command
-    //     let command = self.config.to_command();
-
-    //     // Create server config
-    //     let server_config = ServerConfig {
-    //         port: self.config.rpc_port(),
-    //         host: "127.0.0.1".to_string(),
-    //         connection_attempts: 60,
-    //         connection_delay_ms: 2000,
-    //         ..Default::default()
-    //     };
-
-    //     // Start new instance
-    //     self.server = Server::start_process(command, server_config)
-    //         .await
-    //         .map_err(MadaraError::Server)?;
-
-    //     println!("✅ Madara service restarted");
-    //     Ok(())
-    // }
-
-    // /// Create database directory if it doesn't exist
-    // pub async fn ensure_database_directory(&self) -> Result<(), MadaraError> {
-    //     if !self.config.database_path().exists() {
-    //         tokio::fs::create_dir_all(self.config.database_path()).await?;
-    //         println!("📁 Created database directory: {}", self.config.database_path().display());
-    //     }
-    //     Ok(())
-    // }
-
-    // /// Check if database has been initialized
-    // pub fn is_database_initialized(&self) -> bool {
-    //     self.config.database_path().exists() && self.config.database_path().join("db").exists()
-    // }
-
-    // /// Get database size in bytes
-    // pub async fn get_database_size(&self) -> Result<u64, MadaraError> {
-    //     if !self.config.database_path().exists() {
-    //         return Ok(0);
-    //     }
-
-    //     let mut size = 0u64;
-    //     let mut entries = tokio::fs::read_dir(self.config.database_path()).await?;
-
-    //     while let Some(entry) = entries.next_entry().await? {
-    //         let metadata = entry.metadata().await?;
-    //         if metadata.is_file() {
-    //             size += metadata.len();
-    //         }
-    //     }
-
-    //     Ok(size)
-    // }
 
 }
 

--- a/e2e/src/services/madara/mod.rs
+++ b/e2e/src/services/madara/mod.rs
@@ -11,8 +11,8 @@ use crate::services::server::{Server, ServerConfig};
 use reqwest::Url;
 use std::path::PathBuf;
 
-use crate::services::helpers::NodeRpcMethods;
 use crate::services::constants::*;
+use crate::services::helpers::NodeRpcMethods;
 use tokio::time::Duration;
 
 pub struct MadaraService {
@@ -39,9 +39,7 @@ impl MadaraService {
         };
 
         // Start the server using the generic Server::start_process
-        let server = Server::start_process(command, server_config)
-            .await
-            .map_err(MadaraError::Server)?;
+        let server = Server::start_process(command, server_config).await.map_err(MadaraError::Server)?;
 
         Ok(Self { server, config })
     }
@@ -64,12 +62,7 @@ impl MadaraService {
 
     /// Get the Feeder Gateway endpoint URL
     pub fn feeder_gateway_endpoint(&self) -> Url {
-        Url::parse(&format!(
-            "http://{}:{}/feeder_gateway",
-            DEFAULT_SERVICE_HOST,
-            self.config().gateway_port()
-        ))
-        .unwrap()
+        Url::parse(&format!("http://{}:{}/feeder_gateway", DEFAULT_SERVICE_HOST, self.config().gateway_port())).unwrap()
     }
 
     /// Get the main endpoint URL (alias for rpc_endpoint)
@@ -80,6 +73,11 @@ impl MadaraService {
     /// Get the RPC port number
     pub fn port(&self) -> u16 {
         self.config().rpc_port()
+    }
+
+    /// Get the RPC admin port number
+    pub fn rpc_admin_port(&self) -> u16 {
+        self.config().rpc_admin_port()
     }
 
     /// Get the Gateway port number
@@ -117,17 +115,15 @@ impl MadaraService {
         self.server.pid()
     }
 
-
     /// Check if the service is running
     pub fn is_running(&mut self) -> bool {
-        self.server.is_running()
+        self.server.has_exited().is_none()
     }
 
     pub async fn wait_for_block_mined(&self, block_number: u64) -> Result<(), MadaraError> {
         println!("⏳ Waiting for Madara block {} to be mined", block_number);
 
-        while self.get_latest_block_number().await
-            .map_err(|err| MadaraError::RpcError(err))? < 0 {
+        while self.get_latest_block_number().await.map_err(|err| MadaraError::RpcError(err))? < 0 {
             println!("⏳ Checking Madara block status...");
             tokio::time::sleep(Duration::from_millis(1000)).await;
         }
@@ -135,9 +131,7 @@ impl MadaraService {
 
         Ok(())
     }
-
 }
-
 
 impl NodeRpcMethods for MadaraService {
     fn get_endpoint(&self) -> Url {

--- a/e2e/src/services/madara/mod.rs
+++ b/e2e/src/services/madara/mod.rs
@@ -54,15 +54,6 @@ impl MadaraService {
         Url::parse(&format!("http://{}:{}", DEFAULT_SERVICE_HOST, self.config().rpc_port())).unwrap()
     }
 
-    /// Get the Gateway endpoint URL
-    pub fn gateway_endpoint(&self) -> Url {
-        Url::parse(&format!("http://{}:{}", DEFAULT_SERVICE_HOST, self.config().gateway_port())).unwrap()
-    }
-
-    /// Get the Feeder Gateway endpoint URL
-    pub fn feeder_gateway_endpoint(&self) -> Url {
-        Url::parse(&format!("http://{}:{}/feeder_gateway", DEFAULT_SERVICE_HOST, self.config().gateway_port())).unwrap()
-    }
 
     /// Get the main endpoint URL (alias for rpc_endpoint)
     pub fn endpoint(&self) -> Url {

--- a/e2e/src/services/madara/mod.rs
+++ b/e2e/src/services/madara/mod.rs
@@ -106,8 +106,8 @@ impl MadaraService {
     }
 
     /// Check if the service is running
-    pub fn is_running(&mut self) -> bool {
-        self.server.has_exited().is_none()
+    pub fn is_running(&mut self) -> Result<bool, MadaraError> {
+        Ok(self.server.has_exited()?.is_none())
     }
 
     pub async fn wait_for_block_mined(&self, block_number: u64) -> Result<(), MadaraError> {

--- a/e2e/src/services/madara/mod.rs
+++ b/e2e/src/services/madara/mod.rs
@@ -1,0 +1,226 @@
+// =============================================================================
+// MADARA SERVICE - Starknet Sequencer using generic Server
+// =============================================================================
+
+pub mod config;
+
+// Re-export common utilities
+pub use config::*;
+
+use crate::services::server::{Server, ServerConfig};
+use reqwest::Url;
+use std::path::PathBuf;
+
+use crate::services::helpers::NodeRpcMethods;
+use tokio::time::Duration;
+use super::server::DEFAULT_SERVICE_HOST;
+
+pub struct MadaraService {
+    server: Server,
+    config: MadaraConfig,
+}
+
+impl MadaraService {
+    /// Start a new Madara service
+    pub async fn start(config: MadaraConfig) -> Result<Self, MadaraError> {
+        // TODO: Validation should move to madara config
+
+        // Build the command using the immutable config
+        let command = config.to_command();
+
+        // Create server config using the immutable config getters
+        let server_config = ServerConfig {
+            rpc_port: Some(config.rpc_port()),
+            service_name: format!("Madara-{}", config.mode().to_string()),
+            connection_attempts: 60, // Madara might take time to start
+            connection_delay_ms: 2000,
+            logs: config.logs(),
+            ..Default::default()
+        };
+
+        // Start the server using the generic Server::start_process
+        let server = Server::start_process(command, server_config)
+            .await
+            .map_err(MadaraError::Server)?;
+
+        Ok(Self { server, config })
+    }
+
+    // TODO: deps should be an enum
+    /// Get the dependencies required by Madara
+    pub fn dependencies(&self) -> Vec<String> {
+        vec!["anvil".to_string()] // L1 endpoint dependency
+    }
+
+    // TODO: ideally validating deps should be done inside setup coz it has the deps listed within itself as Option
+    /// Validate that all required dependencies are available
+    pub fn validate_dependencies(&self) -> Result<(), MadaraError> {
+        //  need to move to setup
+        Ok(())
+    }
+
+    /// Get the RPC endpoint URL
+    pub fn rpc_endpoint(&self) -> Url {
+        Url::parse(&format!("http://{}:{}", DEFAULT_SERVICE_HOST, self.config().rpc_port())).unwrap()
+    }
+
+    /// Get the Gateway endpoint URL
+    pub fn gateway_endpoint(&self) -> Url {
+        Url::parse(&format!("http://{}:{}", DEFAULT_SERVICE_HOST, self.config().gateway_port())).unwrap()
+    }
+
+    /// Get the Feeder Gateway endpoint URL
+    pub fn feeder_gateway_endpoint(&self) -> Url {
+        Url::parse(&format!(
+            "http://{}:{}/feeder_gateway",
+            DEFAULT_SERVICE_HOST,
+            self.config().gateway_port()
+        ))
+        .unwrap()
+    }
+
+    /// Get the main endpoint URL (alias for rpc_endpoint)
+    pub fn endpoint(&self) -> Url {
+        self.rpc_endpoint()
+    }
+
+    /// Get the RPC port number
+    pub fn port(&self) -> u16 {
+        self.config().rpc_port()
+    }
+
+    /// Get the Gateway port number
+    pub fn gateway_port(&self) -> u16 {
+        self.config.gateway_port()
+    }
+
+    /// Get the chain name
+    pub fn name(&self) -> &str {
+        self.config.name()
+    }
+
+    /// Get the base path
+    pub fn database_path(&self) -> &PathBuf {
+        self.config.database_path()
+    }
+
+    /// Get the underlying server
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+
+    /// Get the current configuration
+    pub fn config(&self) -> &MadaraConfig {
+        &self.config
+    }
+
+    pub fn stop(&mut self) -> Result<(), MadaraError> {
+        println!("☠️ Stopping Madara");
+        self.server.stop().map_err(|err| MadaraError::Server(err))
+    }
+
+    /// Get the process ID
+    pub fn pid(&self) -> Option<u32> {
+        self.server.pid()
+    }
+
+    /// Check if the process has exited
+    // pub fn has_exited(&mut self) -> Option<ExitStatus> {
+    //     self.server.has_exited().unwrap()
+    // }
+
+    /// Check if the service is running
+    pub fn is_running(&mut self) -> bool {
+        self.server.is_running()
+    }
+
+    pub async fn wait_for_block_mined(&self, block_number: u64) -> Result<(), MadaraError> {
+        println!("⏳ Waiting for Madara block {} to be mined", block_number);
+
+        while self.get_latest_block_number().await
+            .map_err(|err| MadaraError::RpcError(err))? < 0 {
+            println!("⏳ Checking Madara block status...");
+            tokio::time::sleep(Duration::from_millis(1000)).await;
+        }
+        println!("🔔 Madara block {} is mined", block_number);
+
+        Ok(())
+    }
+
+    // Stop the Madara service
+    // pub async fn stop(&mut self) -> Result<(), MadaraError> {
+    //     self.server.stop().await.map_err(MadaraError::Server)
+    // }
+
+    // Restart the Madara service (useful after bootstrapper setup)
+    // pub async fn restart(&mut self) -> Result<(), MadaraError> {
+    //     println!("🔄 Restarting Madara service...");
+
+    //     // Stop current instance
+    //     self.stop().await?;
+
+    //     // Wait a moment for clean shutdown
+    //     tokio::time::sleep(Duration::from_secs(10)).await;
+
+    //     // Build new command
+    //     let command = self.config.to_command();
+
+    //     // Create server config
+    //     let server_config = ServerConfig {
+    //         port: self.config.rpc_port(),
+    //         host: "127.0.0.1".to_string(),
+    //         connection_attempts: 60,
+    //         connection_delay_ms: 2000,
+    //         ..Default::default()
+    //     };
+
+    //     // Start new instance
+    //     self.server = Server::start_process(command, server_config)
+    //         .await
+    //         .map_err(MadaraError::Server)?;
+
+    //     println!("✅ Madara service restarted");
+    //     Ok(())
+    // }
+
+    // /// Create database directory if it doesn't exist
+    // pub async fn ensure_database_directory(&self) -> Result<(), MadaraError> {
+    //     if !self.config.database_path().exists() {
+    //         tokio::fs::create_dir_all(self.config.database_path()).await?;
+    //         println!("📁 Created database directory: {}", self.config.database_path().display());
+    //     }
+    //     Ok(())
+    // }
+
+    // /// Check if database has been initialized
+    // pub fn is_database_initialized(&self) -> bool {
+    //     self.config.database_path().exists() && self.config.database_path().join("db").exists()
+    // }
+
+    // /// Get database size in bytes
+    // pub async fn get_database_size(&self) -> Result<u64, MadaraError> {
+    //     if !self.config.database_path().exists() {
+    //         return Ok(0);
+    //     }
+
+    //     let mut size = 0u64;
+    //     let mut entries = tokio::fs::read_dir(self.config.database_path()).await?;
+
+    //     while let Some(entry) = entries.next_entry().await? {
+    //         let metadata = entry.metadata().await?;
+    //         if metadata.is_file() {
+    //             size += metadata.len();
+    //         }
+    //     }
+
+    //     Ok(size)
+    // }
+
+}
+
+
+impl NodeRpcMethods for MadaraService {
+    fn get_endpoint(&self) -> Url {
+        self.endpoint().clone()
+    }
+}

--- a/e2e/src/services/madara/mod.rs
+++ b/e2e/src/services/madara/mod.rs
@@ -12,8 +12,8 @@ use reqwest::Url;
 use std::path::PathBuf;
 
 use crate::services::helpers::NodeRpcMethods;
+use crate::services::constants::*;
 use tokio::time::Duration;
-use super::server::DEFAULT_SERVICE_HOST;
 
 pub struct MadaraService {
     server: Server,

--- a/e2e/src/services/madara/mod.rs
+++ b/e2e/src/services/madara/mod.rs
@@ -13,7 +13,6 @@ use std::path::PathBuf;
 
 use crate::services::constants::*;
 use crate::services::helpers::NodeRpcMethods;
-use tokio::time::Duration;
 
 pub struct MadaraService {
     server: Server,
@@ -125,7 +124,7 @@ impl MadaraService {
 
         while self.get_latest_block_number().await.map_err(|err| MadaraError::RpcError(err))? < 0 {
             println!("⏳ Checking Madara block status...");
-            tokio::time::sleep(Duration::from_millis(1000)).await;
+            tokio::time::sleep(MADARA_WAITING_DURATION.to_owned()).await;
         }
         println!("🔔 Madara block {} is mined", block_number);
 

--- a/e2e/src/services/mod.rs
+++ b/e2e/src/services/mod.rs
@@ -4,5 +4,6 @@ pub mod bootstrapper;
 pub mod docker;
 pub mod helpers;
 pub mod localstack;
+pub mod madara;
 pub mod mongodb;
 pub mod server;


### PR DESCRIPTION
# Add Madara Service for E2E Testing

## Pull Request type

- Feature

## What is the current behavior?

The e2e testing framework lacks support for running and configuring Madara nodes.

## What is the new behavior?

- Added a comprehensive `MadaraService` implementation for e2e testing
- Created a flexible configuration system with builder pattern for Madara nodes
- Implemented RPC endpoint access and block mining verification
- Added support for different node modes (Sequencer and FullNode)
- Provided methods to access gateway and feeder gateway endpoints

## Does this introduce a breaking change?

No

## Other information

This implementation allows e2e tests to easily spin up and configure Madara nodes with different settings, making it possible to test various node configurations and interactions.