### PR TITLE
bump zaun with bytes deserialize fix

### DIFF
--- a/bootstrapper/Cargo.lock
+++ b/bootstrapper/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "ethereum-instance"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "dirs",
  "ethers",
@@ -4631,7 +4631,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "starkgate-manager-client"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethers",
@@ -4645,7 +4645,7 @@ dependencies = [
 [[package]]
 name = "starkgate-registry-client"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethers",
@@ -4751,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "starknet-core-contract-client"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethers",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "starknet-erc20-client"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethereum-instance",
@@ -4916,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "starknet-eth-bridge-client"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethers",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "starknet-proxy-client"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethereum-instance",
@@ -5005,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "starknet-token-bridge-client"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethers",
@@ -5744,7 +5744,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/karnotxyz/zaun?rev=0a478b561f096c9eb08f994760b50d5e4ed19334#0a478b561f096c9eb08f994760b50d5e4ed19334"
+source = "git+https://github.com/karnotxyz/zaun?rev=1988aa5f2f6eb46d1d40f380a2da1214c96b6c66#1988aa5f2f6eb46d1d40f380a2da1214c96b6c66"
 dependencies = [
  "async-trait",
  "ethers",

--- a/bootstrapper/Cargo.toml
+++ b/bootstrapper/Cargo.toml
@@ -23,15 +23,15 @@ url = "2.4.1"
 
 # Zaun Deps
 # commit taken from the v3-tx branch (mohit 27/10/2025)
-ethereum-instance = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-starkgate-manager-client = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-starkgate-registry-client = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-starknet-core-contract-client = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-starknet-erc20-client = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-starknet-eth-bridge-client = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-starknet-proxy-client = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-starknet-token-bridge-client = { git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
-zaun-utils = { package = "utils", git = "https://github.com/karnotxyz/zaun", rev = "0a478b561f096c9eb08f994760b50d5e4ed19334" }
+ethereum-instance = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+starkgate-manager-client = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+starkgate-registry-client = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+starknet-core-contract-client = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+starknet-erc20-client = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+starknet-eth-bridge-client = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+starknet-proxy-client = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+starknet-token-bridge-client = { git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
+zaun-utils = { package = "utils", git = "https://github.com/karnotxyz/zaun", rev = "1988aa5f2f6eb46d1d40f380a2da1214c96b6c66" }
 # Starknet Deps
 starknet = "0.14.0"
 starknet-accounts = "0.13.0"


### PR DESCRIPTION
- bytes deserialization was breaking after a zaun bump. this was the error

```
thread 'main' panicked at src/contract_clients/starknet_dev_core_contract.rs:33:10:
Failed to deploy the starknet contact: DeployContract(Hex(InvalidHexCharacter { c: 'x', index: 1 }))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
stream closed EOF for madara-system/madara-instance-new-bootstrapper-setup-l1-l94jx (bootstrapper)
```

- should we resolved with this bump