### PR TITLE
fix(orchestrator): requeue SNOS jobs when RPC is unavailable

### DIFF
--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -417,7 +417,6 @@ async fn process_job_with_job_exists_in_db_with_invalid_job_processing_status_er
 /// 4. No failure is recorded
 #[rstest]
 #[tokio::test]
-#[allow(clippy::await_holding_lock)]
 async fn process_job_requeues_when_check_ready_to_process_fails() {
     // Acquire test lock to serialize this test with others that use mocks
     let _test_lock = acquire_test_lock();

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -278,6 +278,8 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
     database_client.create_job(job_item.clone()).await.unwrap();
 
     let mut job_handler = MockJobHandlerTrait::new();
+    // Expecting check_ready_to_process to return Ok (dependencies are ready)
+    job_handler.expect_check_ready_to_process().times(1).returning(|_| Ok(()));
     // Expecting process job function in job processor to return the external ID.
     job_handler.expect_process_job().times(1).returning(move |_, _| Ok("0xbeef".to_string()));
     job_handler.expect_verification_polling_delay_seconds().return_const(1u64);
@@ -345,6 +347,8 @@ async fn process_job_handles_panic() {
     database_client.create_job(job_item.clone()).await.unwrap();
 
     let mut job_handler = MockJobHandlerTrait::new();
+    // Expecting check_ready_to_process to return Ok (dependencies are ready)
+    job_handler.expect_check_ready_to_process().times(1).returning(|_| Ok(()));
     // Setting up mock to panic when process_job is called
     job_handler
         .expect_process_job()
@@ -511,6 +515,9 @@ async fn process_job_two_workers_process_same_job_works() {
     let _test_lock = acquire_test_lock();
 
     let mut job_handler = MockJobHandlerTrait::new();
+    // Expecting check_ready_to_process to return Ok (dependencies are ready)
+    // Both workers will call check_ready_to_process, so expect 2 calls
+    job_handler.expect_check_ready_to_process().times(2).returning(|_| Ok(()));
     // Expecting process job function in job processor to return the external ID.
     job_handler.expect_process_job().times(1).returning(move |_, _| Ok("0xbeef".to_string()));
     job_handler.expect_verification_polling_delay_seconds().return_const(1u64);
@@ -567,6 +574,8 @@ async fn process_job_job_handler_returns_error_works() {
     let _test_lock = acquire_test_lock();
 
     let mut job_handler = MockJobHandlerTrait::new();
+    // Expecting check_ready_to_process to return Ok (dependencies are ready)
+    job_handler.expect_check_ready_to_process().times(1).returning(|_| Ok(()));
     // Expecting process job function in job processor to return the external ID.
     let failure_reason = "Failed to process job";
     job_handler

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -409,6 +409,68 @@ async fn process_job_with_job_exists_in_db_with_invalid_job_processing_status_er
     assert_matches!(queue_error, QueueError::ErrorFromQueueError(_));
 }
 
+/// Tests `process_job` function when `check_ready_to_process` returns Err (dependencies not ready).
+/// This test verifies that:
+/// 1. The job is NOT processed (process_job on handler should not be called)
+/// 2. The job is requeued to the processing queue with a delay
+/// 3. The job status remains unchanged (still Created)
+/// 4. No failure is recorded
+#[rstest]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_requeues_when_check_ready_to_process_fails() {
+    // Acquire test lock to serialize this test with others that use mocks
+    let _test_lock = acquire_test_lock();
+
+    // Building config
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .build()
+        .await;
+    let database_client = services.config.database();
+
+    // Create a job with Created status
+    let job_item = build_job_item(JobType::SnosRun, JobStatus::Created, 1);
+
+    // Creating job in database first
+    database_client.create_job(job_item.clone()).await.unwrap();
+
+    let mut job_handler = MockJobHandlerTrait::new();
+
+    // Mock check_ready_to_process to return Err with 0 second delay (for immediate queue visibility in test)
+    job_handler.expect_check_ready_to_process().times(1).returning(|_| Err(Duration::from_secs(0)));
+
+    // process_job should NOT be called since dependencies are not ready
+    job_handler.expect_process_job().times(0);
+
+    // Mocking the `get_job_handler` call
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx_guard = get_job_handler_context_safe();
+    ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+
+    // Call process_job - should succeed (returns Ok) but job should be requeued, not processed
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_ok(), "process_job should return Ok when requeuing due to check_ready_to_process failure");
+
+    // DB checks - job should still be in Created status (not processed, not failed)
+    let job_in_db = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(job_in_db.status, JobStatus::Created, "Job status should remain Created when requeued");
+    assert!(job_in_db.metadata.common.failure_reason.is_none(), "No failure reason should be recorded when requeuing");
+
+    // Queue checks - job should be requeued to the processing queue (not verification queue)
+    let consumed_messages = consume_message_with_retry(
+        services.config.queue(),
+        job_item.job_type.process_queue_name(),
+        QUEUE_CONSUME_MAX_RETRIES,
+        QUEUE_CONSUME_RETRY_DELAY_SECS,
+    )
+    .await
+    .unwrap();
+    let consumed_message_payload: MessagePayloadType = consumed_messages.payload_serde_json().unwrap().unwrap();
+    assert_eq!(consumed_message_payload.id, job_item.id, "Requeued message should have the same job ID");
+}
+
 /// Tests `process_job` function when job is not in the db
 /// This test should fail
 #[rstest]

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -517,7 +517,7 @@ async fn process_job_two_workers_process_same_job_works() {
     let mut job_handler = MockJobHandlerTrait::new();
     // Expecting check_ready_to_process to return Ok (dependencies are ready)
     // Both workers will call check_ready_to_process, so expect 2 calls
-    job_handler.expect_check_ready_to_process().times(2).returning(|_| Ok(()));
+    job_handler.expect_check_ready_to_process().times(1..=2).returning(|_| Ok(()));
     // Expecting process job function in job processor to return the external ID.
     job_handler.expect_process_job().times(1).returning(move |_, _| Ok("0xbeef".to_string()));
     job_handler.expect_verification_polling_delay_seconds().return_const(1u64);
@@ -526,7 +526,7 @@ async fn process_job_two_workers_process_same_job_works() {
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
     let ctx_guard = get_job_handler_context_safe();
     // Due to timing, worker 2 may see an invalid job status and fail early, so expect 1 or 2 calls
-    ctx_guard.expect().times(1..=2).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+    ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
     // building config
     let services = TestConfigBuilder::new()

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -525,8 +525,8 @@ async fn process_job_two_workers_process_same_job_works() {
     // Mocking the `get_job_handler` call - both workers will call it before one fails due to lock contention
     let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
     let ctx_guard = get_job_handler_context_safe();
-    // Both workers will call get_job_handler (each process_job calls it once), so expect exactly 2 calls
-    ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+    // Due to timing, worker 2 may see an invalid job status and fail early, so expect 1 or 2 calls
+    ctx_guard.expect().times(1..=2).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
     // building config
     let services = TestConfigBuilder::new()

--- a/orchestrator/src/tests/jobs/snos_job/mod.rs
+++ b/orchestrator/src/tests/jobs/snos_job/mod.rs
@@ -135,10 +135,10 @@ async fn test_check_snos_health_unavailable() {
     use crate::worker::event_handler::jobs::snos::check_snos_health;
 
     // Use an invalid/unreachable URL to simulate SNOS being down
-    let invalid_snos_url = "http://127.0.0.1:1";
+    let invalid_snos_url = Url::parse("http://127.0.0.1:1").unwrap();
 
     // check_snos_health should return false for unreachable URL
-    let is_healthy = check_snos_health(invalid_snos_url).await;
+    let is_healthy = check_snos_health(&invalid_snos_url).await;
 
     assert!(!is_healthy, "Expected false when SNOS RPC is unavailable");
 }
@@ -150,7 +150,7 @@ async fn test_check_snos_health_available() {
     use crate::worker::event_handler::jobs::snos::check_snos_health;
 
     let snos_url = match std::env::var(SNOS_PATHFINDER_RPC_URL_ENV) {
-        Ok(url) => url,
+        Ok(url) => Url::parse(&url).unwrap(),
         Err(_) => {
             println!("Ignoring test: {} environment variable is not set", SNOS_PATHFINDER_RPC_URL_ENV);
             return;

--- a/orchestrator/src/tests/jobs/snos_job/mod.rs
+++ b/orchestrator/src/tests/jobs/snos_job/mod.rs
@@ -6,6 +6,7 @@ use rstest::*;
 use url::Url;
 use uuid::Uuid;
 
+use crate::core::client::alert::MockAlertClient;
 use crate::tests::common::default_job_item;
 use crate::tests::config::{MockType, TestConfigBuilder};
 use crate::tests::jobs::ConfigType;
@@ -123,5 +124,67 @@ async fn test_process_job() -> color_eyre::Result<()> {
     let _ = CairoPie::from_bytes(&cairo_pie_data)?;
     let _: serde_json::Value = serde_json::from_slice(&snos_output_data)?;
 
+    Ok(())
+}
+
+/// Test that check_snos_health returns false when SNOS RPC is unavailable.
+/// This tests the core health check logic without needing to manipulate env vars.
+#[rstest]
+#[tokio::test]
+async fn test_check_snos_health_unavailable() {
+    use crate::worker::event_handler::jobs::snos::check_snos_health;
+
+    // Use an invalid/unreachable URL to simulate SNOS being down
+    let invalid_snos_url = "http://127.0.0.1:1";
+
+    // check_snos_health should return false for unreachable URL
+    let is_healthy = check_snos_health(invalid_snos_url).await;
+
+    assert!(!is_healthy, "Expected false when SNOS RPC is unavailable");
+}
+
+/// Test that check_snos_health returns true when SNOS RPC is available.
+#[rstest]
+#[tokio::test]
+async fn test_check_snos_health_available() {
+    use crate::worker::event_handler::jobs::snos::check_snos_health;
+
+    let snos_url = match std::env::var(SNOS_PATHFINDER_RPC_URL_ENV) {
+        Ok(url) => url,
+        Err(_) => {
+            println!("Ignoring test: {} environment variable is not set", SNOS_PATHFINDER_RPC_URL_ENV);
+            return;
+        }
+    };
+
+    // check_snos_health should return true for reachable URL
+    let is_healthy = check_snos_health(&snos_url).await;
+
+    assert!(is_healthy, "Expected true when SNOS RPC is available");
+}
+
+/// Test that when SNOS RPC is available, check_ready_to_process returns Ok
+#[rstest]
+#[tokio::test]
+async fn test_check_ready_to_process_snos_available() -> color_eyre::Result<()> {
+    // Skip if SNOS RPC URL is not set
+    if std::env::var(SNOS_PATHFINDER_RPC_URL_ENV).is_err() {
+        println!("Ignoring test: {} environment variable is not set", SNOS_PATHFINDER_RPC_URL_ENV);
+        return Ok(());
+    }
+
+    // Mock alert client - no alert should be sent when SNOS is available
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(0);
+
+    let services = TestConfigBuilder::new()
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+
+    // Call check_ready_to_process - should return Ok since SNOS is available
+    let result = SnosJobHandler.check_ready_to_process(services.config.clone()).await;
+
+    assert!(result.is_ok(), "Expected Ok when SNOS RPC is available");
     Ok(())
 }

--- a/orchestrator/src/worker/event_handler/jobs/mod.rs
+++ b/orchestrator/src/worker/event_handler/jobs/mod.rs
@@ -12,6 +12,7 @@ use crate::types::jobs::metadata::JobMetadata;
 use crate::types::jobs::status::JobVerificationStatus;
 use async_trait::async_trait;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Job Trait
 ///
@@ -69,4 +70,22 @@ pub trait JobHandlerTrait: Send + Sync {
 
     /// Should return the number of seconds to wait before polling for verification
     fn verification_polling_delay_seconds(&self) -> u64;
+
+    /// Check if external dependencies are ready before processing.
+    ///
+    /// This method is called before locking the job for processing. It allows handlers
+    /// to verify that required external services (e.g., RPC endpoints) are available.
+    ///
+    /// # Arguments
+    /// * `config` - Shared configuration for the job
+    ///
+    /// # Returns
+    /// * `Ok(())` - Dependencies are ready, proceed with processing
+    /// * `Err(Duration)` - Dependencies unavailable, requeue job with the specified delay
+    ///
+    /// # Default Implementation
+    /// Returns `Ok(())` - always ready to process
+    async fn check_ready_to_process(&self, _config: Arc<Config>) -> Result<(), Duration> {
+        Ok(())
+    }
 }

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -28,9 +28,29 @@ use starknet::providers::Url;
 use starknet_api::core::{ChainId, ContractAddress};
 use starknet_core::types::Felt;
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::NamedTempFile;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
+
+/// Tracks whether we've already sent an alert for SNOS being unavailable.
+/// Reset to false when SNOS recovers, so the next downtime triggers a new alert.
+static SNOS_UNAVAILABLE_ALERT_SENT: AtomicBool = AtomicBool::new(false);
+
+/// Delay before retrying when SNOS RPC is unavailable (in seconds)
+const SNOS_UNAVAILABLE_RETRY_DELAY_SECS: u64 = 60;
+
+/// Check if SNOS RPC is healthy by calling chain_id.
+/// Returns true if the RPC is reachable and responds, false otherwise.
+pub async fn check_snos_health(snos_url: &str) -> bool {
+    let url = match Url::parse(snos_url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    let provider = JsonRpcClient::new(HttpTransport::new(url));
+    provider.chain_id().await.is_ok()
+}
 
 pub struct SnosJobHandler;
 
@@ -207,6 +227,30 @@ impl JobHandlerTrait for SnosJobHandler {
 
     fn verification_polling_delay_seconds(&self) -> u64 {
         1
+    }
+
+    async fn check_ready_to_process(&self, config: Arc<Config>) -> Result<(), Duration> {
+        let snos_url = config.snos_config().rpc_for_snos.to_string();
+
+        if !check_snos_health(&snos_url).await {
+            // SNOS is down - signal to requeue with delay
+            warn!(snos_url = %snos_url, "SNOS RPC is unavailable, job will be requeued");
+
+            // Send alert only once per downtime period
+            if !SNOS_UNAVAILABLE_ALERT_SENT.swap(true, Ordering::SeqCst) {
+                let alert_msg =
+                    format!("SNOS RPC {} is unavailable. SnosRun jobs will be requeued until it recovers.", snos_url);
+                if let Err(e) = config.alerts().send_message(alert_msg).await {
+                    error!(error = ?e, "Failed to send SNOS unavailability alert");
+                }
+            }
+
+            return Err(Duration::from_secs(SNOS_UNAVAILABLE_RETRY_DELAY_SECS));
+        }
+
+        // SNOS is available - reset alert flag so next downtime triggers a new alert
+        SNOS_UNAVAILABLE_ALERT_SENT.store(false, Ordering::SeqCst);
+        Ok(())
     }
 }
 

--- a/orchestrator/src/worker/service.rs
+++ b/orchestrator/src/worker/service.rs
@@ -40,7 +40,7 @@ impl JobService {
     ///
     /// # Returns
     /// * `Result<(), JobError>` - Success or an error
-    async fn add_job_to_queue(
+    pub(crate) async fn add_job_to_queue(
         config: Arc<Config>,
         id: Uuid,
         queue: QueueType,


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Testing
- [ ] Other (please describe):

## What is the current behavior?

When the SNOS RPC endpoint (Pathfinder) is down, all SnosRun jobs fail one by one, sending alerts for each failure. This causes:
1. Multiple unnecessary job failures when external infrastructure is temporarily unavailable
2. Alert fatigue from continuous failure notifications
3. Jobs being marked as failed when they should simply wait for the dependency to recover

Resolves: #NA

## What is the new behavior?

- **Health check before processing**: Added `check_ready_to_process()` method to `JobHandlerTrait` that allows handlers to verify dependencies are available before job processing begins
- **SNOS health check**: `SnosJobHandler` implements this method to check if SNOS RPC is reachable using `chain_id()` RPC call
- **Graceful requeue**: When SNOS is unavailable, jobs are requeued with a 60-second delay instead of failing
- **Single alert per downtime**: Uses `AtomicBool` to send only one alert when SNOS goes down, preventing alert fatigue
- **Auto-recovery**: Alert flag resets when SNOS recovers, so the next downtime will trigger a new alert

### Flow:
```
process_job() called
    │
    ├─► check_ready_to_process()
    │       │
    │       ├─► SNOS healthy → Ok() → continue processing
    │       │
    │       └─► SNOS down → Err(60s delay)
    │               │
    │               ├─► Send alert (once per downtime)
    │               └─► Requeue job with delay
    │
    └─► Job not marked as failed, status remains "Created"
```

## Does this introduce a breaking change?

No - This is an additive change. The `check_ready_to_process()` method has a default implementation returning `Ok(())`, so existing job handlers continue to work without modification.

## Other information

### Files changed:
- `orchestrator/src/worker/event_handler/jobs/mod.rs` - Added `check_ready_to_process` to trait
- `orchestrator/src/worker/event_handler/jobs/snos.rs` - Implemented health check for SNOS
- `orchestrator/src/worker/event_handler/service.rs` - Call check before processing
- `orchestrator/src/worker/service.rs` - Made `add_job_to_queue` pub(crate)
- `orchestrator/src/tests/jobs/snos_job/mod.rs` - Added health check tests
- `orchestrator/src/tests/jobs/mod.rs` - Added requeue behavior test