### PR TITLE
replace_chain_tip wait for fsync

### DIFF
--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -745,11 +745,6 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
     /// In addition, you must have fully imported the block using the low level writing primitives for each of the block
     /// parts.
     pub fn new_confirmed_block(&self, block_number: u64) -> Result<()> {
-        self.inner.db.on_new_confirmed_head(block_number)?; // Update snapshots for storage proofs. (TODO (heemank 06/11/2025): decouple this logic)
-
-        // Advance chain & clear preconfirmed atomically
-        self.replace_chain_tip(ChainTip::Confirmed(block_number))?;
-
         // Also flush based on the configured interval if set
         if self
             .inner
@@ -760,6 +755,11 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
             tracing::debug!("Flushing.");
             self.inner.db.flush().context("Periodic database flush")?;
         }
+        
+        self.inner.db.on_new_confirmed_head(block_number)?; // Update snapshots for storage proofs. (TODO (heemank 06/11/2025): decouple this logic)
+
+        // Advance chain & clear preconfirmed atomically
+        self.replace_chain_tip(ChainTip::Confirmed(block_number))?;
 
         Ok(())
     }

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -745,7 +745,7 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
     /// In addition, you must have fully imported the block using the low level writing primitives for each of the block
     /// parts.
     pub fn new_confirmed_block(&self, block_number: u64) -> Result<()> {
-        self.inner.db.on_new_confirmed_head(block_number)?; // Update snapshots for storage proofs. (FIXME: decouple this logic)
+        self.inner.db.on_new_confirmed_head(block_number)?; // Update snapshots for storage proofs. (TODO (heemank 06/11/2025): decouple this logic)
 
         // Advance chain & clear preconfirmed atomically
         self.replace_chain_tip(ChainTip::Confirmed(block_number))?;

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -745,6 +745,11 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
     /// In addition, you must have fully imported the block using the low level writing primitives for each of the block
     /// parts.
     pub fn new_confirmed_block(&self, block_number: u64) -> Result<()> {
+        self.inner.db.on_new_confirmed_head(block_number)?; // Update snapshots for storage proofs. (FIXME: decouple this logic)
+
+        // Advance chain & clear preconfirmed atomically
+        self.replace_chain_tip(ChainTip::Confirmed(block_number))?;
+
         // Also flush based on the configured interval if set
         if self
             .inner
@@ -755,11 +760,6 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
             tracing::debug!("Flushing.");
             self.inner.db.flush().context("Periodic database flush")?;
         }
-
-        self.inner.db.on_new_confirmed_head(block_number)?; // Update snapshots for storage proofs. (FIXME: decouple this logic)
-
-        // Advance chain & clear preconfirmed atomically
-        self.replace_chain_tip(ChainTip::Confirmed(block_number))?;
 
         Ok(())
     }

--- a/madara/crates/client/db/src/rocksdb/meta.rs
+++ b/madara/crates/client/db/src/rocksdb/meta.rs
@@ -139,10 +139,10 @@ impl RocksDBStorageInner {
             }
         };
 
-        // Write chain tip atomically with sync enabled for durability
-        // This ensures the chain tip is persisted to disk before returning,
-        // guaranteeing that the "Closed block" log reflects the actual disk state
-        self.db.write_opt(batch, &self.writeopts_sync)?;
+        // Write chain tip atomically
+        // Note: Using regular write opts (no fsync) for performance
+        // The chain tip will be synced on next flush or graceful shutdown
+        self.db.write_opt(batch, &self.writeopts_no_wal)?;
 
         Ok(())
     }

--- a/madara/crates/client/db/src/rocksdb/meta.rs
+++ b/madara/crates/client/db/src/rocksdb/meta.rs
@@ -143,7 +143,6 @@ impl RocksDBStorageInner {
         // Note: Using regular write opts (no fsync) for performance
         // The chain tip will be synced on next flush or graceful shutdown
         self.db.write_opt(batch, &self.writeopts_no_wal)?;
-
         Ok(())
     }
 

--- a/madara/crates/client/db/src/rocksdb/meta.rs
+++ b/madara/crates/client/db/src/rocksdb/meta.rs
@@ -139,10 +139,11 @@ impl RocksDBStorageInner {
             }
         };
 
-        // Write chain tip atomically
-        // Note: Using regular write opts (no fsync) for performance
-        // The chain tip will be synced on next flush or graceful shutdown
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        // Write chain tip atomically with sync enabled for durability
+        // This ensures the chain tip is persisted to disk before returning,
+        // guaranteeing that the "Closed block" log reflects the actual disk state
+        self.db.write_opt(batch, &self.writeopts_sync)?;
+
         Ok(())
     }
 

--- a/madara/crates/client/db/src/rocksdb/meta.rs
+++ b/madara/crates/client/db/src/rocksdb/meta.rs
@@ -139,10 +139,10 @@ impl RocksDBStorageInner {
             }
         };
 
