### PR TITLE
fix: orchestrator minor fixes for batching and logging

### DIFF
--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -555,14 +555,6 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         let new_tip_in_db = if self.inner.config.save_preconfirmed {
             &new_tip
         } else {
-            // Remove the pre-confirmed case: we save the parent confirmed in that case.
-            // Log when we're dropping a preconfirmed block
-            if let ChainTip::Preconfirmed(preconfirmed_block) = &new_tip {
-                tracing::info!(
-                    "⚠️  Preconfirmed block #{} NOT saved to database. Block will be lost on restart.",
-                    preconfirmed_block.header.block_number
-                );
-            }
             &ChainTip::on_confirmed_block_n_or_empty(new_tip.latest_confirmed_block_n())
         };
         // Write to db if needed.

--- a/madara/crates/primitives/chain_config/src/chain_config.rs
+++ b/madara/crates/primitives/chain_config/src/chain_config.rs
@@ -781,6 +781,12 @@ impl ChainVersionedConstants {
         let mut result = BTreeMap::new();
 
         for (version, path) in version_with_path {
+            tracing::info!(
+                "Loading user specified versioned constants for starknet version {} from file {}",
+                version,
+                path
+            );
+
             // Change the current directory to Madara root
             let mut file = File::open(Path::new(&path)).with_context(|| format!("Failed to open file: {}", path))?;
 

--- a/orchestrator/src/cli/snos.rs
+++ b/orchestrator/src/cli/snos.rs
@@ -7,10 +7,11 @@ use url::Url;
 // Getting the default fee token addresses from the SNOS
 use generate_pie::constants::{DEFAULT_SEPOLIA_ETH_FEE_TOKEN, DEFAULT_SEPOLIA_STRK_FEE_TOKEN};
 
-fn parse_constants(path: &str) -> Result<VersionedConstants, String> {
+fn parse_constants(path: &str) -> color_eyre::Result<VersionedConstants> {
     let path_buf = PathBuf::from(path);
-    tracing::debug!(file_path = %path_buf.display(), "Loading versioned constants from file");
-    VersionedConstants::from_path(&path_buf).map_err(|e| format!("Failed to load versioned constants from file: {}", e))
+    tracing::info!(file_path = %path_buf.display(), "Loading versioned constants from file");
+    VersionedConstants::from_path(&path_buf)
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to load versioned constants from file: {}", e))
 }
 
 #[derive(Debug, Clone, Args)]


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

**Issue 1: Lock not released on error in batching worker**
- The batching worker acquires a lock at the start of execution
- If an error occurs during batch processing, the function returns early with `?`
- The lock release code is never reached, causing the lock to remain held until timeout
- This can block subsequent batching worker executions

**Issue 2: Unnecessary log noise**
- Madara logs a message about preconfirmed blocks not being saved in DB, which is expected behavior and creates unnecessary log noise

**Issue 3: No visibility into custom versioned constants usage**
- When custom versioned constants are loaded from a file, there's no indication in the logs
- Makes it difficult to debug issues related to versioned constants configuration

Resolves: #NA

## What is the new behavior?

**Fix 1: Guaranteed lock release (batching.rs)**
- Wrapped the main batching work in an async block to capture the result
- Lock is now **always** released after work completes, regardless of success or failure
- Proper error handling ensures original errors are preserved while lock release failures are logged
- Only scenario where lock won't release is a panic (which still relies on timeout)

**Fix 2: Remove preconfirmed block log (madara)**
- Removed the unnecessary log message about preconfirmed blocks not being saved
- Reduces log noise for expected behavior

**Fix 3: Add versioned constants logging (snos.rs)**
- Added debug logging when custom versioned constants are loaded from a file
- Shows the file path being used for better observability
- Helps operators understand which constants configuration is active

## Does this introduce a breaking change?

No

This PR contains only bug fixes and logging improvements. No API changes, no schema changes, no breaking changes to existing functionality.

## Other information

### Testing
- Batching lock release has been verified to work correctly with error paths
- Logging changes have been verified in local testing

### Related Files Changed
- `orchestrator/src/worker/event_handler/triggers/batching.rs` - Lock release fix
- `madara/crates/client/db/src/lib.rs` - Remove unnecessary log
- `madara/crates/primitives/chain_config/src/chain_config.rs` - Add versioned constants logging
- `orchestrator/src/cli/snos.rs` - Add versioned constants logging

### Impact
- **Low risk**: Changes are isolated to error handling and logging
- **Positive impact**: Prevents lock starvation in batching worker and improves observability