### PR TITLE
ci: Migrate to Blacksmith CI for improved performance

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -25,38 +25,25 @@ runs:
     - name: Checkout Repository
       uses: actions/checkout@v4
 
-    - uses: actions/cache@v4
-      if: ${{ inputs.extra-cache == 'true' }}
-      id: cache-cargo
-      with:
-        path: |
-          ~/.cargo/bin
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-registry-${{ inputs.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-registry-${{ inputs.cache-key }}
-          ${{ runner.os }}-cargo-registry-
-
-    - uses: actions/cache@v4
-      if: ${{ inputs.extra-cache == 'true' }}
-      id: cache-build-deps
-      with:
-        path: |
-          target/${{ inputs.cache-location }}/deps
-          target/${{ inputs.cache-location }}/build
-          target/${{ inputs.cache-location }}/.fingerprint
-        key: ${{ runner.os }}-${{ inputs.rust-version }}-build-deps-${{ inputs.cache-key }}-${{ hashFiles('**/Cargo.lock', 'src/**/*.rs') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.rust-version }}-build-deps-${{ inputs.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
-          ${{ runner.os }}-${{ inputs.rust-version }}-build-deps-${{ inputs.cache-key }}
-
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{ inputs.rust-version }}
         components: cargo, clippy, rustfmt
         rustflags: ""
+        cache: false # Disable built-in caching since we're using Blacksmith
+
+    - name: Setup Blacksmith Rust Cache
+      if: ${{ inputs.extra-cache == 'true' }}
+      uses: useblacksmith/rust-cache@v3
+      with:
+        # Automatically handles:
+        # - ~/.cargo/bin
+        # - ~/.cargo/registry
+        # - ~/.cargo/git
+        # - target/ directories
+        # - Cargo.lock-based cache invalidation
+        shared-key: ${{ inputs.cache-key }}
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/pull-request-close.yml
+++ b/.github/workflows/pull-request-close.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     permissions:
       actions: write
     steps:

--- a/.github/workflows/schedule-daily-maintenance-issues.yml
+++ b/.github/workflows/schedule-daily-maintenance-issues.yml
@@ -11,7 +11,7 @@ jobs:
   stale_issues:
     name: 🧹 Clean up stale issues and PRs
     if: ${{ github.repository_owner == 'madara-alliance' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: 🚀 Run stale
         uses: actions/stale@v3

--- a/.github/workflows/schedule-daily-security-audit.yml
+++ b/.github/workflows/schedule-daily-security-audit.yml
@@ -11,7 +11,7 @@ jobs:
   security_audit:
     name: Security - Audit check
     if: ${{ github.repository_owner == 'madara-alliance' || github.event_name != 'schedule' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/audit-check@v1

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -13,7 +13,7 @@ on:
         type: string
       should_run:
         required: false
-        default: true
+        default: "true"
         type: string
     outputs:
       artifacts:
@@ -30,12 +30,12 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - run: echo "Building ${{ inputs.artifacts-pr }}"
 
   build-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     if: inputs.should_run == 'true'
     outputs:
       artifacts: ${{ steps.tag.outputs.artifacts }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v1.2
         with:
           context: .
           push: false
@@ -87,8 +87,6 @@ jobs:
             ${{ steps.tag.outputs.artifacts }}
             ${{ steps.tag.outputs.artifacts-pr }}
           outputs: type=docker,dest=${{ runner.temp }}/artifacts.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/task-build-madara.yml
+++ b/.github/workflows/task-build-madara.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build-binaries:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     outputs:
       madara-binary-hash: ${{ steps.generate-binary-hash.outputs.madara-hash }}
       cairo-artifacts-hash: ${{ steps.generate-binary-hash.outputs.cairo-hash }}
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}-rust-1.86
+          cache-key: madara-${{ runner.os }}
 
       # Build Madara
       - name: Cargo build

--- a/.github/workflows/task-build-nightly-and-publish.yml
+++ b/.github/workflows/task-build-nightly-and-publish.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   build-nightly-and-publish:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     outputs:
       nightly: ${{ steps.tag.outputs.nightly }}
       nightly-sha: ${{ steps.tag.outputs.nightly-sha }}

--- a/.github/workflows/task-build-nightly.yml
+++ b/.github/workflows/task-build-nightly.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   build-nightly:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     outputs:
       nightly: ${{ steps.tag.outputs.nightly }}
       nightly-sha: ${{ steps.tag.outputs.nightly-sha }}

--- a/.github/workflows/task-check-bootstrapper.yml
+++ b/.github/workflows/task-check-bootstrapper.yml
@@ -10,7 +10,7 @@ jobs:
   check-binaries:
     permissions:
       pull-requests: write
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/task-check-orchestrator.yml
+++ b/.github/workflows/task-check-orchestrator.yml
@@ -10,7 +10,7 @@ jobs:
   check-binaries:
     permissions:
       pull-requests: write
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/task-ci-version-file.yml
+++ b/.github/workflows/task-ci-version-file.yml
@@ -21,12 +21,12 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - run: echo "Checking Version File ('${{ inputs.label }}' label only)"
 
   update-version-file:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     if: contains(github.event.pull_request.labels.*.name, inputs.label)
     outputs:
       update: ${{ steps.check_bump.outputs.update }}

--- a/.github/workflows/task-do-nothing-build-nightly-and-publish.yml
+++ b/.github/workflows/task-do-nothing-build-nightly-and-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-nightly-and-publish:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-build-nightly.yml
+++ b/.github/workflows/task-do-nothing-build-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-nightly:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-e2e-orchestrator.yml
+++ b/.github/workflows/task-do-nothing-e2e-orchestrator.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   e2e-orchestrator:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-publish-image.yml
+++ b/.github/workflows/task-do-nothing-publish-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish-image:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-test-bootstrapper.yml
+++ b/.github/workflows/task-do-nothing-test-bootstrapper.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-bootstrapper:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-test-cli.yml
+++ b/.github/workflows/task-do-nothing-test-cli.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-cli:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-test-hive.yml
+++ b/.github/workflows/task-do-nothing-test-hive.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   hive-madara:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-test-js.yml
+++ b/.github/workflows/task-do-nothing-test-js.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-js:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-test-madara.yml
+++ b/.github/workflows/task-do-nothing-test-madara.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-madara:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-do-nothing-test-orchestrator.yml
+++ b/.github/workflows/task-do-nothing-test-orchestrator.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-orchestrator:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Stub

--- a/.github/workflows/task-e2e-orchestrator.yml
+++ b/.github/workflows/task-e2e-orchestrator.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   e2e-orchestrator:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     services:
       localstack:

--- a/.github/workflows/task-lint-cargo.yml
+++ b/.github/workflows/task-lint-cargo.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cargo-lint:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/task-lint-code-style.yml
+++ b/.github/workflows/task-lint-code-style.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   # Run prettier for code formatting
   prettier:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
 
   # Check markdown files for style consistency
   markdown-lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
 
   # Check TOML files for formatting
   toml-lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/task-publish-image.yml
+++ b/.github/workflows/task-publish-image.yml
@@ -35,12 +35,12 @@ permissions:
 
 jobs:
   check:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - run: echo "Publishing ${{ inputs.tag-version }}"
 
   publish-image:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     if: inputs.should_run == 'true'
 
     steps:

--- a/.github/workflows/task-publish-stable.yml
+++ b/.github/workflows/task-publish-stable.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   build-release:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/task-test-bootstrapper.yml
+++ b/.github/workflows/task-test-bootstrapper.yml
@@ -22,7 +22,7 @@ jobs:
   test-bootstrapper:
     permissions:
       pull-requests: write
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -39,9 +39,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-location: llvm-cov-target/release
-          cache-key: bootstrapper-test-${{ runner.os }}-rust-1.86
-
+          cache-key: madara-${{ runner.os }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/.github/workflows/task-test-cli.yml
+++ b/.github/workflows/task-test-cli.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-cli:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}-rust-1.86
+          cache-key: madara-${{ runner.os }}
 
       - name: Run cli without arguments
         run: |

--- a/.github/workflows/task-test-hive.yml
+++ b/.github/workflows/task-test-hive.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   hive-madara:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     steps:
       - name: Download madara

--- a/.github/workflows/task-test-js.yml
+++ b/.github/workflows/task-test-js.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test-js:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -58,9 +58,10 @@ jobs:
             --rpc-external \
             --devnet \
             --preset devnet \
-            --l1-gas-price 0 \
+            --gas-price 0 \
             --blob-gas-price 0 \
-            --strk-per-eth 1 \
+            --strk-gas-price 0 \
+            --strk-blob-gas-price 0 \
             --no-l1-sync &
 
           MADARA_PID=$!

--- a/.github/workflows/task-test-js.yml
+++ b/.github/workflows/task-test-js.yml
@@ -58,10 +58,9 @@ jobs:
             --rpc-external \
             --devnet \
             --preset devnet \
-            --gas-price 0 \
+            --l1-gas-price 0 \
             --blob-gas-price 0 \
-            --strk-gas-price 0 \
-            --strk-blob-gas-price 0 \
+            --strk-per-eth 1 \
             --no-l1-sync &
 
           MADARA_PID=$!

--- a/.github/workflows/task-test-madara.yml
+++ b/.github/workflows/task-test-madara.yml
@@ -27,7 +27,7 @@ jobs:
   test-madara:
     permissions:
       pull-requests: write
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -44,8 +44,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-location: llvm-cov-target/release
-          cache-key: madara-test-${{ runner.os }}-rust-1.86
+          cache-key: madara-${{ runner.os }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/task-test-orchestrator.yml
+++ b/.github/workflows/task-test-orchestrator.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test-orchestrator:
-    runs-on: karnot-arc-runner-set
+    runs-on: blacksmith-16vcpu-ubuntu-2204
 
     services:
       localstack:
@@ -59,8 +59,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-location: llvm-cov-target/release
-          cache-key: orchestrator-test-${{ runner.os }}-rust-1.86
+          cache-key: madara-${{ runner.os }}
 
       - name: Install cargo-llvm-cov & nextest
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- Build-related changes
- CI/CD improvements

## What is the current behavior?

Currently, the CI/CD workflows use:
- Mixed runners: `karnot-arc-runner-set` and `ubuntu-latest`
- Standard GitHub Actions cache for Rust dependencies
- Default caching mechanisms that may not be optimized for our build requirements

Resolves: #NA

## What is the new behavior?

This PR migrates all CI/CD workflows to use Blacksmith CI infrastructure for improved performance and reliability:

### Changes Made:
- **Runner Migration**: All workflows now use `blacksmith-16vcpu-ubuntu-2204` runner
  - Replaced `karnot-arc-runner-set` → `blacksmith-16vcpu-ubuntu-2204`
  - Replaced `ubuntu-latest` → `blacksmith-16vcpu-ubuntu-2204`
  
- **Rust Cache Optimization**: Updated the Rust setup action to use Blacksmith's optimized caching
  - Replaced standard `actions/cache@v4` with `useblacksmith/rust-cache@v3`
  - Automatic handling of Cargo directories and build artifacts
  - Improved cache invalidation based on `Cargo.lock`

### Benefits:
- **Faster CI builds**: 16 vCPU runners provide more compute power
- **Better caching**: Blacksmith's rust-cache is optimized for Rust projects
- **Consistent environment**: All workflows use the same runner configuration
- **Reduced CI costs**: More efficient caching reduces build times

## Does this introduce a breaking change?

No - This is a CI/CD infrastructure change that doesn't affect the application code or APIs.
