### PR TITLE
Orchestrator/admin endpoints

### DIFF
--- a/orchestrator/src/cli/server.rs
+++ b/orchestrator/src/cli/server.rs
@@ -11,4 +11,8 @@ pub struct ServerCliArgs {
     /// The port to listen on.
     #[arg(env = "MADARA_ORCHESTRATOR_PORT", long, default_value = "3000")]
     pub port: u16,
+
+    /// Enable admin endpoints for privileged operations.
+    #[arg(env = "MADARA_ORCHESTRATOR_ADMIN_ENABLED", long, default_value_t = false)]
+    pub admin_enabled: bool,
 }

--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -26,7 +26,7 @@ use std::time::Instant;
 ///
 /// # Relationship Rules
 /// - Each SNOS batch belongs to exactly one aggregator batch
-/// - Multiple SNOS batches can exist within one aggregator batch  
+/// - Multiple SNOS batches can exist within one aggregator batch
 /// - When an aggregator batch closes, all its SNOS batches are closed
 /// - SNOS batches can close independently within an open aggregator batch
 #[cfg_attr(test, mockall::automock)]

--- a/orchestrator/src/server/mod.rs
+++ b/orchestrator/src/server/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod middleware;
 pub mod route;
+pub mod service;
 pub mod types;
 
 use crate::core::config::Config;

--- a/orchestrator/src/server/route/admin.rs
+++ b/orchestrator/src/server/route/admin.rs
@@ -85,7 +85,9 @@ async fn handle_retry_all_failed_jobs(
                 );
             }
 
