### PR TITLE
Bug Fixes for Orchestrator

### DIFF
--- a/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
@@ -412,7 +412,7 @@ impl AtlanticClient {
                             error = %error_text,
                             "Search failed"
                         );
-                        Err(AtlanticError::api_error("search_atlantic_queries", status, error_text))
+                        Err(AtlanticError::from_http_error_response("search_atlantic_queries", status, error_text))
                     }
                 }
             })

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -206,12 +206,6 @@ impl JobHandlerTrait for SnosJobHandler {
             // SNOS is down - signal to requeue with delay
             warn!(snos_url = %snos_url, "SNOS RPC is unavailable, job will be requeued");
 
-            let alert_msg =
-                format!("SNOS RPC {} is unavailable. SnosRun jobs will be requeued until it recovers.", snos_url);
-            if let Err(e) = config.alerts().send_message(alert_msg).await {
-                error!(error = ?e, "Failed to send SNOS unavailability alert");
-            }
-
             return Err(Duration::from_secs(SNOS_UNAVAILABLE_RETRY_DELAY_SECS));
         }
 


### PR DESCRIPTION
# Bug Fixes found on Stress Testing

## Problem #1: Atlantic `search_atlantic_queries` fails without retries on infrastructure errors

**Symptom:** Job `d7f31278-5d51-4405-a884-4297307c7aba` failed immediately with "404 page not found" error without any retry attempts.

**Root Cause:** The `search_atlantic_queries` function in `client.rs` was using `AtlanticError::api_error()` for HTTP errors, which creates a non-retryable error. Other functions like `get_bucket`, `add_job`, `get_job_status` correctly use `from_http_error_response()` which classifies infrastructure errors (like "404 page not found" from load balancers) as retryable.

**File:** `orchestrator/crates/prover-clients/atlantic-service/src/client.rs`

**Solution:** Changed the error construction from:
```rust
Err(AtlanticError::api_error("search_atlantic_queries", status, error_text))
```
To:
```rust
Err(AtlanticError::from_http_error_response("search_atlantic_queries", status, error_text))
```

This ensures infrastructure errors trigger exponential backoff retries (2s, 4s, 8s... up to 2 minutes) instead of immediate failure.



## Problem #2: Unnecessary alerts when SNOS RPC is temporarily unavailable

**Symptom:** During stress testing, when SNOS RPC becomes temporarily unavailable, the system sends SNS alerts for every requeued job, causing alert fatigue.

**Root Cause:** The `check_ready_to_process` function in `SnosJobHandler` was sending an SNS alert every time SNOS RPC was unavailable, even though requeuing the job is the expected and correct behavior for temporary unavailability.

**File:** `orchestrator/src/worker/event_handler/jobs/snos.rs`

**Solution:** Removed the SNS alert from the `check_ready_to_process` function. The job is already being requeued with a delay, which is the correct handling for temporary RPC unavailability. A warning log is sufficient for observability without causing alert fatigue.


