### PR TITLE
feat: L1→L2 Message Finality Support

### DIFF
--- a/configs/presets/devnet.yaml
+++ b/configs/presets/devnet.yaml
@@ -32,7 +32,7 @@ bouncer_config:
       mul_mod: 604
       range_check96: 56
 sequencer_address: "0x123"
-eth_core_contract_address: "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+eth_core_contract_address: "0x003f5ea0ec5fad0b020839fec467a872a620e6be6093801a5ac92b1e58d0d33a"
 eth_gps_statement_verifier: "0xf294781D719D2F4169cE54469C28908E6FA752C1"
 mempool_max_transactions: 10000
 mempool_max_declare_transactions: 20

--- a/configs/presets/devnet.yaml
+++ b/configs/presets/devnet.yaml
@@ -32,7 +32,7 @@ bouncer_config:
       mul_mod: 604
       range_check96: 56
 sequencer_address: "0x123"
-eth_core_contract_address: "0x003f5ea0ec5fad0b020839fec467a872a620e6be6093801a5ac92b1e58d0d33a"
+eth_core_contract_address: "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
 eth_gps_statement_verifier: "0xf294781D719D2F4169cE54469C28908E6FA752C1"
 mempool_max_transactions: 10000
 mempool_max_declare_transactions: 20

--- a/madara/crates/primitives/chain_config/src/chain_config.rs
+++ b/madara/crates/primitives/chain_config/src/chain_config.rs
@@ -677,6 +677,8 @@ impl ChainConfig {
             )
             .try_into()
             .unwrap(),
+            // Disable finality for fast test execution
+            l1_messages_finality_blocks: 0,
             ..ChainConfig::starknet_sepolia()
         }
     }

--- a/madara/crates/primitives/chain_config/src/chain_config.rs
+++ b/madara/crates/primitives/chain_config/src/chain_config.rs
@@ -138,6 +138,9 @@ fn default_block_time() -> Duration {
 fn default_l1_messages_replay_max_duration() -> Duration {
     Duration::from_secs(3 * 24 * 60 * 60)
 }
+fn default_l1_messages_finality_blocks() -> u64 {
+    10 // Default: wait for 10 L1 blocks before processing messages (~2 minutes on Ethereum)
+}
 fn default_mempool_min_tip_bump() -> f64 {
     0.1
 }
@@ -292,6 +295,13 @@ pub struct ChainConfigV1 {
         serialize_with = "serialize_duration"
     )]
     pub l1_messages_replay_max_duration: Duration,
+
+    /// Number of L1 blocks to wait before considering a message finalized.
+    /// This provides protection against L1 chain reorganizations.
+    /// Default: 0 (rely on L1's "finalized" block tag).
+    /// Recommended: 12 for Ethereum mainnet (~2.5 minutes).
+    #[serde(default = "default_l1_messages_finality_blocks")]
+    pub l1_messages_finality_blocks: u64,
 }
 
 /// Versioned chain config enum that handles different config versions
@@ -408,6 +418,13 @@ pub struct ChainConfig {
         serialize_with = "serialize_duration"
     )]
     pub l1_messages_replay_max_duration: Duration,
+
+    /// Number of L1 blocks to wait before considering a message finalized.
+    /// This provides protection against L1 chain reorganizations.
+    /// Default: 0 (rely on L1's "finalized" block tag).
+    /// Recommended: 12 for Ethereum mainnet (~2.5 minutes).
+    #[serde(default = "default_l1_messages_finality_blocks")]
+    pub l1_messages_finality_blocks: u64,
 }
 
 impl Clone for ChainConfig {
@@ -442,6 +459,7 @@ impl Clone for ChainConfig {
             l2_gas_price: self.l2_gas_price.clone(),
             block_production_concurrency: self.block_production_concurrency.clone(),
             l1_messages_replay_max_duration: self.l1_messages_replay_max_duration,
+            l1_messages_finality_blocks: self.l1_messages_finality_blocks,
         }
     }
 }
@@ -479,6 +497,7 @@ impl TryFrom<ChainConfigV1> for ChainConfig {
             l2_gas_price: v1.l2_gas_price,
             block_production_concurrency: v1.block_production_concurrency,
             l1_messages_replay_max_duration: v1.l1_messages_replay_max_duration,
+            l1_messages_finality_blocks: v1.l1_messages_finality_blocks,
         })
     }
 }
@@ -601,6 +620,7 @@ impl ChainConfig {
             block_production_concurrency: BlockProductionConfig::default(),
 
             l1_messages_replay_max_duration: default_l1_messages_replay_max_duration(),
+            l1_messages_finality_blocks: default_l1_messages_finality_blocks(),
         }
     }
 

--- a/madara/node/src/cli/chain_config_overrides.rs
+++ b/madara/node/src/cli/chain_config_overrides.rs
@@ -204,6 +204,7 @@ impl ChainConfigOverrideParams {
             no_empty_blocks: chain_config_overrides.no_empty_blocks,
             block_production_concurrency: chain_config_overrides.block_production_concurrency,
             l1_messages_replay_max_duration: chain_config_overrides.l1_messages_replay_max_duration,
+            l1_messages_finality_blocks: chain_config.l1_messages_finality_blocks,
         })
     }
 }


### PR DESCRIPTION

### Description

Adds configurable finality checking for L1→L2 messages to ensure messages are only processed after reaching sufficient block confirmations.

#### Changes

**Core Logic (`messaging.rs`)**
- Messages are now queued in a `VecDeque` and processed only after reaching the required finality threshold
- Uses `tokio::select!` to poll the stream while periodically checking finality on queued events
- Refactored into helper functions: `get_start_block()`, `process_finalized_events()`

**Configuration (`chain_config.rs`)**
- Added `l1_messages_finality_blocks` parameter (default: 10 blocks)
- Configurable per-chain via preset files

**Tests**
- Added `test_finality_blocks_delays_processing` - verifies messages wait for finality
- Added `test_finality_blocks_processes_after_threshold` - verifies messages process after reaching finality

#### Behavior

```
L1 Event (block 100) → Queue → Wait for finality
                              ↓
              Latest L1 block reaches 110 (10 confirmations)
                              ↓
                    Process & store message
```

#### Why

Prevents processing L1 messages from blocks that could be reorged, ensuring message integrity.

---