-        // Write chain tip atomically
-        // Note: Using regular write opts (no fsync) for performance
-        // The chain tip will be synced on next flush or graceful shutdown
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        // Write chain tip atomically with sync enabled for durability
+        // This ensures the chain tip is persisted to disk before returning,
+        // guaranteeing that the "Closed block" log reflects the actual disk state
+        self.db.write_opt(batch, &self.writeopts_sync)?;
         Ok(())
     }
 

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -193,8 +193,8 @@ impl RocksDBStorage {
 
         let mut writeopts_no_wal = WriteOptions::new();
         writeopts_no_wal.disable_wal(true);
-
         let inner = Arc::new(RocksDBStorageInner { writeopts_no_wal, db, config: config.clone() });
+
         let head_block_n = inner.get_chain_tip_without_content()?.and_then(|c| match c {
             StoredChainTipWithoutContent::Confirmed(block_n) => Some(block_n),
             StoredChainTipWithoutContent::Preconfirmed(header) => header.block_number.checked_sub(1),

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -81,6 +81,7 @@ fn deserialize<T: serde::de::DeserializeOwned>(bytes: impl AsRef<[u8]>) -> Resul
 struct RocksDBStorageInner {
     db: DB,
     writeopts_no_wal: WriteOptions,
+    writeopts_sync: WriteOptions,
     config: RocksDBConfig,
 }
 
@@ -193,7 +194,13 @@ impl RocksDBStorage {
 
         let mut writeopts_no_wal = WriteOptions::new();
         writeopts_no_wal.disable_wal(true);
-        let inner = Arc::new(RocksDBStorageInner { writeopts_no_wal, db, config: config.clone() });
+
+        // Create write options with sync for critical operations requiring durability
+        let mut writeopts_sync = WriteOptions::new();
+        writeopts_sync.disable_wal(false); // Enable WAL for durability
+        writeopts_sync.set_sync(true);     // Force fsync to disk
+
+        let inner = Arc::new(RocksDBStorageInner { writeopts_no_wal, writeopts_sync, db, config: config.clone() });
 
         let head_block_n = inner.get_chain_tip_without_content()?.and_then(|c| match c {
             StoredChainTipWithoutContent::Confirmed(block_n) => Some(block_n),

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -81,7 +81,6 @@ fn deserialize<T: serde::de::DeserializeOwned>(bytes: impl AsRef<[u8]>) -> Resul
 struct RocksDBStorageInner {
     db: DB,
     writeopts_no_wal: WriteOptions,
-    writeopts_sync: WriteOptions,
     config: RocksDBConfig,
 }
 
@@ -195,13 +194,7 @@ impl RocksDBStorage {
         let mut writeopts_no_wal = WriteOptions::new();
         writeopts_no_wal.disable_wal(true);
 
-        // Create write options with sync for critical operations requiring durability
-        let mut writeopts_sync = WriteOptions::new();
-        writeopts_sync.disable_wal(false); // Enable WAL for durability
-        writeopts_sync.set_sync(true);     // Force fsync to disk
-
-        let inner = Arc::new(RocksDBStorageInner { writeopts_no_wal, writeopts_sync, db, config: config.clone() });
-
+        let inner = Arc::new(RocksDBStorageInner { writeopts_no_wal, db, config: config.clone() });
         let head_block_n = inner.get_chain_tip_without_content()?.and_then(|c| match c {
             StoredChainTipWithoutContent::Confirmed(block_n) => Some(block_n),
             StoredChainTipWithoutContent::Preconfirmed(header) => header.block_number.checked_sub(1),

--- a/madara/crates/client/db/src/storage.rs
+++ b/madara/crates/client/db/src/storage.rs
@@ -72,6 +72,18 @@ pub enum StorageChainTip {
     Preconfirmed { header: PreconfirmedHeader, content: Vec<PreconfirmedExecutedTransaction> },
 }
 
+impl std::fmt::Display for StorageChainTip {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty state"),
+            Self::Confirmed(block_n) => write!(f, "confirmed block: #{block_n}"),
+            Self::Preconfirmed { header, .. } => {
+                write!(f, "pre-confirmed block: #{}", header.block_number)
+            }
+        }
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct StoredChainInfo {
     pub chain_id: ChainId,

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -243,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
     .context("Starting madara backend")?;
 
     let chain_tip = backend.db.get_chain_tip().expect("Chain tip should have been fetched.");
-    tracing::info!("💼 Starting chain with block: {:?}", chain_tip);
+    tracing::info!("💼 Starting chain with {}", chain_tip);
 
     let service_mempool = MempoolService::new(&run_cmd, backend.clone());
 


### PR DESCRIPTION
Scenarios as such can only happen if graceful shutdown was not done. this code change ensures that we have fsynced with disk before we present with closed block log, ensuring that all criteria related to closing a block have been synced to db and not just the memtable of the db.



<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
