### PR TITLE
fix: send fee_token_address while creating Atlantic bucket

### DIFF
--- a/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
@@ -188,6 +188,7 @@ impl AtlanticClient {
         atlantic_api_key: impl AsRef<str>,
         mock_proof: bool,
         chain_id_hex: Option<String>,
+        fee_token_address: Option<String>,
     ) -> Result<AtlanticBucketResponse, AtlanticError> {
         // TODO(prakhar,19/11/2025): Use the aggregator version calculated from Madara Version being passed through ENV
         let response = self
@@ -206,6 +207,7 @@ impl AtlanticClient {
                     use_kzg_da: AGGREGATOR_USE_KZG_DA,
                     full_output: AGGREGATOR_FULL_OUTPUT,
                     chain_id_hex,
+                    fee_token_address,
                 },
                 mock_proof,
             })

--- a/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use cairo_vm::types::layout_name::LayoutName;
+use cairo_vm::Felt252;
 use orchestrator_utils::http_client::extract_http_error_text;
 use orchestrator_utils::http_client::{HttpClient, RequestBuilder};
 use reqwest::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
@@ -183,7 +184,7 @@ impl AtlanticClient {
     /// Initially, the bucket will be empty when created.
     /// The `bucket_id` returned from here will be used to add child jobs to this bucket.
     /// A new bucket is created when creating a new batch in Batching worker.
-    /// 
+    ///
     // TODO(Mohit,01/12/2025): We should have an AggregatorInput struct here for args, based on:
     // https://github.com/starkware-libs/sequencer/blob/main-v0.14.1/crates/starknet_os/src/hint_processor/aggregator_hint_processor.rs#L42-L52
     // For 0.14.1, we would need to send the public_keys as well.
@@ -192,7 +193,7 @@ impl AtlanticClient {
         atlantic_api_key: impl AsRef<str>,
         mock_proof: bool,
         chain_id_hex: Option<String>,
-        fee_token_address: Option<String>,
+        fee_token_address: Option<Felt252>,
     ) -> Result<AtlanticBucketResponse, AtlanticError> {
         // TODO(prakhar,19/11/2025): Use the aggregator version calculated from Madara Version being passed through ENV
         let response = self

--- a/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
@@ -183,6 +183,10 @@ impl AtlanticClient {
     /// Initially, the bucket will be empty when created.
     /// The `bucket_id` returned from here will be used to add child jobs to this bucket.
     /// A new bucket is created when creating a new batch in Batching worker.
+    /// 
+    // TODO(Mohit,01/12/2025): We should have an AggregatorInput struct here for args, based on:
+    // https://github.com/starkware-libs/sequencer/blob/main-v0.14.1/crates/starknet_os/src/hint_processor/aggregator_hint_processor.rs#L42-L52
+    // For 0.14.1, we would need to send the public_keys as well.
     pub async fn create_bucket(
         &self,
         atlantic_api_key: impl AsRef<str>,

--- a/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
@@ -9,6 +9,7 @@ pub use crate::types::AtlanticQueryStatus;
 use alloy::primitives::B256;
 use async_trait::async_trait;
 use cairo_vm::types::layout_name::LayoutName;
+use cairo_vm::Felt252;
 use orchestrator_gps_fact_checker::FactChecker;
 use orchestrator_prover_client_interface::{
     CreateJobInfo, ProverClient, ProverClientError, Task, TaskStatus, TaskType,
@@ -51,7 +52,7 @@ pub struct AtlanticProverService {
     pub result: AtlanticQueryStep,
     pub cairo_verifier_program_hash: Option<String>,
     pub chain_id_hex: Option<String>,
-    pub fee_token_address: Option<String>,
+    pub fee_token_address: Option<Felt252>,
 }
 
 #[async_trait]
@@ -96,7 +97,12 @@ impl ProverClient for AtlanticProverService {
             Task::CreateBucket => {
                 let response = self
                     .atlantic_client
-                    .create_bucket(self.atlantic_api_key.clone(), self.should_mock_proof(), self.chain_id_hex.clone(), self.fee_token_address.clone())
+                    .create_bucket(
+                        self.atlantic_api_key.clone(),
+                        self.should_mock_proof(),
+                        self.chain_id_hex.clone(),
+                        self.fee_token_address,
+                    )
                     .await?;
                 tracing::debug!(bucket_id = %response.atlantic_bucket.id, "Successfully submitted create bucket task to atlantic: {:?}", response);
                 Ok(response.atlantic_bucket.id)
@@ -277,7 +283,7 @@ impl AtlanticProverService {
         fact_checker: Option<FactChecker>,
         mock_fact_hash: bool,
         cairo_verifier_program_hash: Option<String>,
-        fee_token_address: Option<String>,
+        fee_token_address: Option<Felt252>,
     ) -> Self {
         Self {
             atlantic_client,
@@ -309,7 +315,7 @@ impl AtlanticProverService {
         atlantic_params: &AtlanticValidatedArgs,
         proof_layout: &LayoutName,
         chain_id_hex: Option<String>,
-        fee_token_address: Option<String>,
+        fee_token_address: Option<Felt252>,
     ) -> Self {
         let atlantic_client =
             AtlanticClient::new_with_args(atlantic_params.atlantic_service_url.clone(), atlantic_params);

--- a/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
@@ -51,6 +51,7 @@ pub struct AtlanticProverService {
     pub result: AtlanticQueryStep,
     pub cairo_verifier_program_hash: Option<String>,
     pub chain_id_hex: Option<String>,
+    pub fee_token_address: Option<String>,
 }
 
 #[async_trait]
@@ -95,7 +96,7 @@ impl ProverClient for AtlanticProverService {
             Task::CreateBucket => {
                 let response = self
                     .atlantic_client
-                    .create_bucket(self.atlantic_api_key.clone(), self.should_mock_proof(), self.chain_id_hex.clone())
+                    .create_bucket(self.atlantic_api_key.clone(), self.should_mock_proof(), self.chain_id_hex.clone(), self.fee_token_address.clone())
                     .await?;
                 tracing::debug!(bucket_id = %response.atlantic_bucket.id, "Successfully submitted create bucket task to atlantic: {:?}", response);
                 Ok(response.atlantic_bucket.id)
@@ -276,6 +277,7 @@ impl AtlanticProverService {
         fact_checker: Option<FactChecker>,
         mock_fact_hash: bool,
         cairo_verifier_program_hash: Option<String>,
+        fee_token_address: Option<String>,
     ) -> Self {
         Self {
             atlantic_client,
@@ -288,6 +290,7 @@ impl AtlanticProverService {
             result: job_config.result,
             cairo_verifier_program_hash,
             chain_id_hex: job_config.chain_id_hex,
+            fee_token_address,
         }
     }
 
@@ -297,6 +300,8 @@ impl AtlanticProverService {
     /// # Arguments
     /// * `atlantic_params` - The parameters for the Atlantic service.
     /// * `proof_layout` - The layout name for the proof.
+    /// * `chain_id_hex` - The chain ID in hex format.
+    /// * `fee_token_address` - The fee token address.
     ///
     /// # Returns
     /// * `AtlanticProverService` - A new instance of the service.
@@ -304,6 +309,7 @@ impl AtlanticProverService {
         atlantic_params: &AtlanticValidatedArgs,
         proof_layout: &LayoutName,
         chain_id_hex: Option<String>,
+        fee_token_address: Option<String>,
     ) -> Self {
         let atlantic_client =
             AtlanticClient::new_with_args(atlantic_params.atlantic_service_url.clone(), atlantic_params);
@@ -323,6 +329,7 @@ impl AtlanticProverService {
             fact_checker,
             atlantic_params.atlantic_mock_fact_hash.eq("true"),
             atlantic_params.cairo_verifier_program_hash.clone(),
+            fee_token_address,
         )
     }
 
@@ -344,6 +351,7 @@ impl AtlanticProverService {
             },
             fact_checker,
             atlantic_params.atlantic_mock_fact_hash.eq("true"),
+            None,
             None,
         )
     }

--- a/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
@@ -136,6 +136,8 @@ pub struct AtlanticAggregatorParams {
     pub(crate) full_output: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) chain_id_hex: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fee_token_address: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
@@ -1,3 +1,4 @@
+use cairo_vm::Felt252;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -137,7 +138,7 @@ pub struct AtlanticAggregatorParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) chain_id_hex: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) fee_token_address: Option<String>,
+    pub(crate) fee_token_address: Option<Felt252>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
@@ -79,7 +79,7 @@ async fn atlantic_client_get_task_status_works() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
     };
-    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None);
+    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None);
 
     let atlantic_query_id = "01JPMKV7WFP4JTC0TTQSEAM9GW";
     let task_result = atlantic_service.atlantic_client.get_job_status(atlantic_query_id).await;
@@ -105,7 +105,7 @@ async fn atlantic_client_get_bucket_status_works() {
         atlantic_cairo_vm: AtlanticCairoVm::Python,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
     };
-    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None);
+    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None);
 
     let bucket_id = "01K0RN2JFJW3382CZPHRBC48NR";
     let task_result = atlantic_service.atlantic_client.get_bucket(bucket_id).await;
@@ -135,7 +135,7 @@ async fn atlantic_client_submit_task_and_get_job_status_with_mock_fact_hash() {
     };
 
     // Create the Atlantic service with actual configuration
-    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None);
+    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None);
 
     // Load the Cairo PIE from the test data
     let cairo_pie_path = env!("CARGO_MANIFEST_DIR").to_string() + CAIRO_PIE_PATH;

--- a/orchestrator/src/core/config.rs
+++ b/orchestrator/src/core/config.rs
@@ -253,6 +253,7 @@ impl Config {
                     .map_err(|e| OrchestratorError::ConfigError(format!("Failed to get Chain ID from RPC: {}", e)))?
                     .to_fixed_hex_string(),
             ),
+            Some(params.snos_config.strk_fee_token_address.clone()),
         );
         let da_client = Self::build_da_client(&da_config).await;
         let settlement_client = Self::build_settlement_client(&settlement_config).await?;
@@ -318,12 +319,16 @@ impl Config {
     ///
     /// # Arguments
     /// * `prover_params` - The proving service parameters
+    /// * `params` - The config parameters
+    /// * `chain_id_hex` - The chain ID in hex format
+    /// * `fee_token_address` - The fee token address
     /// # Returns
     /// * `Box<dyn ProverClient>` - The proving service
     pub(crate) fn build_prover_service(
         prover_params: &ProverConfig,
         params: &ConfigParam,
         chain_id_hex: Option<String>,
+        fee_token_address: Option<String>,
     ) -> Box<dyn ProverClient + Send + Sync> {
         match prover_params {
             ProverConfig::Sharp(sharp_params) => {
@@ -333,6 +338,7 @@ impl Config {
                 atlantic_params,
                 &params.prover_layout_name,
                 chain_id_hex,
+                fee_token_address,
             )),
         }
     }

--- a/orchestrator/src/core/config.rs
+++ b/orchestrator/src/core/config.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "testing")]
 use alloy::providers::ProviderBuilder;
+use cairo_vm::Felt252;
 
 use crate::utils::rest_client::RestClient;
 use anyhow::Context;
@@ -253,9 +254,9 @@ impl Config {
                     .map_err(|e| OrchestratorError::ConfigError(format!("Failed to get Chain ID from RPC: {}", e)))?
                     .to_fixed_hex_string(),
             ),
-            Some(params.snos_config.strk_fee_token_address.clone()),
+            Some(Felt252::from_str(params.snos_config.strk_fee_token_address.clone().as_str())?),
         );
