### PR TITLE
Configurable RocksDB Write Options

### DIFF
--- a/madara/crates/client/db/src/rocksdb/blocks.rs
+++ b/madara/crates/client/db/src/rocksdb/blocks.rs
@@ -148,7 +148,7 @@ impl RocksDBStorageInner {
             &super::serialize_to_smallvec::<[u8; 16]>(&block_n)?,
         );
 
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
         Ok(())
     }
 
@@ -191,7 +191,7 @@ impl RocksDBStorageInner {
             value.iter().map(|tx_with_receipt| *tx_with_receipt.receipt.transaction_hash()).collect();
         batch.put_cf(&block_info_col, block_n_u32.to_be_bytes(), super::serialize(&block_info)?);
 
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
         Ok(())
     }
 
@@ -202,7 +202,7 @@ impl RocksDBStorageInner {
 
         let block_n_to_state_diff = self.get_column(BLOCK_STATE_DIFF_COLUMN);
         batch.put_cf(&block_n_to_state_diff, block_n_u32.to_be_bytes(), &super::serialize(value)?);
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
 
         Ok(())
     }
@@ -214,7 +214,7 @@ impl RocksDBStorageInner {
 
         let block_n_to_bouncer_weights = self.get_column(BLOCK_BOUNCER_WEIGHT_COLUMN);
         batch.put_cf(&block_n_to_bouncer_weights, block_n_u32.to_be_bytes(), &super::serialize(value)?);
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
 
         Ok(())
     }
@@ -248,7 +248,7 @@ impl RocksDBStorageInner {
             );
         }
 
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
         Ok(())
     }
 
@@ -380,7 +380,7 @@ impl RocksDBStorageInner {
             batch.delete_cf(&block_info_col, block_n_u32.to_be_bytes());
             batch.delete_cf(&block_hash_to_block_n_col, block_info.block_hash.to_bytes_be());
 
-            self.db.write_opt(batch, &self.writeopts_no_wal)?;
+            self.db.write_opt(batch, &self.writeopts)?;
             tracing::debug!("📦 REORG [block_db_revert]: Block {} successfully removed from database", block_n);
         }
 

--- a/madara/crates/client/db/src/rocksdb/classes.rs
+++ b/madara/crates/client/db/src/rocksdb/classes.rs
@@ -56,7 +56,7 @@ impl RocksDBStorageInner {
                         );
                     }
                 }
-                self.db.write_opt(batch, &self.writeopts_no_wal)?;
+                self.db.write_opt(batch, &self.writeopts)?;
                 anyhow::Ok(())
             },
         )?;
@@ -83,7 +83,7 @@ impl RocksDBStorageInner {
                             })?,
                         );
                     }
-                    self.db.write_opt(batch, &self.writeopts_no_wal)?;
+                    self.db.write_opt(batch, &self.writeopts)?;
                     anyhow::Ok(())
                 },
             )?;
@@ -156,7 +156,7 @@ impl RocksDBStorageInner {
             total_classes
         );
 
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
 
         tracing::info!("✅ REORG [class_db_revert]: Successfully removed all declared classes");
 

--- a/madara/crates/client/db/src/rocksdb/events.rs
+++ b/madara/crates/client/db/src/rocksdb/events.rs
@@ -139,7 +139,7 @@ impl RocksDBStorageInner {
             &self.get_column(EVENTS_BLOOM_COLUMN),
             block_n.to_be_bytes(),
             &super::serialize(&writer)?,
-            &self.writeopts_no_wal,
+            &self.writeopts,
         )?;
         Ok(())
     }

