### PR TITLE
Manual Docker Image Build Workflow

### DIFF
--- a/.github/workflows/manual-build-docker-images.yml
+++ b/.github/workflows/manual-build-docker-images.yml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Manual Docker Image Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-madara:
+        description: "Build Madara image"
+        required: true
+        type: boolean
+        default: true
+      build-orchestrator:
+        description: "Build Orchestrator image"
+        required: true
+        type: boolean
+        default: true
+      build-bootstrapper:
+        description: "Build Bootstrapper image"
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  build-and-publish-madara:
+    if: ${{ inputs.build-madara }}
+    uses: ./.github/workflows/task-build-manual-and-publish.yml
+    with:
+      image-name: madara
+      image-file: ./madara/Dockerfile
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    secrets: inherit
+
+  build-and-publish-orchestrator:
+    if: ${{ inputs.build-orchestrator }}
+    uses: ./.github/workflows/task-build-manual-and-publish.yml
+    with:
+      image-name: orchestrator
+      image-file: ./orchestrator/Dockerfile
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    secrets: inherit
+
+  build-and-publish-bootstrapper:
+    if: ${{ inputs.build-bootstrapper }}
+    uses: ./.github/workflows/task-build-manual-and-publish.yml
+    with:
+      image-name: bootstrapper
+      image-file: ./bootstrapper/Dockerfile
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    secrets: inherit