-            let message = if result.failed_count > 0 {
+            let message = if result.success_count == 0 && result.failed_count == 0 {
+                "No failed jobs to retry".to_string()
+            } else if result.failed_count > 0 {
                 format!(
                     "Queued {} job(s) for retry. {} job(s) failed to queue.",
                     result.success_count, result.failed_count
@@ -162,7 +164,9 @@ async fn handle_requeue_pending_verification(
                 );
             }
 
-            let message = if result.failed_count > 0 {
+            let message = if result.success_count == 0 && result.failed_count == 0 {
+                "No pending verification jobs to requeue".to_string()
+            } else if result.failed_count > 0 {
                 format!(
                     "Re-queued {} job(s) for verification. {} job(s) failed to queue.",
                     result.success_count, result.failed_count
@@ -240,7 +244,9 @@ async fn handle_requeue_created_jobs(
                 );
             }
 
-            let message = if result.failed_count > 0 {
+            let message = if result.success_count == 0 && result.failed_count == 0 {
+                "No created jobs to requeue".to_string()
+            } else if result.failed_count > 0 {
                 format!(
                     "Re-queued {} created job(s) for processing. {} job(s) failed to queue.",
                     result.success_count, result.failed_count

--- a/orchestrator/src/server/route/admin.rs
+++ b/orchestrator/src/server/route/admin.rs
@@ -1,0 +1,295 @@
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
+use opentelemetry::KeyValue;
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use super::super::error::JobRouteError;
+use super::super::service::admin::AdminService;
+use super::super::types::{ApiResponse, JobRouteResult};
+use crate::core::config::Config;
+use crate::types::jobs::types::JobType;
+use crate::utils::metrics::ORCHESTRATOR_METRICS;
+
+/// Query parameters for filtering jobs by types
+#[derive(Debug, Deserialize)]
+pub struct JobTypeFilter {
+    /// Optional job types filter (comma-separated or multiple query params)
+    /// If empty, all job types will be processed
+    #[serde(default)]
+    pub job_type: Vec<JobType>,
+}
+
+/// Response for bulk job operations
+#[derive(Debug, Serialize)]
+pub struct BulkJobResponse {
+    /// Number of jobs successfully queued
+    pub success_count: u64,
+    /// List of job IDs that were successfully queued
+    pub successful_job_ids: Vec<Uuid>,
+    /// Number of jobs that failed to queue
+    pub failed_count: u64,
+    /// List of job IDs that failed to queue
+    pub failed_job_ids: Vec<Uuid>,
+}
+
+/// Handles HTTP requests to retry all failed jobs.
+///
+/// This endpoint initiates the retry process for all jobs in Failed status.
+/// Optionally filters by job types if provided in query parameters.
+///
+/// # Arguments
+/// * `State(config)` - Shared application configuration
+/// * `Query(filter)` - Optional job types filter from query parameters
+///
+/// # Returns
+/// * `JobRouteResult` - Success response with job count and IDs, or error details
+///
+/// # Errors
+/// * `JobRouteError::ProcessingError` - If the bulk retry operation fails
+async fn handle_retry_all_failed_jobs(
+    State(config): State<Arc<Config>>,
+    Query(filter): Query<JobTypeFilter>,
+) -> JobRouteResult {
+    // Check if admin is enabled
+    if !config.server_config().admin_enabled {
+        error!("Admin endpoints are disabled");
+        return Err(JobRouteError::ProcessingError("Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string()));
+    }
+
+    info!(job_types = ?filter.job_type, "Admin: Retry all failed jobs request received");
+
+    match AdminService::retry_all_failed_jobs(filter.job_type.clone(), config.clone()).await {
+        Ok(result) => {
+            info!(
+                success = result.success_count,
+                failed = result.failed_count,
+                job_types = ?filter.job_type,
+                "Admin: Completed retry of failed jobs"
+            );
+
+            ORCHESTRATOR_METRICS.successful_job_operations.add(
+                result.success_count as f64,
+                &[KeyValue::new("operation_type", "admin_retry_failed"), KeyValue::new("admin", "true")],
+            );
+
+            if result.failed_count > 0 {
+                ORCHESTRATOR_METRICS.failed_job_operations.add(
+                    result.failed_count as f64,
+                    &[KeyValue::new("operation_type", "admin_retry_failed"), KeyValue::new("admin", "true")],
+                );
+            }
+
+            let message = if result.failed_count > 0 {
+                format!(
+                    "Queued {} job(s) for retry. {} job(s) failed to queue.",
+                    result.success_count, result.failed_count
+                )
+            } else {
+                format!("Successfully queued {} job(s) for retry", result.success_count)
+            };
+
+            Ok(Json(ApiResponse::<BulkJobResponse>::success_with_data(
+                BulkJobResponse {
+                    success_count: result.success_count,
+                    successful_job_ids: result.successful_job_ids,
+                    failed_count: result.failed_count,
+                    failed_job_ids: result.failed_job_ids,
+                },
+                Some(message),
+            ))
+            .into_response())
+        }
+        Err(e) => {
+            error!(error = %e, job_types = ?filter.job_type, "Admin: Failed to retry failed jobs");
+            ORCHESTRATOR_METRICS
+                .failed_job_operations
+                .add(1.0, &[KeyValue::new("operation_type", "admin_retry_failed"), KeyValue::new("admin", "true")]);
+            Err(JobRouteError::ProcessingError(e.to_string()))
+        }
+    }
+}
+
+/// Handles HTTP requests to re-queue all pending verification jobs.
+///
+/// This endpoint re-adds all jobs in PendingVerification status to their
+/// respective verification queues based on their job types.
+///
+/// # Arguments
+/// * `State(config)` - Shared application configuration
+/// * `Query(filter)` - Optional job types filter from query parameters
+///
+/// # Returns
+/// * `JobRouteResult` - Success response with job count and IDs, or error details
+///
+/// # Errors
+/// * `JobRouteError::ProcessingError` - If the bulk requeue operation fails
+async fn handle_requeue_pending_verification(
+    State(config): State<Arc<Config>>,
+    Query(filter): Query<JobTypeFilter>,
+) -> JobRouteResult {
+    // Check if admin is enabled
+    if !config.server_config().admin_enabled {
+        error!("Admin endpoints are disabled");
+        return Err(JobRouteError::ProcessingError("Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string()));
+    }
+
+    info!(job_types = ?filter.job_type, "Admin: Requeue pending verification jobs request received");
+
+    match AdminService::requeue_pending_verification(filter.job_type.clone(), config.clone()).await {
+        Ok(result) => {
+            info!(
+                success = result.success_count,
+                failed = result.failed_count,
+                job_types = ?filter.job_type,
+                "Admin: Completed requeue of pending verification jobs"
+            );
+
+            ORCHESTRATOR_METRICS.successful_job_operations.add(
+                result.success_count as f64,
+                &[KeyValue::new("operation_type", "admin_requeue_verification"), KeyValue::new("admin", "true")],
+            );
+
+            if result.failed_count > 0 {
+                ORCHESTRATOR_METRICS.failed_job_operations.add(
+                    result.failed_count as f64,
+                    &[KeyValue::new("operation_type", "admin_requeue_verification"), KeyValue::new("admin", "true")],
+                );
+            }
+
+            let message = if result.failed_count > 0 {
+                format!(
+                    "Re-queued {} job(s) for verification. {} job(s) failed to queue.",
+                    result.success_count, result.failed_count
+                )
+            } else {
+                format!("Successfully re-queued {} job(s) for verification", result.success_count)
+            };
+
+            Ok(Json(ApiResponse::<BulkJobResponse>::success_with_data(
+                BulkJobResponse {
+                    success_count: result.success_count,
+                    successful_job_ids: result.successful_job_ids,
+                    failed_count: result.failed_count,
+                    failed_job_ids: result.failed_job_ids,
+                },
+                Some(message),
+            ))
+            .into_response())
+        }
+        Err(e) => {
+            error!(error = %e, job_types = ?filter.job_type, "Admin: Failed to requeue pending verification jobs");
+            ORCHESTRATOR_METRICS.failed_job_operations.add(
+                1.0,
+                &[KeyValue::new("operation_type", "admin_requeue_verification"), KeyValue::new("admin", "true")],
+            );
+            Err(JobRouteError::ProcessingError(e.to_string()))
+        }
+    }
+}
+
+/// Handles HTTP requests to re-queue all created jobs.
+///
+/// This endpoint re-adds all jobs in Created status to their respective
+/// processing queues based on their job types.
+///
+/// # Arguments
+/// * `State(config)` - Shared application configuration
+/// * `Query(filter)` - Optional job types filter from query parameters
+///
+/// # Returns
+/// * `JobRouteResult` - Success response with job count and IDs, or error details
+///
+/// # Errors
+/// * `JobRouteError::ProcessingError` - If the bulk requeue operation fails
+async fn handle_requeue_created_jobs(
+    State(config): State<Arc<Config>>,
+    Query(filter): Query<JobTypeFilter>,
+) -> JobRouteResult {
+    // Check if admin is enabled
+    if !config.server_config().admin_enabled {
+        error!("Admin endpoints are disabled");
+        return Err(JobRouteError::ProcessingError("Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string()));
+    }
+
+    info!(job_types = ?filter.job_type, "Admin: Requeue created jobs request received");
+
+    match AdminService::requeue_created_jobs(filter.job_type.clone(), config.clone()).await {
+        Ok(result) => {
+            info!(
+                success = result.success_count,
+                failed = result.failed_count,
+                job_types = ?filter.job_type,
+                "Admin: Completed requeue of created jobs"
+            );
+
+            ORCHESTRATOR_METRICS.successful_job_operations.add(
+                result.success_count as f64,
+                &[KeyValue::new("operation_type", "admin_requeue_created"), KeyValue::new("admin", "true")],
+            );
+
+            if result.failed_count > 0 {
+                ORCHESTRATOR_METRICS.failed_job_operations.add(
+                    result.failed_count as f64,
+                    &[KeyValue::new("operation_type", "admin_requeue_created"), KeyValue::new("admin", "true")],
+                );
+            }
+
+            let message = if result.failed_count > 0 {
+                format!(
+                    "Re-queued {} created job(s) for processing. {} job(s) failed to queue.",
+                    result.success_count, result.failed_count
+                )
+            } else {
+                format!("Successfully re-queued {} created job(s) for processing", result.success_count)
+            };
+
+            Ok(Json(ApiResponse::<BulkJobResponse>::success_with_data(
+                BulkJobResponse {
+                    success_count: result.success_count,
+                    successful_job_ids: result.successful_job_ids,
+                    failed_count: result.failed_count,
+                    failed_job_ids: result.failed_job_ids,
+                },
+                Some(message),
+            ))
+            .into_response())
+        }
+        Err(e) => {
+            error!(error = %e, job_types = ?filter.job_type, "Admin: Failed to requeue created jobs");
+            ORCHESTRATOR_METRICS.failed_job_operations.add(
+                1.0,
+                &[KeyValue::new("operation_type", "admin_requeue_created"), KeyValue::new("admin", "true")],
+            );
+            Err(JobRouteError::ProcessingError(e.to_string()))
+        }
+    }
+}
+
+/// Creates a router for admin endpoints.
+///
+/// This function sets up all admin-related routes. These routes are only
+/// functional when the admin_enabled flag is set in the configuration.
+///
+/// # Arguments
+/// * `config` - Shared application configuration
+///
+/// # Returns
+/// * `Router` - Configured router with all admin endpoints
+///
+/// # Available Endpoints
+/// * `POST /jobs/retry/failed` - Retry all failed jobs (optionally filtered by job_type[])
+/// * `POST /jobs/requeue/pending-verification` - Re-queue pending verification jobs
+/// * `POST /jobs/requeue/created` - Re-queue created jobs
+pub fn admin_router(config: Arc<Config>) -> Router {
+    Router::new()
+        .route("/jobs/retry/failed", post(handle_retry_all_failed_jobs))
+        .route("/jobs/requeue/pending-verification", post(handle_requeue_pending_verification))
+        .route("/jobs/requeue/created", post(handle_requeue_created_jobs))
+        .with_state(config)
+}

--- a/orchestrator/src/server/route/admin.rs
+++ b/orchestrator/src/server/route/admin.rs
@@ -26,7 +26,7 @@ pub struct JobTypeFilter {
 }
 
 /// Response for bulk job operations
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BulkJobResponse {
     /// Number of jobs successfully queued
     pub success_count: u64,
@@ -59,7 +59,9 @@ async fn handle_retry_all_failed_jobs(
     // Check if admin is enabled
     if !config.server_config().admin_enabled {
         error!("Admin endpoints are disabled");
-        return Err(JobRouteError::ProcessingError("Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string()));
+        return Err(JobRouteError::ProcessingError(
+            "Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string(),
+        ));
     }
 
     info!(job_types = ?filter.job_type, "Admin: Retry all failed jobs request received");
@@ -138,7 +140,9 @@ async fn handle_requeue_pending_verification(
     // Check if admin is enabled
     if !config.server_config().admin_enabled {
         error!("Admin endpoints are disabled");
-        return Err(JobRouteError::ProcessingError("Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string()));
+        return Err(JobRouteError::ProcessingError(
+            "Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string(),
+        ));
     }
 
     info!(job_types = ?filter.job_type, "Admin: Requeue pending verification jobs request received");
@@ -218,7 +222,9 @@ async fn handle_requeue_created_jobs(
     // Check if admin is enabled
     if !config.server_config().admin_enabled {
         error!("Admin endpoints are disabled");
-        return Err(JobRouteError::ProcessingError("Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string()));
+        return Err(JobRouteError::ProcessingError(
+            "Admin endpoints are disabled. Enable with --admin-enabled flag.".to_string(),
+        ));
     }
 
     info!(job_types = ?filter.job_type, "Admin: Requeue created jobs request received");
@@ -268,10 +274,9 @@ async fn handle_requeue_created_jobs(
         }
         Err(e) => {
             error!(error = %e, job_types = ?filter.job_type, "Admin: Failed to requeue created jobs");
-            ORCHESTRATOR_METRICS.failed_job_operations.add(
-                1.0,
-                &[KeyValue::new("operation_type", "admin_requeue_created"), KeyValue::new("admin", "true")],
-            );
+            ORCHESTRATOR_METRICS
+                .failed_job_operations
+                .add(1.0, &[KeyValue::new("operation_type", "admin_requeue_created"), KeyValue::new("admin", "true")]);
             Err(JobRouteError::ProcessingError(e.to_string()))
         }
     }

--- a/orchestrator/src/server/route/admin.rs
+++ b/orchestrator/src/server/route/admin.rs
@@ -125,7 +125,7 @@ async fn handle_retry_all_failed_jobs(
     .await
 }
 
-async fn handle_retry_verification_timeout_jobs(
+async fn handle_reverify_verification_timeout_jobs(
     State(config): State<Arc<Config>>,
     Query(filter): Query<JobTypeFilter>,
 ) -> JobRouteResult {
@@ -133,12 +133,12 @@ async fn handle_retry_verification_timeout_jobs(
         config,
         filter,
         AdminOp {
-            name: "retry verification-timeout jobs",
-            metric_key: "admin_retry_verification_timeout",
-            empty_msg: "No verification-timeout jobs to retry",
-            success_msg: "Queued for retry:",
+            name: "reverify verification-timeout jobs",
+            metric_key: "admin_reverify_verification_timeout",
+            empty_msg: "No verification-timeout jobs to reverify",
+            success_msg: "Queued for verification:",
         },
-        AdminService::retry_all_verification_timeout_jobs,
+        AdminService::reverify_all_verification_timeout_jobs,
     )
     .await
 }
@@ -188,7 +188,7 @@ async fn handle_requeue_created_jobs(
 pub fn admin_router(config: Arc<Config>) -> Router {
     Router::new()
         .route("/jobs/retry/failed", post(handle_retry_all_failed_jobs))
-        .route("/jobs/retry/verification-timeout", post(handle_retry_verification_timeout_jobs))
+        .route("/jobs/reverify/verification-timeout", post(handle_reverify_verification_timeout_jobs))
         .route("/jobs/requeue/pending-verification", post(handle_requeue_pending_verification))
         .route("/jobs/requeue/created", post(handle_requeue_created_jobs))
         .with_state(config)

--- a/orchestrator/src/server/route/mod.rs
+++ b/orchestrator/src/server/route/mod.rs
@@ -7,7 +7,7 @@ use jobs::job_router;
 use public::local_route;
 use std::sync::Arc;
 
-pub(super) mod admin;
+pub mod admin;
 pub(super) mod blocks;
 pub(super) mod jobs;
 

--- a/orchestrator/src/server/service/admin.rs
+++ b/orchestrator/src/server/service/admin.rs
@@ -1,0 +1,288 @@
+use std::sync::Arc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::core::config::Config;
+use crate::error::job::JobError;
+use crate::types::jobs::types::{JobStatus, JobType};
+use crate::worker::event_handler::service::JobHandlerService;
+use crate::worker::service::JobService;
+
+/// Result of a bulk job operation
+#[derive(Debug, Clone)]
+pub struct BulkJobResult {
+    /// Number of jobs successfully queued
+    pub success_count: u64,
+    /// IDs of jobs that were successfully queued
+    pub successful_job_ids: Vec<Uuid>,
+    /// Number of jobs that failed to queue
+    pub failed_count: u64,
+    /// IDs of jobs that failed to queue
+    pub failed_job_ids: Vec<Uuid>,
+}
+
+/// Admin service for bulk job operations
+pub struct AdminService;
+
+impl AdminService {
+    /// Retry all failed jobs, optionally filtered by job types
+    ///
+    /// # Arguments
+    /// * `job_types` - Optional vector of job types to filter by (empty vec = all types)
+    /// * `config` - Shared configuration
+    ///
+    /// # Returns
+    /// * `Result<BulkJobResult, JobError>` - Result containing success and failure counts/IDs
+    pub async fn retry_all_failed_jobs(
+        job_types: Vec<JobType>,
+        config: Arc<Config>,
+    ) -> Result<BulkJobResult, JobError> {
+        info!(
+            job_types = ?job_types,
+            "Admin: Starting retry of all failed jobs"
+        );
+
+        // Query all failed jobs with optional type filter
+        let failed_jobs = config
+            .database()
+            .get_jobs_by_types_and_statuses(job_types.clone(), vec![JobStatus::Failed], None)
+            .await?;
+
+        let total_jobs = failed_jobs.len();
+        info!(
+            job_types = ?job_types,
+            count = total_jobs,
+            "Admin: Found failed jobs to retry"
+        );
+
+        let mut successful_job_ids = Vec::new();
+        let mut failed_job_ids = Vec::new();
+
+        // Retry each failed job
+        for job in failed_jobs {
+            match JobHandlerService::retry_job(job.id, config.clone()).await {
+                Ok(_) => {
+                    successful_job_ids.push(job.id);
+                    info!(
+                        job_id = %job.id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        "Admin: Successfully retried failed job"
+                    );
+                }
+                Err(e) => {
+                    failed_job_ids.push(job.id);
+                    error!(
+                        job_id = %job.id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        error = %e,
+                        "Admin: Failed to retry job - job remains in Failed status"
+                    );
+                    // Continue with other jobs even if one fails
+                }
+            }
+        }
+
+        let result = BulkJobResult {
+            success_count: successful_job_ids.len() as u64,
+            successful_job_ids,
+            failed_count: failed_job_ids.len() as u64,
+            failed_job_ids: failed_job_ids.clone(),
+        };
+
+        if result.failed_count > 0 {
+            warn!(
+                job_types = ?job_types,
+                total = total_jobs,
+                success = result.success_count,
+                failed = result.failed_count,
+                failed_job_ids = ?failed_job_ids,
+                "Admin: Completed retry of failed jobs with some failures"
+            );
+        } else {
+            info!(
+                job_types = ?job_types,
+                total = total_jobs,
+                success = result.success_count,
+                "Admin: Completed retry of failed jobs - all successful"
+            );
+        }
+
+        Ok(result)
+    }
+
+    /// Re-add all PendingVerification jobs to verification queue
+    ///
+    /// # Arguments
+    /// * `job_types` - Optional vector of job types to filter by (empty vec = all types)
+    /// * `config` - Shared configuration
+    ///
+    /// # Returns
+    /// * `Result<BulkJobResult, JobError>` - Result containing success and failure counts/IDs
+    pub async fn requeue_pending_verification(
+        job_types: Vec<JobType>,
+        config: Arc<Config>,
+    ) -> Result<BulkJobResult, JobError> {
+        info!(
+            job_types = ?job_types,
+            "Admin: Starting requeue of pending verification jobs"
+        );
+
+        // Query all PendingVerification jobs with optional type filter
+        let jobs = config
+            .database()
+            .get_jobs_by_types_and_statuses(job_types.clone(), vec![JobStatus::PendingVerification], None)
+            .await?;
+
+        let total_jobs = jobs.len();
+        info!(
+            job_types = ?job_types,
+            count = total_jobs,
+            "Admin: Found pending verification jobs to requeue"
+        );
+
+        let mut successful_job_ids = Vec::new();
+        let mut failed_job_ids = Vec::new();
+
+        // Queue each job to appropriate verification queue
+        for job in jobs {
+            match JobService::add_job_to_verify_queue(config.clone(), job.id, &job.job_type, None).await {
+                Ok(_) => {
+                    successful_job_ids.push(job.id);
+                    info!(
+                        job_id = %job.id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        "Admin: Successfully re-queued job for verification"
+                    );
+                }
+                Err(e) => {
+                    failed_job_ids.push(job.id);
+                    error!(
+                        job_id = %job.id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        error = %e,
+                        "Admin: Failed to queue job for verification - job remains in PendingVerification status"
+                    );
+                    // Continue with other jobs even if one fails
+                }
+            }
+        }
+
+        let result = BulkJobResult {
+            success_count: successful_job_ids.len() as u64,
+            successful_job_ids,
+            failed_count: failed_job_ids.len() as u64,
+            failed_job_ids: failed_job_ids.clone(),
+        };
+
+        if result.failed_count > 0 {
+            warn!(
+                job_types = ?job_types,
+                total = total_jobs,
+                success = result.success_count,
+                failed = result.failed_count,
+                failed_job_ids = ?failed_job_ids,
+                "Admin: Completed requeue of pending verification jobs with some failures"
+            );
+        } else {
+            info!(
+                job_types = ?job_types,
+                total = total_jobs,
+                success = result.success_count,
+                "Admin: Completed requeue of pending verification jobs - all successful"
+            );
+        }
+
+        Ok(result)
+    }
+
+    /// Re-add all Created jobs to processing queue
+    ///
+    /// # Arguments
+    /// * `job_types` - Optional vector of job types to filter by (empty vec = all types)
+    /// * `config` - Shared configuration
+    ///
+    /// # Returns
+    /// * `Result<BulkJobResult, JobError>` - Result containing success and failure counts/IDs
+    pub async fn requeue_created_jobs(
+        job_types: Vec<JobType>,
+        config: Arc<Config>,
+    ) -> Result<BulkJobResult, JobError> {
+        info!(
+            job_types = ?job_types,
+            "Admin: Starting requeue of created jobs"
+        );
+
+        // Query all Created jobs with optional type filter
+        let jobs = config
+            .database()
+            .get_jobs_by_types_and_statuses(job_types.clone(), vec![JobStatus::Created], None)
+            .await?;
+
+        let total_jobs = jobs.len();
+        info!(
+            job_types = ?job_types,
+            count = total_jobs,
+            "Admin: Found created jobs to requeue"
+        );
+
+        let mut successful_job_ids = Vec::new();
+        let mut failed_job_ids = Vec::new();
+
+        // Queue each job to appropriate processing queue
+        for job in jobs {
+            match JobService::add_job_to_process_queue(job.id, &job.job_type, config.clone()).await {
+                Ok(_) => {
+                    successful_job_ids.push(job.id);
+                    info!(
+                        job_id = %job.id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        "Admin: Successfully re-queued created job for processing"
+                    );
+                }
+                Err(e) => {
+                    failed_job_ids.push(job.id);
+                    error!(
+                        job_id = %job.id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        error = %e,
+                        "Admin: Failed to queue job for processing - job remains in Created status"
+                    );
+                    // Continue with other jobs even if one fails
+                }
+            }
+        }
+
+        let result = BulkJobResult {
+            success_count: successful_job_ids.len() as u64,
+            successful_job_ids,
+            failed_count: failed_job_ids.len() as u64,
+            failed_job_ids: failed_job_ids.clone(),
+        };
+
+        if result.failed_count > 0 {
+            warn!(
+                job_types = ?job_types,
+                total = total_jobs,
+                success = result.success_count,
+                failed = result.failed_count,
+                failed_job_ids = ?failed_job_ids,
+                "Admin: Completed requeue of created jobs with some failures"
+            );
+        } else {
+            info!(
+                job_types = ?job_types,
+                total = total_jobs,
+                success = result.success_count,
+                "Admin: Completed requeue of created jobs - all successful"
+            );
+        }
+
+        Ok(result)
+    }
+}

--- a/orchestrator/src/server/service/admin.rs
+++ b/orchestrator/src/server/service/admin.rs
@@ -43,10 +43,8 @@ impl AdminService {
         );
 
         // Query all failed jobs with optional type filter
-        let failed_jobs = config
-            .database()
-            .get_jobs_by_types_and_statuses(job_types.clone(), vec![JobStatus::Failed], None)
-            .await?;
+        let failed_jobs =
+            config.database().get_jobs_by_types_and_statuses(job_types.clone(), vec![JobStatus::Failed], None).await?;
 
         let total_jobs = failed_jobs.len();
         info!(
@@ -207,20 +205,15 @@ impl AdminService {
     ///
     /// # Returns
     /// * `Result<BulkJobResult, JobError>` - Result containing success and failure counts/IDs
-    pub async fn requeue_created_jobs(
-        job_types: Vec<JobType>,
-        config: Arc<Config>,
-    ) -> Result<BulkJobResult, JobError> {
+    pub async fn requeue_created_jobs(job_types: Vec<JobType>, config: Arc<Config>) -> Result<BulkJobResult, JobError> {
         info!(
             job_types = ?job_types,
             "Admin: Starting requeue of created jobs"
         );
 
         // Query all Created jobs with optional type filter
-        let jobs = config
-            .database()
-            .get_jobs_by_types_and_statuses(job_types.clone(), vec![JobStatus::Created], None)
-            .await?;
+        let jobs =
+            config.database().get_jobs_by_types_and_statuses(job_types.clone(), vec![JobStatus::Created], None).await?;
 
         let total_jobs = jobs.len();
         info!(

--- a/orchestrator/src/server/service/admin.rs
+++ b/orchestrator/src/server/service/admin.rs
@@ -87,7 +87,7 @@ impl AdminService {
         .await
     }
 
-    pub async fn retry_all_verification_timeout_jobs(
+    pub async fn reverify_all_verification_timeout_jobs(
         job_types: Vec<JobType>,
         config: Arc<Config>,
     ) -> Result<BulkJobResult, JobError> {
@@ -95,8 +95,8 @@ impl AdminService {
             JobStatus::VerificationTimeout,
             job_types,
             config.clone(),
-            "retry verification-timeout",
-            |id, _, cfg| async move { JobHandlerService::retry_job(id, cfg).await },
+            "reverify verification-timeout",
+            |id, job_type, cfg| async move { JobService::add_job_to_verify_queue(cfg, id, &job_type, None).await },
         )
         .await
     }

--- a/orchestrator/src/server/service/mod.rs
+++ b/orchestrator/src/server/service/mod.rs
@@ -1,0 +1,1 @@
+pub mod admin;

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -806,6 +806,7 @@ pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
         port: get_env_var_or_panic("MADARA_ORCHESTRATOR_PORT")
             .parse()
             .expect("Failed to parse MADARA_ORCHESTRATOR_PORT"),
+        admin_enabled: true, // Enable admin endpoints for tests
     };
 
     let orchestrator_params = ConfigParam {

--- a/orchestrator/src/tests/server/admin_routes.rs
+++ b/orchestrator/src/tests/server/admin_routes.rs
@@ -182,6 +182,90 @@ async fn test_admin_requeue_pending_verification() {
     assert_eq!(data.failed_count, 0);
 }
 
+/// Test that POST /admin/jobs/retry/verification-timeout retries verification-timeout jobs
+#[tokio::test]
+#[rstest]
+async fn test_admin_retry_verification_timeout_jobs() {
+    dotenvy::from_filename_override("../.env.test").ok();
+    // Set required env var if not present (for mocked tests)
+    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
+        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
+    }
+
+    let server = MockServer::start();
+    let mut db = MockDatabaseClient::new();
+    let mut queue = MockQueueClient::new();
+    let da_client = MockDaClient::new();
+    let prover_client = MockProverClient::new();
+    let settlement_client = MockSettlementClient::new();
+
+    let job_type = JobType::DataSubmission;
+
+    // Create verification timeout job
+    let timeout_job = build_job_item(job_type.clone(), JobStatus::VerificationTimeout, 4001);
+    let job_id = timeout_job.id;
+
+    let timeout_jobs = vec![timeout_job.clone()];
+
+    // Mock get_jobs_by_types_and_statuses to return verification timeout jobs
+    db.expect_get_jobs_by_types_and_statuses()
+        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::VerificationTimeout])
+        .times(1)
+        .returning(move |_, _, _| Ok(timeout_jobs.clone()));
+
+    // Mock get_job_by_id for retry
+    let job_clone = timeout_job.clone();
+    db.expect_get_job_by_id().with(eq(job_id)).times(1).returning(move |_| Ok(Some(job_clone.clone())));
+
+    // Mock update_job for transitioning to PendingRetry
+    db.expect_update_job().times(1).returning(move |job, _| Ok(job.clone()));
+
+    // Mock queue send_message for adding job to process queue
+    queue
+        .expect_send_message()
+        .times(1)
+        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobProcessing)
+        .returning(|_, _, _| Ok(()));
+
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
+    ));
+
+    let services = TestConfigBuilder::new()
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(da_client.into())
+        .configure_prover_client(prover_client.into())
+        .configure_settlement_client(settlement_client.into())
+        .configure_api_server(crate::tests::config::ConfigType::Actual)
+        .build()
+        .await;
+
+    let addr = services.api_server_address.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .method("POST")
+                .uri(format!("http://{}/admin/jobs/retry/verification-timeout", addr))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(response.success);
+
+    let data = response.data.unwrap();
+    assert_eq!(data.success_count, 1);
+    assert_eq!(data.failed_count, 0);
+}
+
 /// Test that POST /admin/jobs/requeue/created requeues created jobs
 #[tokio::test]
 #[rstest]

--- a/orchestrator/src/tests/server/admin_routes.rs
+++ b/orchestrator/src/tests/server/admin_routes.rs
@@ -1,0 +1,258 @@
+use httpmock::MockServer;
+use mockall::predicate::eq;
+use rstest::*;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
+use url::Url;
+
+use crate::core::client::database::MockDatabaseClient;
+use crate::core::client::queue::MockQueueClient;
+use crate::server::route::admin::BulkJobResponse;
+use crate::server::types::ApiResponse;
+use crate::tests::config::TestConfigBuilder;
+use crate::tests::utils::build_job_item;
+use crate::types::jobs::types::{JobStatus, JobType};
+use crate::types::queue::QueueType;
+use hyper::{Body, Request};
+use orchestrator_da_client_interface::MockDaClient;
+use orchestrator_prover_client_interface::MockProverClient;
+use orchestrator_settlement_client_interface::MockSettlementClient;
+
+/// Test that POST /admin/jobs/retry/failed retries all failed jobs
+#[tokio::test]
+#[rstest]
+async fn test_admin_retry_all_failed_jobs() {
+    dotenvy::from_filename_override("../.env.test").ok();
+    // Set required env var if not present (for mocked tests)
+    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
+        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
+    }
+
+    let server = MockServer::start();
+    let mut db = MockDatabaseClient::new();
+    let mut queue = MockQueueClient::new();
+    let da_client = MockDaClient::new();
+    let prover_client = MockProverClient::new();
+    let settlement_client = MockSettlementClient::new();
+
+    let job_type = JobType::DataSubmission;
+
+    // Create failed jobs
+    let failed_job_1 = build_job_item(job_type.clone(), JobStatus::Failed, 1001);
+    let failed_job_2 = build_job_item(job_type.clone(), JobStatus::Failed, 1002);
+    let job_id_1 = failed_job_1.id;
+    let job_id_2 = failed_job_2.id;
+
+    let failed_jobs = vec![failed_job_1.clone(), failed_job_2.clone()];
+
+    // Mock get_jobs_by_types_and_statuses to return failed jobs
+    db.expect_get_jobs_by_types_and_statuses()
+        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::Failed])
+        .times(1)
+        .returning(move |_, _, _| Ok(failed_jobs.clone()));
+
+    // Mock get_job_by_id for each retry
+    let job1_clone = failed_job_1.clone();
+    db.expect_get_job_by_id().with(eq(job_id_1)).times(1).returning(move |_| Ok(Some(job1_clone.clone())));
+
+    let job2_clone = failed_job_2.clone();
+    db.expect_get_job_by_id().with(eq(job_id_2)).times(1).returning(move |_| Ok(Some(job2_clone.clone())));
+
+    // Mock update_job for transitioning to PendingRetry
+    db.expect_update_job().times(2).returning(move |job, _| Ok(job.clone()));
+
+    // Mock queue send_message for adding jobs to process queue
+    queue
+        .expect_send_message()
+        .times(2)
+        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobProcessing)
+        .returning(|_, _, _| Ok(()));
+
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
+    ));
+
+    let services = TestConfigBuilder::new()
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(da_client.into())
+        .configure_prover_client(prover_client.into())
+        .configure_settlement_client(settlement_client.into())
+        .configure_api_server(crate::tests::config::ConfigType::Actual)
+        .build()
+        .await;
+
+    let addr = services.api_server_address.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .method("POST")
+                .uri(format!("http://{}/admin/jobs/retry/failed", addr))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(response.success);
+
+    let data = response.data.unwrap();
+    assert_eq!(data.success_count, 2);
+    assert_eq!(data.failed_count, 0);
+}
+
+/// Test that POST /admin/jobs/requeue/pending-verification requeues pending verification jobs
+#[tokio::test]
+#[rstest]
+async fn test_admin_requeue_pending_verification() {
+    dotenvy::from_filename_override("../.env.test").ok();
+    // Set required env var if not present (for mocked tests)
+    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
+        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
+    }
+
+    let server = MockServer::start();
+    let mut db = MockDatabaseClient::new();
+    let mut queue = MockQueueClient::new();
+    let da_client = MockDaClient::new();
+    let prover_client = MockProverClient::new();
+    let settlement_client = MockSettlementClient::new();
+
+    let job_type = JobType::DataSubmission;
+
+    // Create pending verification job
+    let pending_job = build_job_item(job_type.clone(), JobStatus::PendingVerification, 2001);
+    let pending_jobs = vec![pending_job.clone()];
+
+    // Mock get_jobs_by_types_and_statuses
+    db.expect_get_jobs_by_types_and_statuses()
+        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::PendingVerification])
+        .times(1)
+        .returning(move |_, _, _| Ok(pending_jobs.clone()));
+
+    // Mock queue send_message for adding job to verification queue
+    queue
+        .expect_send_message()
+        .times(1)
+        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobVerification)
+        .returning(|_, _, _| Ok(()));
+
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
+    ));
+
+    let services = TestConfigBuilder::new()
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(da_client.into())
+        .configure_prover_client(prover_client.into())
+        .configure_settlement_client(settlement_client.into())
+        .configure_api_server(crate::tests::config::ConfigType::Actual)
+        .build()
+        .await;
+
+    let addr = services.api_server_address.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .method("POST")
+                .uri(format!("http://{}/admin/jobs/requeue/pending-verification", addr))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(response.success);
+
+    let data = response.data.unwrap();
+    assert_eq!(data.success_count, 1);
+    assert_eq!(data.failed_count, 0);
+}
+
+/// Test that POST /admin/jobs/requeue/created requeues created jobs
+#[tokio::test]
+#[rstest]
+async fn test_admin_requeue_created_jobs() {
+    dotenvy::from_filename_override("../.env.test").ok();
+    // Set required env var if not present (for mocked tests)
+    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
+        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
+    }
+
+    let server = MockServer::start();
+    let mut db = MockDatabaseClient::new();
+    let mut queue = MockQueueClient::new();
+    let da_client = MockDaClient::new();
+    let prover_client = MockProverClient::new();
+    let settlement_client = MockSettlementClient::new();
+
+    let job_type = JobType::DataSubmission;
+
+    // Create job in Created status
+    let created_job = build_job_item(job_type.clone(), JobStatus::Created, 3001);
+    let created_jobs = vec![created_job.clone()];
+
+    // Mock get_jobs_by_types_and_statuses
+    db.expect_get_jobs_by_types_and_statuses()
+        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::Created])
+        .times(1)
+        .returning(move |_, _, _| Ok(created_jobs.clone()));
+
+    // Mock queue send_message for adding job to process queue
+    queue
+        .expect_send_message()
+        .times(1)
+        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobProcessing)
+        .returning(|_, _, _| Ok(()));
+
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
+    ));
+
+    let services = TestConfigBuilder::new()
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(da_client.into())
+        .configure_prover_client(prover_client.into())
+        .configure_settlement_client(settlement_client.into())
+        .configure_api_server(crate::tests::config::ConfigType::Actual)
+        .build()
+        .await;
+
+    let addr = services.api_server_address.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .method("POST")
+                .uri(format!("http://{}/admin/jobs/requeue/created", addr))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(response.success);
+
+    let data = response.data.unwrap();
+    assert_eq!(data.success_count, 1);
+    assert_eq!(data.failed_count, 0);
+}

--- a/orchestrator/src/tests/server/admin_routes.rs
+++ b/orchestrator/src/tests/server/admin_routes.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use httpmock::MockServer;
 use mockall::predicate::eq;
 use rstest::*;
@@ -7,6 +9,7 @@ use url::Url;
 
 use crate::core::client::database::MockDatabaseClient;
 use crate::core::client::queue::MockQueueClient;
+use crate::core::config::Config;
 use crate::server::route::admin::BulkJobResponse;
 use crate::server::types::ApiResponse;
 use crate::tests::config::TestConfigBuilder;
@@ -18,325 +21,146 @@ use orchestrator_da_client_interface::MockDaClient;
 use orchestrator_prover_client_interface::MockProverClient;
 use orchestrator_settlement_client_interface::MockSettlementClient;
 
-/// Test that POST /admin/jobs/retry/failed retries all failed jobs
+fn setup_env() {
+    dotenvy::from_filename_override("../.env.test").ok();
+    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
+        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
+    }
+}
+
+async fn build_test_config(db: MockDatabaseClient, queue: MockQueueClient) -> (Arc<Config>, String) {
+    let server = MockServer::start();
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
+    ));
+    let services = TestConfigBuilder::new()
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(MockDaClient::new().into())
+        .configure_prover_client(MockProverClient::new().into())
+        .configure_settlement_client(MockSettlementClient::new().into())
+        .configure_api_server(crate::tests::config::ConfigType::Actual)
+        .build()
+        .await;
+    let addr = services.api_server_address.unwrap();
+    (services.config, addr.to_string())
+}
+
+async fn call_endpoint(addr: &str, path: &str) -> ApiResponse<BulkJobResponse> {
+    let client = hyper::Client::new();
+    let response = client
+        .request(Request::builder().method("POST").uri(format!("http://{}{}", addr, path)).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    serde_json::from_slice(&body_bytes).unwrap()
+}
+
 #[tokio::test]
 #[rstest]
 async fn test_admin_retry_all_failed_jobs() {
-    dotenvy::from_filename_override("../.env.test").ok();
-    // Set required env var if not present (for mocked tests)
-    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
-        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
-    }
-
-    let server = MockServer::start();
+    setup_env();
     let mut db = MockDatabaseClient::new();
     let mut queue = MockQueueClient::new();
-    let da_client = MockDaClient::new();
-    let prover_client = MockProverClient::new();
-    let settlement_client = MockSettlementClient::new();
 
-    let job_type = JobType::DataSubmission;
+    let job1 = build_job_item(JobType::DataSubmission, JobStatus::Failed, 1001);
+    let job2 = build_job_item(JobType::DataSubmission, JobStatus::Failed, 1002);
+    let (id1, id2) = (job1.id, job2.id);
+    let jobs = vec![job1.clone(), job2.clone()];
 
-    // Create failed jobs
-    let failed_job_1 = build_job_item(job_type.clone(), JobStatus::Failed, 1001);
-    let failed_job_2 = build_job_item(job_type.clone(), JobStatus::Failed, 1002);
-    let job_id_1 = failed_job_1.id;
-    let job_id_2 = failed_job_2.id;
-
-    let failed_jobs = vec![failed_job_1.clone(), failed_job_2.clone()];
-
-    // Mock get_jobs_by_types_and_statuses to return failed jobs
     db.expect_get_jobs_by_types_and_statuses()
-        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::Failed])
+        .withf(|t, s, _| t.is_empty() && s == &vec![JobStatus::Failed])
         .times(1)
-        .returning(move |_, _, _| Ok(failed_jobs.clone()));
+        .returning(move |_, _, _| Ok(jobs.clone()));
+    let j1 = job1.clone();
+    db.expect_get_job_by_id().with(eq(id1)).times(1).returning(move |_| Ok(Some(j1.clone())));
+    let j2 = job2.clone();
+    db.expect_get_job_by_id().with(eq(id2)).times(1).returning(move |_| Ok(Some(j2.clone())));
+    db.expect_update_job().times(2).returning(|job, _| Ok(job.clone()));
+    queue.expect_send_message().times(2).returning(|_, _, _| Ok(()));
 
-    // Mock get_job_by_id for each retry
-    let job1_clone = failed_job_1.clone();
-    db.expect_get_job_by_id().with(eq(job_id_1)).times(1).returning(move |_| Ok(Some(job1_clone.clone())));
-
-    let job2_clone = failed_job_2.clone();
-    db.expect_get_job_by_id().with(eq(job_id_2)).times(1).returning(move |_| Ok(Some(job2_clone.clone())));
-
-    // Mock update_job for transitioning to PendingRetry
-    db.expect_update_job().times(2).returning(move |job, _| Ok(job.clone()));
-
-    // Mock queue send_message for adding jobs to process queue
-    queue
-        .expect_send_message()
-        .times(2)
-        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobProcessing)
-        .returning(|_, _, _| Ok(()));
-
-    let provider = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
-    ));
-
-    let services = TestConfigBuilder::new()
-        .configure_starknet_client(provider.into())
-        .configure_database(db.into())
-        .configure_queue_client(queue.into())
-        .configure_da_client(da_client.into())
-        .configure_prover_client(prover_client.into())
-        .configure_settlement_client(settlement_client.into())
-        .configure_api_server(crate::tests::config::ConfigType::Actual)
-        .build()
-        .await;
-
-    let addr = services.api_server_address.unwrap();
-
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .method("POST")
-                .uri(format!("http://{}/admin/jobs/retry/failed", addr))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
-    assert!(response.success);
-
-    let data = response.data.unwrap();
-    assert_eq!(data.success_count, 2);
-    assert_eq!(data.failed_count, 0);
+    let (_, addr) = build_test_config(db, queue).await;
+    let resp = call_endpoint(&addr, "/admin/jobs/retry/failed").await;
+    assert!(resp.success);
+    assert_eq!(resp.data.unwrap().success_count, 2);
 }
 