--- a/madara/crates/client/db/src/rocksdb/l1_to_l2_messages.rs
+++ b/madara/crates/client/db/src/rocksdb/l1_to_l2_messages.rs
@@ -29,21 +29,21 @@ impl RocksDBStorageInner {
             batch.put_cf(&on_l2_cf, key, receipt.transaction_hash.to_bytes_be());
         }
 
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
         Ok(())
     }
 
     /// If the message is already pending, this will overwrite it.
     pub(super) fn write_pending_message_to_l2(&self, msg: &L1HandlerTransactionWithFee) -> Result<()> {
         let pending_cf = self.get_column(L1_TO_L2_PENDING_MESSAGE_BY_NONCE);
-        self.db.put_cf_opt(&pending_cf, msg.tx.nonce.to_be_bytes(), super::serialize(&msg)?, &self.writeopts_no_wal)?;
+        self.db.put_cf_opt(&pending_cf, msg.tx.nonce.to_be_bytes(), super::serialize(&msg)?, &self.writeopts)?;
         Ok(())
     }
 
     /// If the message does not exist, this does nothing.
     pub(super) fn remove_pending_message_to_l2(&self, core_contract_nonce: u64) -> Result<()> {
         let pending_cf = self.get_column(L1_TO_L2_PENDING_MESSAGE_BY_NONCE);
-        self.db.delete_cf_opt(&pending_cf, core_contract_nonce.to_be_bytes(), &self.writeopts_no_wal)?;
+        self.db.delete_cf_opt(&pending_cf, core_contract_nonce.to_be_bytes(), &self.writeopts)?;
         Ok(())
     }
 
@@ -82,7 +82,7 @@ impl RocksDBStorageInner {
             &on_l2_cf,
             core_contract_nonce.to_be_bytes(),
             txn_hash.to_bytes_be(),
-            &self.writeopts_no_wal,
+            &self.writeopts,
         )?;
         Ok(())
     }

--- a/madara/crates/client/db/src/rocksdb/mempool.rs
+++ b/madara/crates/client/db/src/rocksdb/mempool.rs
@@ -32,7 +32,7 @@ impl RocksDBStorageInner {
             batch.delete_cf(&col, super::serialize(&tx_hash)?);
         }
 
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
         Ok(())
     }
 

--- a/madara/crates/client/db/src/rocksdb/meta.rs
+++ b/madara/crates/client/db/src/rocksdb/meta.rs
@@ -32,13 +32,13 @@ impl RocksDBStorageInner {
                 &self.get_column(META_COLUMN),
                 META_LAST_SYNCED_L1_EVENT_BLOCK_KEY,
                 block_n.to_be_bytes(),
-                &self.writeopts_no_wal,
+                &self.writeopts,
             )?;
         } else {
             self.db.delete_cf_opt(
                 &self.get_column(META_COLUMN),
                 META_LAST_SYNCED_L1_EVENT_BLOCK_KEY,
-                &self.writeopts_no_wal,
+                &self.writeopts,
             )?;
         }
         Ok(())
@@ -61,13 +61,13 @@ impl RocksDBStorageInner {
                 &self.get_column(META_COLUMN),
                 META_CONFIRMED_ON_L1_TIP_KEY,
                 block_n.to_be_bytes(),
-                &self.writeopts_no_wal,
+                &self.writeopts,
             )?;
         } else {
             self.db.delete_cf_opt(
                 &self.get_column(META_COLUMN),
                 META_CONFIRMED_ON_L1_TIP_KEY,
-                &self.writeopts_no_wal,
+                &self.writeopts,
             )?;
         }
         Ok(())
@@ -97,7 +97,7 @@ impl RocksDBStorageInner {
             &self.get_column(META_COLUMN),
             META_DEVNET_KEYS_KEY,
             super::serialize(&devnet_keys)?,
-            &self.writeopts_no_wal,
+            &self.writeopts,
         )?;
         Ok(())
     }
@@ -142,7 +142,7 @@ impl RocksDBStorageInner {
         // Write chain tip atomically
         // Note: Using regular write opts (no fsync) for performance
         // The chain tip will be synced on next flush or graceful shutdown
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
         Ok(())
     }
 
@@ -168,7 +168,7 @@ impl RocksDBStorageInner {
             let tx_index = u16::try_from(tx_index).context("Converting tx_index to u16")?;
             batch.put_cf(&col, tx_index.to_be_bytes(), super::serialize(&value)?);
         }
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
         Ok(())
     }
 