--- a/.github/workflows/task-build-manual-and-publish.yml
+++ b/.github/workflows/task-build-manual-and-publish.yml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Build And Publish Manual Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: Name of the Docker image
+        required: true
+        type: string
+      image-file:
+        description: Dockerfile used to build the image
+        required: true
+        type: string
+      registry:
+        description: Container registry domain
+        required: false
+        default: ghcr.io
+        type: string
+    outputs:
+      manual-sha:
+        description: Manual image tag (with commit sha)
+        value: ${{ jobs.build-manual-and-publish.outputs.manual-sha }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  build-manual-and-publish:
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    outputs:
+      manual-sha: ${{ steps.tag.outputs.manual-sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Load env
+        uses: ./.github/actions/load-env
+
+      - name: Rust setup
+        uses: ./.github/actions/setup-rust
+        with:
+          rust-version: ${{ env.BUILD_RUST_VERSION }}
+          cache-key: madara-${{ runner.os }}-rust-1.89
+
+      - name: Python Cairo setup (for apollo_starknet_os_program dependencies)
+        if: inputs.is-standalone == false
+        uses: ./.github/actions/setup-python-cairo
+        with:
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
+
+      - name: Run make artifacts
+        run: yes | make artifacts
+
+      - name: Run cargo check
+        run: cargo check
+
+      - name: Tags
+        id: tag
+        run: |
+          IMAGE="${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}"
+          SHA=$(git rev-parse --short=7 "$GITHUB_SHA")
+          MANUAL_SHA="$IMAGE:manual-$SHA"
+
+          echo "manual-sha=$MANUAL_SHA" >> $GITHUB_OUTPUT
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker Image and Publish
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: ${{ inputs.image-file }}
+          tags: ${{ steps.tag.outputs.manual-sha }}

--- a/madara/crates/primitives/receipt/src/from_blockifier.rs
+++ b/madara/crates/primitives/receipt/src/from_blockifier.rs
@@ -79,6 +79,119 @@ fn recursive_call_info_iter(res: &TransactionExecutionInfo) -> impl Iterator<Ite
         .flat_map(|call_info| call_info.iter()) // flatmap over the roots' recursive inner call infos
 }
 
+/// Formats the revert error string by removing redundant VM tracebacks.
+///
+/// The blockifier generates verbose error messages with VM tracebacks at every level
+/// of the call stack. This function filters them to show the traceback only once,
+/// positioned after the last regular contract call (CallContract) entry point frame
+/// and before any library call (LibraryCall) frames or the final error.
+///
+/// This makes error messages more concise while preserving the most relevant debugging information.
+fn format_revert_error(error_string: &str) -> String {
+    // Check if the original string ends with a newline
+    let ends_with_newline = error_string.ends_with('\n');
+
+    let lines: Vec<&str> = error_string.lines().collect();
+    let mut output_lines = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+
+        // Check if this is the start of a VM exception frame
+        // VM exception frames start with "Error at pc=..."
+        if line.trim().starts_with("Error at pc=") {
+            // Look ahead to see if there's another "Error in the called contract" entry
+            // or "Error in a library call" coming up
+            let mut has_nested_call_contract = false;
+            let mut j = i + 1;
+
+            // Scan forward to find the next entry point frame
+            while j < lines.len() {
+                let next_line = lines[j].trim();
+
+                // Found the next entry point - check if it's a CallContract or LibraryCall
+                if next_line.starts_with("Error in the called contract") {
+                    has_nested_call_contract = true;
+                    break;
+                } else if next_line.starts_with("Error in a library call")
+                    || next_line.starts_with("Execution failed")
+                    || next_line.starts_with("Entry point") {
+                    // Next entry is a library call or final error - don't skip this traceback
+                    has_nested_call_contract = false;
+                    break;
+                }
+
+                // Keep scanning through the traceback lines
+                if next_line.starts_with("Unknown location")
+                    || next_line.starts_with("Cairo traceback")
+                    || next_line.is_empty() {
+                    j += 1;
+                } else {
+                    // Reached a numbered entry like "1:" - check if it contains the patterns
+                    if let Some(colon_pos) = next_line.find(':') {
+                        let after_colon = &next_line[colon_pos + 1..].trim();
+                        if after_colon.starts_with("Error in the called contract") {
+                            has_nested_call_contract = true;
+                            break;
+                        } else if after_colon.starts_with("Error in a library call") {
+                            has_nested_call_contract = false;
+                            break;
+                        }
+                    }
+                    j += 1;
+                }
+            }
+
+            // Skip the VM traceback if there's a nested CallContract
+            if has_nested_call_contract {
+                // Skip this "Error at pc=..." line and all traceback lines until the next entry
+                while i < lines.len() {
+                    let current_line = lines[i].trim();
+                    i += 1;
+
+                    // Stop when we hit the next numbered entry or end
+                    if i < lines.len() {
+                        let next_line = lines[i].trim();
+                        if let Some(first_char) = next_line.chars().next() {
+                            if first_char.is_ascii_digit() && next_line.contains(':') {
+                                break;
+                            }
+                        }
+                    }
+
+                    // Also stop at the end or at lines that look like new entries
+                    if current_line.is_empty() && i < lines.len() {
+                        let peek = lines[i].trim();
+                        if let Some(first_char) = peek.chars().next() {
+                            if first_char.is_ascii_digit() || peek.starts_with("Execution failed") {
+                                break;
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Keep this traceback - it's before a library call or final error
+                output_lines.push(line);
+                i += 1;
+            }
+        } else {
+            // Not a VM traceback line - keep it
+            output_lines.push(line);
+            i += 1;
+        }
+    }
+
+    let mut result = output_lines.join("\n");
+
+    // Preserve the trailing newline if the original had one
+    if ends_with_newline {
+        result.push('\n');
+    }
+
+    result
+}
+
 pub fn from_blockifier_execution_info(res: &TransactionExecutionInfo, tx: &Transaction) -> TransactionReceipt {
     let price_unit = match blockifier_tx_fee_type(tx) {
         FeeType::Eth => PriceUnit::Wei,
@@ -196,7 +309,8 @@ pub fn from_blockifier_execution_info(res: &TransactionExecutionInfo, tx: &Trans
     };
 
     let execution_result = if let Some(reason) = &res.revert_error {
-        ExecutionResult::Reverted { reason: reason.to_string() }
+        let formatted_reason = format_revert_error(&reason.to_string());
+        ExecutionResult::Reverted { reason: formatted_reason }
     } else {
         ExecutionResult::Succeeded
     };


### PR DESCRIPTION
# Add Manual Docker Image Build Workflow

## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

Resolves: #NA

Currently, Docker images for Madara, Orchestrator, and Bootstrapper can only be built:
- Automatically via scheduled nightly runs (daily at midnight UTC if commits were merged)
- As part of the nightly workflow via manual `workflow_dispatch` trigger

All images built this way are tagged with `nightly` and `nightly-<sha>`, making it difficult to distinguish between scheduled and on-demand builds.

## What is the new behavior?

- Added a new manually triggerable GitHub Actions workflow that allows building Docker images on-demand
- Users can select which components to build via checkboxes in the GitHub Actions UI:
  - Madara
  - Orchestrator
  - Bootstrapper
- Manual builds are tagged as `manual-<sha>` (7-character commit SHA) to distinguish them from scheduled nightly builds (`nightly-<sha>`)
- Created a separate reusable workflow (`task-build-manual-and-publish.yml`) specifically for manual builds with appropriate tagging

## Does this introduce a breaking change?

No

## Other information

**Usage:**
1. Go to Actions tab in GitHub
2. Select "Manual Docker Image Build" workflow
3. Click "Run workflow"
4. Select which images to build
5. Images will be published to `ghcr.io/<org>/<component>:manual-<sha>`

This provides more flexibility for developers and DevOps to trigger builds for specific commits without waiting for or interfering with the scheduled nightly builds.
