### PR TITLE
fix(estimate_fee): should use charge_fee from config

### DIFF
--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -831,6 +831,7 @@ pub struct Starknet {
     pub(crate) block_prod_handle: Option<mc_block_production::BlockProductionHandle>,
     pub ctx: ServiceContext,
     pub(crate) rpc_unsafe_enabled: bool,
+    pub(crate) charge_fee: bool,
 }
 
 impl Starknet {
@@ -851,6 +852,7 @@ impl Starknet {
             ctx,
             pre_v0_9_preconfirmed_as_pending: false,
             rpc_unsafe_enabled: false,
+            charge_fee: true,
         }
     }
 
@@ -860,6 +862,10 @@ impl Starknet {
 
     pub fn set_rpc_unsafe_enabled(&mut self, value: bool) {
         self.rpc_unsafe_enabled = value;
+    }
+
+    pub fn set_charge_fee(&mut self, value: bool) {
+        self.charge_fee = value;
     }
 }
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
@@ -35,6 +35,7 @@ pub async fn estimate_fee(
     }
 
     let validate = !simulation_flags.contains(&SimulationFlagForEstimateFee::SkipValidate);
+    let charge_fee = starknet.charge_fee;
 
     let transactions = request
         .into_iter()
@@ -42,7 +43,7 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: true };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -389,7 +389,12 @@ async fn main() -> anyhow::Result<()> {
 
     // User-facing RPC
 
-    let service_rpc_user = RpcService::user(run_cmd.rpc_params.clone(), backend.clone(), tx_submit.clone());
+    let service_rpc_user = RpcService::user(
+        run_cmd.rpc_params.clone(),
+        backend.clone(),
+        tx_submit.clone(),
+        !run_cmd.validator_params.no_charge_fee,
+    );
 
     // Admin-facing RPC (for node operators)
 
@@ -398,6 +403,7 @@ async fn main() -> anyhow::Result<()> {
         backend.clone(),
         tx_submit.clone(),
         service_block_production.handle(),
+        !run_cmd.validator_params.no_charge_fee,
     );
 
     // Feeder gateway

--- a/madara/node/src/service/rpc/mod.rs
+++ b/madara/node/src/service/rpc/mod.rs
@@ -27,6 +27,7 @@ pub struct RpcService {
     server_handle: Option<ServerHandle>,
     rpc_type: RpcType,
     block_prod_handle: Option<BlockProductionHandle>,
+    charge_fee: bool,
 }
 
 impl RpcService {
@@ -34,6 +35,7 @@ impl RpcService {
         config: RpcParams,
         backend: Arc<MadaraBackend>,
         submit_tx_provider: MakeSubmitTransactionSwitch,
+        charge_fee: bool,
     ) -> Self {
         Self {
             config,
@@ -42,6 +44,7 @@ impl RpcService {
             server_handle: None,
             rpc_type: RpcType::User,
             block_prod_handle: None,
+            charge_fee,
         }
     }
 
@@ -50,6 +53,7 @@ impl RpcService {
         backend: Arc<MadaraBackend>,
         submit_tx_provider: MakeSubmitTransactionSwitch,
         block_prod_handle: BlockProductionHandle,
+        charge_fee: bool,
     ) -> Self {
         Self {
             config,
@@ -58,6 +62,7 @@ impl RpcService {
             server_handle: None,
             rpc_type: RpcType::Admin,
             block_prod_handle: Some(block_prod_handle),
+            charge_fee,
         }
     }
 }
@@ -77,6 +82,7 @@ impl Service for RpcService {
 
         let pre_v0_9_preconfirmed_as_pending = self.config.rpc_pre_v0_9_preconfirmed_as_pending;
         let rpc_unsafe_enabled = self.config.rpc_unsafe;
+        let charge_fee = self.charge_fee;
 
         runner.service_loop(move |ctx| async move {
             let submit_tx = Arc::new(submit_tx_provider.make(ctx.clone()));
@@ -90,6 +96,7 @@ impl Service for RpcService {
             );
             starknet.set_pre_v0_9_preconfirmed_as_pending(pre_v0_9_preconfirmed_as_pending);
             starknet.set_rpc_unsafe_enabled(rpc_unsafe_enabled);
+            starknet.set_charge_fee(charge_fee);
 
             let metrics = RpcMetrics::register()?;
 


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

The estimate_fee RPC method always sets charge_fee to false when creating execution flags, ignoring the node's charge_fee configuration.

Resolves: #NA

## What is the new behavior?

The estimate_fee method now respects the charge_fee configuration from the node's validator parameters. The charge_fee value is passed through the RPC service and used when creating execution flags for fee estimation.

## Does this introduce a breaking change?

No