@@ -208,7 +208,7 @@ impl RocksDBStorageInner {
             &self.get_column(META_COLUMN),
             META_CHAIN_INFO_KEY,
             super::serialize_to_smallvec::<[u8; 128]>(info)?,
-            &self.writeopts_no_wal,
+            &self.writeopts,
         )?;
         Ok(())
     }
@@ -228,13 +228,13 @@ impl RocksDBStorageInner {
                 &self.get_column(META_COLUMN),
                 META_LATEST_APPLIED_TRIE_UPDATE,
                 super::serialize_to_smallvec::<[u8; 128]>(block_n)?,
-                &self.writeopts_no_wal,
+                &self.writeopts,
             )?;
         } else {
             self.db.delete_cf_opt(
                 &self.get_column(META_COLUMN),
                 META_LATEST_APPLIED_TRIE_UPDATE,
-                &self.writeopts_no_wal,
+                &self.writeopts,
             )?;
         }
         Ok(())

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -52,7 +52,7 @@ pub mod update_global_trie;
 type WriteBatchWithTransaction = rocksdb::WriteBatchWithTransaction<false>;
 type DB = DBWithThreadMode<MultiThreaded>;
 
-pub use options::{RocksDBConfig, StatsLevel};
+pub use options::{DbWriteMode, RocksDBConfig, StatsLevel};
 
 const DB_UPDATES_BATCH_SIZE: usize = 1024;
 
@@ -80,7 +80,7 @@ fn deserialize<T: serde::de::DeserializeOwned>(bytes: impl AsRef<[u8]>) -> Resul
 
 struct RocksDBStorageInner {
     db: DB,
-    writeopts_no_wal: WriteOptions,
+    writeopts: WriteOptions,
     config: RocksDBConfig,
 }
 
@@ -191,9 +191,8 @@ impl RocksDBStorage {
             ALL_COLUMNS.iter().map(|col| ColumnFamilyDescriptor::new(col.rocksdb_name, col.rocksdb_options(&config))),
         )?;
 
-        let mut writeopts_no_wal = WriteOptions::new();
-        writeopts_no_wal.disable_wal(true);
-        let inner = Arc::new(RocksDBStorageInner { writeopts_no_wal, db, config: config.clone() });
+        let writeopts = config.write_mode.to_write_options();
+        let inner = Arc::new(RocksDBStorageInner { writeopts, db, config: config.clone() });
 
         let head_block_n = inner.get_chain_tip_without_content()?.and_then(|c| match c {
             StoredChainTipWithoutContent::Confirmed(block_n) => Some(block_n),

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -192,6 +192,7 @@ impl RocksDBStorage {
         )?;
 
         let writeopts = config.write_mode.to_write_options();
+        tracing::info!("💾 Database write mode: {}", config.write_mode);
         let inner = Arc::new(RocksDBStorageInner { writeopts, db, config: config.clone() });
 
         let head_block_n = inner.get_chain_tip_without_content()?.and_then(|c| match c {

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -192,7 +192,7 @@ impl RocksDBStorage {
         )?;
 
         let writeopts = config.write_mode.to_write_options();
-        tracing::info!("💾 Database write mode: {}", config.write_mode);
+        tracing::info!("📝 Database write mode: {}", config.write_mode);
         let inner = Arc::new(RocksDBStorageInner { writeopts, db, config: config.clone() });
 
         let head_block_n = inner.get_chain_tip_without_content()?.and_then(|c| match c {

--- a/madara/crates/client/db/src/rocksdb/options.rs
+++ b/madara/crates/client/db/src/rocksdb/options.rs
@@ -75,6 +75,17 @@ impl DbWriteMode {
     }
 }
 
+impl std::fmt::Display for DbWriteMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DbWriteMode::WalWithFsync => write!(f, "wal-with-fsync (safest)"),
+            DbWriteMode::WalNoFsync => write!(f, "wal-no-fsync (recommended)"),
+            DbWriteMode::NoWalWithFsync => write!(f, "no-wal-with-fsync (fast)"),
+            DbWriteMode::NoWalNoFsync => write!(f, "no-wal-no-fsync (fastest)"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RocksDBConfig {
     /// Enable statistics. Statistics will be put in the `LOG` file in the db folder. This can have an effect on performance.

--- a/madara/crates/client/db/src/rocksdb/state.rs
+++ b/madara/crates/client/db/src/rocksdb/state.rs
@@ -153,7 +153,7 @@ impl RocksDBStorageInner {
                         super::serialize_to_smallvec::<[u8; 64]>(&value)?,
                     );
                 }
-                self.db.write_opt(batch, &self.writeopts_no_wal)?;
+                self.db.write_opt(batch, &self.writeopts)?;
                 anyhow::Ok(())
             },
         )?;
@@ -168,7 +168,7 @@ impl RocksDBStorageInner {
                         super::serialize_to_smallvec::<[u8; 64]>(&value)?,
                     );
                 }
-                self.db.write_opt(batch, &self.writeopts_no_wal)?;
+                self.db.write_opt(batch, &self.writeopts)?;
                 anyhow::Ok(())
             },
         )?;
@@ -183,7 +183,7 @@ impl RocksDBStorageInner {
                         super::serialize_to_smallvec::<[u8; 64]>(&value)?,
                     );
                 }