-/// Test that POST /admin/jobs/requeue/pending-verification requeues pending verification jobs
-#[tokio::test]
-#[rstest]
-async fn test_admin_requeue_pending_verification() {
-    dotenvy::from_filename_override("../.env.test").ok();
-    // Set required env var if not present (for mocked tests)
-    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
-        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
-    }
-
-    let server = MockServer::start();
-    let mut db = MockDatabaseClient::new();
-    let mut queue = MockQueueClient::new();
-    let da_client = MockDaClient::new();
-    let prover_client = MockProverClient::new();
-    let settlement_client = MockSettlementClient::new();
-
-    let job_type = JobType::DataSubmission;
-
-    // Create pending verification job
-    let pending_job = build_job_item(job_type.clone(), JobStatus::PendingVerification, 2001);
-    let pending_jobs = vec![pending_job.clone()];
-
-    // Mock get_jobs_by_types_and_statuses
-    db.expect_get_jobs_by_types_and_statuses()
-        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::PendingVerification])
-        .times(1)
-        .returning(move |_, _, _| Ok(pending_jobs.clone()));
-
-    // Mock queue send_message for adding job to verification queue
-    queue
-        .expect_send_message()
-        .times(1)
-        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobVerification)
-        .returning(|_, _, _| Ok(()));
-
-    let provider = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
-    ));
-
-    let services = TestConfigBuilder::new()
-        .configure_starknet_client(provider.into())
-        .configure_database(db.into())
-        .configure_queue_client(queue.into())
-        .configure_da_client(da_client.into())
-        .configure_prover_client(prover_client.into())
-        .configure_settlement_client(settlement_client.into())
-        .configure_api_server(crate::tests::config::ConfigType::Actual)
-        .build()
-        .await;
-
-    let addr = services.api_server_address.unwrap();
-
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .method("POST")
-                .uri(format!("http://{}/admin/jobs/requeue/pending-verification", addr))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
-    assert!(response.success);
-
-    let data = response.data.unwrap();
-    assert_eq!(data.success_count, 1);
-    assert_eq!(data.failed_count, 0);
-}
-
-/// Test that POST /admin/jobs/retry/verification-timeout retries verification-timeout jobs
 #[tokio::test]
 #[rstest]
 async fn test_admin_retry_verification_timeout_jobs() {
-    dotenvy::from_filename_override("../.env.test").ok();
-    // Set required env var if not present (for mocked tests)
-    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
-        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
-    }
-
-    let server = MockServer::start();
+    setup_env();
     let mut db = MockDatabaseClient::new();
     let mut queue = MockQueueClient::new();
