### PR TITLE
feat: add max_blocks_per_snos_batch check to batch closing logic

### DIFF
--- a/orchestrator/src/cli/batching.rs
+++ b/orchestrator/src/cli/batching.rs
@@ -27,6 +27,9 @@ pub struct BatchingCliArgs {
     #[arg(env = "MADARA_ORCHESTRATOR_MAX_BLOCKS_PER_SNOS_BATCH", long)]
     pub max_blocks_per_snos_batch: Option<u64>,
 
+    #[arg(env = "MADARA_ORCHESTRATOR_FIXED_BLOCKS_PER_SNOS_BATCH", long)]
+    pub fixed_blocks_per_snos_batch: Option<u64>,
+
     /// Maximum number of SNOS batches that can be children of one aggregator batch.
     #[arg(env = "MADARA_ORCHESTRATOR_MAX_SNOS_BATCHES_PER_AGGREGATOR_BATCH", long, default_value = "50")]
     pub max_snos_batches_per_aggregator_batch: u64,

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -754,8 +754,8 @@ pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
             .unwrap()
             .map(|s| s.parse::<u64>().unwrap()),
         max_blocks_per_snos_batch: get_env_var_optional("MADARA_ORCHESTRATOR_MAX_BLOCKS_PER_SNOS_BATCH")
-            .parse::<u64>()
-            .unwrap(),
+            .unwrap()
+            .map(|s| s.parse::<u64>().unwrap()),
         max_snos_batches_per_aggregator_batch: get_env_var_or_default(
             "MADARA_ORCHESTRATOR_MAX_SNOS_BATCHES_PER_AGGREGATOR_BATCH",
             "50",

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -750,9 +750,12 @@ pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
         batching_worker_lock_duration: get_env_var_or_panic("MADARA_ORCHESTRATOR_BATCHING_LOCK_DURATION_SECONDS")
             .parse::<u64>()
             .unwrap(),
-        max_blocks_per_snos_batch: get_env_var_optional("MADARA_ORCHESTRATOR_MAX_BLOCKS_PER_SNOS_BATCH")
+        fixed_blocks_per_snos_batch: get_env_var_optional("MADARA_ORCHESTRATOR_FIXED_BLOCKS_PER_SNOS_BATCH")
             .unwrap()
             .map(|s| s.parse::<u64>().unwrap()),
+        max_blocks_per_snos_batch: get_env_var_optional("MADARA_ORCHESTRATOR_MAX_BLOCKS_PER_SNOS_BATCH")
+            .parse::<u64>()
+            .unwrap(),
         max_snos_batches_per_aggregator_batch: get_env_var_or_default(
             "MADARA_ORCHESTRATOR_MAX_SNOS_BATCHES_PER_AGGREGATOR_BATCH",
             "50",

--- a/orchestrator/src/types/params/batching.rs
+++ b/orchestrator/src/types/params/batching.rs
@@ -7,6 +7,7 @@ pub struct BatchingParams {
     pub max_batch_size: u64,
     pub batching_worker_lock_duration: u64,
     pub max_blocks_per_snos_batch: Option<u64>,
+    pub fixed_blocks_per_snos_batch: Option<u64>,
     pub max_snos_batches_per_aggregator_batch: u64,
     pub max_num_blobs: usize,
     /// Max number of felts (each encoded using 256 bits) that can be attached in a single state
@@ -29,6 +30,7 @@ impl From<BatchingCliArgs> for BatchingParams {
             max_batch_size: args.max_batch_size,
             batching_worker_lock_duration: args.batching_worker_lock_duration,
             max_blocks_per_snos_batch: args.max_blocks_per_snos_batch,
+            fixed_blocks_per_snos_batch: args.fixed_blocks_per_snos_batch,
             max_snos_batches_per_aggregator_batch: args.max_snos_batches_per_aggregator_batch,
             max_num_blobs: args.max_num_blobs,
             max_blob_size: args.max_num_blobs * BLOB_LEN,

--- a/orchestrator/src/worker/event_handler/triggers/batching.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching.rs
@@ -102,7 +102,6 @@ impl JobTrigger for BatchingTrigger {
             Layer::L3 => self.get_range_for_assigning_batches_l3(&config).await?,
         };
 
-        tracing::info!("in batching code");
         // Invoking method to assign batches to all the blocks in the range
         if start_block < end_block {
             match config.layer() {
@@ -1038,7 +1037,7 @@ impl BatchingTrigger {
     /// 3. Here, only fetch the next block's weights (end_block + 1) and check overflow
     async fn should_close_snos_batch(&self, config: &Arc<Config>, batch: &SnosBatch) -> Result<bool, JobError> {
         if let Some(fixed_blocks_per_snos_batch) = config.params.batching_config.fixed_blocks_per_snos_batch {
-            // If the MADARA_ORCHESTRATOR_MAX_BLOCKS_PER_SNOS_BATCH env is set, we use that value
+            // If the MADARA_ORCHESTRATOR_FIXED_BLOCKS_PER_SNOS_BATCH env is set, we use that value
             // Mostly, it'll be used for testing purposes
             debug!("Using MADARA_ORCHESTRATOR_FIXED_BLOCKS_PER_SNOS_BATCH env variable to close snos batch with max blocks = {}", fixed_blocks_per_snos_batch);
             return Ok(batch.num_blocks >= fixed_blocks_per_snos_batch);


### PR DESCRIPTION
## Pull Request type

- [x] Feature

## What is the current behavior?

The `should_close_snos_batch` function only checked `fixed_blocks_per_snos_batch` (used for testing) but did not check `max_blocks_per_snos_batch` as a separate condition. When `max_blocks_per_snos_batch` was set, it was not being used to determine if a batch should be closed.

Resolves: #NA

## What is the new behavior?

- Added separate check for `max_blocks_per_snos_batch` in `should_close_snos_batch` function
- If `max_blocks_per_snos_batch` is set and batch has reached that limit, returns `true` to close the batch
- If condition is not met, continues with other batch closing checks (time-based, bouncer weights)
- Added `fixed_blocks_per_snos_batch` CLI argument and config parameter (for testing purposes)

## Does this introduce a breaking change?

No

## Other information

- `fixed_blocks_per_snos_batch` takes precedence over `max_blocks_per_snos_batch` when both are set
- `max_blocks_per_snos_batch` is now properly checked as a separate condition before other closing criteria