### PR TITLE
fix: batching logic edge cases

### DIFF
--- a/orchestrator/src/cli/batching.rs
+++ b/orchestrator/src/cli/batching.rs
@@ -21,16 +21,19 @@ pub struct BatchingCliArgs {
     #[arg(env = "MADARA_ORCHESTRATOR_BATCHING_LOCK_DURATION_SECONDS", long, default_value = "3600")]
     pub batching_worker_lock_duration: u64,
 
-    /// Maximum number of blocks allowed in a single SNOS batch.
-    /// Keep this None if you don't want to specify a hard limit.
-    /// This can be used to test with RPC other than Madara.
     #[arg(env = "MADARA_ORCHESTRATOR_MAX_BLOCKS_PER_SNOS_BATCH", long)]
     pub max_blocks_per_snos_batch: Option<u64>,
 
+    /// Fixed number of blocks allowed in a single SNOS batch.
+    /// If this is set, nothing will be checked and every SNOS batch will have these many blocks.
+    /// Keep this None if you don't want to specify a hard limit.
+    /// This can be used to test with RPC other than Madara.
     #[arg(env = "MADARA_ORCHESTRATOR_FIXED_BLOCKS_PER_SNOS_BATCH", long)]
     pub fixed_blocks_per_snos_batch: Option<u64>,
 
     /// Maximum number of SNOS batches that can be children of one aggregator batch.
+    ///
+    /// NOTE: This is not actually being used in the batching logic
     #[arg(env = "MADARA_ORCHESTRATOR_MAX_SNOS_BATCHES_PER_AGGREGATOR_BATCH", long, default_value = "50")]
     pub max_snos_batches_per_aggregator_batch: u64,
 


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

The batching logic had several edge cases that could lead to data corruption or incorrect batch creation:

1. When SNOS and aggregator batches have different end blocks during batch closure, both were saved which could cause data corruption
2. When starting a new SNOS batch after closing one, the start block was set to the current `block_number` instead of the correct next sequential block
3. The `num_snos_batches` field in aggregator batches was not being calculated correctly
4. Documentation for batching CLI parameters was unclear about the difference between `max_blocks_per_snos_batch` and `fixed_blocks_per_snos_batch`
5. Insufficient logging made debugging batching issues difficult

Resolves: #NA

## What is the new behavior?

- **Data corruption prevention**: Added a safety check when closing batches. If SNOS batch and aggregator batch have different end blocks, only the aggregator batch is saved and a warning is logged to prevent data corruption
- **Fixed SNOS batch start block**: When starting a new SNOS batch after closing one, the start block is now correctly set to `current_snos_batch.end_block + 1` instead of `block_number`
- **Fixed num_snos_batches calculation**: Now correctly calculates as `end_snos_batch - start_snos_batch + 1` when updating aggregator batches
- **Improved documentation**: Clarified CLI parameter descriptions and noted that `max_snos_batches_per_aggregator_batch` is not currently being used
- **Enhanced logging**: 
  - Added debug logging at batch assignment showing current batch indices
  - Improved info logging to show start_block, end_block, and batch counts
  - Updated log messages to show current_batches vs max_batches (instead of blocks vs max_blocks) for clarity
- **Code refactoring**: Extracted `save_aggregator_batch_state` method to allow saving only aggregator batch state when needed

## Does this introduce a breaking change?

No

## Other information

These fixes address critical edge cases that could lead to batch state inconsistencies. The changes are backward compatible and only affect the internal batching logic without changing any external APIs or interfaces.