### PR TITLE
Fix test CLI

### DIFF
--- a/.github/workflows/task-test-cli.yml
+++ b/.github/workflows/task-test-cli.yml
@@ -1,11 +1,9 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
 name: Task - Run CLI tests
-
 on:
   workflow_dispatch:
   workflow_call:
-
 jobs:
   test-cli:
     runs-on: blacksmith-16vcpu-ubuntu-2204
@@ -14,24 +12,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-
       - name: Load env
         uses: ./.github/actions/load-env
-
       - name: Rust setup
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: madara-${{ runner.os }}
-
       - name: Run cli without arguments
+        timeout-minutes: 10
         run: |
           CARGO_TARGET_DIR=target cargo run --manifest-path madara/Cargo.toml --bin madara --release -- --no-l1-sync --devnet &
           MADARA_PID=$!
           while ! echo exit | nc localhost 9944; do sleep 1; done
           kill $MADARA_PID
-
       - name: Run cli pointing to a file
+        timeout-minutes: 10
         run: |
           CARGO_TARGET_DIR=target cargo run --manifest-path madara/Cargo.toml --bin madara --release -- --no-l1-sync --devnet --config-file ./configs/args/config.json &
           MADARA_PID=$!

--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -27,7 +27,9 @@
     "db_memtable_blocks_budget_mib": 1024,
     "db_memtable_contracts_budget_mib": 128,
     "db_memtable_other_budget_mib": 128,
-    "db_memtable_prefix_bloom_filter_ratio": 0
+    "db_memtable_prefix_bloom_filter_ratio": 0,
+    "db_wal": true,
+    "db_fsync": false
   },
   "l2_sync_params": {
     "l2_sync_disabled": false,


### PR DESCRIPTION
Pull Request type

- [x] Bugfix

## What is the current behavior?

Resolves: #NA

The config file `configs/args/config.json` was missing the newly added `db_wal` and `db_fsync` fields, causing the CLI test workflow to fail when running with the config file option.

## What is the new behavior?

- Added `db_wal: true` to the config file (enables Write-Ahead Log for crash recovery)
- Added `db_fsync: false` to the config file (balances performance and durability)

These fields were introduced in commit 152fd5f4d (#844) but the example config file was not updated accordingly.

## Does this introduce a breaking change?

No

## Other information

The `db_wal` and `db_fsync` fields control RocksDB write behavior:
- `db_wal: true` - Enables Write-Ahead Log for crash recovery (recommended for production)
- `db_fsync: false` - Disables fsync for better performance while maintaining crash safety (good balance for most use cases)