-        let da_client = Self::build_da_client(&da_config).await;
+        let da_client: Box<dyn DaClient + Send + Sync + 'static> = Self::build_da_client(&da_config).await;
         let settlement_client = Self::build_settlement_client(&settlement_config).await?;
 
         Ok(Self {
@@ -328,7 +329,7 @@ impl Config {
         prover_params: &ProverConfig,
         params: &ConfigParam,
         chain_id_hex: Option<String>,
-        fee_token_address: Option<String>,
+        fee_token_address: Option<Felt252>,
     ) -> Box<dyn ProverClient + Send + Sync> {
         match prover_params {
             ProverConfig::Sharp(sharp_params) => {

--- a/orchestrator/src/error/mod.rs
+++ b/orchestrator/src/error/mod.rs
@@ -11,6 +11,7 @@ use aws_sdk_sqs::operation::set_queue_attributes::SetQueueAttributesError;
 use mongodb::bson;
 use opentelemetry_otlp::ExporterBuildError;
 use opentelemetry_sdk::trace::TraceError;
+use starknet_core::types::FromStrError;
 use thiserror::Error;
 
 use crate::core::client::alert::AlertError;
@@ -53,6 +54,10 @@ pub enum OrchestratorError {
     /// Setup Command error
     #[error("Error While Downcasting from object: {0}")]
     FromDownstreamError(String),
+
+    /// Felt conversion error
+    #[error("Felt conversion error: {0}")]
+    FeltConversionError(#[from] FromStrError),
 
     #[error("Orchestrator Error: {0}")]
     OrchestratorAnyHowError(#[from] anyhow::Error),

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -509,7 +509,7 @@ pub mod implement_client {
         match service {
             ConfigType::Mock(client) => client.into(),
             ConfigType::Actual => {
-                Config::build_prover_service(&params.prover_params, &params.orchestrator_params, None)
+                Config::build_prover_service(&params.prover_params, &params.orchestrator_params, None, None)
             }
             ConfigType::Dummy => Box::new(MockProverClient::new()),
         }


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

When creating a bucket with the Atlantic prover service, the `fee_token_address` is not being sent in the `aggregator_params`. This is required by the Atlantic API for proper bucket creation.

Resolves: MDR-655

## What is the new behavior?

- Added `fee_token_address` field to `AtlanticAggregatorParams` struct
- Updated `create_bucket` function to accept and pass `fee_token_address` parameter
- Updated `AtlanticProverService` to store and pass `fee_token_address` when creating buckets
- The `strk_fee_token_address` from SNOS config is now passed when building the prover service

The bucket creation request now includes `fee_token_address` in the `aggregator_params`:
```json
{
  "aggregator_params": {
    "use_kzg_da": true,
    "full_output": false,
    "chain_id_hex": "0x...",
    "fee_token_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
  }
}
```

## Does this introduce a breaking change?

No

## Other information

Files modified:
- `orchestrator/crates/prover-clients/atlantic-service/src/types.rs`
- `orchestrator/crates/prover-clients/atlantic-service/src/client.rs`
- `orchestrator/crates/prover-clients/atlantic-service/src/lib.rs`
- `orchestrator/src/core/config.rs`
- `orchestrator/src/tests/config.rs`
- `orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs`