### PR TITLE
fix: max concurrent flag not being applied from CLI args

### DIFF
--- a/orchestrator/src/types/queue_control.rs
+++ b/orchestrator/src/types/queue_control.rs
@@ -1,6 +1,5 @@
 use crate::types::queue::QueueType;
 use crate::types::Layer;
-use orchestrator_utils::env_utils::get_env_var_or_default;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
@@ -39,8 +38,8 @@ pub struct QueueConfig {
     pub supported_layers: Vec<Layer>,
 }
 
-// TODO: this should be dynamically created based on the run command params.
-// So that we can skip parsing envs here again
+// Note: max_message_count values set here are defaults. They can be overridden
+// via CLI/config args in EventWorker::new() using config.service_config()
 pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| {
     let mut map = HashMap::new();
     map.insert(
@@ -66,9 +65,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
         QueueConfig {
             visibility_timeout: 300,
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
-            queue_control: QueueControlConfig::default_with_message_count(
-                get_env_var_or_default("MADARA_ORCHESTRATOR_MAX_CONCURRENT_SNOS_JOBS", "5").parse().expect("MADARA_ORCHESTRATOR_MAX_CONCURRENT_SNOS_JOBS does not have correct value. Should be a whole number"),
-            ),
+            queue_control: QueueControlConfig::default_with_message_count(5),
             supported_layers: vec![Layer::L2, Layer::L3],
         },
     );
@@ -86,9 +83,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
         QueueConfig {
             visibility_timeout: 300,
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
-            queue_control: QueueControlConfig::default_with_message_count(
-                get_env_var_or_default("MADARA_ORCHESTRATOR_MAX_CONCURRENT_PROVING_JOBS", "10").parse().expect("MADARA_ORCHESTRATOR_MAX_CONCURRENT_PROVING_JOBS does not have correct value. Should be a whole number"),
-            ),
+            queue_control: QueueControlConfig::default_with_message_count(10),
             supported_layers: vec![Layer::L2, Layer::L3],
         },
     );

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -51,27 +51,19 @@ impl EventWorker {
         // Override with service config values if provided via CLI/env args
         // This ensures CLI arguments like --max-concurrent-snos-jobs actually take effect
         let service_config = config.service_config();
-        match queue_type {
-            QueueType::SnosJobProcessing => {
-                if let Some(max_concurrent) = service_config.max_concurrent_snos_jobs {
-                    info!(
-                        "Overriding SnosJobProcessing max_message_count from {} to {} (from service config)",
-                        queue_control.max_message_count, max_concurrent
-                    );
-                    queue_control.max_message_count = max_concurrent;
-                }
-            }
-            QueueType::ProvingJobProcessing => {
-                if let Some(max_concurrent) = service_config.max_concurrent_proving_jobs {
-                    info!(
-                        "Overriding ProvingJobProcessing max_message_count from {} to {} (from service config)",
-                        queue_control.max_message_count, max_concurrent
-                    );
-                    queue_control.max_message_count = max_concurrent;
-                }
-            }
-            _ => {}
-        }
+let override_val = match queue_type {
+    QueueType::SnosJobProcessing => service_config.max_concurrent_snos_jobs,
+    QueueType::ProvingJobProcessing => service_config.max_concurrent_proving_jobs,
+    _ => None,
+};
+
+if let Some(max_concurrent) = override_val {
+    info!(
+        "Overriding {:?} max_message_count from {} to {} (from service config)",
+        queue_type, queue_control.max_message_count, max_concurrent
+    );
+    queue_control.max_message_count = max_concurrent;
+}
 
         Ok(Self { queue_type, config, queue_control, cancellation_token })
     }

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -50,20 +50,19 @@ impl EventWorker {
 
         // Override with service config values if provided via CLI/env args
         // This ensures CLI arguments like --max-concurrent-snos-jobs actually take effect
-        let service_config = config.service_config();
-let override_val = match queue_type {
-    QueueType::SnosJobProcessing => service_config.max_concurrent_snos_jobs,
-    QueueType::ProvingJobProcessing => service_config.max_concurrent_proving_jobs,
-    _ => None,
-};
+        let override_val = match queue_type {
+            QueueType::SnosJobProcessing => config.service_config().max_concurrent_snos_jobs,
+            QueueType::ProvingJobProcessing => config.service_config().max_concurrent_proving_jobs,
+            _ => None,
+        };
 
-if let Some(max_concurrent) = override_val {
-    info!(
-        "Overriding {:?} max_message_count from {} to {} (from service config)",
-        queue_type, queue_control.max_message_count, max_concurrent
-    );
-    queue_control.max_message_count = max_concurrent;
-}
+        if let Some(max_concurrent) = override_val {
+            info!(
+                "Overriding {:?} max_message_count from {} to {} (from service config)",
+                queue_type, queue_control.max_message_count, max_concurrent
+            );
+            queue_control.max_message_count = max_concurrent;
+        }
 
         Ok(Self { queue_type, config, queue_control, cancellation_token })
     }


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix

## What is the current behavior?

CLI arguments `--max-concurrent-snos-jobs` and `--max-concurrent-proving-jobs` were not being applied to the event worker queue control, causing the flags to have no effect.

Resolves: #NA

## What is the new behavior?

- Override queue control `max_message_count` with service config values when CLI/env args are provided
- Added logging to show when overrides are applied

## Does this introduce a breaking change?

No

## Other information

N/A