### PR TITLE
Add `--rpc-unsafe` flag to protect dangerous admin RPC methods

### DIFF
--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -82,6 +82,7 @@
     "rpc_external": false,
     "rpc_admin": false,
     "rpc_admin_external": false,
+    "rpc_unsafe": false,
     "rpc_max_request_size": 15,
     "rpc_max_response_size": 15,
     "rpc_max_subscriptions_per_connection": 1024,

--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -830,6 +830,7 @@ pub struct Starknet {
     storage_proof_config: StorageProofConfig,
     pub(crate) block_prod_handle: Option<mc_block_production::BlockProductionHandle>,
     pub ctx: ServiceContext,
+    pub(crate) rpc_unsafe_enabled: bool,
 }
 
 impl Starknet {
@@ -849,11 +850,16 @@ impl Starknet {
             block_prod_handle,
             ctx,
             pre_v0_9_preconfirmed_as_pending: false,
+            rpc_unsafe_enabled: false,
         }
     }
 
     pub fn set_pre_v0_9_preconfirmed_as_pending(&mut self, value: bool) {
         self.pre_v0_9_preconfirmed_as_pending = value;
+    }
+
+    pub fn set_rpc_unsafe_enabled(&mut self, value: bool) {
+        self.rpc_unsafe_enabled = value;
     }
 }
 

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -99,7 +99,9 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
         }
 
         self.backend.revert_to(&block_hash).map_err(StarknetRpcApiError::from)?;
-        let fresh_chain_tip = self.backend.db.get_chain_tip().unwrap();
+        let fresh_chain_tip = self.backend.db.get_chain_tip()
+            .context("Failed to get chain tip after revert")
+            .map_err(StarknetRpcApiError::from)?;
         let backend_chain_tip = mc_db::ChainTip::from_storage(fresh_chain_tip);
         self.backend.chain_tip.send_replace(backend_chain_tip);
         Ok(())

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -11,7 +11,6 @@ use mp_rpc::v0_9_0::{
 };
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use mp_block::header::CustomHeader;
-use mp_utils::service::MadaraServiceId;
 
 
 #[async_trait]
@@ -90,24 +89,22 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
     }
 
     /// Force revert chain to a previous block by hash.