-    let da_client = MockDaClient::new();
-    let prover_client = MockProverClient::new();
-    let settlement_client = MockSettlementClient::new();
 
-    let job_type = JobType::DataSubmission;
+    let job = build_job_item(JobType::DataSubmission, JobStatus::VerificationTimeout, 4001);
+    let job_id = job.id;
+    let jobs = vec![job.clone()];
 
-    // Create verification timeout job
-    let timeout_job = build_job_item(job_type.clone(), JobStatus::VerificationTimeout, 4001);
-    let job_id = timeout_job.id;
-
-    let timeout_jobs = vec![timeout_job.clone()];
-
-    // Mock get_jobs_by_types_and_statuses to return verification timeout jobs
     db.expect_get_jobs_by_types_and_statuses()
-        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::VerificationTimeout])
+        .withf(|t, s, _| t.is_empty() && s == &vec![JobStatus::VerificationTimeout])
         .times(1)
-        .returning(move |_, _, _| Ok(timeout_jobs.clone()));
+        .returning(move |_, _, _| Ok(jobs.clone()));
+    let jc = job.clone();
+    db.expect_get_job_by_id().with(eq(job_id)).times(1).returning(move |_| Ok(Some(jc.clone())));
+    db.expect_update_job().times(1).returning(|job, _| Ok(job.clone()));
+    queue.expect_send_message().times(1).returning(|_, _, _| Ok(()));
 
