### PR TITLE
chore: add message retention period (TTL) for worker trigger queue

### DIFF
--- a/orchestrator/src/core/client/queue/sqs.rs
+++ b/orchestrator/src/core/client/queue/sqs.rs
@@ -105,9 +105,25 @@ impl InnerSQS {
     }
 
     /// Create a new queue with the given name
-    pub async fn create_queue(&self, queue_name: String, visibility_timeout: u32) -> Result<String, OrchestratorError> {
+    ///
+    /// # Arguments
+    /// * `queue_name` - The name of the queue to create
+    /// * `visibility_timeout` - The visibility timeout in seconds
+    /// * `message_retention_period` - Optional message retention period (TTL) in seconds.
+    ///   Valid values: 60 to 1,209,600 seconds. If None, uses SQS default (4 days).
+    pub async fn create_queue(
+        &self,
+        queue_name: String,
+        visibility_timeout: u32,
+        message_retention_period: Option<u32>,
+    ) -> Result<String, OrchestratorError> {
         let mut attributes = HashMap::new();
         attributes.insert(QueueAttributeName::VisibilityTimeout, visibility_timeout.to_string());
+
+        if let Some(retention_period) = message_retention_period {
+            attributes.insert(QueueAttributeName::MessageRetentionPeriod, retention_period.to_string());
+        }
+
         let res = self
             .client()
             .create_queue()

--- a/orchestrator/src/types/queue_control.rs
+++ b/orchestrator/src/types/queue_control.rs
@@ -48,6 +48,9 @@ pub struct QueueConfig {
     pub queue_control: QueueControlConfig,
     pub dlq_config: Option<DlqConfig>,
     pub supported_layers: Vec<Layer>,
+    /// Message retention period (TTL) in seconds. If None, uses SQS default (4 days).
+    /// Valid values: 60 to 1,209,600 seconds.
+    pub message_retention_period: Option<u32>,
 }
 
 // TODO: this should be dynamically created based on the run command params.
@@ -61,6 +64,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: None,
             queue_control: QueueControlConfig::default(),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -70,6 +74,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: None,
             queue_control: QueueControlConfig::default_with_message_count(50),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: Some(60), // 60 second TTL for worker triggers
         },
     );
     map.insert(
@@ -81,6 +86,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
                 get_env_var_or_default("MADARA_ORCHESTRATOR_MAX_CONCURRENT_SNOS_JOBS", "5").parse().expect("MADARA_ORCHESTRATOR_MAX_CONCURRENT_SNOS_JOBS does not have correct value. Should be a whole number"),
             ),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -90,6 +96,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::default_with_message_count(5),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -101,6 +108,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
                 get_env_var_or_default("MADARA_ORCHESTRATOR_MAX_CONCURRENT_PROVING_JOBS", "10").parse().expect("MADARA_ORCHESTRATOR_MAX_CONCURRENT_PROVING_JOBS does not have correct value. Should be a whole number"),
             ),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -110,6 +118,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -119,6 +128,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -128,6 +138,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -137,6 +148,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -146,6 +158,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -155,6 +168,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -164,6 +178,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -173,6 +188,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L2],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -182,6 +198,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(10),
             supported_layers: vec![Layer::L2],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -191,6 +208,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(1), // Single reader (PQ Worker)
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map.insert(
@@ -200,6 +218,7 @@ pub static QUEUES: LazyLock<HashMap<QueueType, QueueConfig>> = LazyLock::new(|| 
             dlq_config: Some(DlqConfig { max_receive_count: 5, dlq_name: QueueType::JobHandleFailure }),
             queue_control: QueueControlConfig::new(1), // Single reader (PQ Worker)
             supported_layers: vec![Layer::L2, Layer::L3],
+            message_retention_period: None,
         },
     );
     map


### PR DESCRIPTION
## Summary
- Adds configurable message retention period (TTL) support for SQS queues
- Sets 60 second TTL for WorkerTrigger queue to auto-expire stale worker trigger messages
- Worker triggers are time-sensitive and stale triggers should not be processed

## Changes
- Added `message_retention_period: Option<u32>` field to `QueueConfig`
- Updated `create_queue` to accept and set `MessageRetentionPeriod` SQS attribute
- Updated SQS setup to pass message retention period when creating queues
- Added test verification for message retention period

## Test plan
- [x] Existing SQS setup tests pass
- [x] New test verification confirms 60s TTL is set for WorkerTrigger queue
- [x] `cargo test -p orchestrator --lib tests::setup::sqs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)