### PR TITLE
run merge ci once a day or manually

### DIFF
--- a/.github/workflows/pull-request-merge.yml
+++ b/.github/workflows/pull-request-merge.yml
@@ -97,36 +97,22 @@ jobs:
   # Run coverage tests (Madara)
   test-madara:
     uses: ./.github/workflows/task-do-nothing-test-madara.yml
-    needs: [check-merged-today]
-    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # Run coverage tests (Orchestrator)
   test-orchestrator:
     uses: ./.github/workflows/task-do-nothing-test-orchestrator.yml
-    needs: [check-merged-today]
-    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
-
-  # Run e2e tests (Orchestrator)
-  # e2e-orchestrator:
-  #   uses: ./.github/workflows/task-do-nothing-e2e-orchestrator.yml
 
   # Run coverage tests (Bootstrapper)
   test-bootstrapper:
     uses: ./.github/workflows/task-do-nothing-test-bootstrapper.yml
-    needs: [check-merged-today]
-    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # Run JavaScript tests
   test-js:
     uses: ./.github/workflows/task-do-nothing-test-js.yml
-    needs: [check-merged-today]
-    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # Run CLI tests
   test-cli:
     uses: ./.github/workflows/task-do-nothing-test-cli.yml
-    needs: [check-merged-today]
-    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # ========================================================================= #
   #                                E2E Test                                   #

--- a/.github/workflows/pull-request-merge.yml
+++ b/.github/workflows/pull-request-merge.yml
@@ -4,9 +4,38 @@ name: Workflow - Pull Request Main (merge)
 
 on:
   workflow_dispatch:
-  merge_group:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
+  # ========================================================================= #
+  #                               SCHEDULE GATE                               #
+  # ========================================================================= #
+
+  check-merged-today:
+    name: Check commits merged in previous UTC day
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check commits on main in previous UTC day
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          SINCE="$(date -u -d 'yesterday 00:00' +%Y-%m-%dT%H:%M:%SZ)"
+          UNTIL="$(date -u -d 'today 00:00' +%Y-%m-%dT%H:%M:%SZ)"
+          git fetch origin main --prune
+          COUNT="$(git rev-list --count --since="$SINCE" --until="$UNTIL" origin/main)"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
   # ========================================================================= #
   #                              NIGHTLY RELEASE                              #
   # ========================================================================= #
@@ -16,6 +45,8 @@ jobs:
     with:
       image-name: madara
       image-file: ./madara/Dockerfile
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
     permissions:
       contents: read
       packages: write
@@ -35,6 +66,8 @@ jobs:
     with:
       image-name: orchestrator
       image-file: ./orchestrator/Dockerfile
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
     permissions:
       contents: read
       packages: write
@@ -48,6 +81,8 @@ jobs:
     with:
       image-name: bootstrapper
       image-file: ./bootstrapper/Dockerfile
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
     permissions:
       contents: read
       packages: write
@@ -62,10 +97,14 @@ jobs:
   # Run coverage tests (Madara)
   test-madara:
     uses: ./.github/workflows/task-do-nothing-test-madara.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # Run coverage tests (Orchestrator)
   test-orchestrator:
     uses: ./.github/workflows/task-do-nothing-test-orchestrator.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # Run e2e tests (Orchestrator)
   # e2e-orchestrator:
@@ -74,14 +113,20 @@ jobs:
   # Run coverage tests (Bootstrapper)
   test-bootstrapper:
     uses: ./.github/workflows/task-do-nothing-test-bootstrapper.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # Run JavaScript tests
   test-js:
     uses: ./.github/workflows/task-do-nothing-test-js.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # Run CLI tests
   test-cli:
     uses: ./.github/workflows/task-do-nothing-test-cli.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
 
   # ========================================================================= #
   #                                E2E Test                                   #
@@ -90,21 +135,29 @@ jobs:
   # Build Madara binary
   build-madara:
     uses: ./.github/workflows/task-build-madara.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
     secrets: inherit
 
   # Build Orchestrator binary
   build-orchestrator:
     uses: ./.github/workflows/task-build-orchestrator.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
     secrets: inherit
 
   # Build Bootstrapper binary
   build-bootstrapper:
     uses: ./.github/workflows/task-build-bootstrapper.yml
+    needs: [check-merged-today]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
     secrets: inherit
 
   # End-to-end tests
   test-end-to-end:
-    needs: [build-madara, build-orchestrator, build-bootstrapper]
+    needs:
+      [check-merged-today, build-madara, build-orchestrator, build-bootstrapper]
+    if: github.event_name != 'schedule' || needs.check-merged-today.outputs.should_run == 'true'
     uses: ./.github/workflows/task-test-end-to-end.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}


### PR DESCRIPTION
- running merge CI on every merge to main is expensive as we increase commit frequency
- new merge CI runs every day at 12:00 AM UTC ONLY if there's a commit in the last UTC day
- it can also run through manual triggers like before