-    // Mock get_job_by_id for retry
-    let job_clone = timeout_job.clone();
-    db.expect_get_job_by_id().with(eq(job_id)).times(1).returning(move |_| Ok(Some(job_clone.clone())));
+    let (_, addr) = build_test_config(db, queue).await;
+    let resp = call_endpoint(&addr, "/admin/jobs/retry/verification-timeout").await;
+    assert!(resp.success);
+    assert_eq!(resp.data.unwrap().success_count, 1);
+}
 
-    // Mock update_job for transitioning to PendingRetry
-    db.expect_update_job().times(1).returning(move |job, _| Ok(job.clone()));
+#[tokio::test]
+#[rstest]
+async fn test_admin_requeue_pending_verification() {
+    setup_env();
+    let mut db = MockDatabaseClient::new();
+    let mut queue = MockQueueClient::new();
 
-    // Mock queue send_message for adding job to process queue
+    let job = build_job_item(JobType::DataSubmission, JobStatus::PendingVerification, 2001);
+    let jobs = vec![job.clone()];
+
+    db.expect_get_jobs_by_types_and_statuses()
+        .withf(|t, s, _| t.is_empty() && s == &vec![JobStatus::PendingVerification])
+        .times(1)
+        .returning(move |_, _, _| Ok(jobs.clone()));
     queue
         .expect_send_message()
         .times(1)
-        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobProcessing)
+        .withf(|qt, _, _| *qt == QueueType::DataSubmissionJobVerification)
         .returning(|_, _, _| Ok(()));
 