-    /// Only works in full node mode.
+    /// Only available when unsafe RPC methods are enabled.
     async fn revert_to(&self, block_hash: Felt) -> RpcResult<()> {
-        // Only allow revert when in full node mode
-        if self.ctx.service_status(MadaraServiceId::BlockProduction).is_off() {
-            self.backend.revert_to(&block_hash).map_err(StarknetRpcApiError::from)?;
-            // TODO(heemankv, 04-11-25): We should spend time in ruling out the two sources of truth problem for ChainTip
-            // For now, we have to manually fetch Chain Tip from DB and update this in backend
-            let fresh_chain_tip = self.backend.db.get_chain_tip().unwrap();
-            let backend_chain_tip = mc_db::ChainTip::from_storage(fresh_chain_tip);
-            self.backend.chain_tip.send_replace(backend_chain_tip);
-            Ok(())
-        } else {
-            Err(StarknetRpcApiError::ErrUnexpectedError {
-                error: "This method is only available in full node mode".to_string().into()
-            })?
+        // Check if unsafe RPC methods are enabled
+        if !self.rpc_unsafe_enabled {
+            return Err(StarknetRpcApiError::ErrUnexpectedError {
+                error: "This method requires the --rpc-unsafe flag to be enabled".to_string().into()
+            }.into());
         }
+
+        self.backend.revert_to(&block_hash).map_err(StarknetRpcApiError::from)?;
+        let fresh_chain_tip = self.backend.db.get_chain_tip().unwrap();
+        let backend_chain_tip = mc_db::ChainTip::from_storage(fresh_chain_tip);
+        self.backend.chain_tip.send_replace(backend_chain_tip);
+        Ok(())
     }
-    
+
     async fn add_l1_handler_message(
         &self,
         l1_handler_message: L1HandlerTransactionWithFee,
@@ -122,6 +119,13 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
     }
 
     async fn set_block_header(&self, custom_block_headers: CustomHeader) -> RpcResult<()> {
+        // Check if unsafe RPC methods are enabled
+        if !self.rpc_unsafe_enabled {
+            return Err(StarknetRpcApiError::ErrUnexpectedError {
+                error: "This method requires the --rpc-unsafe flag to be enabled".to_string().into()
+            }.into());
+        }
+
         self.backend.set_custom_header(custom_block_headers);
         Ok(())
     }

--- a/madara/node/src/cli/rpc.rs
+++ b/madara/node/src/cli/rpc.rs
@@ -91,6 +91,12 @@ pub struct RpcParams {
     #[arg(env = "MADARA_RPC_ADMIN_EXTERNAL", long, default_value_t = false)]
     pub rpc_admin_external: bool,
 
+    /// Enables unsafe admin RPC methods. This includes dangerous methods like
+    /// `revertTo` and `setCustomBlockHeader` that can modify the blockchain state.
+    /// Use with extreme caution. Requires `--rpc-admin` to be enabled.
+    #[arg(env = "MADARA_RPC_UNSAFE", long, default_value_t = false, requires = "rpc_admin")]
+    pub rpc_unsafe: bool,
+
     /// Set the maximum RPC request payload size for both HTTP and WebSockets in mebibytes.
     #[arg(env = "MADARA_RPC_MAX_REQUEST_SIZE", long, default_value_t = RPC_DEFAULT_MAX_REQUEST_SIZE_MIB)]
     pub rpc_max_request_size: u32,

--- a/madara/node/src/service/rpc/mod.rs
+++ b/madara/node/src/service/rpc/mod.rs
@@ -76,6 +76,7 @@ impl Service for RpcService {
         let block_prod_handle = self.block_prod_handle.clone();
 
         let pre_v0_9_preconfirmed_as_pending = self.config.rpc_pre_v0_9_preconfirmed_as_pending;
+        let rpc_unsafe_enabled = self.config.rpc_unsafe;
 
         runner.service_loop(move |ctx| async move {
             let submit_tx = Arc::new(submit_tx_provider.make(ctx.clone()));
@@ -88,6 +89,7 @@ impl Service for RpcService {
                 ctx.clone(),
             );
             starknet.set_pre_v0_9_preconfirmed_as_pending(pre_v0_9_preconfirmed_as_pending);
+            starknet.set_rpc_unsafe_enabled(rpc_unsafe_enabled);
 
             let metrics = RpcMetrics::register()?;
 


### PR DESCRIPTION
# Add `--rpc-unsafe` flag to protect dangerous admin RPC methods

## Pull Request type

- [x] Feature

## What is the current behavior?

The admin RPC methods `revertTo` and `setCustomBlockHeader` are exposed without additional safety guards. The `revertTo` method was hidden behind a "no block production" check, which was not the intended protection mechanism.

Resolves: #NA

## What is the new behavior?

- Added a new `--rpc-unsafe` CLI flag (env: `MADARA_RPC_UNSAFE`) that must be explicitly enabled to use dangerous admin methods
- The flag requires `--rpc-admin` to be enabled first
- Both `revertTo` and `setCustomBlockHeader` now check for this flag before execution
- Removed the block production mode check from `revertTo` - it now works in any mode when the unsafe flag is set
- Clear error messages returned when attempting to use these methods without the flag

Usage:
```bash
madara --rpc-admin --rpc-unsafe
```

## Does this introduce a breaking change?

Yes - existing users calling `revertTo` or `setCustomBlockHeader` will need to add the `--rpc-unsafe` flag to their node configuration.

## Other information

This change improves security by requiring explicit opt-in for methods that can modify blockchain state. The flag name clearly indicates the dangerous nature of these operations.