### PR TITLE
Update Atlantic client to 0.14.1

### DIFF
--- a/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
@@ -435,6 +435,7 @@ impl AtlanticClient {
         mock_proof: bool,
         chain_id_hex: Option<String>,
         fee_token_address: Option<Felt252>,
+        da_public_keys: Option<Vec<String>>,
     ) -> Result<AtlanticBucketResponse, AtlanticError> {
         let context = format!("mock_proof: {}, chain_id_hex: {:?}", mock_proof, chain_id_hex);
 
@@ -454,12 +455,13 @@ impl AtlanticClient {
                 let bucket_request = AtlanticCreateBucketRequest {
                     external_id: None,
                     node_width: None,
-                    aggregator_version: AtlanticAggregatorVersion::SnosAggregator0_13_3,
+                    aggregator_version: AtlanticAggregatorVersion::SnosAggregator0_14_1,
                     aggregator_params: AtlanticAggregatorParams {
                         use_kzg_da: AGGREGATOR_USE_KZG_DA,
                         full_output: AGGREGATOR_FULL_OUTPUT,
                         chain_id_hex: chain_id_clone.clone(),
                         fee_token_address,
+                        da_public_keys: da_public_keys.clone(),
                     },
                     mock_proof,
                 };

--- a/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
@@ -56,6 +56,7 @@ pub struct AtlanticProverService {
     pub cairo_verifier_program_hash: Option<String>,
     pub chain_id_hex: Option<String>,
     pub fee_token_address: Option<Felt252>,
+    pub da_public_keys: Option<Vec<String>>,
 }
 
 #[async_trait]
@@ -148,6 +149,7 @@ impl ProverClient for AtlanticProverService {
                         self.should_mock_proof(),
                         self.chain_id_hex.clone(),
                         self.fee_token_address,
+                        self.da_public_keys.clone(),
                     )
                     .await?;
                 tracing::debug!(bucket_id = %response.atlantic_bucket.id, "Successfully submitted create bucket task to atlantic: {:?}", response);
@@ -316,6 +318,7 @@ impl ProverClient for AtlanticProverService {
 }
 
 impl AtlanticProverService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         atlantic_client: AtlanticClient,
         atlantic_api_key: String,
@@ -324,6 +327,7 @@ impl AtlanticProverService {
         mock_fact_hash: bool,
         cairo_verifier_program_hash: Option<String>,
         fee_token_address: Option<Felt252>,
+        da_public_keys: Option<Vec<String>>,
     ) -> Self {
         Self {
             atlantic_client,
@@ -337,6 +341,7 @@ impl AtlanticProverService {
             cairo_verifier_program_hash,
             chain_id_hex: job_config.chain_id_hex,
             fee_token_address,
+            da_public_keys,
         }
     }
 
@@ -356,6 +361,7 @@ impl AtlanticProverService {
         proof_layout: &LayoutName,
         chain_id_hex: Option<String>,
         fee_token_address: Option<Felt252>,
+        da_public_keys: Option<Vec<String>>,
     ) -> Self {
         let atlantic_client =
             AtlanticClient::new_with_args(atlantic_params.atlantic_service_url.clone(), atlantic_params);
@@ -376,6 +382,7 @@ impl AtlanticProverService {
             atlantic_params.atlantic_mock_fact_hash.eq("true"),
             atlantic_params.cairo_verifier_program_hash.clone(),
             fee_token_address,
+            da_public_keys,
         )
     }
 
@@ -397,6 +404,7 @@ impl AtlanticProverService {
             },
             fact_checker,
             atlantic_params.atlantic_mock_fact_hash.eq("true"),
+            None,
             None,
             None,
         )

--- a/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
@@ -154,6 +154,8 @@ pub struct AtlanticAggregatorParams {
     pub(crate) chain_id_hex: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) fee_token_address: Option<Felt252>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) da_public_keys: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
@@ -207,7 +207,8 @@ async fn atlantic_client_get_task_status_works() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
     };