-    let provider = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
-    ));
-
-    let services = TestConfigBuilder::new()
-        .configure_starknet_client(provider.into())
-        .configure_database(db.into())
-        .configure_queue_client(queue.into())
-        .configure_da_client(da_client.into())
-        .configure_prover_client(prover_client.into())
-        .configure_settlement_client(settlement_client.into())
-        .configure_api_server(crate::tests::config::ConfigType::Actual)
-        .build()
-        .await;
-
-    let addr = services.api_server_address.unwrap();
-
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .method("POST")
-                .uri(format!("http://{}/admin/jobs/retry/verification-timeout", addr))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
-    assert!(response.success);
-
-    let data = response.data.unwrap();
-    assert_eq!(data.success_count, 1);
-    assert_eq!(data.failed_count, 0);
+    let (_, addr) = build_test_config(db, queue).await;
+    let resp = call_endpoint(&addr, "/admin/jobs/requeue/pending-verification").await;
+    assert!(resp.success);
+    assert_eq!(resp.data.unwrap().success_count, 1);
 }
 
-/// Test that POST /admin/jobs/requeue/created requeues created jobs
 #[tokio::test]
 #[rstest]
 async fn test_admin_requeue_created_jobs() {
-    dotenvy::from_filename_override("../.env.test").ok();
-    // Set required env var if not present (for mocked tests)
-    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
-        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
-    }
-
-    let server = MockServer::start();
+    setup_env();
     let mut db = MockDatabaseClient::new();
     let mut queue = MockQueueClient::new();
