### PR TITLE
Fix/blob-settlement

### DIFF
--- a/orchestrator/src/worker/event_handler/jobs/state_update.rs
+++ b/orchestrator/src/worker/event_handler/jobs/state_update.rs
@@ -381,7 +381,6 @@ impl StateUpdateJobHandler {
         Ok(())
     }
 
-
     /// Parent method to update state based on the layer being used
     /// The layer decides if we want to update the state using Blob or DA
     async fn update_state(
@@ -478,14 +477,8 @@ impl StateUpdateJobHandler {
             let snos_output = vec_felt_to_vec_bytes32(calculate_output(parsed_snos_proof.clone()));
             let program_output = vec_felt_to_vec_bytes32(calculate_output(parsed_bridge_proof));
 
-            let onchain_data = self.fetch_onchain_data_for_block(block_no, config.clone()).await;
             settlement_client
-                .update_state_calldata(
-                    snos_output,
-                    program_output,
-                    [0u8; 32],
-                    [0u8; 32],
-                )
+                .update_state_calldata(snos_output, program_output, [0u8; 32], [0u8; 32])
                 .await
                 .map_err(|e| JobError::Other(OtherError(e)))?
         } else {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Fix L3 settlement when KZG DA flag is enabled

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

When running an L3 chain with the KZG DA flag enabled (`use_kzg_da = 1`), settlement breaks because the code attempts to use blob-based settlement (`update_state_with_blobs`) which is not supported by L3 core contracts. The L3 settlement logic previously only handled the case where `use_kzg_da = 0`, and when the flag was set to `1`, it would incorrectly try to use blob settlement, causing the settlement process to fail.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- L3 chains now always use calldata-based settlement regardless of the KZG DA flag value (0 or 1)
- The condition for L3 state updates now accepts both `Felt::ZERO` and `Felt::ONE` for the `use_kzg_da` flag
- Removed the blob-based settlement path for L3 chains that was causing failures
- Simplified the calldata update by removing unused onchain data fetching logic
- Added documentation comments explaining that L3 core contracts do not support blobs and always require calldata for state updates

## Does this introduce a breaking change?

<!-- Yes or No -->

No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- If you modify database schema, ensure you:

     1. Add the 'db-migration label to the PR

     2. Document the schema changes

     3. Provide migration instructions if needed

-->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

This fix ensures that L3 chains can successfully perform state updates to the settlement layer even when KZG DA is enabled. The core contract for L3 chains does not support blob transactions, so all state updates must use calldata. When KZG DA is enabled on L3, this configuration effectively provides private DA functionality, as the state diff is not included in the snos_output while still maintaining the ability to update state on the settlement layer.

