### PR TITLE
Fix/orch test parallel

### DIFF
--- a/.github/workflows/task-test-orchestrator.yml
+++ b/.github/workflows/task-test-orchestrator.yml
@@ -118,7 +118,6 @@ jobs:
             --features testing \
             --lcov \
             --output-path lcov.info \
-            --test-threads=1 \
             --package "orchestrator*" \
             --no-fail-fast
 

--- a/orchestrator/src/server/mod.rs
+++ b/orchestrator/src/server/mod.rs
@@ -38,7 +38,15 @@ pub async fn setup_server(config: Arc<Config>) -> OrchestratorResult<SocketAddr>
 }
 
 pub(crate) async fn get_server_url(server_params: &ServerParams) -> (SocketAddr, tokio::net::TcpListener) {
-    let address = format!("{}:{}", server_params.host, server_params.port);
+    // In test mode, use port 0 to get a random available port (prevents "Address already in use" errors)
+    // In production, use the configured port
+    let port = if cfg!(test) {
+        0 // Let OS assign an available port
+    } else {
+        server_params.port
+    };
+
+    let address = format!("{}:{}", server_params.host, port);
     let listener = tokio::net::TcpListener::bind(address.clone()).await.expect("Failed to get listener");
     let api_server_url = listener.local_addr().expect("Unable to bind address to listener.");
 

--- a/orchestrator/src/server/types.rs
+++ b/orchestrator/src/server/types.rs
@@ -35,7 +35,7 @@ pub struct JobId {
 /// ```
 /// // Success response
 /// use orchestrator::server::types::ApiResponse;
-/// let response = ApiResponse::success(None);
+/// let response: ApiResponse<()> = ApiResponse::success(None);
 /// assert_eq!(response.success, true);
 /// assert_eq!(response.message, None);
 ///
@@ -91,7 +91,7 @@ impl<T> ApiResponse<T> {
     /// # Examples
     /// ```
     /// use orchestrator::server::types::ApiResponse;
-    /// let response = ApiResponse::success(None);
+    /// let response: ApiResponse<()> = ApiResponse::success(None);
     /// assert_eq!(response.success, true);
     /// ```
     pub fn success(message: Option<String>) -> Self {
@@ -107,14 +107,15 @@ impl<T> ApiResponse<T> {
 /// # Examples
 /// ```
 /// use axum::Json;
+/// use axum::response::IntoResponse;
 /// use orchestrator::server::types::{ApiResponse, JobRouteResult};
+/// use orchestrator::server::error::JobRouteError;
 ///
-///  async fn handle_job() -> JobRouteResult {
+/// async fn handle_job() -> JobRouteResult {
 ///     // Success case
-///     Ok(Json(ApiResponse::success(None)).into_response())
-///
-///     // Error case
-///     Err(JobRouteError::NotFound("123".to_string()))
+///     Ok(Json(ApiResponse::<()>::success(None)).into_response())
+///     // Error case would be:
+///     // Err(JobRouteError::NotFound("123".to_string()))
 /// }
 /// ```
 pub type JobRouteResult = Result<Response<axum::body::Body>, JobRouteError>;

--- a/orchestrator/src/tests/alerts/mod.rs
+++ b/orchestrator/src/tests/alerts/mod.rs
@@ -7,7 +7,6 @@ use orchestrator_utils::env_utils::get_env_var_or_panic;
 use rstest::rstest;
 use std::time::Duration;
 use tokio::time::sleep;
-use uuid::Uuid;
 
 pub const SNS_ALERT_TEST_QUEUE: &str = "orchestrator_sns_alert_testing_queue";
 

--- a/orchestrator/src/tests/alerts/mod.rs
+++ b/orchestrator/src/tests/alerts/mod.rs
@@ -1,5 +1,5 @@
 use crate::core::client::SNS;
-use crate::tests::common::{get_sns_client, get_sqs_client};
+use crate::tests::common::{create_unique_queue_name, get_sns_client, get_sqs_client};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::types::params::{AWSResourceIdentifier, AlertArgs};
 use aws_sdk_sqs::types::QueueAttributeName::QueueArn;
@@ -21,8 +21,7 @@ async fn sns_alert_subscribe_to_topic_receive_alert_works() {
     let sqs_client = get_sqs_client(services.provider_config.clone()).await;
 
     // Use unique queue name to avoid conflicts in parallel tests
-    let uuid_str = uuid::Uuid::new_v4().to_string();
-    let unique_queue_name = format!("{}-{}", SNS_ALERT_TEST_QUEUE, &uuid_str[..8]);
+    let unique_queue_name = create_unique_queue_name(SNS_ALERT_TEST_QUEUE);
 
     // Create the queue
     let queue = sqs_client.create_queue().queue_name(&unique_queue_name).send().await.unwrap();

--- a/orchestrator/src/tests/common/constants.rs
+++ b/orchestrator/src/tests/common/constants.rs
@@ -2,3 +2,15 @@
 pub const ETHEREUM_MAX_BYTES_PER_BLOB: u64 = 131072;
 #[allow(dead_code)]
 pub const ETHEREUM_MAX_BLOB_PER_TXN: u64 = 6;
+
+/// Maximum number of retries for queue message consumption in tests
+pub const QUEUE_CONSUME_MAX_RETRIES: usize = 10;
+
+/// Delay in seconds between retries for queue message consumption in tests
+pub const QUEUE_CONSUME_RETRY_DELAY_SECS: u64 = 2;
+
+/// Maximum number of retries for queue message consumption in tests (alternative configuration)
+pub const QUEUE_CONSUME_MAX_RETRIES_ALT: usize = 5;
+
+/// Delay in seconds between retries for queue message consumption in tests (alternative configuration)
+pub const QUEUE_CONSUME_RETRY_DELAY_SECS_ALT: u64 = 1;

--- a/orchestrator/src/tests/common/mock_helpers.rs
+++ b/orchestrator/src/tests/common/mock_helpers.rs
@@ -1,0 +1,65 @@
+use crate::worker::event_handler::factory::mock_factory;
+use std::ops::{Deref, DerefMut};
+use std::sync::Mutex;
+
+/// Thread-safe wrapper for mock factory context
+/// This ensures that only one test sets expectations at a time, preventing PoisonError
+/// when tests run in parallel
+static MOCK_CONTEXT_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Test-level mutex to serialize tests that use mocks
+/// This ensures only one test using mocks runs at a time, preventing interference
+/// between tests when they set expectations for the same JobType
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Wrapper that holds both the mutex guard and the mock context
+/// This ensures the guard is held for the lifetime of the context usage
+pub struct MockContextGuard {
+    _guard: std::sync::MutexGuard<'static, ()>,
+    context: mock_factory::__get_job_handler::Context,
+}
+
+impl Deref for MockContextGuard {
+    type Target = mock_factory::__get_job_handler::Context;
+
+    fn deref(&self) -> &Self::Target {
+        &self.context
+    }
+}
+
+impl DerefMut for MockContextGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.context
+    }
+}
+
+/// Get the mock job handler context in a thread-safe way
+/// This function ensures that only one test can set expectations at a time
+/// by using a Mutex to serialize access to the global mock context
+pub fn get_job_handler_context_safe() -> MockContextGuard {
+    // Lock the mutex to ensure exclusive access
+    // The guard will be held until MockContextGuard is dropped
+    let guard = MOCK_CONTEXT_MUTEX.lock().unwrap_or_else(|e| {
+        // If the mutex is poisoned (a test panicked while holding the lock),
+        // recover by getting the inner value
+        e.into_inner()
+    });
+
+    // Get the context - the guard will be held until MockContextGuard is dropped
+    // This ensures only one test can set expectations at a time
+    let context = mock_factory::get_job_handler_context();
+
+    MockContextGuard { _guard: guard, context }
+}
+
+/// Acquire a test-level lock to serialize tests that use mocks
+/// This ensures only one test using mocks runs at a time, preventing interference
+/// Call this at the start of tests that use mocks, and the lock will be held
+/// for the entire test duration
+pub fn acquire_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    TEST_MUTEX.lock().unwrap_or_else(|e| {
+        // If the mutex is poisoned (a test panicked while holding the lock),
+        // recover by getting the inner value
+        e.into_inner()
+    })
+}

--- a/orchestrator/src/tests/common/mod.rs
+++ b/orchestrator/src/tests/common/mod.rs
@@ -257,13 +257,11 @@ pub async fn consume_message_with_retry(
                     } else {
                         panic!("No message found in queue after {} retries: {}", max_retries, e);
                     }
+                } else if retries < max_retries - 1 {
+                    tokio::time::sleep(Duration::from_secs(retry_delay)).await;
+                    retries += 1;
                 } else {
-                    if retries < max_retries - 1 {
-                        tokio::time::sleep(Duration::from_secs(retry_delay)).await;
-                        retries += 1;
-                    } else {
-                        panic!("Failed to consume message: {}", e);
-                    }
+                    panic!("Failed to consume message: {}", e);
                 }
             }
         }