-    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None);
+    let atlantic_service =
+        AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None, None);
 
     let atlantic_query_id = "01JPMKV7WFP4JTC0TTQSEAM9GW";
     let task_result = atlantic_service.atlantic_client.get_job_status(atlantic_query_id).await;
@@ -233,7 +234,8 @@ async fn atlantic_client_get_bucket_status_works() {
         atlantic_cairo_vm: AtlanticCairoVm::Python,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
     };
-    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None);
+    let atlantic_service =
+        AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None, None);
 
     let bucket_id = "01K0RN2JFJW3382CZPHRBC48NR";
     let task_result = atlantic_service.atlantic_client.get_bucket(bucket_id).await;
@@ -263,7 +265,8 @@ async fn atlantic_client_submit_task_and_get_job_status_with_mock_fact_hash() {
     };
 
     // Create the Atlantic service with actual configuration
-    let atlantic_service = AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None);
+    let atlantic_service =
+        AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None, None);
 
     // Load the Cairo PIE from the test data
     let cairo_pie_path = env!("CARGO_MANIFEST_DIR").to_string() + CAIRO_PIE_PATH;

--- a/orchestrator/src/cli/mod.rs
+++ b/orchestrator/src/cli/mod.rs
@@ -160,6 +160,9 @@ pub struct RunCmd {
     #[arg(env = "MADARA_ORCHESTRATOR_LAYER", long, default_value = "l2", value_enum)]
     pub layer: Layer,
 
+    #[arg(env = "MADARA_ORCHESTRATOR_DA_PUBLIC_KEYS", long, required = true)]
+    pub da_public_keys: Vec<String>,
+
     #[arg(env = "MADARA_ORCHESTRATOR_MADARA_VERSION", long, required = true)]
     pub madara_version: StarknetVersion,
 

--- a/orchestrator/src/core/config.rs
+++ b/orchestrator/src/core/config.rs
@@ -290,6 +290,7 @@ impl Config {
             &params,
             Some(format!("0x{}", hex::encode(&chain_details.chain_id))),
             Some(Felt252::from_str(chain_details.strk_fee_token_address.as_str())?),
+            Some(run_cmd.da_public_keys.clone()),
         );
         let da_client: Box<dyn DaClient + Send + Sync + 'static> = Self::build_da_client(&da_config).await;
         let settlement_client = Self::build_settlement_client(&settlement_config).await?;
@@ -375,6 +376,7 @@ impl Config {
         params: &ConfigParam,
         chain_id_hex: Option<String>,
         fee_token_address: Option<Felt252>,
+        da_public_keys: Option<Vec<String>>,
     ) -> Box<dyn ProverClient + Send + Sync> {
         match prover_params {
             ProverConfig::Sharp(sharp_params) => {
@@ -385,6 +387,7 @@ impl Config {
                 &params.prover_layout_name,
                 chain_id_hex,
                 fee_token_address,
+                da_public_keys,
             )),
         }
     }

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -520,7 +520,7 @@ pub mod implement_client {
         match service {
             ConfigType::Mock(client) => client.into(),
             ConfigType::Actual => {
-                Config::build_prover_service(&params.prover_params, &params.orchestrator_params, None, None)
+                Config::build_prover_service(&params.prover_params, &params.orchestrator_params, None, None, None)
             }
             ConfigType::Dummy => Box::new(MockProverClient::new()),
         }


### PR DESCRIPTION
## Pull Request type

- [x] Feature

## What is the current behavior?

Atlantic client uses aggregator version `SnosAggregator0_13_3`.

Resolves: #NA

## What is the new behavior?

- Update Atlantic aggregator version to `SnosAggregator0_14_1`
- Add `da_public_keys` parameter support for bucket creation
- Add `MADARA_ORCHESTRATOR_DA_PUBLIC_KEYS` CLI argument

## Does this introduce a breaking change?

Yes - requires `MADARA_ORCHESTRATOR_DA_PUBLIC_KEYS` environment variable to be set.

## Other information

N/A