### PR TITLE
fix: <0.14.1 will sync now

### DIFF
--- a/madara/crates/client/gateway/client/src/methods.rs
+++ b/madara/crates/client/gateway/client/src/methods.rs
@@ -428,7 +428,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn get_preconfirmed_block(client_testnet_fixture: GatewayProvider) {
         let latest_block_number =
             client_testnet_fixture.get_header(BlockId::Tag(BlockTag::Latest)).await.unwrap().block_number;
@@ -441,7 +440,6 @@ mod tests {
     // TODO: Fix this test
     #[rstest]
     #[tokio::test]
-    #[ignore = "Ignoring for now because of changes in SN version 0.14.0"]
     async fn get_state_update(client_mainnet_fixture: GatewayProvider) {
         let state_update = client_mainnet_fixture.get_state_update(BlockId::Number(0)).await.unwrap();
         assert_eq!(

--- a/madara/crates/primitives/gateway/src/state_update.rs
+++ b/madara/crates/primitives/gateway/src/state_update.rs
@@ -49,6 +49,9 @@ pub struct StateDiff {
     pub declared_classes: Vec<DeclaredClassItem>,
     pub nonces: HashMap<Felt, Felt>,
     pub replaced_classes: Vec<DeployedContractItem>,
+    /// New in Starknet 0.14.1 - parsed but not stored in DB
+    #[serde(default)]
+    pub migrated_compiled_classes: Vec<Felt>,
 }
 
 impl From<mp_state_update::StateDiff> for StateDiff {
@@ -75,6 +78,7 @@ impl From<mp_state_update::StateDiff> for StateDiff {
                     class_hash,
                 })
                 .collect(),
+            migrated_compiled_classes: Vec::new(),
         }
     }
 }

--- a/madara/crates/tests/src/lib.rs
+++ b/madara/crates/tests/src/lib.rs
@@ -569,7 +569,6 @@ fn madara_help_shows() {
 
 #[rstest]
 #[tokio::test]
-#[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
 async fn madara_can_sync_a_few_blocks() {
     use starknet_core::types::BlockHashAndNumber;
     use starknet_types_core::felt::Felt;
@@ -603,7 +602,6 @@ async fn madara_can_sync_a_few_blocks() {
 
 #[rstest]
 #[tokio::test]
-#[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
 async fn madara_can_sync_and_restart() {
     use starknet_core::types::BlockHashAndNumber;
     use starknet_types_core::felt::Felt;

--- a/madara/crates/tests/src/rpc/read.rs
+++ b/madara/crates/tests/src/rpc/read.rs
@@ -56,7 +56,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_block_hash_and_number_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -91,7 +90,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_block_txn_count_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -127,7 +125,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_batched_requests_work() {
         let madara = get_madara().await;
 
@@ -276,7 +273,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_block_txn_with_tx_hashes_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -320,7 +316,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_block_txn_with_tx_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -371,7 +366,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_class_hash_at_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -410,7 +404,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_nonce_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -449,7 +442,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_txn_by_block_id_and_index_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -489,7 +481,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_txn_by_hash_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -534,7 +525,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     // TODO: replace this with jsonrpsee client
     async fn test_get_txn_receipt_works() {
         let madara = get_madara().await;
@@ -589,7 +579,6 @@ mod test_rpc_read_calls {
     /// Hence, all the txn would be marked as AcceptedOnL2.
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_txn_status_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -630,7 +619,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_storage_at_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -669,7 +657,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_state_update_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -760,7 +747,6 @@ mod test_rpc_read_calls {
     /// the continuation token.
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_events_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -840,7 +826,6 @@ mod test_rpc_read_calls {
     /// ```
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_events_with_continuation_token_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -1005,7 +990,6 @@ mod test_rpc_read_calls {
     /// Along with that we are also checking for abi and the entry points.
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_class_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();
@@ -1044,7 +1028,6 @@ mod test_rpc_read_calls {
     /// for Sierra class versions > v1.1.0, we always use the latest version of the compiler.
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_compiled_casm_works() {
         let madara = get_madara().await;
 
@@ -1103,7 +1086,6 @@ mod test_rpc_read_calls {
     /// Note: The program has been compressed using the same script mentioned in the above test case.
     #[rstest]
     #[tokio::test]
-    #[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
     async fn test_get_class_at_works() {
         let madara = get_madara().await;
         let json_client = madara.json_rpc();

--- a/madara/crates/tests/src/storage_proof.rs
+++ b/madara/crates/tests/src/storage_proof.rs
@@ -14,7 +14,6 @@ fn normalize(json: &mut serde_json::Value) {
 
 #[rstest]
 #[tokio::test]
-#[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
 async fn test_storage_proof_snapshots() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
@@ -47,7 +46,6 @@ async fn test_storage_proof_snapshots() {
 
 #[rstest]
 #[tokio::test]
-#[ignore = "Madara is incompatible with 0.14.1 feeder gateway changes, specifically migrated_compiled_classes."]
 async fn test_storage_proof_trie_log() {
     // use trie log
     let cmd_builder = MadaraCmdBuilder::new().args([


### PR DESCRIPTION
Patch for networks with <0.14.1 but full-node needs to sync 

PS: won't work for >=0.14.1 
