### PR TITLE
fix: onchain data calculation is dead code

### DIFF
--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -10,7 +10,7 @@ use crate::types::jobs::metadata::{JobMetadata, JobSpecificMetadata, SnosMetadat
 use crate::types::jobs::status::JobVerificationStatus;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::worker::event_handler::jobs::JobHandlerTrait;
-use crate::worker::utils::fact_info::{build_on_chain_data, get_fact_info, get_fact_l2, get_program_output};
+use crate::worker::utils::fact_info::{get_fact_info, get_fact_l2, get_program_output};
 use async_trait::async_trait;
 use bytes::Bytes;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
@@ -180,11 +180,7 @@ impl JobHandlerTrait for SnosJobHandler {
         }
 
         debug!("Storing SNOS outputs");
-        if config.layer() == &Layer::L3 {
-            // Store the on-chain data path
-            self.store_l2(internal_id.clone(), config.storage(), &snos_metadata, cairo_pie, os_output, program_output)
-                .await?;
-        } else if config.layer() == &Layer::L2 {
+        if config.layer() == &Layer::L2 {
             // Store the Cairo Pie path
             self.store(internal_id.clone(), config.storage(), &snos_metadata, cairo_pie, os_output, program_output)
                 .await?;
@@ -218,38 +214,6 @@ impl JobHandlerTrait for SnosJobHandler {
 }
 
 impl SnosJobHandler {
-    /// Stores the [CairoPie] and the [StarknetOsOutput] and [OnChainData] in the Data Storage.
-    /// The paths will be:
-    ///     - [block_number]/cairo_pie.zip
-    ///     - [block_number]/snos_output.json
-    ///     - [block_number]/onchain_data.json
-    ///     - [block_number]/program_output.json
-    async fn store_l2(
-        &self,
-        internal_id: String,
-        data_storage: &dyn StorageClient,
-        snos_metadata: &SnosMetadata,
-        cairo_pie: CairoPie,
-        snos_output: Vec<Felt>,
-        program_output: Vec<Felt252>,
-    ) -> Result<(), SnosError> {
-        let on_chain_data = build_on_chain_data(&cairo_pie)
-            .map_err(|_e| SnosError::FactCalculationError(FactError::OnChainDataCompute))?;
-
-        self.store(internal_id.clone(), data_storage, snos_metadata, cairo_pie, snos_output, program_output).await?;
-        let on_chain_data_key = snos_metadata
-            .on_chain_data_path
-            .as_ref()
-            .ok_or_else(|| SnosError::Other(OtherError(eyre!("OnChain data path is not found"))))?;
-
-        let on_chain_data_vec = serde_json::to_vec(&on_chain_data).map_err(|e| {
-            SnosError::OnChainDataUnserializable { internal_id: internal_id.to_string(), message: e.to_string() }
-        })?;
-        data_storage.put_data(on_chain_data_vec.into(), on_chain_data_key).await.map_err(|e| {
-            SnosError::OnChainDataUnstorable { internal_id: internal_id.to_string(), message: e.to_string() }
-        })?;
-        Ok(())
-    }
     /// Stores the [CairoPie] and the [StarknetOsOutput] in the Data Storage.
     /// The paths will be:
     ///     - [block_number]/cairo_pie.zip

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -180,11 +180,8 @@ impl JobHandlerTrait for SnosJobHandler {
         }
 
         debug!("Storing SNOS outputs");
-        if config.layer() == &Layer::L2 {
-            // Store the Cairo Pie path
-            self.store(internal_id.clone(), config.storage(), &snos_metadata, cairo_pie, os_output, program_output)
-                .await?;
-        }
+        // Store the Cairo Pie path
+        self.store(internal_id.clone(), config.storage(), &snos_metadata, cairo_pie, os_output, program_output).await?;
 
         info!(log_type = "completed", job_id = %job.id, "✅ {:?} job {} processed successfully", JobType::SnosRun, internal_id);
 

--- a/orchestrator/src/worker/utils/fact_info.rs
+++ b/orchestrator/src/worker/utils/fact_info.rs
@@ -95,16 +95,6 @@ pub fn get_fact_l2(cairo_pie: &CairoPie, program_hash: Option<Felt>) -> color_ey
     Ok(B256::from_slice(&fact_hash.to_bytes_be()))
 }
 
-pub fn build_on_chain_data(cairo_pie: &CairoPie) -> color_eyre::Result<OnChainData> {
-    let program_output = get_program_output(cairo_pie, false)?;
-    let fact_topology = get_fact_topology(cairo_pie, program_output.len())?;
-    let fact_root = generate_merkle_root(&program_output, &fact_topology)?;
-
-    let da_child = fact_root.children.last().expect("fact_root is empty");
-
-    Ok(OnChainData { on_chain_data_hash: da_child.node_hash, on_chain_data_size: da_child.page_size })
-}
-
 pub fn get_fact_info(
     cairo_pie: &CairoPie,
     program_hash: Option<Felt>,

--- a/orchestrator/src/worker/utils/fact_info.rs
+++ b/orchestrator/src/worker/utils/fact_info.rs
@@ -281,7 +281,7 @@ mod tests {
     use cairo_vm::vm::runners::cairo_pie::CairoPie;
     use rstest::rstest;
 
-    use super::get_fact_info;
+    use super::{get_fact_info, get_program_output};
 
     #[rstest]
     #[case("fibonacci.zip", "0xca15503f02f8406b599cb220879e842394f5cf2cef753f3ee430647b5981b782")]
@@ -294,5 +294,17 @@ mod tests {
         let cairo_pie = CairoPie::read_zip_file(&cairo_pie_path).unwrap();
         let fact_info = get_fact_info(&cairo_pie, None, false).unwrap();
         assert_eq!(expected_fact, fact_info.fact.to_string());
+    }
+
+    #[ignore]
+    #[rstest]
+    #[case("0.zip")]
+    async fn test_program_output(#[case] cairo_pie_path: &str) {
+        dotenvy::from_filename_override("../.env.test").expect("Failed to load the .env.test file");
+        let cairo_pie_path: PathBuf =
+            [env!("CARGO_MANIFEST_DIR"), "src", "tests", "artifacts", cairo_pie_path].iter().collect();
+        let cairo_pie = CairoPie::read_zip_file(&cairo_pie_path).unwrap();
+        let program_output = get_program_output(&cairo_pie, false).unwrap();
+        println!("the program output is {:?}", program_output);
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

- Onchain data hash/size calculation is dead code and is not required now
- Also, when and l3 chain is run with `use_kzg_da`: true, this breaks with not able to find `fact_root`

## What is the new behavior?
- Removes onchain data hash and size calculation.

## Does this introduce a breaking change?

- No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->