--- a/orchestrator/src/tests/common/mod.rs
+++ b/orchestrator/src/tests/common/mod.rs
@@ -1,6 +1,6 @@
 pub mod constants;
 #[cfg(test)]
-pub mod mock_helpers;
+pub mod test_utils;
 
 use crate::core::client::queue::sqs::InnerSQS;
 use crate::core::client::queue::{QueueClient, QueueError};
@@ -143,7 +143,6 @@ pub async fn delete_storage(provider_config: Arc<CloudProvider>, s3_params: &Sto
 }
 
 // SQS structs & functions
-
 pub async fn create_queues(provider_config: Arc<CloudProvider>, queue_params: &QueueArgs) -> color_eyre::Result<()> {
     let sqs_client = get_sqs_client(provider_config).await;
 
@@ -155,6 +154,8 @@ pub async fn create_queues(provider_config: Arc<CloudProvider>, queue_params: &Q
     // 1. Each test has a unique UUID, so queues are isolated
     // 2. LocalStack will be killed after tests, so cleanup isn't needed
     // 3. Deleting queues can cause race conditions in parallel execution
+    //
+    // TODO (mohit 14/11/25): Use InnerSQS::setup method to create queues and DLQs (code duplication as of now)
     for queue_type in QueueType::iter() {
         let queue_name = InnerSQS::get_queue_name_from_type(&queue_template, &queue_type);
 

--- a/orchestrator/src/tests/common/test_utils.rs
+++ b/orchestrator/src/tests/common/test_utils.rs
@@ -1,24 +1,19 @@
 use crate::worker::event_handler::factory::mock_factory;
 use std::ops::{Deref, DerefMut};
-use std::sync::Mutex;
-
-/// Mutex to protect access to the mock factory context
-/// This ensures that only one test can access the mock context at a time,
-/// preventing PoisonError when tests run in parallel.
-/// Note: This is separate from TEST_MUTEX because tests hold TEST_MUTEX for the
-/// entire test duration, and we need to lock the mock context separately within the test.
-static MOCK_CONTEXT_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Test-level mutex to serialize tests that use mocks
 /// This ensures only one test using mocks runs at a time, preventing interference
 /// between tests when they set expectations for the same JobType.
 /// This is held for the entire test duration via acquire_test_lock().
-static TEST_MUTEX: Mutex<()> = Mutex::new(());
+///
+/// Since all tests that use get_job_handler_context_safe() also use acquire_test_lock(),
+/// we only need this single mutex to serialize test execution and protect the mock context.
+static TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Wrapper that holds both the mutex guard and the mock context
-/// This ensures the guard is held for the lifetime of the context usage
+/// Wrapper that holds the mock context
+/// The context is protected by TEST_MUTEX which must be acquired via acquire_test_lock()
+/// before calling get_job_handler_context_safe()
 pub struct MockContextGuard {
-    _guard: std::sync::MutexGuard<'static, ()>,
     context: mock_factory::__get_job_handler::Context,
 }
 
@@ -36,27 +31,18 @@ impl DerefMut for MockContextGuard {
     }
 }
 
-/// Get the mock job handler context in a thread-safe way
-/// This function ensures that only one test can set expectations at a time
-/// by using a Mutex to serialize access to the global mock context.
-/// Note: This uses MOCK_CONTEXT_MUTEX (not TEST_MUTEX) because tests already
-/// hold TEST_MUTEX for the entire test duration, and we need a separate lock
-/// for the mock context access within the test.
+/// Get the mock job handler context
+///
+/// # Safety
+/// This function assumes that TEST_MUTEX is already held via acquire_test_lock().
+/// All tests that use this function must call acquire_test_lock() at the start of the test.
+/// Since TEST_MUTEX serializes entire tests, no additional locking is needed here.
 pub fn get_job_handler_context_safe() -> MockContextGuard {
-    // Lock the mutex to ensure exclusive access
-    // The guard will be held until MockContextGuard is dropped
-    let guard = MOCK_CONTEXT_MUTEX.lock().unwrap_or_else(|e| {
-        // If the mutex is poisoned (a test panicked while holding the lock),
-        // recover by getting the inner value
-        tracing::warn!("MOCK_CONTEXT_MUTEX was poisoned (a test panicked while holding the lock), recovering");
-        e.into_inner()
-    });
-
-    // Get the context - the guard will be held until MockContextGuard is dropped
-    // This ensures only one test can set expectations at a time
+    // Get the context - TEST_MUTEX (acquired via acquire_test_lock()) ensures
+    // only one test can access this at a time
     let context = mock_factory::get_job_handler_context();
 
-    MockContextGuard { _guard: guard, context }
+    MockContextGuard { context }
 }
 
 /// Acquire a test-level lock to serialize tests that use mocks

--- a/orchestrator/src/tests/common/test_utils.rs
+++ b/orchestrator/src/tests/common/test_utils.rs
@@ -2,14 +2,17 @@ use crate::worker::event_handler::factory::mock_factory;
 use std::ops::{Deref, DerefMut};
 use std::sync::Mutex;
 
-/// Thread-safe wrapper for mock factory context
-/// This ensures that only one test sets expectations at a time, preventing PoisonError
-/// when tests run in parallel
+/// Mutex to protect access to the mock factory context
+/// This ensures that only one test can access the mock context at a time,
+/// preventing PoisonError when tests run in parallel.
+/// Note: This is separate from TEST_MUTEX because tests hold TEST_MUTEX for the
+/// entire test duration, and we need to lock the mock context separately within the test.
 static MOCK_CONTEXT_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Test-level mutex to serialize tests that use mocks
 /// This ensures only one test using mocks runs at a time, preventing interference
-/// between tests when they set expectations for the same JobType
+/// between tests when they set expectations for the same JobType.
+/// This is held for the entire test duration via acquire_test_lock().
 static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Wrapper that holds both the mutex guard and the mock context
@@ -35,13 +38,17 @@ impl DerefMut for MockContextGuard {
 
 /// Get the mock job handler context in a thread-safe way
 /// This function ensures that only one test can set expectations at a time
-/// by using a Mutex to serialize access to the global mock context
+/// by using a Mutex to serialize access to the global mock context.
+/// Note: This uses MOCK_CONTEXT_MUTEX (not TEST_MUTEX) because tests already
+/// hold TEST_MUTEX for the entire test duration, and we need a separate lock
+/// for the mock context access within the test.
 pub fn get_job_handler_context_safe() -> MockContextGuard {
     // Lock the mutex to ensure exclusive access
     // The guard will be held until MockContextGuard is dropped
     let guard = MOCK_CONTEXT_MUTEX.lock().unwrap_or_else(|e| {
         // If the mutex is poisoned (a test panicked while holding the lock),
         // recover by getting the inner value
+        tracing::warn!("MOCK_CONTEXT_MUTEX was poisoned (a test panicked while holding the lock), recovering");
         e.into_inner()
     });
 
@@ -60,6 +67,7 @@ pub fn acquire_test_lock() -> std::sync::MutexGuard<'static, ()> {
     TEST_MUTEX.lock().unwrap_or_else(|e| {
         // If the mutex is poisoned (a test panicked while holding the lock),
         // recover by getting the inner value
+        tracing::warn!("TEST_MUTEX was poisoned (a test panicked while holding the lock), recovering");
         e.into_inner()
     })
 }

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -43,6 +43,7 @@ use orchestrator_utils::env_utils::{
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use url::Url;
+use uuid::Uuid;
 // Inspiration : https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 // TestConfigBuilder allows to heavily customise the global configs based on the test's requirement.
 // Eg: We want to mock only the da client and leave rest to be as it is, use mock_da_client.
@@ -101,6 +102,8 @@ impl_mock_from! {
 
 // TestBuilder for Config
 pub struct TestConfigBuilder {
+    /// Unique identifier for this test instance (for resource isolation)
+    test_id: String,
     /// The RPC url used by the starknet client
     starknet_rpc_url_type: ConfigType,
     /// The starknet client to get data from the node
@@ -150,12 +153,55 @@ pub struct TestConfigBuilderReturns {
     pub config: Arc<Config>,
     pub provider_config: Arc<CloudProvider>,
     pub api_server_address: Option<SocketAddr>,
+    pub cleanup: TestCleanup,
+}
+
+/// TestCleanup handles automatic cleanup of test resources when dropped.
+/// This ensures that parallel tests don't leave orphaned resources.
+pub struct TestCleanup {
+    /// Database parameters for cleanup
+    db_params: Option<DatabaseArgs>,
+    /// Queue parameters for cleanup
+    queue_params: Option<QueueArgs>,
+    /// Storage parameters for cleanup
+    storage_params: Option<StorageArgs>,
+    /// Cloud provider for AWS resource cleanup
+    provider_config: Option<Arc<CloudProvider>>,
+}
+
+impl TestCleanup {
+    fn new(
+        db_params: Option<DatabaseArgs>,
+        queue_params: Option<QueueArgs>,
+        storage_params: Option<StorageArgs>,
+        provider_config: Option<Arc<CloudProvider>>,
+    ) -> Self {
+        Self { db_params, queue_params, storage_params, provider_config }
+    }
+}
+
+impl Drop for TestCleanup {
+    fn drop(&mut self) {
+        // Skip cleanup since LocalStack will be killed anyway after tests complete
+        // This prevents race conditions where cleanup interferes with parallel tests
+        // and ensures queues/resources remain available throughout test execution
+        tracing::debug!("Skipping cleanup - LocalStack will be killed after tests complete");
+
+        // Note: We could optionally cleanup here, but it's not necessary since:
+        // 1. LocalStack is ephemeral and will be destroyed after tests
+        // 2. Each test uses unique UUIDs for resource isolation
+        // 3. Cleanup can cause race conditions in parallel test execution
+    }
 }
 
 impl TestConfigBuilder {
     /// Create a new config
     pub fn new() -> TestConfigBuilder {
+        // Generate a unique identifier for this test instance
+        let test_id = Uuid::new_v4().to_string();
+
         TestConfigBuilder {
+            test_id,
             starknet_rpc_url_type: ConfigType::default(),
             starknet_client_type: ConfigType::default(),
             da_client_type: ConfigType::default(),
@@ -264,12 +310,13 @@ impl TestConfigBuilder {
     pub async fn build(self) -> TestConfigBuilderReturns {
         dotenvy::from_filename_override("../.env.test").expect("Failed to load the .env.test file");
 
-        let mut params = get_env_params();
+        let mut params = get_env_params(Some(&self.test_id));
 
         let provider_config =
             Arc::new(CloudProvider::try_from(params.aws_params.clone()).expect("Failed to create provider config"));
 
         let TestConfigBuilder {
+            test_id: _,
             starknet_rpc_url_type,
             starknet_client_type,
             alerts_type,
@@ -296,6 +343,7 @@ impl TestConfigBuilder {
 
         let using_actual_queue = matches!(queue_type, ConfigType::Actual);
         let using_actual_database = matches!(database_type, ConfigType::Actual);
+        let using_actual_storage = matches!(storage_type, ConfigType::Actual);
         let using_actual_alerts = matches!(alerts_type, ConfigType::Actual);
 
         // init alerts
@@ -363,11 +411,20 @@ impl TestConfigBuilder {
 
         let api_server_address = implement_api_server(api_server_type, config.clone()).await;
 
+        // Create cleanup handle for automatic resource cleanup
+        let cleanup = TestCleanup::new(
+            if using_actual_database { Some(params.db_params.clone()) } else { None },
+            if using_actual_queue { Some(params.queue_params.clone()) } else { None },
+            if using_actual_storage { Some(params.storage_params.clone()) } else { None },
+            if using_actual_queue || using_actual_storage { Some(provider_config.clone()) } else { None },
+        );
+
         TestConfigBuilderReturns {
             starknet_server,
             config,
             provider_config: provider_config.clone(),
             api_server_address,
+            cleanup,
         }
     }
 }
@@ -595,25 +652,53 @@ pub struct EnvParams {
     instrumentation_params: OTELConfig,
 }
 
-pub(crate) fn get_env_params() -> EnvParams {
+pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
+    // Generate unique resource names for parallel test execution
+    let db_name = get_env_var_or_panic("MADARA_ORCHESTRATOR_DATABASE_NAME");
+    let database_name = if let Some(id) = test_id {
+        // MongoDB allows hyphens in database names, so we can use the UUID as-is
+        format!("{}-{}", db_name, id)
+    } else {
+        db_name
+    };
+
     let db_params = DatabaseArgs {
         connection_uri: get_env_var_or_panic("MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL"),
-        database_name: get_env_var_or_panic("MADARA_ORCHESTRATOR_DATABASE_NAME"),
+        database_name,
     };
 
-    let storage_params = StorageArgs {
-        bucket_identifier: AWSResourceIdentifier::Name(format!(
-            "{}-{}",
-            get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_PREFIX"),
-            get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_S3_BUCKET_IDENTIFIER")
-        )),
+    let bucket_base = format!(
+        "{}-{}",
+        get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_PREFIX"),
+        get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_S3_BUCKET_IDENTIFIER")
+    );
+    let bucket_name = if let Some(id) = test_id {
+        // S3 bucket names can contain hyphens, but let's use a shorter format
+        // Remove hyphens from UUID to make it shorter and ensure it fits within limits
+        let sanitized_id = id.replace('-', "");
+        format!("{}-{}", bucket_base, sanitized_id)
+    } else {
+        bucket_base
     };
 
-    let queue_params = QueueArgs {
-        queue_template_identifier: AWSResourceIdentifier::Name(get_env_var_or_panic(
-            "MADARA_ORCHESTRATOR_AWS_SQS_QUEUE_IDENTIFIER",
-        )),
+    let storage_params = StorageArgs { bucket_identifier: AWSResourceIdentifier::Name(bucket_name) };
+
+    let queue_base = get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_SQS_QUEUE_IDENTIFIER");
+    let queue_identifier = if let Some(id) = test_id {
+        // SQS queue names have strict limits: alphanumeric, hyphens, underscores, 1-80 chars
+        // Remove hyphens from UUID to make it shorter
+        // Use first 16 chars of UUID (without hyphens) - this provides 2^64 uniqueness which is more than enough
+        // The template format is "test_{}_queue", so after replacement it becomes "test_{queue_type}_queue-{uuid}"
+        // Longest queue type is ~30 chars, so: "test_" (5) + queue_type (~30) + "_queue" (6) + "-" (1) + uuid (16) = ~58 chars
+        let sanitized_id = id.replace('-', "");
+        // Use first 16 characters for uniqueness (still provides 2^64 combinations)
+        let short_id = &sanitized_id[..sanitized_id.len().min(16)];
+        format!("{}-{}", queue_base, short_id)
+    } else {
+        queue_base
     };
+
+    let queue_params = QueueArgs { queue_template_identifier: AWSResourceIdentifier::Name(queue_identifier) };
 
     let aws_params = AWSCredentials { prefix: get_env_var_optional_or_panic("MADARA_ORCHESTRATOR_AWS_PREFIX") };
 

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -157,26 +157,13 @@ pub struct TestConfigBuilderReturns {
 }
 
 /// TestCleanup handles automatic cleanup of test resources when dropped.
-/// This ensures that parallel tests don't leave orphaned resources.
-pub struct TestCleanup {
-    /// Database parameters for cleanup
-    db_params: Option<DatabaseArgs>,
-    /// Queue parameters for cleanup
-    queue_params: Option<QueueArgs>,
-    /// Storage parameters for cleanup
-    storage_params: Option<StorageArgs>,
-    /// Cloud provider for AWS resource cleanup
-    provider_config: Option<Arc<CloudProvider>>,
-}
+/// Currently, cleanup is disabled since LocalStack is ephemeral and will be destroyed after tests.
+/// This ensures that parallel tests don't interfere with each other's resources.
+pub struct TestCleanup;
 
 impl TestCleanup {
-    fn new(
-        db_params: Option<DatabaseArgs>,
-        queue_params: Option<QueueArgs>,
-        storage_params: Option<StorageArgs>,
-        provider_config: Option<Arc<CloudProvider>>,
-    ) -> Self {
-        Self { db_params, queue_params, storage_params, provider_config }
+    fn new() -> Self {
+        Self
     }
 }
 
@@ -343,7 +330,6 @@ impl TestConfigBuilder {
 
         let using_actual_queue = matches!(queue_type, ConfigType::Actual);
         let using_actual_database = matches!(database_type, ConfigType::Actual);
-        let using_actual_storage = matches!(storage_type, ConfigType::Actual);
         let using_actual_alerts = matches!(alerts_type, ConfigType::Actual);
 
         // init alerts
@@ -412,12 +398,8 @@ impl TestConfigBuilder {
         let api_server_address = implement_api_server(api_server_type, config.clone()).await;
 
         // Create cleanup handle for automatic resource cleanup
-        let cleanup = TestCleanup::new(
-            if using_actual_database { Some(params.db_params.clone()) } else { None },
-            if using_actual_queue { Some(params.queue_params.clone()) } else { None },
-            if using_actual_storage { Some(params.storage_params.clone()) } else { None },
-            if using_actual_queue || using_actual_storage { Some(provider_config.clone()) } else { None },
-        );
+        // Note: Cleanup is currently disabled since LocalStack is ephemeral
+        let cleanup = TestCleanup::new();
 
         TestConfigBuilderReturns {
             starknet_server,

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::await_holding_lock)]
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -49,6 +51,7 @@ use assert_matches::assert_matches;
 /// Tests `create_job` function when job is not existing in the db.
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn create_job_job_does_not_exists_in_db_works() {
     // Acquire test lock to serialize this test with others that use mocks
     let _test_lock = crate::tests::common::mock_helpers::acquire_test_lock();
@@ -152,6 +155,7 @@ async fn create_job_job_exists_in_db_works() {
 /// and that no job is created in the database or added to the queue when creation fails
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn create_job_job_handler_returns_error() {
     // Acquire test lock to serialize this test with others that use mocks
     let _test_lock = crate::tests::common::mock_helpers::acquire_test_lock();
@@ -223,6 +227,7 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
     #[case] job_status: JobStatus,
 ) {
     // Acquire test lock to serialize this test with others that use mocks
+    // This lock is intentionally held for the entire test to serialize execution
     let _test_lock = crate::tests::common::mock_helpers::acquire_test_lock();
 
     // Building config
@@ -280,6 +285,7 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
 /// 3. Appropriate error message is set in the job metadata
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn process_job_handles_panic() {
     // Acquire test lock to serialize this test with others that use mocks
     // This prevents Mockall's global context from being interfered with by parallel tests
@@ -400,6 +406,7 @@ async fn process_job_job_does_not_exists_in_db_works() {
 /// when updating the job status.
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn process_job_two_workers_process_same_job_works() {
     // Acquire test lock to serialize this test with others that use mocks
     let _test_lock = acquire_test_lock();

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -107,9 +107,9 @@ async fn create_job_job_does_not_exists_in_db_works() {
     // Set up mock AFTER creating services to ensure proper ordering
     // Keep the guard alive for the entire test to prevent other tests from overwriting expectations
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
-    let _ctx_guard = get_job_handler_context_safe();
+    let ctx_guard = get_job_handler_context_safe();
     // create_job calls get_job_handler exactly once
-    _ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+    ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
     assert!(JobHandlerService::create_job(JobType::SnosRun, "0".to_string(), metadata, services.config.clone())
         .await
@@ -219,8 +219,8 @@ async fn create_job_job_handler_returns_error() {
 
     // Mock the `get_job_handler` call to return our error-producing handler
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
-    let _ctx_guard = get_job_handler_context_safe();
-    _ctx_guard.expect().times(1).with(eq(job_type.clone())).returning(move |_| Arc::clone(&job_handler));
+    let ctx_guard = get_job_handler_context_safe();
+    ctx_guard.expect().times(1).with(eq(job_type.clone())).returning(move |_| Arc::clone(&job_handler));
 
     // Verify that create_job returns an error
     let result =
@@ -456,9 +456,9 @@ async fn process_job_two_workers_process_same_job_works() {
 
     // Mocking the `get_job_handler` call - both workers will call it before one fails due to lock contention
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
-    let _ctx_guard = get_job_handler_context_safe();
+    let ctx_guard = get_job_handler_context_safe();
     // Both workers will call get_job_handler (each process_job calls it once), so expect exactly 2 calls
-    _ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+    ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
     // building config
     let services = TestConfigBuilder::new()

--- a/orchestrator/src/tests/queue/mod.rs
+++ b/orchestrator/src/tests/queue/mod.rs
@@ -23,18 +23,27 @@ mod tests {
     }
 
     /// Fixture to create a test queue with InnerSQS
-    /// Returns tuple of (InnerSQS, queue_name, queue_url)
+    /// Returns tuple of (InnerSQS, queue_template, queue_url)
     #[fixture]
     async fn test_queue(#[future] localstack_config: aws_config::SdkConfig) -> (InnerSQS, String, String) {
         let config = localstack_config.await;
-        let queue_name = format!("test-snos-job-processing-{}", uuid::Uuid::new_v4());
+        // Create queue name with template format: "test-{uuid}-{}_queue"
+        // This matches the format expected by get_queue_name_from_type
+        let uuid = uuid::Uuid::new_v4();
+        let uuid_str = uuid.to_string();
+        let queue_template = format!("test-{}-{{}}_queue", &uuid_str[..8]);
+        let queue_name = InnerSQS::get_queue_name_from_type(&queue_template, &QueueType::SnosJobProcessing);
 
         let inner_sqs = InnerSQS::new(&config);
         inner_sqs.client().create_queue().queue_name(&queue_name).send().await.expect("Failed to create queue");
 
+        // Wait a bit for queue to be fully available
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
         let queue_url = inner_sqs.get_queue_url_from_client(&queue_name).await.expect("Failed to get queue URL");
 
-        (inner_sqs, queue_name, queue_url)
+        // Create QueueArgs with the template (not the specific queue name)
+        (inner_sqs, queue_template, queue_url)
     }
 
     /// Test that send_message adds the OrchestratorVersion message attribute using Omni Queue
@@ -45,11 +54,16 @@ mod tests {
         #[future] test_queue: (InnerSQS, String, String),
     ) {
         let config = localstack_config.await;
-        let (inner_sqs, queue_name, queue_url) = test_queue.await;
+        let (inner_sqs, queue_template, _queue_url) = test_queue.await;
 
         // Create SQS client using our QueueClient abstraction
-        let queue_args = QueueArgs { queue_template_identifier: AWSResourceIdentifier::Name(queue_name.clone()) };
+        let queue_args = QueueArgs { queue_template_identifier: AWSResourceIdentifier::Name(queue_template.clone()) };
         let sqs = SQS::new(&config, &queue_args);
+
+        // Get the actual queue name and URL for this specific queue type
+        let actual_queue_name = InnerSQS::get_queue_name_from_type(&queue_template, &QueueType::SnosJobProcessing);
+        let actual_queue_url =
+            inner_sqs.get_queue_url_from_client(&actual_queue_name).await.expect("Failed to get queue URL");
 
         // Send message using our QueueClient (which adds version attribute)
         let test_payload = "test message content";
@@ -69,8 +83,11 @@ mod tests {
         // Acknowledge the message
         delivery.ack().await.expect("Failed to ack message");
 
-        // Cleanup
-        inner_sqs.client().delete_queue().queue_url(&queue_url).send().await.ok();
+        // Cleanup - delete the queue we created
+        let actual_queue_name = InnerSQS::get_queue_name_from_type(&queue_template, &QueueType::SnosJobProcessing);
+        let actual_queue_url =
+            inner_sqs.get_queue_url_from_client(&actual_queue_name).await.expect("Failed to get queue URL");
+        inner_sqs.client().delete_queue().queue_url(&actual_queue_url).send().await.ok();
     }
 
     /// Integration test for version-based message filtering
@@ -90,13 +107,18 @@ mod tests {
         use tokio::time::{sleep, Duration};
 
         let config = localstack_config.await;
-        let (inner_sqs, queue_name, queue_url) = test_queue.await;
+        let (inner_sqs, queue_template, _queue_url) = test_queue.await;
 
         // Create CloudProvider and use Config to build queue client (proper way for tests)
         let provider_config = Arc::new(CloudProvider::AWS(Box::new(config.clone())));
-        let queue_args = QueueArgs { queue_template_identifier: AWSResourceIdentifier::Name(queue_name.clone()) };
+        let queue_args = QueueArgs { queue_template_identifier: AWSResourceIdentifier::Name(queue_template.clone()) };
         let sqs =
             Config::build_queue_client(&queue_args, provider_config).await.expect("Failed to create queue client");
+
+        // Get the actual queue name and URL for this specific queue type
+        let actual_queue_name = InnerSQS::get_queue_name_from_type(&queue_template, &QueueType::SnosJobProcessing);
+        let actual_queue_url =
+            inner_sqs.get_queue_url_from_client(&actual_queue_name).await.expect("Failed to get queue URL");
 
         let incompatible_version = "orchestrator-0.0.1";
 
@@ -112,7 +134,7 @@ mod tests {
             inner_sqs
                 .client()
                 .send_message()
-                .queue_url(&queue_url)
+                .queue_url(&actual_queue_url)
                 .message_body(&payload)
                 .message_attributes(ORCHESTRATOR_VERSION_ATTRIBUTE, version_attr)
                 .send()
@@ -179,7 +201,7 @@ mod tests {
         let queue_attributes = inner_sqs
             .client()
             .get_queue_attributes()
-            .queue_url(&queue_url)
+            .queue_url(&actual_queue_url)
             .attribute_names(aws_sdk_sqs::types::QueueAttributeName::ApproximateNumberOfMessages)
             .send()
             .await
@@ -196,6 +218,6 @@ mod tests {
         assert_eq!(approximate_message_count, 5, "Should have exactly 5 incompatible messages remaining in queue");
 
         // Cleanup
-        inner_sqs.client().delete_queue().queue_url(&queue_url).send().await.ok();
+        inner_sqs.client().delete_queue().queue_url(&actual_queue_url).send().await.ok();
     }
 }

--- a/orchestrator/src/tests/queue/mod.rs
+++ b/orchestrator/src/tests/queue/mod.rs
@@ -62,7 +62,7 @@ mod tests {
 
         // Get the actual queue name and URL for this specific queue type
         let actual_queue_name = InnerSQS::get_queue_name_from_type(&queue_template, &QueueType::SnosJobProcessing);
-        let actual_queue_url =
+        let _actual_queue_url =
             inner_sqs.get_queue_url_from_client(&actual_queue_name).await.expect("Failed to get queue URL");
 
         // Send message using our QueueClient (which adds version attribute)

--- a/orchestrator/src/tests/queue/mod.rs
+++ b/orchestrator/src/tests/queue/mod.rs
@@ -29,9 +29,11 @@ mod tests {
         let config = localstack_config.await;
         // Create queue name with template format: "test-{uuid}-{}_queue"
         // This matches the format expected by get_queue_name_from_type
-        let uuid = uuid::Uuid::new_v4();
-        let uuid_str = uuid.to_string();
-        let queue_template = format!("test-{}-{{}}_queue", &uuid_str[..8]);
+        // Use create_unique_queue_name helper to generate unique queue name
+        let unique_name = crate::tests::common::create_unique_queue_name("test");
+        // Extract the UUID prefix (first 8 chars after "test-")
+        let uuid_prefix = unique_name.strip_prefix("test-").map(|s| &s[..8.min(s.len())]).unwrap_or("default");
+        let queue_template = format!("test-{}-{{}}_queue", uuid_prefix);
         let queue_name = InnerSQS::get_queue_name_from_type(&queue_template, &QueueType::SnosJobProcessing);
 
         let inner_sqs = InnerSQS::new(&config);

--- a/orchestrator/src/tests/server/job_routes.rs
+++ b/orchestrator/src/tests/server/job_routes.rs
@@ -12,7 +12,8 @@ use url::Url;
 
 use crate::core::config::Config;
 use crate::server::types::ApiResponse;
-use crate::tests::common::mock_helpers::get_job_handler_context_safe;
+use crate::tests::common::consume_message_with_retry;
+use crate::tests::common::mock_helpers::{acquire_test_lock, get_job_handler_context_safe};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::build_job_item;
 use crate::types::jobs::metadata::{JobSpecificMetadata, SettlementContext};
@@ -46,6 +47,9 @@ async fn setup_trigger() -> (SocketAddr, Arc<Config>) {
 #[tokio::test]
 #[rstest]
 async fn test_trigger_process_job(#[future] setup_trigger: (SocketAddr, Arc<Config>)) {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let (addr, config) = setup_trigger.await;
     let job_type = JobType::DataSubmission;
 
@@ -53,12 +57,12 @@ async fn test_trigger_process_job(#[future] setup_trigger: (SocketAddr, Arc<Conf
     config.database().create_job(job_item.clone()).await.unwrap();
     let job_id = job_item.clone().id;
 
-    // Set up mock job handler (needed for queue_job_for_verification which calls get_job_handler)
+    // Set up mock job handler - queue_job_for_processing doesn't call get_job_handler, so times(0)
     let mut job_handler = MockJobHandlerTrait::new();
     job_handler.expect_verification_polling_delay_seconds().return_const(1u64);
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
     let ctx = get_job_handler_context_safe();
-    ctx.expect().with(eq(job_type.clone())).times(0..).returning(move |_| Arc::clone(&job_handler));
+    ctx.expect().with(eq(job_type.clone())).times(0).returning(move |_| Arc::clone(&job_handler));
 
     let client = hyper::Client::new();
     let response = client
@@ -130,6 +134,9 @@ async fn test_trigger_process_job(#[future] setup_trigger: (SocketAddr, Arc<Conf
 #[tokio::test]
 #[rstest]
 async fn test_trigger_verify_job(#[future] setup_trigger: (SocketAddr, Arc<Config>)) {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let (addr, config) = setup_trigger.await;
     let job_type = JobType::DataSubmission;
 
@@ -166,42 +173,7 @@ async fn test_trigger_verify_job(#[future] setup_trigger: (SocketAddr, Arc<Confi
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Verify job was added to verification queue - retry a few times in case of timing issues
-    let mut retries = 0;
-    let max_retries = 5;
-    let mut queue_message = None;
-
-    while retries < max_retries && queue_message.is_none() {
-        match config.queue().consume_message_from_queue(job_type.verify_queue_name()).await {
-            Ok(msg) => queue_message = Some(msg),
-            Err(e) => {
-                let error_str = e.to_string();
-                if error_str.contains("QueueDoesNotExist") || error_str.contains("GetQueueUrlError") {
-                    if retries < max_retries - 1 {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        retries += 1;
-                    } else {
-                        panic!("Queue does not exist after {} retries: {}", max_retries, e);
-                    }
-                } else if error_str.contains("NoData") {
-                    if retries < max_retries - 1 {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        retries += 1;
-                    } else {
-                        panic!("No message found in queue after {} retries: {}", max_retries, e);
-                    }
-                } else {
-                    if retries < max_retries - 1 {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        retries += 1;
-                    } else {
-                        panic!("Failed to consume message: {}", e);
-                    }
-                }
-            }
-        }
-    }
-
-    let queue_message = queue_message.expect("Should have received message");
+    let queue_message = consume_message_with_retry(config.queue(), job_type.verify_queue_name(), 5, 1).await;
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 
@@ -227,12 +199,12 @@ async fn test_trigger_retry_job_when_failed(#[future] setup_trigger: (SocketAddr
     config.database().create_job(job_item.clone()).await.unwrap();
     let job_id = job_item.clone().id;
 
-    // Set up mock job handler (needed for retry_job and queue_job_for_verification)
+    // Set up mock job handler - retry_job doesn't call get_job_handler directly, so times(0)
     let mut job_handler = MockJobHandlerTrait::new();
     job_handler.expect_verification_polling_delay_seconds().return_const(1u64);
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
     let ctx = get_job_handler_context_safe();
-    ctx.expect().with(eq(job_type.clone())).times(0..).returning(move |_| Arc::clone(&job_handler));
+    ctx.expect().with(eq(job_type.clone())).times(0).returning(move |_| Arc::clone(&job_handler));
 
     let client = hyper::Client::new();
     let response = client
@@ -250,42 +222,7 @@ async fn test_trigger_retry_job_when_failed(#[future] setup_trigger: (SocketAddr
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Verify job was added to process queue - retry a few times in case of timing issues
-    let mut retries = 0;
-    let max_retries = 5;
-    let mut queue_message = None;
-
-    while retries < max_retries && queue_message.is_none() {
-        match config.queue().consume_message_from_queue(job_type.process_queue_name()).await {
-            Ok(msg) => queue_message = Some(msg),
-            Err(e) => {
-                let error_str = e.to_string();
-                if error_str.contains("QueueDoesNotExist") || error_str.contains("GetQueueUrlError") {
-                    if retries < max_retries - 1 {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        retries += 1;
-                    } else {
-                        panic!("Queue does not exist after {} retries: {}", max_retries, e);
-                    }
-                } else if error_str.contains("NoData") {
-                    if retries < max_retries - 1 {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        retries += 1;
-                    } else {
-                        panic!("No message found in queue after {} retries: {}", max_retries, e);
-                    }
-                } else {
-                    if retries < max_retries - 1 {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        retries += 1;
-                    } else {
-                        panic!("Failed to consume message: {}", e);
-                    }
-                }
-            }
-        }
-    }
-
-    let queue_message = queue_message.expect("Should have received message");
+    let queue_message = consume_message_with_retry(config.queue(), job_type.process_queue_name(), 5, 1).await;
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 

--- a/orchestrator/src/tests/server/job_routes.rs
+++ b/orchestrator/src/tests/server/job_routes.rs
@@ -11,8 +11,9 @@ use url::Url;
 
 use crate::core::config::Config;
 use crate::server::types::ApiResponse;
+use crate::tests::common::constants::{QUEUE_CONSUME_MAX_RETRIES, QUEUE_CONSUME_RETRY_DELAY_SECS};
 use crate::tests::common::consume_message_with_retry;
-use crate::tests::common::mock_helpers::{acquire_test_lock, get_job_handler_context_safe};
+use crate::tests::common::test_utils::{acquire_test_lock, get_job_handler_context_safe};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::build_job_item;
 use crate::types::jobs::metadata::{JobSpecificMetadata, SettlementContext};
@@ -73,7 +74,14 @@ async fn test_trigger_process_job(#[future] setup_trigger: (SocketAddr, Arc<Conf
     assert_eq!(response.message, Some(format!("Job with id {} queued for processing", job_id)));
 
     // Verify job was added to process queue - retry a few times in case of timing issues
-    let queue_message = consume_message_with_retry(config.queue(), job_type.process_queue_name(), 10, 2).await.unwrap();
+    let queue_message = consume_message_with_retry(
+        config.queue(),
+        job_type.process_queue_name(),
+        QUEUE_CONSUME_MAX_RETRIES,
+        QUEUE_CONSUME_RETRY_DELAY_SECS,
+    )
+    .await
+    .unwrap();
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 
@@ -127,7 +135,14 @@ async fn test_trigger_verify_job(#[future] setup_trigger: (SocketAddr, Arc<Confi
     assert_eq!(response.message, Some(format!("Job with id {} queued for verification", job_id)));
 
     // Verify job was added to verification queue - retry a few times in case of timing issues
-    let queue_message = consume_message_with_retry(config.queue(), job_type.verify_queue_name(), 10, 2).await.unwrap();
+    let queue_message = consume_message_with_retry(
+        config.queue(),
+        job_type.verify_queue_name(),
+        QUEUE_CONSUME_MAX_RETRIES,
+        QUEUE_CONSUME_RETRY_DELAY_SECS,
+    )
+    .await
+    .unwrap();
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 
@@ -166,7 +181,14 @@ async fn test_trigger_retry_job_when_failed(#[future] setup_trigger: (SocketAddr
     assert_eq!(response.message, Some(format!("Job with id {} retry initiated", job_id)));
 
     // Verify job was added to process queue - retry a few times in case of timing issues
-    let queue_message = consume_message_with_retry(config.queue(), job_type.process_queue_name(), 10, 2).await.unwrap();
+    let queue_message = consume_message_with_retry(
+        config.queue(),
+        job_type.process_queue_name(),
+        QUEUE_CONSUME_MAX_RETRIES,
+        QUEUE_CONSUME_RETRY_DELAY_SECS,
+    )
+    .await
+    .unwrap();
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 

--- a/orchestrator/src/tests/server/job_routes.rs
+++ b/orchestrator/src/tests/server/job_routes.rs
@@ -73,7 +73,7 @@ async fn test_trigger_process_job(#[future] setup_trigger: (SocketAddr, Arc<Conf
     assert_eq!(response.message, Some(format!("Job with id {} queued for processing", job_id)));
 
     // Verify job was added to process queue - retry a few times in case of timing issues
-    let queue_message = consume_message_with_retry(config.queue(), job_type.process_queue_name(), 5, 1).await;
+    let queue_message = consume_message_with_retry(config.queue(), job_type.process_queue_name(), 10, 2).await.unwrap();
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 
@@ -127,7 +127,7 @@ async fn test_trigger_verify_job(#[future] setup_trigger: (SocketAddr, Arc<Confi
     assert_eq!(response.message, Some(format!("Job with id {} queued for verification", job_id)));
 
     // Verify job was added to verification queue - retry a few times in case of timing issues
-    let queue_message = consume_message_with_retry(config.queue(), job_type.verify_queue_name(), 5, 1).await;
+    let queue_message = consume_message_with_retry(config.queue(), job_type.verify_queue_name(), 10, 2).await.unwrap();
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 
@@ -166,7 +166,7 @@ async fn test_trigger_retry_job_when_failed(#[future] setup_trigger: (SocketAddr
     assert_eq!(response.message, Some(format!("Job with id {} retry initiated", job_id)));
 
     // Verify job was added to process queue - retry a few times in case of timing issues
-    let queue_message = consume_message_with_retry(config.queue(), job_type.process_queue_name(), 5, 1).await;
+    let queue_message = consume_message_with_retry(config.queue(), job_type.process_queue_name(), 10, 2).await.unwrap();
     let message_payload: JobQueueMessage = queue_message.payload_serde_json().unwrap().unwrap();
     assert_eq!(message_payload.id, job_id);
 

--- a/orchestrator/src/tests/setup/sqs.rs
+++ b/orchestrator/src/tests/setup/sqs.rs
@@ -1,7 +1,6 @@
 use crate::core::client::queue::sqs::InnerSQS;
 use crate::core::cloud::CloudProvider;
 use crate::core::traits::resource::Resource;
-use crate::tests::common::get_sqs_client;
 use crate::types::params::{AWSResourceIdentifier, QueueArgs, ARN};
 use crate::types::queue_control::QUEUES;
 use crate::types::Layer;
@@ -43,20 +42,6 @@ fn queue_args() -> QueueArgs {
 async fn cleanup_queues_for_test(provider_config: Arc<CloudProvider>, queue_args: &QueueArgs) {
     use crate::tests::common::cleanup_queues;
     let _ = cleanup_queues(provider_config, queue_args).await;
-}
-
-/// Helper function to cleanup all test queues (use with caution in parallel tests)
-/// This is kept for backward compatibility but should be avoided in parallel test scenarios
-async fn cleanup_queues(provider_config: Arc<CloudProvider>) {
-    let sqs_client = get_sqs_client(provider_config).await;
-    let list_queues_output = sqs_client.list_queues().send().await.expect("Failed to list queues");
-    let queue_urls = list_queues_output.queue_urls();
-
-    for queue_url in queue_urls {
-        if queue_url.contains("test-") {
-            sqs_client.delete_queue().queue_url(queue_url).send().await.ok();
-        }
-    }
 }
 
 /// Helper function to verify queue setup for a given layer

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use crate::core::client::database::MockDatabaseClient;
 use crate::core::client::queue::MockQueueClient;
+use crate::tests::common::mock_helpers::get_job_handler_context_safe;
 use crate::tests::config::TestConfigBuilder;
 use crate::tests::workers::utils::{db_checks_proving_worker, get_job_by_mock_id_vector};
 use crate::types::batch::AggregatorBatch;
 use crate::types::jobs::metadata::JobSpecificMetadata;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::types::queue::QueueType;
-use crate::worker::event_handler::factory::mock_factory::get_job_handler_context;
 use crate::worker::event_handler::jobs::{JobHandlerTrait, MockJobHandlerTrait};
 use crate::worker::event_handler::triggers::proving::ProvingJobTrigger;
 use crate::worker::event_handler::triggers::JobTrigger;
@@ -114,7 +114,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
         .await;
 
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
 
     // Mocking the `get_job_handler` call in create_job function.
     if incomplete_runs {

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::core::client::database::MockDatabaseClient;
 use crate::core::client::queue::MockQueueClient;
-use crate::tests::common::mock_helpers::{acquire_test_lock, get_job_handler_context_safe};
+use crate::tests::common::test_utils::{acquire_test_lock, get_job_handler_context_safe};
 use crate::tests::config::TestConfigBuilder;
 use crate::tests::workers::utils::{db_checks_proving_worker, get_job_by_mock_id_vector};
 use crate::types::batch::AggregatorBatch;

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::core::client::database::MockDatabaseClient;
 use crate::core::client::queue::MockQueueClient;
-use crate::tests::common::mock_helpers::get_job_handler_context_safe;
+use crate::tests::common::mock_helpers::{acquire_test_lock, get_job_handler_context_safe};
 use crate::tests::config::TestConfigBuilder;
 use crate::tests::workers::utils::{db_checks_proving_worker, get_job_by_mock_id_vector};
 use crate::types::batch::AggregatorBatch;
@@ -28,6 +28,9 @@ use url::Url;
 #[case(false)]
 #[tokio::test]
 async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dyn Error>> {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let num_jobs = 5;
     // Choosing a random incomplete job ID out of the total number of jobs
     let random_incomplete_job_id: u64 = 3;

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::await_holding_lock)]
+
 use std::error::Error;
 use std::sync::Arc;
 
@@ -29,6 +31,7 @@ use url::Url;
 #[tokio::test]
 async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dyn Error>> {
     // Acquire test lock to serialize this test with others that use mocks
+    // This lock is intentionally held for the entire test to serialize execution
     let _test_lock = acquire_test_lock();
 
     let num_jobs = 5;

--- a/orchestrator/src/tests/workers/snos/mod.rs
+++ b/orchestrator/src/tests/workers/snos/mod.rs
@@ -1,11 +1,11 @@
 use crate::core::client::database::MockDatabaseClient;
 use crate::core::client::queue::MockQueueClient;
+use crate::tests::common::mock_helpers::get_job_handler_context_safe;
 use crate::tests::config::TestConfigBuilder;
 use crate::tests::workers::utils::get_job_item_mock_by_id;
 use crate::types::batch::{SnosBatch, SnosBatchStatus};
 use crate::types::jobs::types::JobType;
 use crate::types::queue::QueueType;
-use crate::worker::event_handler::factory::mock_factory::get_job_handler_context;
 use crate::worker::event_handler::jobs::{JobHandlerTrait, MockJobHandlerTrait};
 use crate::worker::event_handler::triggers::JobTrigger;
 use httpmock::MockServer;
@@ -73,7 +73,7 @@ async fn test_snos_worker(#[case] completed_snos_batches: Vec<u64>) -> Result<()
 
     // Setup job handler context
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
     // Mock queue operations
@@ -176,7 +176,7 @@ async fn test_create_snos_job_for_existing_batch(
 
     // Setup job handler context
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
     // Expecting 3 calls to send_message for the SNOS job trigger

--- a/orchestrator/src/tests/workers/snos/mod.rs
+++ b/orchestrator/src/tests/workers/snos/mod.rs
@@ -1,6 +1,8 @@
+#![allow(clippy::await_holding_lock)]
+
 use crate::core::client::database::MockDatabaseClient;
 use crate::core::client::queue::MockQueueClient;
-use crate::tests::common::mock_helpers::get_job_handler_context_safe;
+use crate::tests::common::test_utils::{acquire_test_lock, get_job_handler_context_safe};
 use crate::tests::config::TestConfigBuilder;
 use crate::tests::workers::utils::get_job_item_mock_by_id;
 use crate::types::batch::{SnosBatch, SnosBatchStatus};
@@ -25,6 +27,9 @@ use uuid::Uuid;
 #[case(vec![1, 2, 3])]
 #[tokio::test]
 async fn test_snos_worker(#[case] completed_snos_batches: Vec<u64>) -> Result<(), Box<dyn Error>> {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     dotenvy::from_filename_override(".env.test").expect("Failed to load the .env file");
 
     // Setup mock server and clients

--- a/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/orchestrator/src/tests/workers/update_state/mod.rs
@@ -170,8 +170,11 @@ async fn update_state_worker_continues_from_previous_state_update() {
 
     services.config.database().create_job(job_item).await.unwrap();
 
-    let ctx = get_job_handler_context_safe();
-    ctx.expect().with(eq(JobType::StateTransition)).returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
+    let _ctx_guard = get_job_handler_context_safe();
+    _ctx_guard
+        .expect()
+        .with(eq(JobType::StateTransition))
+        .returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
 
     assert!(UpdateStateJobTrigger.run_worker(services.config.clone()).await.is_ok());
 

--- a/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/orchestrator/src/tests/workers/update_state/mod.rs
@@ -186,11 +186,8 @@ async fn update_state_worker_continues_from_previous_state_update() {
 
     services.config.database().create_job(job_item).await.unwrap();
 
-    let _ctx_guard = get_job_handler_context_safe();
-    _ctx_guard
-        .expect()
-        .with(eq(JobType::StateTransition))
-        .returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
+    let ctx_guard = get_job_handler_context_safe();
+    ctx_guard.expect().with(eq(JobType::StateTransition)).returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
 
     assert!(UpdateStateJobTrigger.run_worker(services.config.clone()).await.is_ok());
 

--- a/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/orchestrator/src/tests/workers/update_state/mod.rs
@@ -4,6 +4,7 @@ use mockall::predicate::eq;
 use rstest::*;
 use uuid::Uuid;
 
+use crate::tests::common::mock_helpers::get_job_handler_context_safe;
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::workers::utils::{create_and_store_prerequisite_jobs, get_job_item_mock_by_id};
 use crate::types::constant::{BLOB_DATA_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME, SNOS_OUTPUT_FILE_NAME};
@@ -11,7 +12,6 @@ use crate::types::jobs::metadata::{
     CommonMetadata, JobMetadata, JobSpecificMetadata, SettlementContext, SettlementContextData, StateUpdateMetadata,
 };
 use crate::types::jobs::types::{JobStatus, JobType};
-use crate::worker::event_handler::factory::mock_factory::get_job_handler_context;
 use crate::worker::event_handler::jobs::state_update::StateUpdateJobHandler;
 use crate::worker::event_handler::triggers::update_state::UpdateStateJobTrigger;
 use crate::worker::event_handler::triggers::JobTrigger;
@@ -52,7 +52,7 @@ async fn update_state_worker_first_block() {
     // Create both SNOS and Aggregator jobs for block 0 with Completed status
     let (_, _) = create_and_store_prerequisite_jobs(services.config.clone(), 1, JobStatus::Completed).await.unwrap();
 
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(JobType::StateTransition)).returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
 
     assert!(UpdateStateJobTrigger.run_worker(services.config.clone()).await.is_ok());
@@ -81,7 +81,7 @@ async fn update_state_worker_first_block_missing() {
     // Note: Block 0 and 1 are missing, so the worker should not create a job
     let (_, _) = create_and_store_prerequisite_jobs(services.config.clone(), 2, JobStatus::Completed).await.unwrap();
 
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(JobType::StateTransition)).returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
 
     assert!(UpdateStateJobTrigger.run_worker(services.config.clone()).await.is_ok());
@@ -104,7 +104,7 @@ async fn update_state_worker_selects_consecutive_blocks() {
     let (_, _) = create_and_store_prerequisite_jobs(services.config.clone(), 2, JobStatus::Completed).await.unwrap();
     let (_, _) = create_and_store_prerequisite_jobs(services.config.clone(), 4, JobStatus::Completed).await.unwrap();
 
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(JobType::StateTransition)).returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
 
     assert!(UpdateStateJobTrigger.run_worker(services.config.clone()).await.is_ok());
@@ -170,7 +170,7 @@ async fn update_state_worker_continues_from_previous_state_update() {
 
     services.config.database().create_job(job_item).await.unwrap();
 
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(JobType::StateTransition)).returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
 
     assert!(UpdateStateJobTrigger.run_worker(services.config.clone()).await.is_ok());
@@ -238,7 +238,7 @@ async fn update_state_worker_next_block_missing() {
 
     services.config.database().create_job(job_item).await.unwrap();
 
-    let ctx = get_job_handler_context();
+    let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(JobType::StateTransition)).returning(move |_| Arc::new(Box::new(StateUpdateJobHandler)));
 
     assert!(UpdateStateJobTrigger.run_worker(services.config.clone()).await.is_ok());

--- a/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/orchestrator/src/tests/workers/update_state/mod.rs
@@ -4,7 +4,7 @@ use mockall::predicate::eq;
 use rstest::*;
 use uuid::Uuid;
 
-use crate::tests::common::mock_helpers::get_job_handler_context_safe;
+use crate::tests::common::test_utils::{acquire_test_lock, get_job_handler_context_safe};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::workers::utils::{create_and_store_prerequisite_jobs, get_job_item_mock_by_id};
 use crate::types::constant::{BLOB_DATA_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME, SNOS_OUTPUT_FILE_NAME};
@@ -42,7 +42,11 @@ async fn update_state_worker_with_pending_jobs() {
 
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn update_state_worker_first_block() {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)
@@ -70,7 +74,11 @@ async fn update_state_worker_first_block() {
 
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn update_state_worker_first_block_missing() {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)
@@ -92,7 +100,11 @@ async fn update_state_worker_first_block_missing() {
 
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn update_state_worker_selects_consecutive_blocks() {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)
@@ -123,7 +135,11 @@ async fn update_state_worker_selects_consecutive_blocks() {
 
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn update_state_worker_continues_from_previous_state_update() {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)
@@ -192,7 +208,11 @@ async fn update_state_worker_continues_from_previous_state_update() {
 
 #[rstest]
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn update_state_worker_next_block_missing() {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)

--- a/orchestrator/src/utils/helpers.rs
+++ b/orchestrator/src/utils/helpers.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 /// use orchestrator::utils::helpers::wait_until_ready;
 ///
 /// async fn wait_for_ready() -> Result<(), Box<dyn std::error::Error>> {
-///     let result = wait_until_ready(|| async { Ok(()) }, 10).await;
+///     let result: Result<(), Box<dyn std::error::Error>> = wait_until_ready(|| Box::pin(async { Ok(()) }), 10).await;
 ///     assert!(result.is_ok());
 ///     Ok(())
 /// }

--- a/orchestrator/src/utils/signal_handler.rs
+++ b/orchestrator/src/utils/signal_handler.rs
@@ -46,6 +46,8 @@ impl SignalHandler {
     ///
     /// Use this to create child tokens for different subsystems:
     /// ```rust
+    /// use orchestrator::utils::signal_handler::SignalHandler;
+    /// let signal_handler = SignalHandler::new();
     /// let worker_token = signal_handler.get_shutdown_token().child_token();
     /// ```
     pub fn get_shutdown_token(&self) -> CancellationToken {


### PR DESCRIPTION
# Parallelize Orchestrator Tests

## Summary

This PR implements parallel test execution for the orchestrator test suite, significantly reducing test execution time and CI costs. The implementation ensures proper resource isolation using UUIDs and addresses all race conditions and test interference issues that arise when running tests concurrently.

## Problem

Previously, all orchestrator tests ran sequentially (~23.5 minutes execution time) because they shared the same MongoDB database, SQS queues, and S3 buckets. This caused:
- Race conditions when tests ran in parallel
- Long CI execution times
- High CI costs

## Solution

### 1. Resource Isolation with UUIDs

- **Unique Test Identifiers**: Each test now generates a unique UUID (`test_id`) that is appended to:
  - MongoDB database names
  - SQS queue identifiers (sanitized and truncated to fit AWS naming limits)
  - S3 bucket names

- **TestConfigBuilder Changes**:
  - Added `test_id: String` field that auto-generates a UUID on creation
  - Modified `get_env_params()` to append `test_id` to all resource names
  - Ensures complete isolation between parallel test executions

### 2. Thread-Safe Mock Helpers

- **Created `mock_helpers.rs`**: New module providing thread-safe wrappers for Mockall's global context
  - `MockContextGuard`: Wraps mock context with a mutex guard to prevent concurrent access
  - `TEST_MUTEX`: Test-level mutex to serialize tests that use mocks
  - `acquire_test_lock()`: Function to acquire test-level lock for serializing mock-using tests
  - `get_job_handler_context_safe()`: Thread-safe wrapper for `get_job_handler_context()`

- **Prevents `PoisonError`**: All tests using mocks now use the thread-safe helpers, preventing mutex poisoning when tests run in parallel

### 3. Dynamic Port Allocation

- **Server Tests**: Modified `get_server_url()` to use port `0` in test mode, allowing the OS to assign available ports dynamically
- **Prevents "Address already in use" errors**: Each test server gets its own port when running in parallel

### 4. Queue Retry Logic Refactoring

- **Created `consume_message_with_retry()` helper**: Centralized retry logic for queue message consumption
  - Handles `QueueDoesNotExist`, `GetQueueUrlError`, and `NoData` errors
  - Configurable retry count and delay

## Breaking Changes

None. This is purely an internal test infrastructure improvement.

## Notes

- LocalStack cleanup is intentionally disabled as it's ephemeral and destroyed after tests
- Some tests intentionally hold locks across await points for test serialization - this is documented with `#![allow(clippy::await_holding_lock)]`
- Mock expectations use exact call counts to ensure tests verify actual behavior

