### PR TITLE
fix: line continuation in bash condition

### DIFF
--- a/scripts/artifacts.sh
+++ b/scripts/artifacts.sh
@@ -1,10 +1,10 @@
-if [ -d "./build-artifacts/argent" ] ||
-  [ -d "./build-artifacts/braavos" ] ||
-  [ -d "./build-artifacts/cairo_lang" ] ||
-  [ -d "./build-artifacts/js_tests" ] ||
-  [ -d "./build-artifacts/orchestrator_tests" ] ||
-  [ -d "./build-artifacts/starkgate_latest" ] ||
-  [ -d "./build-artifacts/starkgate_legacy" ] ||
+if [ -d "./build-artifacts/argent" ] || \
+  [ -d "./build-artifacts/braavos" ] || \
+  [ -d "./build-artifacts/cairo_lang" ] || \
+  [ -d "./build-artifacts/js_tests" ] || \
+  [ -d "./build-artifacts/orchestrator_tests" ] || \
+  [ -d "./build-artifacts/starkgate_latest" ] || \
+  [ -d "./build-artifacts/starkgate_legacy" ] || \
   [ -d "./build-artifacts/bootstrapper" ]; then
   echo -e "\033[2;3;37martifacts already exists, do you want to remove it?\033[0m \033[1;32m[y/N] \033[0m"
   read -r ans


### PR DESCRIPTION
## Pull Request type

- Bugfix

## What is the current behavior?

the `if` condition with multiple `||` checks was broken because each line was not properly continued, causing bash to treat them as separate statements.

## What is the new behavior?

added `\` at the end of every line with `||` so bash correctly interprets the condition as a single block.  
no other logic was changed.

## Does this introduce a breaking change?

No

## Other information

nothing else was modified beyond fixing the condition formatting.