-                self.db.write_opt(batch, &self.writeopts_no_wal)?;
+                self.db.write_opt(batch, &self.writeopts)?;
                 anyhow::Ok(())
             },
         )?;
@@ -277,7 +277,7 @@ impl RocksDBStorageInner {
             total_storage_entries
         );
 
-        self.db.write_opt(batch, &self.writeopts_no_wal)?;
+        self.db.write_opt(batch, &self.writeopts)?;
 
         tracing::info!("✅ REORG [contract_db_revert]: Successfully removed all contract state");
 


### PR DESCRIPTION
# Configurable RocksDB Write Options (WAL and fsync)

## Pull Request type

- [x] Feature

## What is the current behavior?

Currently, Madara uses hardcoded RocksDB write options with WAL (Write-Ahead Log) disabled and no fsync (`no-wal-no-fsync`). This configuration is:
- The fastest option but least safe
- Not configurable by users
- Applied inconsistently (trie.rs had local WriteOptions creation)
- May lose data on process crashes or power failures

Resolves: #NA

## What is the new behavior?

Added configurable RocksDB write durability modes via CLI/environment variable:

**Available Modes:**
- `wal-with-fsync` - Safest, slowest (survives crashes and power failures)
- `wal-no-fsync` - **NEW DEFAULT** - Production recommended (survives crashes, faster)
- `no-wal-with-fsync` - Fast with some durability
- `no-wal-no-fsync` - Fastest, least safe (old behavior, testing only)

**Usage:**
```bash
# CLI
madara --db-write-mode wal-no-fsync

# Environment variable
MADARA_DB_WRITE_MODE=wal-with-fsync madara
```

**Changes:**
- Added `DbWriteMode` enum with 4 durability configurations
- Added `--db-write-mode` CLI parameter (default: `wal-no-fsync`)
- Changed default from `no-wal-no-fsync` to `wal-no-fsync` for better production safety
- Fixed inconsistencies: all write operations now use the same configurable settings
- Renamed `writeopts_no_wal` → `writeopts` throughout codebase for clarity

## Does this introduce a breaking change?

No - the CLI interface is new. However, the **default write behavior has changed** to be more conservative (`wal-no-fsync` instead of `no-wal-no-fsync`), which improves safety with a minor performance trade-off. Users wanting the old behavior can explicitly set `--db-write-mode no-wal-no-fsync`.

## Other information

- Default `wal-no-fsync` is recommended for production sequencers - provides crash safety while maintaining good performance
- Use `wal-with-fsync` for maximum durability in critical environments
- Use `no-wal-no-fsync` only for devnet/testing where speed matters more than data safety
- All write paths (blocks, state, classes, mempool, trie) now consistently use the configured mode