### PR TITLE
chore(db/subscription): fix doc references to SubscribeNewBlocksTag

### DIFF
--- a/madara/crates/client/db/src/subscription.rs
+++ b/madara/crates/client/db/src/subscription.rs
@@ -127,8 +127,8 @@ pub enum SubscribeNewBlocksTag {
     Confirmed,
 }
 
-/// Subscribe to new blocks. When used with [`WatchBlockTag::Confirmed`], this will return a new notification
-/// everytime a new block is confirmed. When used with [`WatchBlockTag::Preconfirmed`], this will return a new
+/// Subscribe to new blocks. When used with [`SubscribeNewBlocksTag::Confirmed`], this will return a new notification
+/// everytime a new block is confirmed. When used with [`SubscribeNewBlocksTag::Preconfirmed`], this will return a new
 /// notification everytime a new block is confirmed, and everytime a new preconfirmed block is added or replaced.
 /// If a preconfirmed block is replaced (consensus failure, etc.) a new notification will be sent.
 ///


### PR DESCRIPTION
Replace incorrect WatchBlockTag mentions with the actual enum SubscribeNewBlocksTag used by the API. This aligns documentation with the code and prevents confusion for users integrating with subscribe_new_heads.