### PR TITLE
Using RevertError for removing VM tracebacks

### DIFF
--- a/madara/Cargo.lock
+++ b/madara/Cargo.lock
@@ -6810,6 +6810,7 @@ dependencies = [
  "mp-chain-config",
  "mp-class",
  "mp-convert",
+ "mp-receipt",
  "mp-rpc",
  "mp-state-update",
  "mp-transactions",

--- a/madara/Cargo.toml
+++ b/madara/Cargo.toml
@@ -131,7 +131,7 @@ starknet-types-core = { version = "0.2.1", default-features = false, features = 
 #blockifier = { version = "=0.16.0-rc.0", features = ["node_api"] }
 #starknet_api = "=0.16.0-rc.0"
 blockifier = { git = "https://github.com/karnotxyz/sequencer", rev = "ff514ad8f39ac04302d0b176cef673a6a3820914", features = [
-  "node_api",
+  "node_api", "testing"
 ] }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "ff514ad8f39ac04302d0b176cef673a6a3820914" }
 cairo-lang-starknet-classes = "2.12.3"

--- a/madara/Cargo.toml
+++ b/madara/Cargo.toml
@@ -131,7 +131,7 @@ starknet-types-core = { version = "0.2.1", default-features = false, features = 
 #blockifier = { version = "=0.16.0-rc.0", features = ["node_api"] }
 #starknet_api = "=0.16.0-rc.0"
 blockifier = { git = "https://github.com/karnotxyz/sequencer", rev = "ff514ad8f39ac04302d0b176cef673a6a3820914", features = [
-  "node_api", "testing"
+  "node_api"
 ] }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "ff514ad8f39ac04302d0b176cef673a6a3820914" }
 cairo-lang-starknet-classes = "2.12.3"

--- a/madara/Cargo.toml
+++ b/madara/Cargo.toml
@@ -131,7 +131,7 @@ starknet-types-core = { version = "0.2.1", default-features = false, features = 
 #blockifier = { version = "=0.16.0-rc.0", features = ["node_api"] }
 #starknet_api = "=0.16.0-rc.0"
 blockifier = { git = "https://github.com/karnotxyz/sequencer", rev = "ff514ad8f39ac04302d0b176cef673a6a3820914", features = [
-  "node_api"
+  "node_api",
 ] }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "ff514ad8f39ac04302d0b176cef673a6a3820914" }
 cairo-lang-starknet-classes = "2.12.3"

--- a/madara/crates/client/exec/Cargo.toml
+++ b/madara/crates/client/exec/Cargo.toml
@@ -19,6 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 # Madara
 mc-db = { workspace = true }
 mp-block = { workspace = true }
+mp-receipt = { workspace = true }
 mp-chain-config = { workspace = true }
 mp-class = { workspace = true }
 mp-convert = { workspace = true }

--- a/madara/crates/client/exec/Cargo.toml
+++ b/madara/crates/client/exec/Cargo.toml
@@ -19,10 +19,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 # Madara
 mc-db = { workspace = true }
 mp-block = { workspace = true }
-mp-receipt = { workspace = true }
 mp-chain-config = { workspace = true }
 mp-class = { workspace = true }
 mp-convert = { workspace = true }
+mp-receipt = { workspace = true }
 mp-rpc = { workspace = true }
 mp-state-update = { workspace = true }
 mp-transactions = { workspace = true }

--- a/madara/crates/client/exec/src/execution.rs
+++ b/madara/crates/client/exec/src/execution.rs
@@ -63,7 +63,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                 let mut execution_info =
                     tx.execute_raw(&mut transactional_state, &self.block_context, false).map_err(make_reexec_error)?;
                 
-                execution_info.revert_error = execution_info.revert_error.map(|e| e.format_properly());
+                execution_info.revert_error = execution_info.revert_error.map(|e| e.format_for_receipt());
 
                 let state_diff = transactional_state
                     .to_state_diff()

--- a/madara/crates/client/exec/src/execution.rs
+++ b/madara/crates/client/exec/src/execution.rs
@@ -60,15 +60,10 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
 
                 let mut transactional_state = TransactionalState::create_transactional(&mut self.state);
                 // NB: We use execute_raw because execute already does transaactional state.
-                let old_execution_info =
+                let mut execution_info =
                     tx.execute_raw(&mut transactional_state, &self.block_context, false).map_err(make_reexec_error)?;
-
-                let mut execution_info = old_execution_info.clone();
-
-                if let Some(revert_error) = execution_info.revert_error {
-                    let new_revrt_error = revert_error.format_properly();
-                    execution_info.revert_error = Some(new_revrt_error);
-                }
+                
+                execution_info.revert_error = execution_info.revert_error.map(|e| e.format_properly());
 
                 let state_diff = transactional_state
                     .to_state_diff()

--- a/madara/crates/client/exec/src/execution.rs
+++ b/madara/crates/client/exec/src/execution.rs
@@ -1,4 +1,4 @@
-use mp_receipt::from_blockifier::RevertErrorExt;
+use mp_receipt::RevertErrorExt;
 use crate::{Error, ExecutionContext, ExecutionResult, TxExecError};
 use blockifier::fee::gas_usage::estimate_minimal_gas_vector;
 use blockifier::state::cached_state::TransactionalState;
@@ -62,8 +62,8 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                 // NB: We use execute_raw because execute already does transaactional state.
                 let mut execution_info =
                     tx.execute_raw(&mut transactional_state, &self.block_context, false).map_err(make_reexec_error)?;
-                
-                execution_info.revert_error = execution_info.revert_error.map(|e| e.format_for_receipt());
+
+                execution_info.revert_error = execution_info.revert_error.take().map(|e| e.format_for_receipt());
 
                 let state_diff = transactional_state
                     .to_state_diff()

--- a/madara/crates/primitives/receipt/src/from_blockifier.rs
+++ b/madara/crates/primitives/receipt/src/from_blockifier.rs
@@ -4,9 +4,10 @@ use crate::{
 };
 use anyhow::anyhow;
 use blockifier::execution::call_info::CallInfo;
+use blockifier::execution::stack_trace::{ErrorStack, ErrorStackSegment, PreambleType};
 use blockifier::transaction::{
     account_transaction::AccountTransaction as BlockifierAccountTransaction,
-    objects::{HasRelatedFeeType, TransactionExecutionInfo},
+    objects::{HasRelatedFeeType, RevertError, TransactionExecutionInfo},
     transaction_execution::Transaction,
 };
 use cairo_vm::types::builtin_name::BuiltinName;
@@ -18,6 +19,120 @@ use starknet_core::types::Hash256;
 use starknet_types_core::felt::Felt;
 use std::convert::TryFrom;
 use thiserror::Error;
+
+/// Extension trait for `RevertError` to provide proper formatting with filtered VM tracebacks.
+///
+/// This trait implements the `format_properly()` method that was removed from blockifier.
+/// It filters redundant VM tracebacks from error stacks to make error messages more readable.
+pub trait RevertErrorExt {
+    /// Returns a new RevertError with filtered VM tracebacks.
+    ///
+    /// This method leverages the typed structure of `RevertError`. For execution errors,
+    /// it filters redundant VM tracebacks from the error stack, keeping only the most
+    /// relevant ones. For post-execution errors, it returns a clone of the original error.
+    ///
+    /// # Returns
+    /// A new `RevertError` with filtered error information.
+    fn format_properly(&self) -> RevertError;
+}
+
+impl RevertErrorExt for RevertError {
+    fn format_properly(&self) -> RevertError {
+        match self {
+            RevertError::Execution(error_stack) => {
+                // Create a new ErrorStack with filtered segments
+                let filtered_segments = filter_redundant_vm_tracebacks(error_stack);
+                let mut new_stack = ErrorStack {
+                    header: error_stack.header.clone(),
+                    stack: Vec::new(),
+                };
+
+                // Clone the filtered segments into the new stack
+                for segment in filtered_segments {
+                    new_stack.push(segment.clone());
+                }
+
+                RevertError::Execution(new_stack)
+            }
+            RevertError::PostExecution(fee_error) => RevertError::PostExecution(fee_error.clone()),
+        }
+    }
+}
+
+/// Filters redundant VM tracebacks from the error stack.
+///
+/// The blockifier generates VM tracebacks at every level of the call stack.
+/// This function filters them to show the traceback only once, positioned after
+/// the last regular contract call (CallContract) entry point frame and before
+/// any library call (LibraryCall) frames or the final error.
+///
+/// Rules:
+/// - Always keep VM tracebacks that belong to LibraryCall entries
+/// - For CallContract entries:
+///   - Keep the traceback if the next entry is a LibraryCall or if it's the last entry
+///   - Remove the traceback if the next entry is another CallContract
+fn filter_redundant_vm_tracebacks(error_stack: &ErrorStack) -> Vec<&ErrorStackSegment> {
+    let mut filtered = Vec::new();
+    let len = error_stack.stack.len();
+
+    for i in 0..len {
+        let segment = &error_stack.stack[i];
+
+        match segment {
+            ErrorStackSegment::Vm(_) => {
+                // Find the owning EntryPoint by looking backward
+                let owning_entry = find_owning_entry_point(error_stack, i);
+
+                let should_keep = match owning_entry {
+                    Some(entry_point) => {
+                        // Always keep VM tracebacks for LibraryCall entries
+                        if entry_point.preamble_type == PreambleType::LibraryCall {
+                            true
+                        } else {
+                            // For CallContract entries, check what comes next
+                            !has_nested_call_contract_after(error_stack, i)
+                        }
+                    }
+                    // If we can't find an owning entry, keep the traceback
+                    None => true,
+                };
+
+                if should_keep {
+                    filtered.push(segment);
+                }
+            }
+            // Always keep non-VM segments
+            _ => filtered.push(segment),
+        }
+    }
+
+    filtered
+}
+
+/// Finds the EntryPoint that owns the VM traceback at the given index.
+/// Looks backward from the current index to find the most recent EntryPoint.
+fn find_owning_entry_point(error_stack: &ErrorStack, vm_index: usize) -> Option<&blockifier::execution::stack_trace::EntryPointErrorFrame> {
+    for i in (0..vm_index).rev() {
+        if let ErrorStackSegment::EntryPoint(entry_point) = &error_stack.stack[i] {
+            return Some(entry_point);
+        }
+    }
+    None
+}
+
+/// Checks if there's a nested CallContract entry after the given VM traceback index.
+/// Returns true if the next EntryPoint is a CallContract, false otherwise.
+fn has_nested_call_contract_after(error_stack: &ErrorStack, vm_index: usize) -> bool {
+    // Scan forward to find the next EntryPoint
+    for segment in error_stack.stack.iter().skip(vm_index + 1) {
+        if let ErrorStackSegment::EntryPoint(entry_point) = segment {
+            // Found the next entry point - check if it's a CallContract
+            return entry_point.preamble_type == PreambleType::CallContract;
+        }
+    }
+    // No next EntryPoint found, so this is the last one - keep the traceback
+    false
+}
 
 fn blockifier_tx_fee_type(tx: &Transaction) -> FeeType {
     match tx {
@@ -77,119 +192,6 @@ fn recursive_call_info_iter(res: &TransactionExecutionInfo) -> impl Iterator<Ite
     res
         .non_optional_call_infos() // all root callinfos
         .flat_map(|call_info| call_info.iter()) // flatmap over the roots' recursive inner call infos
-}
-
-/// Formats the revert error string by removing redundant VM tracebacks.
-///
-/// The blockifier generates verbose error messages with VM tracebacks at every level
-/// of the call stack. This function filters them to show the traceback only once,
-/// positioned after the last regular contract call (CallContract) entry point frame
-/// and before any library call (LibraryCall) frames or the final error.
-///
-/// This makes error messages more concise while preserving the most relevant debugging information.
-fn format_revert_error(error_string: &str) -> String {
-    // Check if the original string ends with a newline
-    let ends_with_newline = error_string.ends_with('\n');
-
-    let lines: Vec<&str> = error_string.lines().collect();
-    let mut output_lines = Vec::new();
-    let mut i = 0;
-
-    while i < lines.len() {
-        let line = lines[i];
-
-        // Check if this is the start of a VM exception frame
-        // VM exception frames start with "Error at pc=..."
-        if line.trim().starts_with("Error at pc=") {
-            // Look ahead to see if there's another "Error in the called contract" entry
-            // or "Error in a library call" coming up
-            let mut has_nested_call_contract = false;
-            let mut j = i + 1;
-
-            // Scan forward to find the next entry point frame
-            while j < lines.len() {
-                let next_line = lines[j].trim();
-
-                // Found the next entry point - check if it's a CallContract or LibraryCall
-                if next_line.starts_with("Error in the called contract") {
-                    has_nested_call_contract = true;
-                    break;
-                } else if next_line.starts_with("Error in a library call")
-                    || next_line.starts_with("Execution failed")
-                    || next_line.starts_with("Entry point") {
-                    // Next entry is a library call or final error - don't skip this traceback
-                    has_nested_call_contract = false;
-                    break;
-                }
-
-                // Keep scanning through the traceback lines
-                if next_line.starts_with("Unknown location")
-                    || next_line.starts_with("Cairo traceback")
-                    || next_line.is_empty() {
-                    j += 1;
-                } else {
-                    // Reached a numbered entry like "1:" - check if it contains the patterns
-                    if let Some(colon_pos) = next_line.find(':') {
-                        let after_colon = &next_line[colon_pos + 1..].trim();
-                        if after_colon.starts_with("Error in the called contract") {
-                            has_nested_call_contract = true;
-                            break;
-                        } else if after_colon.starts_with("Error in a library call") {
-                            has_nested_call_contract = false;
-                            break;
-                        }
-                    }
-                    j += 1;
-                }
-            }
-
-            // Skip the VM traceback if there's a nested CallContract
-            if has_nested_call_contract {
-                // Skip this "Error at pc=..." line and all traceback lines until the next entry
-                while i < lines.len() {
-                    let current_line = lines[i].trim();
-                    i += 1;
-
-                    // Stop when we hit the next numbered entry or end
-                    if i < lines.len() {
-                        let next_line = lines[i].trim();
-                        if let Some(first_char) = next_line.chars().next() {
-                            if first_char.is_ascii_digit() && next_line.contains(':') {
-                                break;
-                            }
-                        }
-                    }
-
-                    // Also stop at the end or at lines that look like new entries
-                    if current_line.is_empty() && i < lines.len() {
-                        let peek = lines[i].trim();
-                        if let Some(first_char) = peek.chars().next() {
-                            if first_char.is_ascii_digit() || peek.starts_with("Execution failed") {
-                                break;
-                            }
-                        }
-                    }
-                }
-            } else {
-                // Keep this traceback - it's before a library call or final error
-                output_lines.push(line);
-                i += 1;
-            }
-        } else {
-            // Not a VM traceback line - keep it
-            output_lines.push(line);
-            i += 1;
-        }
-    }
-
-    let mut result = output_lines.join("\n");
-
-    // Preserve the trailing newline if the original had one
-    if ends_with_newline {
-        result.push('\n');
-    }
-
-    result
 }
 
 pub fn from_blockifier_execution_info(res: &TransactionExecutionInfo, tx: &Transaction) -> TransactionReceipt {
@@ -309,8 +311,8 @@ pub fn from_blockifier_execution_info(res: &TransactionExecutionInfo, tx: &Trans
     };
 
     let execution_result = if let Some(reason) = &res.revert_error {
-        let formatted_reason = format_revert_error(&reason.to_string());
-        ExecutionResult::Reverted { reason: formatted_reason }
+        let formatted_reason = reason.format_properly();
+        ExecutionResult::Reverted { reason: formatted_reason.to_string() }
     } else {
         ExecutionResult::Succeeded
     };
@@ -441,6 +443,9 @@ mod events_logic_tests {
 #[cfg(test)]
 mod test {
     use super::*;
+    use blockifier::execution::stack_trace::{
+        EntryPointErrorFrame, ErrorStackHeader, VmExceptionFrame,
+    };
     use std::str::FromStr;
 
     #[test]
@@ -462,59 +467,204 @@ mod test {
     }
 
     #[test]
-    fn test_format_revert_error_filters_redundant_tracebacks() {
-        // Real example from blockifier with VM tracebacks at every CallContract level
+    fn test_format_properly_filters_redundant_tracebacks() {
+        use cairo_vm::types::relocatable::Relocatable;
+        use starknet_api::core::EntryPointSelector;
+        use starknet_api::{class_hash, contract_address, felt};
+
+        // Build the ErrorStack structure that represents the unfiltered error
+        let mut error_stack = ErrorStack {
+            header: ErrorStackHeader::Execution,
+            stack: vec![],
+        };
+
+        // Entry 0: CallContract with VM traceback (should be removed)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 0,
+                preamble_type: PreambleType::CallContract,
+                storage_address: contract_address!("0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3"),
+                class_hash: class_hash!("0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2"),
+                selector: Some(EntryPointSelector(felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 35988 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:330)\nUnknown location (pc=0:11695)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 1: CallContract with VM traceback (should be removed)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 1,
+                preamble_type: PreambleType::CallContract,
+                storage_address: contract_address!("0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6"),
+                class_hash: class_hash!("0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b"),
+                selector: Some(EntryPointSelector(felt!("0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 115867 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:9435)\nUnknown location (pc=0:43555)\nUnknown location (pc=0:93296)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 2: CallContract with VM traceback (should be kept - last before LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 2,
+                preamble_type: PreambleType::CallContract,
+                storage_address: contract_address!("0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e"),
+                class_hash: class_hash!("0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d"),
+                selector: Some(EntryPointSelector(felt!("0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 32 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 3: LibraryCall with final error
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 3,
+                preamble_type: PreambleType::LibraryCall,
+                storage_address: contract_address!("0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e"),
+                class_hash: class_hash!("0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed"),
+                selector: Some(EntryPointSelector(felt!("0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            ErrorStackSegment::StringFrame("Execution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n".to_string()),
+        );
+
+        let revert_error = RevertError::Execution(error_stack);
+
+        // Verify that the RevertError structure produces the correct input (unfiltered)
         let input = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3, class hash: 0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:35988:\nCairo traceback (most recent call last):\nUnknown location (pc=0:330)\nUnknown location (pc=0:11695)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\n\n1: Error in the called contract (contract address: 0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6, class hash: 0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b, selector: 0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6):\nError at pc=0:115867:\nCairo traceback (most recent call last):\nUnknown location (pc=0:9435)\nUnknown location (pc=0:43555)\nUnknown location (pc=0:93296)\n\n2: Error in the called contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nExecution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n";
+        assert_eq!(revert_error.to_string(), input);
 
         // Expected output: only the traceback from entry 2 (last CallContract before LibraryCall) is kept
         let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3, class hash: 0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\n1: Error in the called contract (contract address: 0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6, class hash: 0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b, selector: 0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6):\n2: Error in the called contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nExecution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n";
 
-        let result = format_revert_error(input);
+        let result = revert_error.format_properly().to_string();
 
         assert_eq!(result, expected);
     }
 
     #[test]
-    fn test_format_revert_error_preserves_trailing_newline() {
-        let input_with_newline = "Error at pc=0:123:\nCairo traceback\n";
-        let input_without_newline = "Error at pc=0:123:\nCairo traceback";
+    fn test_format_properly_filters_redundant_tracebacks_2() {
+        use cairo_vm::types::relocatable::Relocatable;
+        use starknet_api::core::EntryPointSelector;
+        use starknet_api::{class_hash, contract_address, felt};
 
-        let result_with = format_revert_error(input_with_newline);
-        let result_without = format_revert_error(input_without_newline);
+        // Build the ErrorStack structure that represents the unfiltered error
+        let mut error_stack = ErrorStack {
+            header: ErrorStackHeader::Execution,
+            stack: vec![],
+        };
 
-        assert!(result_with.ends_with('\n'));
-        assert!(!result_without.ends_with('\n'));
-    }
+        // Entry 0: CallContract with VM traceback (should be kept - next is LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 0,
+                preamble_type: PreambleType::CallContract,
+                storage_address: contract_address!("0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb"),
+                class_hash: class_hash!("0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9"),
+                selector: Some(EntryPointSelector(felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 12 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n".to_string()),
+            }
+            .into(),
+        );
 
-    #[test]
-    fn test_format_revert_error_keeps_traceback_before_library_call() {
-        let input = "0: Error in the called contract:\nError at pc=0:100:\nCairo traceback\n\n1: Error in a library call:\nExecution failed\n";
-        let result = format_revert_error(input);
+        // Entry 1: LibraryCall with VM traceback (should be kept - belongs to LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 1,
+                preamble_type: PreambleType::LibraryCall,
+                storage_address: contract_address!("0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb"),
+                class_hash: class_hash!("0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e"),
+                selector: Some(EntryPointSelector(felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 56 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n".to_string()),
+            }
+            .into(),
+        );
 
-        // Should keep the traceback because it's before a library call
-        assert!(result.contains("Error at pc=0:100:"));
-        assert!(result.contains("Cairo traceback"));
-    }
+        // Entry 2: CallContract with VM traceback (should be kept - next is LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 2,
+                preamble_type: PreambleType::CallContract,
+                storage_address: contract_address!("0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef"),
+                class_hash: class_hash!("0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d"),
+                selector: Some(EntryPointSelector(felt!("0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 32 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n".to_string()),
+            }
+            .into(),
+        );
 
-    #[test]
-    fn test_format_revert_error_skips_traceback_with_nested_call_contract() {
-        let input = "0: Error in the called contract:\nError at pc=0:100:\nCairo traceback\n\n1: Error in the called contract:\nError at pc=0:200:\nAnother traceback\n";
-        let result = format_revert_error(input);
+        // Entry 3: LibraryCall with final error
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 3,
+                preamble_type: PreambleType::LibraryCall,
+                storage_address: contract_address!("0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef"),
+                class_hash: class_hash!("0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046"),
+                selector: Some(EntryPointSelector(felt!("0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            ErrorStackSegment::StringFrame("Execution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n".to_string()),
+        );
 
-        // Should skip the first traceback because there's a nested CallContract
-        assert!(!result.contains("Error at pc=0:100:"));
-        assert!(!result.contains("Cairo traceback"));
-        // Should keep the second one
-        assert!(result.contains("Error at pc=0:200:"));
-        assert!(result.contains("Another traceback"));
-    }
+        let revert_error = RevertError::Execution(error_stack);
 
-    #[test]
-    fn test_format_revert_error_no_tracebacks() {
-        let input = "Transaction execution has failed:\nExecution failed. Failure reason: 'Some error'\n";
-        let result = format_revert_error(input);
+        // Verify that the RevertError structure produces the correct input (unfiltered)
+        let input = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:12:\nCairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n\n1: Error in a library call (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:56:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n\n2: Error in the called contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nExecution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n";
+        assert_eq!(revert_error.to_string(), input);
 
-        // Should preserve the error message as-is when there are no tracebacks
-        assert_eq!(result, input);
+        // Expected output: all tracebacks kept (entry 0 before LibraryCall, entry 1 belongs to LibraryCall, entry 2 before LibraryCall)
+        let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:12:\nCairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n\n1: Error in a library call (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:56:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n\n2: Error in the called contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nExecution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n";
+
+        let result = revert_error.format_properly().to_string();
+
+        assert_eq!(result, expected);
     }
 }

--- a/madara/crates/primitives/receipt/src/from_blockifier.rs
+++ b/madara/crates/primitives/receipt/src/from_blockifier.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 
 /// Extension trait for `RevertError` to provide proper formatting with filtered VM tracebacks.
 ///
-/// This trait implements the `format_properly()` method that was removed from blockifier.
+/// This trait implements the `format_for_receipt()` method that was removed from blockifier.
 /// It filters redundant VM tracebacks from error stacks to make error messages more readable.
 pub trait RevertErrorExt {
     /// Returns a new RevertError with filtered VM tracebacks.
@@ -33,11 +33,11 @@ pub trait RevertErrorExt {
     ///
     /// # Returns
     /// A new `RevertError` with filtered error information.
-    fn format_properly(&self) -> RevertError;
+    fn format_for_receipt(&self) -> RevertError;
 }
 
 impl RevertErrorExt for RevertError {
-    fn format_properly(&self) -> RevertError {
+    fn format_for_receipt(&self) -> RevertError {
         match self {
             RevertError::Execution(error_stack) => {
                 // Create a new ErrorStack with filtered segments
@@ -81,7 +81,7 @@ fn filter_redundant_vm_tracebacks(error_stack: &ErrorStack) -> Vec<&ErrorStackSe
         match segment {
             ErrorStackSegment::Vm(_) => {
                 // Find the owning EntryPoint by looking backward
-                let owning_entry = find_owning_entry_point(error_stack, i);
+                let owning_entry = find_parent_entry_point(error_stack, i);
 
                 let should_keep = match owning_entry {
                     Some(entry_point) => {
@@ -111,7 +111,7 @@ fn filter_redundant_vm_tracebacks(error_stack: &ErrorStack) -> Vec<&ErrorStackSe
 
 /// Finds the EntryPoint that owns the VM traceback at the given index.
 /// Looks backward from the current index to find the most recent EntryPoint.
-fn find_owning_entry_point(error_stack: &ErrorStack, vm_index: usize) -> Option<&blockifier::execution::stack_trace::EntryPointErrorFrame> {
+fn find_parent_entry_point(error_stack: &ErrorStack, vm_index: usize) -> Option<&blockifier::execution::stack_trace::EntryPointErrorFrame> {
     for i in (0..vm_index).rev() {
         if let ErrorStackSegment::EntryPoint(entry_point) = &error_stack.stack[i] {
             return Some(entry_point);
@@ -311,7 +311,7 @@ pub fn from_blockifier_execution_info(res: &TransactionExecutionInfo, tx: &Trans
     };
 
     let execution_result = if let Some(reason) = &res.revert_error {
-        let formatted_reason = reason.format_properly();
+        let formatted_reason = reason.format_for_receipt();
         ExecutionResult::Reverted { reason: formatted_reason.to_string() }
     } else {
         ExecutionResult::Succeeded
@@ -467,7 +467,7 @@ mod test {
     }
 
     #[test]
-    fn test_format_properly_filters_redundant_tracebacks() {
+    fn test_format_for_receipt_filters_redundant_tracebacks() {
         use cairo_vm::types::relocatable::Relocatable;
         use starknet_api::core::EntryPointSelector;
         use starknet_api::{class_hash, contract_address, felt};
@@ -562,13 +562,13 @@ mod test {
         // Expected output: only the traceback from entry 2 (last CallContract before LibraryCall) is kept
         let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3, class hash: 0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\n1: Error in the called contract (contract address: 0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6, class hash: 0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b, selector: 0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6):\n2: Error in the called contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nExecution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n";
 
-        let result = revert_error.format_properly().to_string();
+        let result = revert_error.format_for_receipt().to_string();
 
         assert_eq!(result, expected);
     }
 
     #[test]
-    fn test_format_properly_filters_redundant_tracebacks_2() {
+    fn test_format_for_receipt_filters_redundant_tracebacks_2() {
         use cairo_vm::types::relocatable::Relocatable;
         use starknet_api::core::EntryPointSelector;
         use starknet_api::{class_hash, contract_address, felt};
@@ -663,7 +663,7 @@ mod test {
         // Expected output: all tracebacks kept (entry 0 before LibraryCall, entry 1 belongs to LibraryCall, entry 2 before LibraryCall)
         let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:12:\nCairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n\n1: Error in a library call (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:56:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n\n2: Error in the called contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nExecution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n";
 
-        let result = revert_error.format_properly().to_string();
+        let result = revert_error.format_for_receipt().to_string();
 
         assert_eq!(result, expected);
     }

--- a/madara/crates/primitives/receipt/src/from_blockifier.rs
+++ b/madara/crates/primitives/receipt/src/from_blockifier.rs
@@ -2,12 +2,12 @@ use crate::{
     DeclareTransactionReceipt, DeployAccountTransactionReceipt, Event, ExecutionResources, ExecutionResult, FeePayment,
     GasVector, InvokeTransactionReceipt, L1HandlerTransactionReceipt, MsgToL1, MsgToL2, PriceUnit, TransactionReceipt,
 };
+use crate::revert_error::RevertErrorExt;
 use anyhow::anyhow;
 use blockifier::execution::call_info::CallInfo;
-use blockifier::execution::stack_trace::{ErrorStack, ErrorStackSegment, PreambleType};
 use blockifier::transaction::{
     account_transaction::AccountTransaction as BlockifierAccountTransaction,
-    objects::{HasRelatedFeeType, RevertError, TransactionExecutionInfo},
+    objects::{HasRelatedFeeType, TransactionExecutionInfo},
     transaction_execution::Transaction,
 };
 use cairo_vm::types::builtin_name::BuiltinName;
@@ -19,120 +19,6 @@ use starknet_core::types::Hash256;
 use starknet_types_core::felt::Felt;
 use std::convert::TryFrom;
 use thiserror::Error;
-
-/// Extension trait for `RevertError` to provide proper formatting with filtered VM tracebacks.
-///
-/// This trait implements the `format_for_receipt()` method that was removed from blockifier.
-/// It filters redundant VM tracebacks from error stacks to make error messages more readable.
-pub trait RevertErrorExt {
-    /// Returns a new RevertError with filtered VM tracebacks.
-    ///
-    /// This method leverages the typed structure of `RevertError`. For execution errors,
-    /// it filters redundant VM tracebacks from the error stack, keeping only the most
-    /// relevant ones. For post-execution errors, it returns a clone of the original error.
-    ///
-    /// # Returns
-    /// A new `RevertError` with filtered error information.
-    fn format_for_receipt(&self) -> RevertError;
-}
-
-impl RevertErrorExt for RevertError {
-    fn format_for_receipt(&self) -> RevertError {
-        match self {
-            RevertError::Execution(error_stack) => {
-                // Create a new ErrorStack with filtered segments
-                let filtered_segments = filter_redundant_vm_tracebacks(error_stack);
-                let mut new_stack = ErrorStack {
-                    header: error_stack.header.clone(),
-                    stack: Vec::new(),
-                };
-
-                // Clone the filtered segments into the new stack
-                for segment in filtered_segments {
-                    new_stack.push(segment.clone());
-                }
-
-                RevertError::Execution(new_stack)
-            }
-            RevertError::PostExecution(fee_error) => RevertError::PostExecution(fee_error.clone()),
-        }
-    }
-}
-
-/// Filters redundant VM tracebacks from the error stack.
-///
-/// The blockifier generates VM tracebacks at every level of the call stack.
-/// This function filters them to show the traceback only once, positioned after
-/// the last regular contract call (CallContract) entry point frame and before
-/// any library call (LibraryCall) frames or the final error.
-///
-/// Rules:
-/// - Always keep VM tracebacks that belong to LibraryCall entries
-/// - For CallContract entries:
-///   - Keep the traceback if the next entry is a LibraryCall or if it's the last entry
-///   - Remove the traceback if the next entry is another CallContract
-fn filter_redundant_vm_tracebacks(error_stack: &ErrorStack) -> Vec<&ErrorStackSegment> {
-    let mut filtered = Vec::new();
-    let len = error_stack.stack.len();
-
-    for i in 0..len {
-        let segment = &error_stack.stack[i];
-
-        match segment {
-            ErrorStackSegment::Vm(_) => {
-                // Find the owning EntryPoint by looking backward
-                let owning_entry = find_parent_entry_point(error_stack, i);
-
-                let should_keep = match owning_entry {
-                    Some(entry_point) => {
-                        // Always keep VM tracebacks for LibraryCall entries
-                        if entry_point.preamble_type == PreambleType::LibraryCall {
-                            true
-                        } else {
-                            // For CallContract entries, check what comes next
-                            !has_nested_call_contract_after(error_stack, i)
-                        }
-                    }
-                    // If we can't find an owning entry, keep the traceback
-                    None => true,
-                };
-
-                if should_keep {
-                    filtered.push(segment);
-                }
-            }
-            // Always keep non-VM segments
-            _ => filtered.push(segment),
-        }
-    }
-
-    filtered
-}
-
-/// Finds the EntryPoint that owns the VM traceback at the given index.
-/// Looks backward from the current index to find the most recent EntryPoint.
-fn find_parent_entry_point(error_stack: &ErrorStack, vm_index: usize) -> Option<&blockifier::execution::stack_trace::EntryPointErrorFrame> {
-    for i in (0..vm_index).rev() {
-        if let ErrorStackSegment::EntryPoint(entry_point) = &error_stack.stack[i] {
-            return Some(entry_point);
-        }
-    }
-    None
-}
-
-/// Checks if there's a nested CallContract entry after the given VM traceback index.
-/// Returns true if the next EntryPoint is a CallContract, false otherwise.
-fn has_nested_call_contract_after(error_stack: &ErrorStack, vm_index: usize) -> bool {
-    // Scan forward to find the next EntryPoint
-    for segment in error_stack.stack.iter().skip(vm_index + 1) {
-        if let ErrorStackSegment::EntryPoint(entry_point) = segment {
-            // Found the next entry point - check if it's a CallContract
-            return entry_point.preamble_type == PreambleType::CallContract;
-        }
-    }
-    // No next EntryPoint found, so this is the last one - keep the traceback
-    false
-}
 
 fn blockifier_tx_fee_type(tx: &Transaction) -> FeeType {
     match tx {
@@ -311,8 +197,7 @@ pub fn from_blockifier_execution_info(res: &TransactionExecutionInfo, tx: &Trans
     };
 
     let execution_result = if let Some(reason) = &res.revert_error {
-        let formatted_reason = reason.format_for_receipt();
-        ExecutionResult::Reverted { reason: formatted_reason.to_string() }
+        ExecutionResult::Reverted { reason: reason.format_for_receipt_string() }
     } else {
         ExecutionResult::Succeeded
     };
@@ -443,9 +328,6 @@ mod events_logic_tests {
 #[cfg(test)]
 mod test {
     use super::*;
-    use blockifier::execution::stack_trace::{
-        EntryPointErrorFrame, ErrorStackHeader, VmExceptionFrame,
-    };
     use std::str::FromStr;
 
     #[test]
@@ -464,207 +346,5 @@ mod test {
             Hash256::from_str("0xeec1e25e91757d5e9c8a11cf6e84ddf078dbfbee23382ee979234fc86a8608a5").unwrap();
 
         assert_eq!(hash, expected_hash);
-    }
-
-    #[test]
-    fn test_format_for_receipt_filters_redundant_tracebacks() {
-        use cairo_vm::types::relocatable::Relocatable;
-        use starknet_api::core::EntryPointSelector;
-        use starknet_api::{class_hash, contract_address, felt};
-
-        // Build the ErrorStack structure that represents the unfiltered error
-        let mut error_stack = ErrorStack {
-            header: ErrorStackHeader::Execution,
-            stack: vec![],
-        };
-
-        // Entry 0: CallContract with VM traceback (should be removed)
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 0,
-                preamble_type: PreambleType::CallContract,
-                storage_address: contract_address!("0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3"),
-                class_hash: class_hash!("0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2"),
-                selector: Some(EntryPointSelector(felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            VmExceptionFrame {
-                pc: Relocatable { segment_index: 0, offset: 35988 },
-                error_attr_value: None,
-                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:330)\nUnknown location (pc=0:11695)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\n".to_string()),
-            }
-            .into(),
-        );
-
-        // Entry 1: CallContract with VM traceback (should be removed)
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 1,
-                preamble_type: PreambleType::CallContract,
-                storage_address: contract_address!("0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6"),
-                class_hash: class_hash!("0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b"),
-                selector: Some(EntryPointSelector(felt!("0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            VmExceptionFrame {
-                pc: Relocatable { segment_index: 0, offset: 115867 },
-                error_attr_value: None,
-                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:9435)\nUnknown location (pc=0:43555)\nUnknown location (pc=0:93296)\n".to_string()),
-            }
-            .into(),
-        );
-
-        // Entry 2: CallContract with VM traceback (should be kept - last before LibraryCall)
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 2,
-                preamble_type: PreambleType::CallContract,
-                storage_address: contract_address!("0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e"),
-                class_hash: class_hash!("0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d"),
-                selector: Some(EntryPointSelector(felt!("0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            VmExceptionFrame {
-                pc: Relocatable { segment_index: 0, offset: 32 },
-                error_attr_value: None,
-                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n".to_string()),
-            }
-            .into(),
-        );
-
-        // Entry 3: LibraryCall with final error
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 3,
-                preamble_type: PreambleType::LibraryCall,
-                storage_address: contract_address!("0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e"),
-                class_hash: class_hash!("0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed"),
-                selector: Some(EntryPointSelector(felt!("0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            ErrorStackSegment::StringFrame("Execution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n".to_string()),
-        );
-
-        let revert_error = RevertError::Execution(error_stack);
-
-        // Verify that the RevertError structure produces the correct input (unfiltered)
-        let input = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3, class hash: 0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:35988:\nCairo traceback (most recent call last):\nUnknown location (pc=0:330)\nUnknown location (pc=0:11695)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\n\n1: Error in the called contract (contract address: 0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6, class hash: 0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b, selector: 0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6):\nError at pc=0:115867:\nCairo traceback (most recent call last):\nUnknown location (pc=0:9435)\nUnknown location (pc=0:43555)\nUnknown location (pc=0:93296)\n\n2: Error in the called contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nExecution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n";
-        assert_eq!(revert_error.to_string(), input);
-
-        // Expected output: only the traceback from entry 2 (last CallContract before LibraryCall) is kept
-        let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3, class hash: 0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\n1: Error in the called contract (contract address: 0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6, class hash: 0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b, selector: 0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6):\n2: Error in the called contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nExecution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n";
-
-        let result = revert_error.format_for_receipt().to_string();
-
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_format_for_receipt_filters_redundant_tracebacks_2() {
-        use cairo_vm::types::relocatable::Relocatable;
-        use starknet_api::core::EntryPointSelector;
-        use starknet_api::{class_hash, contract_address, felt};
-
-        // Build the ErrorStack structure that represents the unfiltered error
-        let mut error_stack = ErrorStack {
-            header: ErrorStackHeader::Execution,
-            stack: vec![],
-        };
-
-        // Entry 0: CallContract with VM traceback (should be kept - next is LibraryCall)
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 0,
-                preamble_type: PreambleType::CallContract,
-                storage_address: contract_address!("0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb"),
-                class_hash: class_hash!("0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9"),
-                selector: Some(EntryPointSelector(felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            VmExceptionFrame {
-                pc: Relocatable { segment_index: 0, offset: 12 },
-                error_attr_value: None,
-                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n".to_string()),
-            }
-            .into(),
-        );
-
-        // Entry 1: LibraryCall with VM traceback (should be kept - belongs to LibraryCall)
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 1,
-                preamble_type: PreambleType::LibraryCall,
-                storage_address: contract_address!("0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb"),
-                class_hash: class_hash!("0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e"),
-                selector: Some(EntryPointSelector(felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            VmExceptionFrame {
-                pc: Relocatable { segment_index: 0, offset: 56 },
-                error_attr_value: None,
-                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n".to_string()),
-            }
-            .into(),
-        );
-
-        // Entry 2: CallContract with VM traceback (should be kept - next is LibraryCall)
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 2,
-                preamble_type: PreambleType::CallContract,
-                storage_address: contract_address!("0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef"),
-                class_hash: class_hash!("0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d"),
-                selector: Some(EntryPointSelector(felt!("0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            VmExceptionFrame {
-                pc: Relocatable { segment_index: 0, offset: 32 },
-                error_attr_value: None,
-                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n".to_string()),
-            }
-            .into(),
-        );
-
-        // Entry 3: LibraryCall with final error
-        error_stack.push(
-            EntryPointErrorFrame {
-                depth: 3,
-                preamble_type: PreambleType::LibraryCall,
-                storage_address: contract_address!("0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef"),
-                class_hash: class_hash!("0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046"),
-                selector: Some(EntryPointSelector(felt!("0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409"))),
-            }
-            .into(),
-        );
-        error_stack.push(
-            ErrorStackSegment::StringFrame("Execution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n".to_string()),
-        );
-
-        let revert_error = RevertError::Execution(error_stack);
-
-        // Verify that the RevertError structure produces the correct input (unfiltered)
-        let input = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:12:\nCairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n\n1: Error in a library call (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:56:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n\n2: Error in the called contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nExecution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n";
-        assert_eq!(revert_error.to_string(), input);
-
-        // Expected output: all tracebacks kept (entry 0 before LibraryCall, entry 1 belongs to LibraryCall, entry 2 before LibraryCall)
-        let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:12:\nCairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n\n1: Error in a library call (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:56:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n\n2: Error in the called contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nExecution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n";
-
-        let result = revert_error.format_for_receipt().to_string();
-
-        assert_eq!(result, expected);
     }
 }

--- a/madara/crates/primitives/receipt/src/lib.rs
+++ b/madara/crates/primitives/receipt/src/lib.rs
@@ -8,10 +8,12 @@ use starknet_types_core::{
 };
 
 pub mod from_blockifier;
+pub mod revert_error;
 
 mod to_starknet_types;
 
 pub use from_blockifier::from_blockifier_execution_info;
+pub use revert_error::RevertErrorExt;
 pub use starknet_core::types::Hash256;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/madara/crates/primitives/receipt/src/revert_error.rs
+++ b/madara/crates/primitives/receipt/src/revert_error.rs
@@ -1,0 +1,445 @@
+//! RevertError formatting utilities for filtering redundant VM tracebacks.
+//!
+//! This module provides extension traits and utilities for formatting blockifier's
+//! `RevertError` type to produce cleaner, more readable error messages by filtering
+//! redundant VM tracebacks that appear at every level of the call stack.
+
+use blockifier::execution::stack_trace::{ErrorStack, ErrorStackSegment, PreambleType, VmExceptionFrame};
+use blockifier::transaction::objects::RevertError;
+
+/// Extension trait for `RevertError` to provide proper formatting with filtered VM tracebacks.
+///
+/// This trait implements the `format_for_receipt()` method.
+/// It filters redundant VM tracebacks from error stacks to make error messages more readable.
+pub trait RevertErrorExt {
+    /// Returns a new RevertError with filtered VM tracebacks (consuming version).
+    ///
+    /// This method leverages the typed structure of `RevertError`. For execution errors,
+    /// it filters redundant VM tracebacks from the error stack, keeping only the most
+    /// relevant ones. For post-execution errors, it returns the original error moved.
+    ///
+    /// Note: This method consumes self to avoid cloning non-Clone types.
+    ///
+    /// # Returns
+    /// A new `RevertError` with filtered error information.
+    fn format_for_receipt(self) -> RevertError;
+
+    /// Returns a formatted string representation with filtered VM tracebacks (non-consuming version).
+    ///
+    /// This method is used when you only have a reference and need the formatted string output.
+    /// It directly formats to string without needing to clone the RevertError.
+    ///
+    /// # Returns
+    /// A formatted string with filtered error information.
+    fn format_for_receipt_string(&self) -> String;
+}
+
+impl RevertErrorExt for RevertError {
+    fn format_for_receipt(self) -> RevertError {
+        match self {
+            RevertError::Execution(error_stack) => {
+                // Create a new ErrorStack with filtered segments
+                let new_stack = filter_redundant_vm_tracebacks(error_stack);
+                RevertError::Execution(new_stack)
+            }
+            RevertError::PostExecution(fee_error) => RevertError::PostExecution(fee_error),
+        }
+    }
+
+    fn format_for_receipt_string(&self) -> String {
+        match self {
+            RevertError::Execution(error_stack) => {
+                // Create a filtered version for display purposes only
+                let filtered = filter_redundant_vm_tracebacks_ref(error_stack);
+                filtered.to_string()
+            }
+            RevertError::PostExecution(fee_error) => fee_error.to_string(),
+        }
+    }
+}
+
+/// Filters redundant VM tracebacks from the error stack.
+///
+/// The blockifier generates VM tracebacks at every level of the call stack.
+/// This function filters them to show the traceback only once, positioned after
+/// the last regular contract call (CallContract) entry point frame and before
+/// any library call (LibraryCall) frames or the final error.
+///
+/// Rules:
+/// - Always keep VM tracebacks that belong to LibraryCall entries
+/// - For CallContract entries:
+///   - Keep the traceback if the next entry is a LibraryCall or if it's the last entry
+///   - Remove the traceback if the next entry is another CallContract
+fn filter_redundant_vm_tracebacks(error_stack: ErrorStack) -> ErrorStack {
+    let len = error_stack.stack.len();
+
+    // Create a list of indices to keep
+    let mut indices_to_keep = Vec::new();
+
+    for i in 0..len {
+        let segment = &error_stack.stack[i];
+
+        match segment {
+            ErrorStackSegment::Vm(_) => {
+                // Find the owning EntryPoint by looking backward
+                let owning_entry = find_parent_entry_point(&error_stack, i);
+
+                let should_keep = match owning_entry {
+                    Some(entry_point) => {
+                        // Always keep VM tracebacks for LibraryCall entries
+                        if entry_point.preamble_type == PreambleType::LibraryCall {
+                            true
+                        } else {
+                            // For CallContract entries, check what comes next
+                            !has_nested_call_contract_after(&error_stack, i)
+                        }
+                    }
+                    // If we can't find an owning entry, keep the traceback
+                    None => true,
+                };
+
+                if should_keep {
+                    indices_to_keep.push(i);
+                }
+            }
+            // Always keep non-VM segments
+            _ => indices_to_keep.push(i),
+        }
+    }
+
+    // Move the segments we want to keep into the new stack
+    let mut stack_vec = error_stack.stack;
+    for (new_idx, original_idx) in indices_to_keep.iter().enumerate() {
+        // For indices we're keeping, move them to the front of the vec
+        if new_idx != *original_idx {
+            stack_vec.swap(new_idx, *original_idx);
+        }
+    }
+
+    // Truncate to only keep the elements we want
+    stack_vec.truncate(indices_to_keep.len());
+
+    ErrorStack {
+        header: error_stack.header,
+        stack: stack_vec,
+    }
+}
+
+/// Filters redundant VM tracebacks from the error stack (reference version for display).
+///
+/// This version works with references and constructs a new ErrorStack for display purposes.
+/// Used when we can't move out of the original error stack.
+fn filter_redundant_vm_tracebacks_ref(error_stack: &ErrorStack) -> ErrorStack {
+    let mut new_stack = ErrorStack {
+        header: error_stack.header.clone(),
+        stack: Vec::new(),
+    };
+
+    let len = error_stack.stack.len();
+
+    for i in 0..len {
+        let segment = &error_stack.stack[i];
+
+        match segment {
+            ErrorStackSegment::Vm(vm_frame) => {
+                // Find the owning EntryPoint by looking backward
+                let owning_entry = find_parent_entry_point(error_stack, i);
+
+                let should_keep = match owning_entry {
+                    Some(entry_point) => {
+                        // Always keep VM tracebacks for LibraryCall entries
+                        if entry_point.preamble_type == PreambleType::LibraryCall {
+                            true
+                        } else {
+                            // For CallContract entries, check what comes next
+                            !has_nested_call_contract_after(error_stack, i)
+                        }
+                    }
+                    // If we can't find an owning entry, keep the traceback
+                    None => true,
+                };
+
+                if should_keep {
+                    // Manually reconstruct the VmExceptionFrame
+                    new_stack.push(ErrorStackSegment::Vm(VmExceptionFrame {
+                        pc: vm_frame.pc,
+                        error_attr_value: vm_frame.error_attr_value.clone(),
+                        traceback: vm_frame.traceback.clone(),
+                    }));
+                }
+            }
+            ErrorStackSegment::EntryPoint(entry_point) => {
+                // Manually reconstruct the EntryPointErrorFrame
+                new_stack.push(ErrorStackSegment::EntryPoint(
+                    blockifier::execution::stack_trace::EntryPointErrorFrame {
+                        depth: entry_point.depth,
+                        preamble_type: entry_point.preamble_type.clone(),
+                        storage_address: entry_point.storage_address,
+                        class_hash: entry_point.class_hash,
+                        selector: entry_point.selector,
+                    }
+                ));
+            }
+            ErrorStackSegment::Cairo1RevertSummary(summary) => {
+                new_stack.push(ErrorStackSegment::Cairo1RevertSummary(summary.clone()));
+            }
+            ErrorStackSegment::StringFrame(s) => {
+                new_stack.push(ErrorStackSegment::StringFrame(s.clone()));
+            }
+        }
+    }
+
+    new_stack
+}
+
+/// Finds the EntryPoint that owns the VM traceback at the given index.
+/// Looks backward from the current index to find the most recent EntryPoint.
+fn find_parent_entry_point(error_stack: &ErrorStack, vm_index: usize) -> Option<&blockifier::execution::stack_trace::EntryPointErrorFrame> {
+    for i in (0..vm_index).rev() {
+        if let ErrorStackSegment::EntryPoint(entry_point) = &error_stack.stack[i] {
+            return Some(entry_point);
+        }
+    }
+    None
+}
+
+/// Checks if there's a nested CallContract entry after the given VM traceback index.
+/// Returns true if the next EntryPoint is a CallContract, false otherwise.
+fn has_nested_call_contract_after(error_stack: &ErrorStack, vm_index: usize) -> bool {
+    // Scan forward to find the next EntryPoint
+    for segment in error_stack.stack.iter().skip(vm_index + 1) {
+        if let ErrorStackSegment::EntryPoint(entry_point) = segment {
+            // Found the next entry point - check if it's a CallContract
+            return entry_point.preamble_type == PreambleType::CallContract;
+        }
+    }
+    // No next EntryPoint found, so this is the last one - keep the traceback
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blockifier::execution::stack_trace::{EntryPointErrorFrame, ErrorStackHeader};
+    use cairo_vm::types::relocatable::Relocatable;
+    use starknet_api::core::EntryPointSelector;
+
+    // Helper macro to create test addresses - works without the testing feature
+    macro_rules! test_contract_address {
+        ($addr:expr) => {{
+            use starknet_api::core::ContractAddress;
+            use starknet_api::core::PatriciaKey;
+            use starknet_types_core::felt::Felt;
+            ContractAddress(PatriciaKey::try_from(Felt::from_hex($addr).unwrap()).unwrap())
+        }};
+    }
+
+    macro_rules! test_class_hash {
+        ($hash:expr) => {{
+            use starknet_api::core::ClassHash;
+            use starknet_types_core::felt::Felt;
+            ClassHash(Felt::from_hex($hash).unwrap())
+        }};
+    }
+
+    macro_rules! test_felt {
+        ($val:expr) => {{
+            use starknet_types_core::felt::Felt;
+            Felt::from_hex($val).unwrap()
+        }};
+    }
+
+    #[test]
+    fn test_format_for_receipt_filters_redundant_tracebacks() {
+        // Build the ErrorStack structure that represents the unfiltered error
+        let mut error_stack = ErrorStack {
+            header: ErrorStackHeader::Execution,
+            stack: vec![],
+        };
+
+        // Entry 0: CallContract with VM traceback (should be removed)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 0,
+                preamble_type: PreambleType::CallContract,
+                storage_address: test_contract_address!("0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3"),
+                class_hash: test_class_hash!("0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2"),
+                selector: Some(EntryPointSelector(test_felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 35988 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:330)\nUnknown location (pc=0:11695)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 1: CallContract with VM traceback (should be removed)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 1,
+                preamble_type: PreambleType::CallContract,
+                storage_address: test_contract_address!("0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6"),
+                class_hash: test_class_hash!("0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b"),
+                selector: Some(EntryPointSelector(test_felt!("0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 115867 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:9435)\nUnknown location (pc=0:43555)\nUnknown location (pc=0:93296)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 2: CallContract with VM traceback (should be kept - last before LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 2,
+                preamble_type: PreambleType::CallContract,
+                storage_address: test_contract_address!("0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e"),
+                class_hash: test_class_hash!("0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d"),
+                selector: Some(EntryPointSelector(test_felt!("0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 32 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 3: LibraryCall with final error
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 3,
+                preamble_type: PreambleType::LibraryCall,
+                storage_address: test_contract_address!("0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e"),
+                class_hash: test_class_hash!("0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed"),
+                selector: Some(EntryPointSelector(test_felt!("0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            ErrorStackSegment::StringFrame("Execution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n".to_string()),
+        );
+
+        let revert_error = RevertError::Execution(error_stack);
+
+        // Verify that the RevertError structure produces the correct input (unfiltered)
+        let input = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3, class hash: 0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:35988:\nCairo traceback (most recent call last):\nUnknown location (pc=0:330)\nUnknown location (pc=0:11695)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\nUnknown location (pc=0:36001)\n\n1: Error in the called contract (contract address: 0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6, class hash: 0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b, selector: 0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6):\nError at pc=0:115867:\nCairo traceback (most recent call last):\nUnknown location (pc=0:9435)\nUnknown location (pc=0:43555)\nUnknown location (pc=0:93296)\n\n2: Error in the called contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nExecution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n";
+        assert_eq!(revert_error.to_string(), input);
+
+        // Expected output: only the traceback from entry 2 (last CallContract before LibraryCall) is kept
+        let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x05743c833ed33a3433f1c5587dac97753ddcc84f9844e6fa2a3268e5ae35cbc3, class hash: 0x073414441639dcd11d1846f287650a00c60c416b9d3ba45d31c651672125b2c2, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\n1: Error in the called contract (contract address: 0x0286003f7c7bfc3f94e8f0af48b48302e7aee2fb13c23b141479ba00832ef2c6, class hash: 0x03e283b1e8bce178469acb94700999ecc7ad180420201e16eb0a81294ae8599b, selector: 0x0056878e39e16b42520b0d7936d3fd3498f86ceda4dbad50f6ff717644c95ed6):\n2: Error in the called contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\nExecution failed. Failure reason:\nError in contract (contract address: 0x06f373b346561036d98ea10fb3e60d2f459c872b1933b50b21fe6ef4fda3b75e, class hash: 0x05ffbcfeb50d200a0677c48a129a11245a3fc519d1d98d76882d1c9a1b19c6ed, selector: 0x0041b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20):\n0x753235365f737562204f766572666c6f77 ('u256_sub Overflow').\n";
+
+        let result = revert_error.format_for_receipt().to_string();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_format_for_receipt_filters_redundant_tracebacks_2() {
+        // Build the ErrorStack structure that represents the unfiltered error
+        let mut error_stack = ErrorStack {
+            header: ErrorStackHeader::Execution,
+            stack: vec![],
+        };
+
+        // Entry 0: CallContract with VM traceback (should be kept - next is LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 0,
+                preamble_type: PreambleType::CallContract,
+                storage_address: test_contract_address!("0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb"),
+                class_hash: test_class_hash!("0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9"),
+                selector: Some(EntryPointSelector(test_felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 12 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 1: LibraryCall with VM traceback (should be kept - belongs to LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 1,
+                preamble_type: PreambleType::LibraryCall,
+                storage_address: test_contract_address!("0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb"),
+                class_hash: test_class_hash!("0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e"),
+                selector: Some(EntryPointSelector(test_felt!("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 56 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 2: CallContract with VM traceback (should be kept - next is LibraryCall)
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 2,
+                preamble_type: PreambleType::CallContract,
+                storage_address: test_contract_address!("0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef"),
+                class_hash: test_class_hash!("0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d"),
+                selector: Some(EntryPointSelector(test_felt!("0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            VmExceptionFrame {
+                pc: Relocatable { segment_index: 0, offset: 32 },
+                error_attr_value: None,
+                traceback: Some("Cairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n".to_string()),
+            }
+            .into(),
+        );
+
+        // Entry 3: LibraryCall with final error
+        error_stack.push(
+            EntryPointErrorFrame {
+                depth: 3,
+                preamble_type: PreambleType::LibraryCall,
+                storage_address: test_contract_address!("0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef"),
+                class_hash: test_class_hash!("0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046"),
+                selector: Some(EntryPointSelector(test_felt!("0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409"))),
+            }
+            .into(),
+        );
+        error_stack.push(
+            ErrorStackSegment::StringFrame("Execution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n".to_string()),
+        );
+
+        let revert_error = RevertError::Execution(error_stack);
+
+        // Verify that the RevertError structure produces the correct input (unfiltered)
+        let input = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:12:\nCairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n\n1: Error in a library call (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:56:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n\n2: Error in the called contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nExecution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n";
+        assert_eq!(revert_error.to_string(), input);
+
+        // Expected output: all tracebacks kept (entry 0 before LibraryCall, entry 1 belongs to LibraryCall, entry 2 before LibraryCall)
+        let expected = "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x03530cc4759d78042f1b543bf797f5f3d647cde0388c33734cf91b7f7b9314a9, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:12:\nCairo traceback (most recent call last):\nUnknown location (pc=0:161)\nUnknown location (pc=0:147)\n\n1: Error in a library call (contract address: 0x006fb38baf7a14acc032ff556c2791b03292861581572d02296c5093fd16cafb, class hash: 0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:56:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1700)\nUnknown location (pc=0:1655)\nError message: multicall 405852601487139132244494309743039711091605094719341446212637486410648343561 failed\nUnknown location (pc=0:179)\n\n2: Error in the called contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x070cdfaea3ec997bd3a8cdedfc0ffe804a58afc3d6b5a6e5c0218ec233ceea6d, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nError at pc=0:32:\nCairo traceback (most recent call last):\nUnknown location (pc=0:1683)\nUnknown location (pc=0:1669)\n\n3: Error in a library call (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\nExecution failed. Failure reason:\nError in contract (contract address: 0x046e9237f5408b5f899e72125dd69bd55485a287aaf24663d3ebe00d237fc7ef, class hash: 0x0358663e6ed9d37efd33d4661e20b2bad143e0f92076b0c91fe65f31ccf55046, selector: 0x00e5b455a836c7a254df57ed39d023d46b641b331162c6c0b369647056655409):\n0x4661696c656420746f20646573657269616c697a6520706172616d202333 ('Failed to deserialize param #3').\n";
+
+        let result = revert_error.format_for_receipt().to_string();
+
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
# RevertError for removing VM tracebacks

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

The current implementation uses string-based parsing to filter redundant VM tracebacks from transaction revert errors. The `format_revert_error()` function parses error strings line-by-line, looking for patterns to identify and filter VM tracebacks. This approach is fragile and difficult to maintain as error formats evolve.

Resolves: #NA

## What is the new behavior?

Refactored VM traceback filtering to use blockifier's typed `RevertError` structure instead of string parsing:

- Added `RevertErrorExt` trait that provides a `format_properly()` method for `RevertError`
- Replaced 195 lines of string parsing logic with structured error stack traversal
- Updated execution to call `format_properly()` on `RevertError` before converting to string
- Enhanced tests to construct proper typed error structures instead of parsing strings
- Added `testing` feature to blockifier dependency

The filtering logic remains unchanged:
- Removes VM tracebacks from nested `CallContract` entries
- Keeps VM tracebacks for the last `CallContract` before a `LibraryCall` or final error
- Always preserves VM tracebacks belonging to `LibraryCall` entries

**Benefits:**
- Type-safe: Works directly with blockifier's error types
- More maintainable: Changes to error format are handled automatically
- Clearer logic: Structured traversal is easier to understand than string parsing

## Does this introduce a breaking change?

No

This is an internal refactoring that maintains the same user-facing error message format.

## Other information

This implementation requires the "testing" feature in blockifier to have ability to `clone` `TransactionExecutionInfo`.