### PR TITLE
update: nack message instead of marking failed when job processing fail

### DIFF
--- a/orchestrator/src/error/job/mod.rs
+++ b/orchestrator/src/error/job/mod.rs
@@ -113,7 +113,4 @@ pub enum JobError {
     /// Indicates an error occurred while downcasting from an object
     #[error("Orchestrator Error: {0}")]
     AnyHowError(#[from] anyhow::Error),
-
-    #[error("Batching Error: {0}")]
-    BatchingNotInSync(String),
 }

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -11,6 +11,7 @@ use crate::core::config::Config;
 use crate::error::job::JobError;
 use crate::error::other::OtherError;
 use crate::types::jobs::external_id::ExternalId;
+use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::job_updates::JobItemUpdates;
 use crate::types::jobs::metadata::JobMetadata;
 use crate::types::jobs::status::JobVerificationStatus;
@@ -366,7 +367,6 @@ impl JobHandlerService {
                 external_id
             }
             Ok(Err(e)) => {
-                // Reset job state so it can be retried when the message comes back
                 error!(
                     job_id = ?id,
                     job_type = ?job.job_type,
@@ -375,21 +375,7 @@ impl JobHandlerService {
                     error = ?e,
                     "Failed to process job, resetting state for retry"
                 );
-                job.metadata.common.process_started_at = None;
-                if let Err(db_err) = config
-                    .database()
-                    .update_job(
-                        &job,
-                        JobItemUpdates::new()
-                            .update_status(original_status)
-                            .update_metadata(job.metadata.clone())
-                            .build(),
-                    )
-                    .await
-                {
-                    error!(job_id = ?id, error = ?db_err, "Failed to reset job state after processing error");
-                }
-                return Err(e);
+                return Err(Self::reset_job_for_retry(&mut job, config.clone(), original_status, e).await);
             }
             Err(panic) => {
                 let panic_msg = panic
@@ -398,26 +384,10 @@ impl JobHandlerService {
                     .or_else(|| panic.downcast_ref::<&str>().copied())
                     .unwrap_or("Unknown panic message");
 
-                // Reset job state so it can be retried when the message comes back
                 error!(job_id = ?id, panic_msg = %panic_msg, "Job handler panicked during processing, resetting state for retry");
-                job.metadata.common.process_started_at = None;
-                if let Err(db_err) = config
-                    .database()
-                    .update_job(
-                        &job,
-                        JobItemUpdates::new()
-                            .update_status(original_status)
-                            .update_metadata(job.metadata.clone())
-                            .build(),
-                    )
-                    .await
-                {
-                    error!(job_id = ?id, error = ?db_err, "Failed to reset job state after panic");
-                }
-                return Err(JobError::Other(OtherError::from(format!(
-                    "Job handler panicked with message: {}",
-                    panic_msg
-                ))));
+                let panic_error =
+                    JobError::Other(OtherError::from(format!("Job handler panicked with message: {}", panic_msg)));
+                return Err(Self::reset_job_for_retry(&mut job, config.clone(), original_status, panic_error).await);
             }
         };
 
@@ -871,6 +841,37 @@ impl JobHandlerService {
 
         ORCHESTRATOR_METRICS.block_gauge.record(block_number, attributes);
         Ok(())
+    }
+
+    /// Resets job state to allow retry when the message comes back from the queue.
+    ///
+    /// Clears `process_started_at` and restores the job to its original status.
+    /// If the DB update fails, returns an error combining both the original error
+    /// and the DB error context.
+    async fn reset_job_for_retry(
+        job: &mut JobItem,
+        config: Arc<Config>,
+        original_status: JobStatus,
+        original_error: JobError,
+    ) -> JobError {
+        job.metadata.common.process_started_at = None;
+        match config
+            .database()
+            .update_job(
+                job,
+                JobItemUpdates::new().update_status(original_status).update_metadata(job.metadata.clone()).build(),
+            )
+            .await
+        {
+            Ok(_) => original_error,
+            Err(db_err) => {
+                error!(job_id = ?job.id, error = ?db_err, "Failed to reset job state for retry");
+                JobError::Other(OtherError::from(format!(
+                    "Failed to reset job state: {}. Original error: {}",
+                    db_err, original_error
+                )))
+            }
+        }
     }
 
     /// To get Box<dyn Worker> handler from `WorkerTriggerType`.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

Job is marked as failed if the job handler returns an error/panics just after one try.

Resolves: #NA

## What is the new behavior?

NACK the message if the job fails so we can re-process it when the message comes back.
If the job fails repeatedly, we mark the job as failed through DLQ route.

## Does this introduce a breaking change?

No

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