-    let da_client = MockDaClient::new();
-    let prover_client = MockProverClient::new();
-    let settlement_client = MockSettlementClient::new();
 
-    let job_type = JobType::DataSubmission;
+    let job = build_job_item(JobType::DataSubmission, JobStatus::Created, 3001);
+    let jobs = vec![job.clone()];
 
-    // Create job in Created status
-    let created_job = build_job_item(job_type.clone(), JobStatus::Created, 3001);
-    let created_jobs = vec![created_job.clone()];
-
-    // Mock get_jobs_by_types_and_statuses
     db.expect_get_jobs_by_types_and_statuses()
-        .withf(|types, statuses, _| types.is_empty() && statuses == &vec![JobStatus::Created])
+        .withf(|t, s, _| t.is_empty() && s == &vec![JobStatus::Created])
         .times(1)
-        .returning(move |_, _, _| Ok(created_jobs.clone()));
-
-    // Mock queue send_message for adding job to process queue
+        .returning(move |_, _, _| Ok(jobs.clone()));
     queue
         .expect_send_message()
         .times(1)
-        .withf(|queue_type, _, _| *queue_type == QueueType::DataSubmissionJobProcessing)
+        .withf(|qt, _, _| *qt == QueueType::DataSubmissionJobProcessing)
         .returning(|_, _, _| Ok(()));
 
-    let provider = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
-    ));
-
-    let services = TestConfigBuilder::new()
-        .configure_starknet_client(provider.into())
-        .configure_database(db.into())
-        .configure_queue_client(queue.into())
-        .configure_da_client(da_client.into())
-        .configure_prover_client(prover_client.into())
-        .configure_settlement_client(settlement_client.into())
-        .configure_api_server(crate::tests::config::ConfigType::Actual)
-        .build()
-        .await;
-
-    let addr = services.api_server_address.unwrap();
-
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .method("POST")
-                .uri(format!("http://{}/admin/jobs/requeue/created", addr))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response: ApiResponse<BulkJobResponse> = serde_json::from_slice(&body_bytes).unwrap();
-    assert!(response.success);
-
-    let data = response.data.unwrap();
-    assert_eq!(data.success_count, 1);
-    assert_eq!(data.failed_count, 0);
+    let (_, addr) = build_test_config(db, queue).await;
+    let resp = call_endpoint(&addr, "/admin/jobs/requeue/created").await;
+    assert!(resp.success);
+    assert_eq!(resp.data.unwrap().success_count, 1);
 }

--- a/orchestrator/src/tests/server/mod.rs
+++ b/orchestrator/src/tests/server/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin_routes;
 pub mod job_routes;
 pub mod jobs_by_status;
 use crate::tests::config::{ConfigType, TestConfigBuilder};

--- a/orchestrator/src/types/params/service.rs
+++ b/orchestrator/src/types/params/service.rs
@@ -28,10 +28,11 @@ impl From<ServiceCliArgs> for ServiceParams {
 pub struct ServerParams {
     pub host: String,
     pub port: u16,
+    pub admin_enabled: bool,
 }
 
 impl From<ServerCliArgs> for ServerParams {
     fn from(value: ServerCliArgs) -> Self {
-        Self { host: value.host, port: value.port }
+        Self { host: value.host, port: value.port, admin_enabled: value.admin_enabled }
     }
 }

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -648,8 +648,7 @@ impl JobHandlerService {
         .await
     }
 
-    /// Retries a failed job by reprocessing it.
-    /// Only jobs with Failed status can be retried.
+    /// Retries a failed or verification-timed-out job by reprocessing it.
     ///
     /// # Arguments
     /// * `id` - UUID of the job to retry
@@ -660,9 +659,10 @@ impl JobHandlerService {
     ///
     /// # State Transitions
     /// * `Failed` -> `PendingRetry` -> (normal processing flow)
+    /// * `VerificationTimeout` -> `PendingRetry` -> (normal processing flow)
     ///
     /// # Notes
-    /// * Only jobs in Failed status can be retried
+    /// * Only jobs in `Failed` or `VerificationTimeout` status can be retried
     /// * Transitions through PendingRetry status before normal processing
     /// * Uses standard process_job function after status update
     pub async fn retry_job(id: Uuid, config: Arc<Config>) -> Result<(), JobError> {
@@ -676,11 +676,11 @@ impl JobHandlerService {
             block_no = %internal_id,
             "General retry job started for block"
         );
-        if job.status != JobStatus::Failed {
+        if !matches!(job.status, JobStatus::Failed | JobStatus::VerificationTimeout) {
             error!(
                 job_id = ?id,
                 status = ?job.status,
-                "Cannot retry job: invalid status"
+                "Cannot retry job: invalid status (must be Failed or VerificationTimeout)"
             );
             return Err(JobError::InvalidStatus { id, job_status: job.status });
         }


### PR DESCRIPTION
Pull Request type

- [x] Feature
- [x] Testing

## What is the current behavior?

The orchestrator lacks administrative endpoints for bulk job management operations. When jobs get stuck in `Failed`, `PendingVerification`, or `Created` states, there's no way to programmatically retry or requeue them in bulk.

Resolves: #NA

## What is the new behavior?

Adds admin endpoints for bulk job management operations, protected behind an `--admin-enabled` flag.

### New Endpoints (under `/admin/`):

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/admin/jobs/retry/failed` | POST | Retries all jobs in `Failed` status, transitioning them to `PendingRetry` and adding them to the process queue |
| `/admin/jobs/requeue/pending-verification` | POST | Re-adds all `PendingVerification` jobs to their respective verification queues |
| `/admin/jobs/requeue/created` | POST | Re-adds all `Created` jobs to their respective processing queues |

### Features:
- All endpoints support optional `?job_type=<type>` query parameter filtering
- Returns detailed response with `success_count`, `failed_count`, and lists of job IDs
- Proper error handling with metrics tracking
- Endpoints are disabled by default - enable via `--admin-enabled` flag or `MADARA_ORCHESTRATOR_ADMIN_ENABLED=true`

### Example Response:
```json
{
  "success": true,
  "message": "Successfully queued 5 job(s) for retry",
  "data": {
    "success_count": 5,
    "successful_job_ids": ["uuid1", "uuid2", ...],
    "failed_count": 0,
    "failed_job_ids": []
  }
}
```

## Does this introduce a breaking change?

No

## Other information

- Includes unit tests with mocked dependencies (no external services required)
- Cherry-picked from `orchestrator-0.14.0/paradex_ready` branch