### PR TITLE
Orchestrator: Automatic Storage Cleanup for Settled Artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,5 @@ sequencer_venv/
 sequencer_requirements.txt
 # AI-generated documentation
 AI_docs/
+.claude
 orchestrator/package-lock.json

--- a/e2e-tests/tests.rs
+++ b/e2e-tests/tests.rs
@@ -633,6 +633,7 @@ pub async fn put_job_data_in_db_update_state(mongo_db: &MongoDbServer, l2_block_
         da_segment_path: Some(format!("{}/{}", block_number, DA_SEGMENT_FILE_NAME)),
         tx_hash: None,
         context: SettlementContext::Block(SettlementContextData { to_settle: block_number, last_failed: None }),
+        storage_artifacts_tagged_at: None,
     };
 
     // Create the common metadata with default values

--- a/orchestrator/src/cli/storage/aws_s3.rs
+++ b/orchestrator/src/cli/storage/aws_s3.rs
@@ -1,5 +1,8 @@
 use clap::Args;
 
+/// Default number of days before S3 deletes tagged objects
+pub const DEFAULT_STORAGE_EXPIRATION_DAYS: i32 = 14;
+
 /// Parameters used to config AWS S3.
 #[derive(Debug, Clone, Args)]
 #[group()] // Note: we are not using bucket_name in requires_all because it has a default value.
@@ -14,4 +17,9 @@ pub struct AWSS3CliArgs {
     /// because s3 is unique globally.
     #[arg(env = "MADARA_ORCHESTRATOR_AWS_S3_BUCKET_IDENTIFIER", long, default_value = Some("mo-bucket"))]
     pub bucket_identifier: Option<String>,
+
+    /// Number of days before S3 automatically deletes objects tagged for expiration.
+    /// Different deployments may need different retention periods (e.g., 7 days for dev, 30 days for production).
+    #[arg(env = "MADARA_ORCHESTRATOR_STORAGE_EXPIRATION_DAYS", long, default_value_t = DEFAULT_STORAGE_EXPIRATION_DAYS)]
+    pub storage_expiration_days: i32,
 }

--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -130,6 +130,19 @@ pub trait DatabaseClient: Send + Sync {
         orchestrator_version: Option<String>,
     ) -> Result<Vec<JobItem>, DatabaseError>;
 
+    /// Get completed StateTransition jobs that haven't had their storage artifacts tagged yet
+    ///
+    /// # Arguments
+    /// * `limit` - Optional limit on number of results
+    ///
+    /// # Returns
+    /// Jobs where status is Completed, job_type is StateTransition, and
+    /// metadata.specific.storage_artifacts_tagged_at is null or doesn't exist
+    async fn get_jobs_without_storage_artifacts_tagged(
+        &self,
+        limit: Option<i64>,
+    ) -> Result<Vec<JobItem>, DatabaseError>;
+
     /// Get jobs between internal IDs for a specific type and status
     ///
     /// # Arguments

--- a/orchestrator/src/core/client/storage/error.rs
+++ b/orchestrator/src/core/client/storage/error.rs
@@ -27,4 +27,6 @@ pub enum StorageError {
     ObjectStreamError(String),
     #[error("Invalid Bucket Name is given: {0}")]
     InvalidBucketName(String),
+    #[error("Object not found: {0}")]
+    NotFound(String),
 }

--- a/orchestrator/src/core/client/storage/mod.rs
+++ b/orchestrator/src/core/client/storage/mod.rs
@@ -29,4 +29,18 @@ pub trait StorageClient: Send + Sync {
     /// * `Ok(())` - If the storage service is healthy and accessible
     /// * `Err(StorageError)` - If the health check fails
     async fn health_check(&self) -> Result<(), StorageError>;
+
+    /// Tag an object with key-value pairs
+    ///
+    /// This method applies tags to an existing object in storage.
+    /// Tags can be used for lifecycle management, cost allocation, or organization.
+    ///
+    /// # Arguments
+    /// * `key` - The key of the object to tag
+    /// * `tags` - A vector of (key, value) pairs representing the tags
+    ///
+    /// # Returns
+    /// * `Ok(())` - If tagging was successful
+    /// * `Err(StorageError)` - If tagging fails
+    async fn tag_object(&self, key: &str, tags: Vec<(String, String)>) -> Result<(), StorageError>;
 }

--- a/orchestrator/src/core/client/storage/mod.rs
+++ b/orchestrator/src/core/client/storage/mod.rs
@@ -37,10 +37,10 @@ pub trait StorageClient: Send + Sync {
     ///
     /// # Arguments
     /// * `key` - The key of the object to tag
-    /// * `tags` - A slice of (key, value) pairs representing the tags (passed by reference to avoid cloning)
+    /// * `tags` - A slice of (key, value) string slice pairs representing the tags
     ///
     /// # Returns
     /// * `Ok(())` - If tagging was successful
     /// * `Err(StorageError)` - If tagging fails
-    async fn tag_object(&self, key: &str, tags: &[(String, String)]) -> Result<(), StorageError>;
+    async fn tag_object<'a>(&self, key: &str, tags: &'a [(&'a str, &'a str)]) -> Result<(), StorageError>;
 }

--- a/orchestrator/src/core/client/storage/mod.rs
+++ b/orchestrator/src/core/client/storage/mod.rs
@@ -37,10 +37,10 @@ pub trait StorageClient: Send + Sync {
     ///
     /// # Arguments
     /// * `key` - The key of the object to tag
-    /// * `tags` - A vector of (key, value) pairs representing the tags
+    /// * `tags` - A slice of (key, value) pairs representing the tags (passed by reference to avoid cloning)
     ///
     /// # Returns
     /// * `Ok(())` - If tagging was successful
     /// * `Err(StorageError)` - If tagging fails
-    async fn tag_object(&self, key: &str, tags: Vec<(String, String)>) -> Result<(), StorageError>;
+    async fn tag_object(&self, key: &str, tags: &[(String, String)]) -> Result<(), StorageError>;
 }

--- a/orchestrator/src/core/client/storage/s3.rs
+++ b/orchestrator/src/core/client/storage/s3.rs
@@ -153,13 +153,13 @@ impl StorageClient for AWSS3 {
     ///
     /// # Arguments
     /// * `key` - The key of the object to tag.
-    /// * `tags` - A vector of (key, value) pairs representing the tags.
+    /// * `tags` - A slice of (key, value) pairs representing the tags.
     ///
     /// # Returns
     /// * `Result<(), StorageError>` - The result of the tagging operation.
-    async fn tag_object(&self, key: &str, tags: Vec<(String, String)>) -> Result<(), StorageError> {
+    async fn tag_object(&self, key: &str, tags: &[(String, String)]) -> Result<(), StorageError> {
         let s3_tags: Result<Vec<Tag>, _> =
-            tags.into_iter().map(|(k, v)| Tag::builder().key(k).value(v).build()).collect();
+            tags.iter().map(|(k, v)| Tag::builder().key(k).value(v).build()).collect();
 
         let s3_tags = s3_tags.map_err(|e| StorageError::ObjectStreamError(format!("Failed to build tags: {:?}", e)))?;
 

--- a/orchestrator/src/core/client/storage/s3.rs
+++ b/orchestrator/src/core/client/storage/s3.rs
@@ -4,6 +4,7 @@ use crate::core::client::storage::StorageError;
 use crate::types::params::AWSResourceIdentifier;
 use async_trait::async_trait;
 use aws_config::SdkConfig;
+use aws_sdk_s3::types::{Tag, Tagging};
 use aws_sdk_s3::Client;
 use bytes::Bytes;
 
@@ -144,6 +145,37 @@ impl StorageClient for AWSS3 {
             .send()
             .await
             .map_err(|e| StorageError::ObjectStreamError(format!("S3 health check failed: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Tag an object with the specified key-value pairs.
+    ///
+    /// # Arguments
+    /// * `key` - The key of the object to tag.
+    /// * `tags` - A vector of (key, value) pairs representing the tags.
+    ///
+    /// # Returns
+    /// * `Result<(), StorageError>` - The result of the tagging operation.
+    async fn tag_object(&self, key: &str, tags: Vec<(String, String)>) -> Result<(), StorageError> {
+        let s3_tags: Result<Vec<Tag>, _> =
+            tags.into_iter().map(|(k, v)| Tag::builder().key(k).value(v).build()).collect();
+
+        let s3_tags = s3_tags.map_err(|e| StorageError::ObjectStreamError(format!("Failed to build tags: {:?}", e)))?;
+
+        let tagging = Tagging::builder()
+            .set_tag_set(Some(s3_tags))
+            .build()
+            .map_err(|e| StorageError::ObjectStreamError(format!("Failed to build tagging object: {:?}", e)))?;
+
+        self.client()
+            .put_object_tagging()
+            .bucket(self.bucket_name()?)
+            .key(key)
+            .tagging(tagging)
+            .send()
+            .await
+            .map_err(|e| StorageError::ObjectStreamError(format!("Failed to tag object '{}': {}", key, e)))?;
 
         Ok(())
     }

--- a/orchestrator/src/core/client/storage/s3.rs
+++ b/orchestrator/src/core/client/storage/s3.rs
@@ -158,8 +158,7 @@ impl StorageClient for AWSS3 {
     /// # Returns
     /// * `Result<(), StorageError>` - The result of the tagging operation.
     async fn tag_object(&self, key: &str, tags: &[(String, String)]) -> Result<(), StorageError> {
-        let s3_tags: Result<Vec<Tag>, _> =
-            tags.iter().map(|(k, v)| Tag::builder().key(k).value(v).build()).collect();
+        let s3_tags: Result<Vec<Tag>, _> = tags.iter().map(|(k, v)| Tag::builder().key(k).value(v).build()).collect();
 
         let s3_tags = s3_tags.map_err(|e| StorageError::ObjectStreamError(format!("Failed to build tags: {:?}", e)))?;
 

--- a/orchestrator/src/setup/aws/event_bus.rs
+++ b/orchestrator/src/setup/aws/event_bus.rs
@@ -29,6 +29,7 @@ lazy_static! {
         WorkerTriggerType::Proving,
         WorkerTriggerType::UpdateState,
         WorkerTriggerType::Aggregator,
+        WorkerTriggerType::StorageCleanup,
     ];
     pub static ref WORKER_TRIGGERS_L3: Vec<WorkerTriggerType> = vec![
         WorkerTriggerType::SnosBatching,
@@ -37,6 +38,7 @@ lazy_static! {
         WorkerTriggerType::ProofRegistration,
         WorkerTriggerType::DataSubmission,
         WorkerTriggerType::UpdateState,
+        WorkerTriggerType::StorageCleanup,
     ];
 }
 

--- a/orchestrator/src/setup/aws/s3.rs
+++ b/orchestrator/src/setup/aws/s3.rs
@@ -6,9 +6,22 @@ use crate::types::params::StorageArgs;
 use crate::types::Layer;
 use crate::{OrchestratorError, OrchestratorResult};
 use async_trait::async_trait;
+use aws_sdk_s3::types::{
+    BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule, LifecycleRuleFilter, Tag,
+};
 use aws_sdk_s3::Error as S3Error;
 use std::sync::Arc;
 use tracing::{info, warn};
+
+/// Tag key used to mark objects for expiration
+const EXPIRATION_TAG_KEY: &str = "expire-after-settlement";
+const EXPIRATION_TAG_VALUE: &str = "true";
+
+/// Number of days after object creation before S3 deletes the object
+const EXPIRATION_DAYS: i32 = 14;
+
+/// Lifecycle rule ID
+const LIFECYCLE_RULE_ID: &str = "expire-settled-artifacts";
 
 #[async_trait]
 impl Resource for InnerAWSS3 {
@@ -34,46 +47,58 @@ impl Resource for InnerAWSS3 {
     }
     /// Set up a new S3 bucket
     async fn setup(&self, _layer: &Layer, args: Self::SetupArgs) -> OrchestratorResult<Self::SetupResult> {
+        let bucket_name = match &args.bucket_identifier {
+            AWSResourceIdentifier::ARN(arn) => arn.resource.clone(),
+            AWSResourceIdentifier::Name(name) => name.clone(),
+        };
+
         // Check if the bucket already exists
-        // If it does, return the existing bucket name and location
+        // If it does, skip creation but still ensure lifecycle rule is set
         if self.check_if_exists(&args.bucket_identifier).await? {
             warn!("  S3 bucket {} already exists , skipping creation", &args.bucket_identifier);
-            return Ok(());
-        }
+        } else {
+            // s3 can have empty region in it's arn : e.g: arn:aws:s3:::mo-bucket
+            // in such scenarios we would want to default to provided region
 
-        // s3 can have empty region in it's arn : e.g: arn:aws:s3:::mo-bucket
-        // in such scenarios we would want to default to provided region
-
-        match &args.bucket_identifier {
-            AWSResourceIdentifier::ARN(arn) => {
-                // If ARN is provided in setup, we have already checked if it exists
-                tracing::info!("Bucket Arn provided, skipping setup for {}", &arn.resource);
-                Ok(())
-            }
-            AWSResourceIdentifier::Name(bucket_name) => {
-                let region =
-                    self.client().config().region().map(|r| r.to_string()).unwrap_or_else(|| "us-east-1".to_string());
-
-                info!("Creating New Bucket: {}", bucket_name);
-
-                let mut bucket_builder = self.client().create_bucket().bucket(bucket_name);
-
-                if region != "us-east-1" {
-                    let constraint = aws_sdk_s3::types::BucketLocationConstraint::from(region.as_str());
-                    let cfg =
-                        aws_sdk_s3::types::CreateBucketConfiguration::builder().location_constraint(constraint).build();
-                    bucket_builder = bucket_builder.create_bucket_configuration(cfg);
+            match &args.bucket_identifier {
+                AWSResourceIdentifier::ARN(arn) => {
+                    // If ARN is provided in setup, we have already checked if it exists
+                    tracing::info!("Bucket Arn provided, skipping setup for {}", &arn.resource);
                 }
+                AWSResourceIdentifier::Name(bucket_name) => {
+                    let region = self
+                        .client()
+                        .config()
+                        .region()
+                        .map(|r| r.to_string())
+                        .unwrap_or_else(|| "us-east-1".to_string());
 
-                let _result = bucket_builder.send().await.map_err(|e| {
-                    OrchestratorError::ResourceSetupError(format!(
-                        "Failed to create S3 bucket '{}': {:?}",
-                        bucket_name, e
-                    ))
-                })?;
-                Ok(())
+                    info!("Creating New Bucket: {}", bucket_name);
+
+                    let mut bucket_builder = self.client().create_bucket().bucket(bucket_name);
+
+                    if region != "us-east-1" {
+                        let constraint = aws_sdk_s3::types::BucketLocationConstraint::from(region.as_str());
+                        let cfg = aws_sdk_s3::types::CreateBucketConfiguration::builder()
+                            .location_constraint(constraint)
+                            .build();
+                        bucket_builder = bucket_builder.create_bucket_configuration(cfg);
+                    }
+
+                    let _result = bucket_builder.send().await.map_err(|e| {
+                        OrchestratorError::ResourceSetupError(format!(
+                            "Failed to create S3 bucket '{}': {:?}",
+                            bucket_name, e
+                        ))
+                    })?;
+                }
             }
         }
+
+        // Setup lifecycle rule for automatic expiration (idempotent - safe to run on existing buckets)
+        self.setup_lifecycle_rule(&bucket_name).await?;
+
+        Ok(())
     }
 
     // TODO: can we simplify if check_if_exists and is_ready_to_use are same ?
@@ -88,5 +113,69 @@ impl Resource for InnerAWSS3 {
 
     async fn is_ready_to_use(&self, _layer: &Layer, args: &Self::SetupArgs) -> OrchestratorResult<bool> {
         Ok(self.check_if_exists(&args.bucket_identifier).await?)
+    }
+}
+
+impl InnerAWSS3 {
+    /// Sets up the lifecycle rule for automatic object expiration based on tags.
+    ///
+    /// Objects tagged with `expire-after-settlement=true` will be automatically
+    /// deleted by S3 after `EXPIRATION_DAYS` days from their creation date.
+    ///
+    /// This operation is idempotent - it will overwrite any existing lifecycle
+    /// configuration with the same rule ID.
+    async fn setup_lifecycle_rule(&self, bucket_name: &str) -> OrchestratorResult<()> {
+        info!(
+            "Setting up S3 lifecycle rule '{}' for bucket '{}' (expire tagged objects after {} days)",
+            LIFECYCLE_RULE_ID, bucket_name, EXPIRATION_DAYS
+        );
+
+        // Create the tag filter
+        let tag_filter = Tag::builder()
+            .key(EXPIRATION_TAG_KEY)
+            .value(EXPIRATION_TAG_VALUE)
+            .build()
+            .map_err(|e| OrchestratorError::ResourceSetupError(format!("Failed to build tag filter: {:?}", e)))?;
+
+        // Create the lifecycle rule filter (filter by tag)
+        let filter = LifecycleRuleFilter::Tag(tag_filter);
+
+        // Create the expiration action
+        let expiration = LifecycleExpiration::builder().days(EXPIRATION_DAYS).build();
+
+        // Create the lifecycle rule
+        let rule = LifecycleRule::builder()
+            .id(LIFECYCLE_RULE_ID)
+            .filter(filter)
+            .status(ExpirationStatus::Enabled)
+            .expiration(expiration)
+            .build()
+            .map_err(|e| OrchestratorError::ResourceSetupError(format!("Failed to build lifecycle rule: {:?}", e)))?;
+
+        // Create the lifecycle configuration
+        let lifecycle_config = BucketLifecycleConfiguration::builder().rules(rule).build().map_err(|e| {
+            OrchestratorError::ResourceSetupError(format!("Failed to build lifecycle configuration: {:?}", e))
+        })?;
+
+        // Apply the lifecycle configuration to the bucket
+        self.client()
+            .put_bucket_lifecycle_configuration()
+            .bucket(bucket_name)
+            .lifecycle_configuration(lifecycle_config)
+            .send()
+            .await
+            .map_err(|e| {
+                OrchestratorError::ResourceSetupError(format!(
+                    "Failed to set lifecycle configuration on bucket '{}': {:?}",
+                    bucket_name, e
+                ))
+            })?;
+
+        info!(
+            "Successfully configured S3 lifecycle rule: objects tagged with '{}={}' will expire after {} days",
+            EXPIRATION_TAG_KEY, EXPIRATION_TAG_VALUE, EXPIRATION_DAYS
+        );
+
+        Ok(())
     }
 }

--- a/orchestrator/src/setup/aws/s3.rs
+++ b/orchestrator/src/setup/aws/s3.rs
@@ -138,7 +138,7 @@ impl InnerAWSS3 {
             .map_err(|e| OrchestratorError::ResourceSetupError(format!("Failed to build tag filter: {:?}", e)))?;
 
         // Create the lifecycle rule filter (filter by tag)
-        let filter = LifecycleRuleFilter::Tag(tag_filter);
+        let filter = LifecycleRuleFilter::builder().tag(tag_filter).build();
 
         // Create the expiration action
         let expiration = LifecycleExpiration::builder().days(EXPIRATION_DAYS).build();

--- a/orchestrator/src/setup/aws/s3.rs
+++ b/orchestrator/src/setup/aws/s3.rs
@@ -35,11 +35,8 @@ impl Resource for InnerAWSS3 {
             AWSResourceIdentifier::Name(name) => name.clone(),
         };
 
-        // Check if the bucket already exists
-        // If it does, skip creation but still ensure lifecycle rule is set
-        if self.check_if_exists(&args.bucket_identifier).await? {
-            warn!("  S3 bucket {} already exists , skipping creation", &args.bucket_identifier);
-        } else {
+        // Check if the bucket already exists - skip creation but still ensure lifecycle rule is set
+        if !self.check_if_exists(&args.bucket_identifier).await? {
             // s3 can have empty region in it's arn : e.g: arn:aws:s3:::mo-bucket
             // in such scenarios we would want to default to provided region
 
@@ -76,6 +73,8 @@ impl Resource for InnerAWSS3 {
                     })?;
                 }
             }
+        } else {
+            warn!("  S3 bucket {} already exists , skipping creation", &args.bucket_identifier);
         }
 
         // Setup lifecycle rule for automatic expiration (idempotent - safe to run on existing buckets)

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -158,6 +158,8 @@ pub struct TestConfigBuilderReturns {
     pub provider_config: Arc<CloudProvider>,
     pub api_server_address: Option<SocketAddr>,
     pub cleanup: TestCleanup,
+    /// Storage configuration with the actual bucket name (including test UUID)
+    pub storage_params: StorageArgs,
 }
 
 /// TestCleanup handles automatic cleanup of test resources when dropped.
@@ -425,6 +427,7 @@ impl TestConfigBuilder {
             provider_config: provider_config.clone(),
             api_server_address,
             cleanup,
+            storage_params: params.storage_params,
         }
     }
 }

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -683,7 +683,10 @@ pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
         bucket_base
     };
 
-    let storage_params = StorageArgs { bucket_identifier: AWSResourceIdentifier::Name(bucket_name) };
+    let storage_params = StorageArgs {
+        bucket_identifier: AWSResourceIdentifier::Name(bucket_name),
+        storage_expiration_days: crate::cli::storage::aws_s3::DEFAULT_STORAGE_EXPIRATION_DAYS,
+    };
 
     let queue_base = get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_SQS_QUEUE_IDENTIFIER");
     let queue_identifier = if let Some(id) = test_id {

--- a/orchestrator/src/tests/jobs/aggregator_job/mod.rs
+++ b/orchestrator/src/tests/jobs/aggregator_job/mod.rs
@@ -3,7 +3,7 @@ use crate::core::client::database::MockDatabaseClient;
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::types::batch::{AggregatorBatch, AggregatorBatchStatus};
 use crate::types::constant::{
-    CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME, PROOF_FILE_NAME, STORAGE_ARTIFACTS_DIR,
+    get_batch_artifact_file, CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME, PROOF_FILE_NAME,
 };
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::metadata::{AggregatorMetadata, CommonMetadata, JobMetadata, JobSpecificMetadata};
@@ -112,10 +112,10 @@ async fn test_verify_job(#[from(default_job_item)] mut job_item: JobItem) {
     job_item.metadata.specific = JobSpecificMetadata::Aggregator(AggregatorMetadata {
         batch_num: 1,
         bucket_id: "bucket_id".to_string(),
-        download_proof: Some(format!("{}/batch/{}/{}", STORAGE_ARTIFACTS_DIR, 1, PROOF_FILE_NAME)),
-        cairo_pie_path: format!("{}/batch/{}/{}", STORAGE_ARTIFACTS_DIR, 1, CAIRO_PIE_FILE_NAME),
-        program_output_path: format!("{}/batch/{}/{}", STORAGE_ARTIFACTS_DIR, 1, PROGRAM_OUTPUT_FILE_NAME),
-        da_segment_path: format!("{}/batch/{}/{}", STORAGE_ARTIFACTS_DIR, 1, DA_SEGMENT_FILE_NAME),
+        download_proof: Some(get_batch_artifact_file(1, PROOF_FILE_NAME)),
+        cairo_pie_path: get_batch_artifact_file(1, CAIRO_PIE_FILE_NAME),
+        program_output_path: get_batch_artifact_file(1, PROGRAM_OUTPUT_FILE_NAME),
+        da_segment_path: get_batch_artifact_file(1, DA_SEGMENT_FILE_NAME),
         ..Default::default()
     });
 

--- a/orchestrator/src/tests/mod.rs
+++ b/orchestrator/src/tests/mod.rs
@@ -8,5 +8,6 @@ pub mod jobs;
 pub mod queue;
 pub mod server;
 pub mod setup;
+pub mod types;
 pub mod utils;
 pub mod workers;

--- a/orchestrator/src/tests/types/constant.rs
+++ b/orchestrator/src/tests/types/constant.rs
@@ -1,87 +1,42 @@
 // Tests for path helper functions in types/constant.rs
-//
-// These functions are used by multiple parts of the codebase (storage cleanup,
-// job handlers, etc.) so they are tested separately for better visibility and
-// maintainability.
 
 use crate::types::constant::{
     get_batch_artifact_file, get_batch_artifacts_dir, get_batch_blob_dir, get_batch_blob_file,
     get_batch_state_update_file, get_snos_legacy_dir,
 };
 
-/// Test that all path helper functions return correctly formatted paths.
-/// This is critical because wrong paths mean wrong files get tagged/read/written.
 #[test]
-fn test_path_helpers_correct_format() {
+fn test_path_helpers_format_and_structure() {
     let job_id: u64 = 12345;
 
-    // Test artifacts directory path
-    let artifacts_dir = get_batch_artifacts_dir(job_id);
-    assert_eq!(artifacts_dir, "artifacts/batch/12345");
+    // Artifacts
+    assert_eq!(get_batch_artifacts_dir(job_id), "artifacts/batch/12345");
+    assert_eq!(get_batch_artifact_file(job_id, "proof.json"), "artifacts/batch/12345/proof.json");
+    assert_eq!(get_batch_artifact_file(job_id, "nested/file.txt"), "artifacts/batch/12345/nested/file.txt");
 
-    // Test artifact file path
-    let artifact_file = get_batch_artifact_file(job_id, "proof.json");
-    assert_eq!(artifact_file, "artifacts/batch/12345/proof.json");
+    // Blobs
+    assert_eq!(get_batch_blob_dir(job_id), "blob/batch/12345");
+    assert_eq!(get_batch_blob_file(job_id, 0), "blob/batch/12345/0.txt");
+    assert_eq!(get_batch_blob_file(job_id, 99), "blob/batch/12345/99.txt");
 
-    // Test blob directory path
-    let blob_dir = get_batch_blob_dir(job_id);
-    assert_eq!(blob_dir, "blob/batch/12345");
+    // State update
+    assert_eq!(get_batch_state_update_file(job_id), "state_update/batch/12345.json");
 
-    // Test blob file path
-    let blob_file = get_batch_blob_file(job_id, 0);
-    assert_eq!(blob_file, "blob/batch/12345/0.txt");
-
-    // Test state update file path
-    let state_update_file = get_batch_state_update_file(job_id);
-    assert_eq!(state_update_file, "state_update/batch/12345.json");
-}
-
-/// Test SNOS legacy directory path format (at root level for backward compatibility)
-#[test]
-fn test_get_snos_legacy_dir_root_level() {
-    let job_id: u64 = 99999;
+    // SNOS legacy (root level, no path separators)
     let snos_dir = get_snos_legacy_dir(job_id);
-
-    // SNOS legacy dir should be at root level (just the job_id)
-    assert_eq!(snos_dir, "99999");
-
-    // Verify it doesn't have any path separators (confirming root level)
-    assert!(!snos_dir.contains('/'), "SNOS legacy dir should be at root level without path separators");
+    assert_eq!(snos_dir, "12345");
+    assert!(!snos_dir.contains('/'), "SNOS legacy dir should be at root level");
 }
 
-/// Test path helpers with edge cases - zero and large values
 #[test]
 fn test_path_helpers_edge_cases() {
-    // Test with zero
+    // Zero
     assert_eq!(get_batch_artifacts_dir(0), "artifacts/batch/0");
     assert_eq!(get_batch_blob_dir(0), "blob/batch/0");
     assert_eq!(get_snos_legacy_dir(0), "0");
     assert_eq!(get_batch_state_update_file(0), "state_update/batch/0.json");
 
-    // Test with large values
+    // Large value
     let large_id: u64 = u64::MAX;
-    let artifacts_dir = get_batch_artifacts_dir(large_id);
-    assert!(artifacts_dir.starts_with("artifacts/batch/"));
-    assert!(artifacts_dir.contains(&large_id.to_string()));
-}
-
-/// Test that blob file paths use correct index formatting
-#[test]
-fn test_blob_file_index_formatting() {
-    let job_id: u64 = 100;
-
-    // Test various blob indices
-    assert_eq!(get_batch_blob_file(job_id, 0), "blob/batch/100/0.txt");
-    assert_eq!(get_batch_blob_file(job_id, 1), "blob/batch/100/1.txt");
-    assert_eq!(get_batch_blob_file(job_id, 99), "blob/batch/100/99.txt");
-}
-
-/// Test artifact file paths with different file names
-#[test]
-fn test_artifact_file_with_different_names() {
-    let job_id: u64 = 42;
-
-    assert_eq!(get_batch_artifact_file(job_id, "proof.json"), "artifacts/batch/42/proof.json");
-    assert_eq!(get_batch_artifact_file(job_id, "output.bin"), "artifacts/batch/42/output.bin");
-    assert_eq!(get_batch_artifact_file(job_id, "nested/file.txt"), "artifacts/batch/42/nested/file.txt");
+    assert!(get_batch_artifacts_dir(large_id).contains(&large_id.to_string()));
 }

--- a/orchestrator/src/tests/types/constant.rs
+++ b/orchestrator/src/tests/types/constant.rs
@@ -1,0 +1,87 @@
+// Tests for path helper functions in types/constant.rs
+//
+// These functions are used by multiple parts of the codebase (storage cleanup,
+// job handlers, etc.) so they are tested separately for better visibility and
+// maintainability.
+
+use crate::types::constant::{
+    get_batch_artifact_file, get_batch_artifacts_dir, get_batch_blob_dir, get_batch_blob_file,
+    get_batch_state_update_file, get_snos_legacy_dir,
+};
+
+/// Test that all path helper functions return correctly formatted paths.
+/// This is critical because wrong paths mean wrong files get tagged/read/written.
+#[test]
+fn test_path_helpers_correct_format() {
+    let job_id: u64 = 12345;
+
+    // Test artifacts directory path
+    let artifacts_dir = get_batch_artifacts_dir(job_id);
+    assert_eq!(artifacts_dir, "artifacts/batch/12345");
+
+    // Test artifact file path
+    let artifact_file = get_batch_artifact_file(job_id, "proof.json");
+    assert_eq!(artifact_file, "artifacts/batch/12345/proof.json");
+
+    // Test blob directory path
+    let blob_dir = get_batch_blob_dir(job_id);
+    assert_eq!(blob_dir, "blob/batch/12345");
+
+    // Test blob file path
+    let blob_file = get_batch_blob_file(job_id, 0);
+    assert_eq!(blob_file, "blob/batch/12345/0.txt");
+
+    // Test state update file path
+    let state_update_file = get_batch_state_update_file(job_id);
+    assert_eq!(state_update_file, "state_update/batch/12345.json");
+}
+
+/// Test SNOS legacy directory path format (at root level for backward compatibility)
+#[test]
+fn test_get_snos_legacy_dir_root_level() {
+    let job_id: u64 = 99999;
+    let snos_dir = get_snos_legacy_dir(job_id);
+
+    // SNOS legacy dir should be at root level (just the job_id)
+    assert_eq!(snos_dir, "99999");
+
+    // Verify it doesn't have any path separators (confirming root level)
+    assert!(!snos_dir.contains('/'), "SNOS legacy dir should be at root level without path separators");
+}
+
+/// Test path helpers with edge cases - zero and large values
+#[test]
+fn test_path_helpers_edge_cases() {
+    // Test with zero
+    assert_eq!(get_batch_artifacts_dir(0), "artifacts/batch/0");
+    assert_eq!(get_batch_blob_dir(0), "blob/batch/0");
+    assert_eq!(get_snos_legacy_dir(0), "0");
+    assert_eq!(get_batch_state_update_file(0), "state_update/batch/0.json");
+
+    // Test with large values
+    let large_id: u64 = u64::MAX;
+    let artifacts_dir = get_batch_artifacts_dir(large_id);
+    assert!(artifacts_dir.starts_with("artifacts/batch/"));
+    assert!(artifacts_dir.contains(&large_id.to_string()));
+}
+
+/// Test that blob file paths use correct index formatting
+#[test]
+fn test_blob_file_index_formatting() {
+    let job_id: u64 = 100;
+
+    // Test various blob indices
+    assert_eq!(get_batch_blob_file(job_id, 0), "blob/batch/100/0.txt");
+    assert_eq!(get_batch_blob_file(job_id, 1), "blob/batch/100/1.txt");
+    assert_eq!(get_batch_blob_file(job_id, 99), "blob/batch/100/99.txt");
+}
+
+/// Test artifact file paths with different file names
+#[test]
+fn test_artifact_file_with_different_names() {
+    let job_id: u64 = 42;
+
+    assert_eq!(get_batch_artifact_file(job_id, "proof.json"), "artifacts/batch/42/proof.json");
+    assert_eq!(get_batch_artifact_file(job_id, "output.bin"), "artifacts/batch/42/output.bin");
+    assert_eq!(get_batch_artifact_file(job_id, "nested/file.txt"), "artifacts/batch/42/nested/file.txt");
+}

--- a/orchestrator/src/tests/types/mod.rs
+++ b/orchestrator/src/tests/types/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+pub mod constant;

--- a/orchestrator/src/tests/utils.rs
+++ b/orchestrator/src/tests/utils.rs
@@ -51,6 +51,7 @@ pub fn build_job_item_with_version(
                 da_segment_path: None,
                 tx_hash: None,
                 context: SettlementContext::Block(SettlementContextData { to_settle: internal_id, last_failed: None }),
+                storage_artifacts_tagged_at: None,
             }),
         },
         JobType::SnosRun => JobMetadata {

--- a/orchestrator/src/tests/workers/batching/e2e.rs
+++ b/orchestrator/src/tests/workers/batching/e2e.rs
@@ -2,6 +2,7 @@ use crate::core::StorageClient;
 use crate::tests::config::{ConfigType, MockType, TestConfigBuilder};
 use crate::tests::jobs::snos_job::SNOS_PATHFINDER_RPC_URL_ENV;
 use crate::tests::utils::read_file_to_string;
+use crate::types::constant::get_batch_blob_file;
 use crate::worker::event_handler::triggers::aggregator_batching::AggregatorBatchingTrigger;
 use crate::worker::event_handler::triggers::snos_batching::SnosBatchingTrigger;
 use crate::worker::event_handler::triggers::JobTrigger;
@@ -48,8 +49,11 @@ async fn test_assign_batch_to_block_new_batch(
     let result = SnosBatchingTrigger.run_worker(services.config.clone()).await;
     assert!(result.is_ok());
 
-    let generated_blobs =
-        get_blobs_from_s3_paths(vec!["blob/batch/1/1.txt", "blob/batch/1/2.txt"], services.config.storage()).await?;
+    let generated_blobs = get_blobs_from_s3_paths(
+        vec![&get_batch_blob_file(1, 1), &get_batch_blob_file(1, 2)],
+        services.config.storage(),
+    )
+    .await?;
 
     // Fetch real blobs from test data
     // The test data contains state update information about block 8373665 on Ethereum Sepolia

--- a/orchestrator/src/tests/workers/batching/mod.rs
+++ b/orchestrator/src/tests/workers/batching/mod.rs
@@ -9,7 +9,7 @@ use crate::core::config::StarknetVersion;
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::default_test_bouncer_weights;
 use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
-use crate::types::constant::ORCHESTRATOR_VERSION;
+use crate::types::constant::{get_batch_state_update_file, ORCHESTRATOR_VERSION};
 use crate::worker::event_handler::triggers::aggregator_batching::{
     AggregatorBatchingTrigger, AGGREGATOR_BATCHING_WORKER_KEY,
 };
@@ -67,7 +67,7 @@ async fn test_batching_worker(#[case] has_existing_batch: bool) -> Result<(), Bo
             end_block: 3,
             num_blocks: 4,
             blob_len: 0,
-            squashed_state_updates_path: "state_update/batch/1.json".to_string(),
+            squashed_state_updates_path: get_batch_state_update_file(1),
             created_at: chrono::Utc::now(),
             starknet_version: StarknetVersion::V0_13_2,
             orchestrator_version: ORCHESTRATOR_VERSION.to_string(),
@@ -215,7 +215,7 @@ async fn test_batching_worker_with_multiple_blocks() -> Result<(), Box<dyn Error
         end_block: 3,
         num_blocks: 4,
         blob_len: 0,
-        squashed_state_updates_path: "state_update/batch/1.json".to_string(),
+        squashed_state_updates_path: get_batch_state_update_file(1),
         created_at: chrono::Utc::now(),
         starknet_version: StarknetVersion::V0_13_2,
         orchestrator_version: ORCHESTRATOR_VERSION.to_string(),
@@ -288,7 +288,7 @@ async fn test_batching_worker_with_multiple_blocks() -> Result<(), Box<dyn Error
                 end_block: 7,
                 num_blocks: 4,
                 blob_len: 0,
-                squashed_state_updates_path: "state_update/batch/2.json".to_string(),
+                squashed_state_updates_path: get_batch_state_update_file(2),
                 starknet_version: StarknetVersion::V0_13_2,
                 orchestrator_version: ORCHESTRATOR_VERSION.to_string(),
                 ..Default::default()
@@ -763,7 +763,7 @@ async fn test_aggregator_no_new_blocks() -> Result<(), Box<dyn Error>> {
         end_block: 9,
         num_blocks: 10,
         blob_len: 0,
-        squashed_state_updates_path: "state_update/batch/1.json".to_string(),
+        squashed_state_updates_path: get_batch_state_update_file(1),
         starknet_version: StarknetVersion::V0_13_2,
         ..Default::default()
     };

--- a/orchestrator/src/tests/workers/mod.rs
+++ b/orchestrator/src/tests/workers/mod.rs
@@ -6,5 +6,7 @@ pub mod proving;
 pub mod self_healing;
 #[cfg(test)]
 pub mod snos;
+#[cfg(test)]
+pub mod storage_cleanup;
 mod update_state;
 pub mod utils;

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -211,7 +211,7 @@ async fn test_tag_object_applies_tags_correctly() -> Result<(), Box<dyn Error>> 
 
     // Apply tags using our method - this should succeed
     let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
-    storage.tag_object(test_key, tags).await?;
+    storage.tag_object(test_key, &tags).await?;
 
     // Verify file is still accessible after tagging
     let retrieved_data = storage.get_data(test_key).await?;
@@ -347,10 +347,10 @@ async fn test_collect_and_tag_artifacts_integration() -> Result<(), Box<dyn Erro
     // Verify we collected 4 files
     assert_eq!(all_paths.len(), 4, "Expected 4 artifact paths, got {}: {:?}", all_paths.len(), all_paths);
 
-    // Tag all artifacts
+    // Tag all artifacts - pass reference to avoid cloning
     let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
     for path in &all_paths {
-        storage.tag_object(path, tags.clone()).await?;
+        storage.tag_object(path, &tags).await?;
     }
 
     // Verify all artifacts are still accessible after tagging (tagging didn't break anything)
@@ -409,7 +409,7 @@ async fn test_tag_nonexistent_object_returns_error() -> Result<(), Box<dyn Error
     let nonexistent_key = "definitely/does/not/exist/file.json";
     let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
 
-    let result = storage.tag_object(nonexistent_key, tags).await;
+    let result = storage.tag_object(nonexistent_key, &tags).await;
 
     // Should return an error (the specific error type depends on S3)
     assert!(result.is_err(), "Tagging non-existent object should return error");

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -1,0 +1,490 @@
+// Storage Cleanup Worker Tests
+//
+// This module contains tests for the StorageCleanupTrigger and related S3 operations.
+// Tests are organized into two categories:
+// 1. Unit tests with mocks for orchestration logic
+// 2. Integration tests with LocalStack for actual S3 operations
+//
+// Note: Path helper function tests are in tests/types/constant.rs since those
+// functions are used by multiple parts of the codebase.
+
+use bytes::Bytes;
+use rstest::rstest;
+use std::error::Error;
+use std::sync::Arc;
+
+use crate::core::client::database::{DatabaseError, MockDatabaseClient};
+use crate::core::client::lock::error::LockError;
+use crate::core::client::lock::{LockResult, MockLockClient};
+use crate::core::client::storage::MockStorageClient;
+use crate::tests::config::{ConfigType, TestConfigBuilder};
+use crate::tests::workers::utils::get_job_by_mock_id_vector;
+use crate::types::constant::{
+    get_batch_artifact_file, get_batch_artifacts_dir, get_batch_blob_dir, get_batch_blob_file,
+    get_batch_state_update_file, get_snos_legacy_dir, STORAGE_EXPIRATION_TAG_KEY, STORAGE_EXPIRATION_TAG_VALUE,
+};
+use crate::types::jobs::job_item::JobItem;
+use crate::types::jobs::metadata::{CommonMetadata, JobMetadata, JobSpecificMetadata};
+use crate::types::jobs::types::{JobStatus, JobType};
+use crate::worker::event_handler::triggers::storage_cleanup::StorageCleanupTrigger;
+use crate::worker::event_handler::triggers::JobTrigger;
+
+// =============================================================================
+// Unit Tests with Mocks - Orchestration Logic
+// =============================================================================
+
+/// Test that the worker skips processing when it cannot acquire the distributed lock.
+/// This is critical for preventing duplicate processing in multi-instance deployments.
+#[rstest]
+#[tokio::test]
+async fn test_run_worker_skips_when_lock_unavailable() -> Result<(), Box<dyn Error>> {
+    let database = MockDatabaseClient::new();
+    let storage = MockStorageClient::new();
+    let mut lock = MockLockClient::new();
+
+    // Mock lock client to simulate another instance holding the lock
+    lock.expect_acquire_lock()
+        .returning(|_, _, _, _| Err(LockError::LockAlreadyHeld { current_owner: "other_instance".to_string() }));
+
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(storage.into())
+        .configure_database(database.into())
+        .configure_lock_client(lock.into())
+        .build()
+        .await;
+
+    // Should complete successfully without processing (graceful exit)
+    let result = StorageCleanupTrigger.run_worker(services.config).await;
+    assert!(result.is_ok(), "Worker should gracefully exit when lock unavailable");
+
+    Ok(())
+}
+
+/// Test that the lock is always released, even when processing fails.
+/// This prevents deadlock scenarios where a crashed worker holds the lock forever.
+#[rstest]
+#[tokio::test]
+async fn test_run_worker_releases_lock_on_error() -> Result<(), Box<dyn Error>> {
+    let mut database = MockDatabaseClient::new();
+    let storage = MockStorageClient::new();
+    let mut lock = MockLockClient::new();
+
+    // Mock lock acquisition success
+    lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
+
+    // Mock database to return an error when fetching jobs
+    database
+        .expect_get_jobs_without_storage_artifacts_tagged()
+        .returning(|_| Err(DatabaseError::KeyNotFound("simulated error".to_string())));
+
+    // Verify lock is released even on error
+    lock.expect_release_lock().times(1).returning(|_, _| Ok(LockResult::Released));
+
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(storage.into())
+        .configure_database(database.into())
+        .configure_lock_client(lock.into())
+        .build()
+        .await;
+
+    // Should return error but lock should be released
+    let result = StorageCleanupTrigger.run_worker(services.config).await;
+    assert!(result.is_err(), "Worker should return error when database fails");
+
+    Ok(())
+}
+
+/// Test that jobs with invalid metadata are skipped without stopping the entire batch.
+/// One bad job shouldn't prevent processing of other valid jobs.
+#[rstest]
+#[tokio::test]
+async fn test_process_completed_jobs_skips_invalid_metadata() -> Result<(), Box<dyn Error>> {
+    let mut database = MockDatabaseClient::new();
+    let storage = MockStorageClient::new();
+    let mut lock = MockLockClient::new();
+
+    // Mock lock
+    lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
+    lock.expect_release_lock().returning(|_, _| Ok(LockResult::Released));
+
+    // Create a job with invalid metadata (not StateUpdateMetadata)
+    let invalid_job = JobItem {
+        id: uuid::Uuid::new_v4(),
+        internal_id: 1,
+        job_type: JobType::StateTransition,
+        status: JobStatus::Completed,
+        external_id: crate::types::jobs::external_id::ExternalId::Number(1),
+        metadata: JobMetadata {
+            common: CommonMetadata::default(),
+            // Use DA metadata instead of StateUpdate - this will fail to parse
+            specific: JobSpecificMetadata::Da(crate::types::jobs::metadata::DaMetadata {
+                block_number: 1,
+                blob_data_path: None,
+                tx_hash: None,
+            }),
+        },
+        version: 0,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+
+    database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![invalid_job.clone()]));
+
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(storage.into())
+        .configure_database(database.into())
+        .configure_lock_client(lock.into())
+        .build()
+        .await;
+
+    // Should complete without error (skips invalid job)
+    let result = StorageCleanupTrigger.run_worker(services.config).await;
+    assert!(result.is_ok(), "Worker should skip invalid jobs and continue");
+
+    Ok(())
+}
+
+/// Test that partial tagging failures don't mark the job as tagged.
+/// If we can't tag all artifacts, the job should be retried next run.
+#[rstest]
+#[tokio::test]
+async fn test_process_completed_jobs_skips_partial_tagging() -> Result<(), Box<dyn Error>> {
+    let mut database = MockDatabaseClient::new();
+    let mut storage = MockStorageClient::new();
+    let mut lock = MockLockClient::new();
+
+    // Mock lock
+    lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
+    lock.expect_release_lock().returning(|_, _| Ok(LockResult::Released));
+
+    // Create a valid StateTransition job using the existing helper from utils
+    let valid_jobs = get_job_by_mock_id_vector(JobType::StateTransition, JobStatus::Completed, 1, 1);
+    let valid_job = valid_jobs.into_iter().next().expect("Should have created one job");
+
+    database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![valid_job.clone()]));
+
+    // Mock storage to return files but fail on tagging
+    storage.expect_list_files_in_dir().returning(|_| Ok(vec!["file1.json".to_string()]));
+
+    // First tag succeeds, but simulate a real S3 error (not NoSuchKey)
+    storage.expect_tag_object().returning(|_, _| {
+        Err(crate::core::client::storage::StorageError::ObjectStreamError("Connection timeout".to_string()))
+    });
+
+    // update_job should NOT be called since tagging failed
+    // Note: We can't use times(0) with returning, so we just don't set it up
+
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(storage.into())
+        .configure_database(database.into())
+        .configure_lock_client(lock.into())
+        .build()
+        .await;
+
+    // Should complete without error (will retry next run)
+    let result = StorageCleanupTrigger.run_worker(services.config).await;
+    assert!(result.is_ok(), "Worker should continue even when tagging fails");
+
+    Ok(())
+}
+
+// =============================================================================
+// Integration Tests with LocalStack - Actual S3 Operations
+// =============================================================================
+
+/// Test that tag_object correctly applies tags to an S3 object.
+/// This test verifies:
+/// 1. We can create a file in S3
+/// 2. We can tag it without errors
+/// 3. We can still read the file after tagging (file wasn't corrupted)
+#[rstest]
+#[tokio::test]
+async fn test_tag_object_applies_tags_correctly() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+
+    let storage = services.config.storage();
+
+    // Create a test file
+    let test_key = "test_tagging/test_file.json";
+    let test_data = Bytes::from(r#"{"test": "data"}"#);
+    storage.put_data(test_data.clone(), test_key).await?;
+
+    // Apply tags using our method - this should succeed
+    let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
+    storage.tag_object(test_key, tags).await?;
+
+    // Verify file is still accessible after tagging
+    let retrieved_data = storage.get_data(test_key).await?;
+    assert_eq!(retrieved_data, test_data, "File data should be unchanged after tagging");
+
+    Ok(())
+}
+
+/// Test that list_files_in_dir returns all files from a directory.
+/// Creates multiple files and verifies all are returned.
+#[rstest]
+#[tokio::test]
+async fn test_list_files_in_dir_returns_all_files() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+
+    let storage = services.config.storage();
+
+    // Create multiple test files in a directory
+    let test_dir = "test_list_files";
+    let file_names = vec!["file1.json", "file2.json", "file3.txt", "nested/file4.json"];
+    let test_data = Bytes::from(r#"{"test": "data"}"#);
+
+    for file_name in &file_names {
+        let key = format!("{}/{}", test_dir, file_name);
+        storage.put_data(test_data.clone(), &key).await?;
+    }
+
+    // List files in the directory
+    let listed_files = storage.list_files_in_dir(test_dir).await?;
+
+    // Verify all files are returned
+    assert_eq!(
+        listed_files.len(),
+        file_names.len(),
+        "Expected {} files, got {}: {:?}",
+        file_names.len(),
+        listed_files.len(),
+        listed_files
+    );
+
+    for file_name in &file_names {
+        let expected_key = format!("{}/{}", test_dir, file_name);
+        assert!(listed_files.contains(&expected_key), "Expected file '{}' not found in listed files", expected_key);
+    }
+
+    Ok(())
+}
+
+/// Test that list_files_in_dir handles pagination correctly for large directories.
+/// S3 returns max 1000 objects per request, so we need to handle pagination.
+#[rstest]
+#[tokio::test]
+async fn test_list_files_in_dir_with_pagination() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+
+    let storage = services.config.storage();
+
+    // Create more than 1000 files to trigger pagination
+    // Note: This test creates 1100 files which takes some time
+    let test_dir = "test_pagination";
+    let num_files = 1100;
+    let test_data = Bytes::from("x");
+
+    for i in 0..num_files {
+        let key = format!("{}/file_{:04}.txt", test_dir, i);
+        storage.put_data(test_data.clone(), &key).await?;
+    }
+
+    // List all files
+    let listed_files = storage.list_files_in_dir(test_dir).await?;
+
+    // Verify all files are returned (pagination worked)
+    assert_eq!(
+        listed_files.len(),
+        num_files,
+        "Expected {} files with pagination, got {}",
+        num_files,
+        listed_files.len()
+    );
+
+    Ok(())
+}
+
+/// Integration test: Create files in all 4 artifact locations, collect paths, tag them,
+/// and verify all are tagged correctly.
+#[rstest]
+#[tokio::test]
+async fn test_collect_and_tag_artifacts_integration() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+
+    let storage = services.config.storage();
+    let job_id: u64 = 42;
+    let test_data = Bytes::from(r#"{"test": "artifact"}"#);
+
+    // Create files in all 4 artifact locations
+    // 1. Artifacts directory
+    let artifact_file = get_batch_artifact_file(job_id, "proof.json");
+    storage.put_data(test_data.clone(), &artifact_file).await?;
+
+    // 2. Blob directory
+    let blob_file = get_batch_blob_file(job_id, 0);
+    storage.put_data(test_data.clone(), &blob_file).await?;
+
+    // 3. SNOS legacy directory
+    let snos_file = format!("{}/output.json", get_snos_legacy_dir(job_id));
+    storage.put_data(test_data.clone(), &snos_file).await?;
+
+    // 4. State update file
+    let state_update_file = get_batch_state_update_file(job_id);
+    storage.put_data(test_data.clone(), &state_update_file).await?;
+
+    // Collect paths from each location
+    let mut all_paths = Vec::new();
+
+    // Artifacts
+    let artifacts_dir = get_batch_artifacts_dir(job_id);
+    let artifact_files = storage.list_files_in_dir(&artifacts_dir).await.unwrap_or_default();
+    all_paths.extend(artifact_files);
+
+    // Blobs
+    let blob_dir = get_batch_blob_dir(job_id);
+    let blob_files = storage.list_files_in_dir(&blob_dir).await.unwrap_or_default();
+    all_paths.extend(blob_files);
+
+    // SNOS legacy
+    let snos_dir = get_snos_legacy_dir(job_id);
+    let snos_files = storage.list_files_in_dir(&snos_dir).await.unwrap_or_default();
+    all_paths.extend(snos_files);
+
+    // State update (single file)
+    all_paths.push(state_update_file.clone());
+
+    // Verify we collected 4 files
+    assert_eq!(all_paths.len(), 4, "Expected 4 artifact paths, got {}: {:?}", all_paths.len(), all_paths);
+
+    // Tag all artifacts
+    let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
+    for path in &all_paths {
+        storage.tag_object(path, tags.clone()).await?;
+    }
+
+    // Verify all artifacts are still accessible after tagging (tagging didn't break anything)
+    for path in &all_paths {
+        // State update file is the only one that might not exist (we add it unconditionally)
+        if path == &state_update_file {
+            // Verify the state update file can be read
+            let data = storage.get_data(path).await?;
+            assert!(!data.is_empty(), "State update file should have content");
+        }
+    }
+
+    Ok(())
+}
+
+/// Test that the lifecycle rule is set up correctly on the bucket.
+/// Verifies the rule exists with the correct tag filter and expiration days.
+#[rstest]
+#[tokio::test]
+async fn test_setup_lifecycle_rule_creates_correct_config() -> Result<(), Box<dyn Error>> {
+    // Build config with Actual storage (this sets up the lifecycle rule)
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+
+    // Get the lifecycle configuration from S3
+    let lifecycle_config = get_bucket_lifecycle_config(&services.provider_config).await?;
+
+    // Find our rule
+    let our_rule = lifecycle_config
+        .iter()
+        .find(|rule| rule.id == crate::types::constant::STORAGE_LIFECYCLE_RULE_ID)
+        .expect("Lifecycle rule not found");
+
+    // Verify rule is enabled
+    assert!(our_rule.enabled, "Lifecycle rule should be enabled");
+
+    // Verify tag filter
+    assert_eq!(our_rule.tag_key, Some(STORAGE_EXPIRATION_TAG_KEY.to_string()), "Tag key mismatch");
+    assert_eq!(our_rule.tag_value, Some(STORAGE_EXPIRATION_TAG_VALUE.to_string()), "Tag value mismatch");
+
+    // Verify expiration is set (we use default 14 days in tests)
+    assert!(our_rule.expiration_days.is_some(), "Expiration days should be set");
+
+    Ok(())
+}
+
+/// Test that tagging a non-existent object returns an appropriate error.
+/// This verifies our error handling for missing files.
+#[rstest]
+#[tokio::test]
+async fn test_tag_nonexistent_object_returns_error() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+
+    let storage = services.config.storage();
+
+    // Try to tag a file that doesn't exist
+    let nonexistent_key = "definitely/does/not/exist/file.json";
+    let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
+
+    let result = storage.tag_object(nonexistent_key, tags).await;
+
+    // Should return an error (the specific error type depends on S3)
+    assert!(result.is_err(), "Tagging non-existent object should return error");
+
+    // Verify we got an error - the specific message varies by S3 implementation
+    // LocalStack may return "service error" while real S3 returns "NoSuchKey"
+    let error_msg = result.unwrap_err().to_string();
+    assert!(!error_msg.is_empty(), "Error message should not be empty: {}", error_msg);
+
+    Ok(())
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Simple struct to hold lifecycle rule info for testing
+struct LifecycleRuleInfo {
+    id: String,
+    enabled: bool,
+    tag_key: Option<String>,
+    tag_value: Option<String>,
+    expiration_days: Option<i32>,
+}
+
+/// Helper to get bucket lifecycle configuration
+async fn get_bucket_lifecycle_config(
+    provider_config: &Arc<crate::core::cloud::CloudProvider>,
+) -> Result<Vec<LifecycleRuleInfo>, Box<dyn Error>> {
+    let aws_config = provider_config.get_aws_client_or_panic();
+
+    let mut s3_config_builder = aws_sdk_s3::config::Builder::from(aws_config);
+    s3_config_builder.set_force_path_style(Some(true));
+    let client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
+
+    let bucket_name = format!(
+        "{}-{}",
+        orchestrator_utils::env_utils::get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_PREFIX"),
+        orchestrator_utils::env_utils::get_env_var_or_panic("MADARA_ORCHESTRATOR_AWS_S3_BUCKET_IDENTIFIER")
+    );
+
+    // Find the test bucket
+    let buckets = client.list_buckets().send().await?;
+    let test_bucket = buckets
+        .buckets()
+        .iter()
+        .find(|b| b.name().map(|n| n.starts_with(&bucket_name)).unwrap_or(false))
+        .and_then(|b| b.name())
+        .ok_or("Test bucket not found")?;
+
+    let lifecycle_output = client.get_bucket_lifecycle_configuration().bucket(test_bucket).send().await?;
+
+    let rules: Vec<LifecycleRuleInfo> = lifecycle_output
+        .rules()
+        .iter()
+        .map(|rule| {
+            let (tag_key, tag_value) = if let Some(filter) = rule.filter() {
+                if let Some(tag) = filter.tag() {
+                    (Some(tag.key().to_string()), Some(tag.value().to_string()))
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            };
+
+            LifecycleRuleInfo {
+                id: rule.id().unwrap_or_default().to_string(),
+                enabled: *rule.status() == aws_sdk_s3::types::ExpirationStatus::Enabled,
+                tag_key,
+                tag_value,
+                expiration_days: rule.expiration().and_then(|e| e.days()),
+            }
+        })
+        .collect();
+
+    Ok(rules)
+}

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -250,7 +250,7 @@ async fn test_tag_object_success_and_error_cases() -> Result<(), Box<dyn Error>>
     storage.put_data(Bytes::from(r#"{"test": "tagging"}"#), test_key).await?;
 
     // Test 1: tag_object applies tags correctly
-    let tags = [(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
+    let tags = [(STORAGE_EXPIRATION_TAG_KEY, STORAGE_EXPIRATION_TAG_VALUE)];
     storage.tag_object(test_key, &tags).await?;
 
     let bucket_name = services.storage_params.bucket_identifier.to_string();

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -1,12 +1,5 @@
 // Storage Cleanup Worker Tests
-//
-// This module contains tests for the StorageCleanupTrigger and related S3 operations.
-// Tests are organized into two categories:
-// 1. Unit tests with mocks for orchestration logic
-// 2. Integration tests with LocalStack for actual S3 operations
-//
-// Note: Path helper function tests are in tests/types/constant.rs since those
-// functions are used by multiple parts of the codebase.
+// Unit tests with mocks for orchestration logic + Integration test with LocalStack/MongoDB
 
 use bytes::Bytes;
 use rstest::rstest;
@@ -20,8 +13,8 @@ use crate::core::client::storage::MockStorageClient;
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::workers::utils::get_job_by_mock_id_vector;
 use crate::types::constant::{
-    get_batch_artifact_file, get_batch_artifacts_dir, get_batch_blob_dir, get_batch_blob_file,
-    get_batch_state_update_file, get_snos_legacy_dir, STORAGE_EXPIRATION_TAG_KEY, STORAGE_EXPIRATION_TAG_VALUE,
+    get_batch_artifact_file, get_batch_blob_file, get_batch_state_update_file, get_snos_legacy_dir,
+    STORAGE_EXPIRATION_TAG_KEY, STORAGE_EXPIRATION_TAG_VALUE,
 };
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::metadata::{
@@ -32,11 +25,10 @@ use crate::worker::event_handler::triggers::storage_cleanup::StorageCleanupTrigg
 use crate::worker::event_handler::triggers::JobTrigger;
 
 // =============================================================================
-// Unit Tests with Mocks - Orchestration Logic
+// Unit Tests with Mocks
 // =============================================================================
 
-/// Test that the worker skips processing when it cannot acquire the distributed lock.
-/// This is critical for preventing duplicate processing in multi-instance deployments.
+/// Test: Worker skips processing when lock is unavailable (another instance running)
 #[rstest]
 #[tokio::test]
 async fn test_run_worker_skips_when_lock_unavailable() -> Result<(), Box<dyn Error>> {
@@ -44,7 +36,6 @@ async fn test_run_worker_skips_when_lock_unavailable() -> Result<(), Box<dyn Err
     let storage = MockStorageClient::new();
     let mut lock = MockLockClient::new();
 
-    // Mock lock client to simulate another instance holding the lock
     lock.expect_acquire_lock()
         .returning(|_, _, _, _| Err(LockError::LockAlreadyHeld { current_owner: "other_instance".to_string() }));
 
@@ -55,15 +46,12 @@ async fn test_run_worker_skips_when_lock_unavailable() -> Result<(), Box<dyn Err
         .build()
         .await;
 
-    // Should complete successfully without processing (graceful exit)
     let result = StorageCleanupTrigger.run_worker(services.config).await;
     assert!(result.is_ok(), "Worker should gracefully exit when lock unavailable");
-
     Ok(())
 }
 
-/// Test that the lock is always released, even when processing fails.
-/// This prevents deadlock scenarios where a crashed worker holds the lock forever.
+/// Test: Lock is released even when processing fails (prevents deadlocks)
 #[rstest]
 #[tokio::test]
 async fn test_run_worker_releases_lock_on_error() -> Result<(), Box<dyn Error>> {
@@ -71,15 +59,10 @@ async fn test_run_worker_releases_lock_on_error() -> Result<(), Box<dyn Error>> 
     let storage = MockStorageClient::new();
     let mut lock = MockLockClient::new();
 
-    // Mock lock acquisition success
     lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
-
-    // Mock database to return an error when fetching jobs
     database
         .expect_get_jobs_without_storage_artifacts_tagged()
         .returning(|_| Err(DatabaseError::KeyNotFound("simulated error".to_string())));
-
-    // Verify lock is released even on error
     lock.expect_release_lock().times(1).returning(|_, _| Ok(LockResult::Released));
 
     let services = TestConfigBuilder::new()
@@ -89,15 +72,12 @@ async fn test_run_worker_releases_lock_on_error() -> Result<(), Box<dyn Error>> 
         .build()
         .await;
 
-    // Should return error but lock should be released
     let result = StorageCleanupTrigger.run_worker(services.config).await;
     assert!(result.is_err(), "Worker should return error when database fails");
-
     Ok(())
 }
 
-/// Test that jobs with invalid metadata are skipped without stopping the entire batch.
-/// One bad job shouldn't prevent processing of other valid jobs.
+/// Test: Jobs with invalid metadata are skipped (one bad job doesn't stop batch)
 #[rstest]
 #[tokio::test]
 async fn test_process_completed_jobs_skips_invalid_metadata() -> Result<(), Box<dyn Error>> {
@@ -105,11 +85,10 @@ async fn test_process_completed_jobs_skips_invalid_metadata() -> Result<(), Box<
     let storage = MockStorageClient::new();
     let mut lock = MockLockClient::new();
 
-    // Mock lock
     lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
     lock.expect_release_lock().returning(|_, _| Ok(LockResult::Released));
 
-    // Create a job with invalid metadata (not StateUpdateMetadata)
+    // Create job with wrong metadata type (DA instead of StateUpdate)
     let invalid_job = JobItem {
         id: uuid::Uuid::new_v4(),
         internal_id: 1,
@@ -118,7 +97,6 @@ async fn test_process_completed_jobs_skips_invalid_metadata() -> Result<(), Box<
         external_id: crate::types::jobs::external_id::ExternalId::Number(1),
         metadata: JobMetadata {
             common: CommonMetadata::default(),
-            // Use DA metadata instead of StateUpdate - this will fail to parse
             specific: JobSpecificMetadata::Da(crate::types::jobs::metadata::DaMetadata {
                 block_number: 1,
                 blob_data_path: None,
@@ -139,15 +117,12 @@ async fn test_process_completed_jobs_skips_invalid_metadata() -> Result<(), Box<
         .build()
         .await;
 
-    // Should complete without error (skips invalid job)
     let result = StorageCleanupTrigger.run_worker(services.config).await;
     assert!(result.is_ok(), "Worker should skip invalid jobs and continue");
-
     Ok(())
 }
 
-/// Test that partial tagging failures don't mark the job as tagged.
-/// If we can't tag all artifacts, the job should be retried next run.
+/// Test: Partial tagging failures don't mark job as tagged (retry next run)
 #[rstest]
 #[tokio::test]
 async fn test_process_completed_jobs_skips_partial_tagging() -> Result<(), Box<dyn Error>> {
@@ -155,25 +130,17 @@ async fn test_process_completed_jobs_skips_partial_tagging() -> Result<(), Box<d
     let mut storage = MockStorageClient::new();
     let mut lock = MockLockClient::new();
 
-    // Mock lock
     lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
     lock.expect_release_lock().returning(|_, _| Ok(LockResult::Released));
 
-    // Create a valid StateTransition job using the existing helper from utils
     let valid_jobs = get_job_by_mock_id_vector(JobType::StateTransition, JobStatus::Completed, 1, 1);
     let valid_job = valid_jobs.into_iter().next().expect("Should have created one job");
 
     database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![valid_job.clone()]));
-
-    // Mock storage to return files but fail on tagging
     storage.expect_list_files_in_dir().returning(|_| Ok(vec!["file1.json".to_string()]));
-
-    // First tag succeeds, but simulate a real S3 error (not NoSuchKey)
     storage.expect_tag_object().returning(|_, _| {
         Err(crate::core::client::storage::StorageError::ObjectStreamError("Connection timeout".to_string()))
     });
-
-    // update_job should NOT be called since tagging failed
     database.expect_update_job().never();
 
     let services = TestConfigBuilder::new()
@@ -183,303 +150,19 @@ async fn test_process_completed_jobs_skips_partial_tagging() -> Result<(), Box<d
         .build()
         .await;
 
-    // Should complete without error (will retry next run)
     let result = StorageCleanupTrigger.run_worker(services.config).await;
     assert!(result.is_ok(), "Worker should continue even when tagging fails");
-
     Ok(())
 }
 
 // =============================================================================
-// Integration Tests with LocalStack - Actual S3 Operations
+// Integration Test with LocalStack + MongoDB
 // =============================================================================
 
-/// Test that tag_object correctly applies tags to an S3 object.
-/// This test verifies:
-/// 1. We can create a file in S3
-/// 2. We can tag it without errors
-/// 3. We can still read the file after tagging (file wasn't corrupted)
-#[rstest]
-#[tokio::test]
-async fn test_tag_object_applies_tags_correctly() -> Result<(), Box<dyn Error>> {
-    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
-
-    let storage = services.config.storage();
-
-    // Create a test file
-    let test_key = "test_tagging/test_file.json";
-    let test_data = Bytes::from(r#"{"test": "data"}"#);
-    storage.put_data(test_data.clone(), test_key).await?;
-
-    // Apply tags using our method - this should succeed
-    let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
-    storage.tag_object(test_key, &tags).await?;
-
-    // Verify file is still accessible after tagging
-    let retrieved_data = storage.get_data(test_key).await?;
-    assert_eq!(retrieved_data, test_data, "File data should be unchanged after tagging");
-
-    Ok(())
-}
-
-/// Test that list_files_in_dir returns all files from a directory.
-/// Creates multiple files and verifies all are returned.
-#[rstest]
-#[tokio::test]
-async fn test_list_files_in_dir_returns_all_files() -> Result<(), Box<dyn Error>> {
-    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
-
-    let storage = services.config.storage();
-
-    // Create multiple test files in a directory
-    let test_dir = "test_list_files";
-    let file_names = vec!["file1.json", "file2.json", "file3.txt", "nested/file4.json"];
-    let test_data = Bytes::from(r#"{"test": "data"}"#);
-
-    for file_name in &file_names {
-        let key = format!("{}/{}", test_dir, file_name);
-        storage.put_data(test_data.clone(), &key).await?;
-    }
-
-    // List files in the directory
-    let listed_files = storage.list_files_in_dir(test_dir).await?;
-
-    // Verify all files are returned
-    assert_eq!(
-        listed_files.len(),
-        file_names.len(),
-        "Expected {} files, got {}: {:?}",
-        file_names.len(),
-        listed_files.len(),
-        listed_files
-    );
-
-    for file_name in &file_names {
-        let expected_key = format!("{}/{}", test_dir, file_name);
-        assert!(listed_files.contains(&expected_key), "Expected file '{}' not found in listed files", expected_key);
-    }
-
-    Ok(())
-}
-
-/// Integration test: Create files in all 4 artifact locations, collect paths, tag them,
-/// and verify all are tagged correctly.
-#[rstest]
-#[tokio::test]
-async fn test_collect_and_tag_artifacts_integration() -> Result<(), Box<dyn Error>> {
-    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
-
-    let storage = services.config.storage();
-    let job_id: u64 = 42;
-    let test_data = Bytes::from(r#"{"test": "artifact"}"#);
-
-    // Create files in all 4 artifact locations
-    // 1. Artifacts directory
-    let artifact_file = get_batch_artifact_file(job_id, "proof.json");
-    storage.put_data(test_data.clone(), &artifact_file).await?;
-
-    // 2. Blob directory
-    let blob_file = get_batch_blob_file(job_id, 0);
-    storage.put_data(test_data.clone(), &blob_file).await?;
-
-    // 3. SNOS legacy directory
-    let snos_file = format!("{}/output.json", get_snos_legacy_dir(job_id));
-    storage.put_data(test_data.clone(), &snos_file).await?;
-
-    // 4. State update file
-    let state_update_file = get_batch_state_update_file(job_id);
-    storage.put_data(test_data.clone(), &state_update_file).await?;
-
-    // Collect paths from each location
-    let mut all_paths = Vec::new();
-
-    // Artifacts
-    let artifacts_dir = get_batch_artifacts_dir(job_id);
-    let artifact_files = storage.list_files_in_dir(&artifacts_dir).await.unwrap_or_default();
-    all_paths.extend(artifact_files);
-
-    // Blobs
-    let blob_dir = get_batch_blob_dir(job_id);
-    let blob_files = storage.list_files_in_dir(&blob_dir).await.unwrap_or_default();
-    all_paths.extend(blob_files);
-
-    // SNOS legacy
-    let snos_dir = get_snos_legacy_dir(job_id);
-    let snos_files = storage.list_files_in_dir(&snos_dir).await.unwrap_or_default();
-    all_paths.extend(snos_files);
-
-    // State update (single file)
-    all_paths.push(state_update_file.clone());
-
-    // Verify we collected 4 files
-    assert_eq!(all_paths.len(), 4, "Expected 4 artifact paths, got {}: {:?}", all_paths.len(), all_paths);
-
-    // Tag all artifacts - pass reference to avoid cloning
-    let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
-    for path in &all_paths {
-        storage.tag_object(path, &tags).await?;
-    }
-
-    // Verify all artifacts are still accessible after tagging (tagging didn't break anything)
-    for path in &all_paths {
-        // State update file is the only one that might not exist (we add it unconditionally)
-        if path == &state_update_file {
-            // Verify the state update file can be read
-            let data = storage.get_data(path).await?;
-            assert!(!data.is_empty(), "State update file should have content");
-        }
-    }
-
-    Ok(())
-}
-
-/// Test that the lifecycle rule is set up correctly on the bucket.
-/// Verifies the rule exists with the correct tag filter and expiration days.
-#[rstest]
-#[tokio::test]
-async fn test_setup_lifecycle_rule_creates_correct_config() -> Result<(), Box<dyn Error>> {
-    // Build config with Actual storage (this sets up the lifecycle rule)
-    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
-
-    // Get the actual bucket name from test config (includes UUID for test isolation)
-    let bucket_name = services.storage_params.bucket_identifier.to_string();
-
-    // Get the lifecycle configuration from S3
-    let lifecycle_config = get_bucket_lifecycle_config(&services.provider_config, &bucket_name).await?;
-
-    // Find our rule
-    let our_rule = lifecycle_config
-        .iter()
-        .find(|rule| rule.id == crate::types::constant::STORAGE_LIFECYCLE_RULE_ID)
-        .expect("Lifecycle rule not found");
-
-    // Verify rule is enabled
-    assert!(our_rule.enabled, "Lifecycle rule should be enabled");
-
-    // Verify tag filter
-    assert_eq!(our_rule.tag_key, Some(STORAGE_EXPIRATION_TAG_KEY.to_string()), "Tag key mismatch");
-    assert_eq!(our_rule.tag_value, Some(STORAGE_EXPIRATION_TAG_VALUE.to_string()), "Tag value mismatch");
-
-    // Verify expiration is set (we use default 14 days in tests)
-    assert!(our_rule.expiration_days.is_some(), "Expiration days should be set");
-
-    Ok(())
-}
-
-/// Test that tagging a non-existent object returns an appropriate error.
-/// This verifies our error handling for missing files.
-#[rstest]
-#[tokio::test]
-async fn test_tag_nonexistent_object_returns_error() -> Result<(), Box<dyn Error>> {
-    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
-
-    let storage = services.config.storage();
-
-    // Try to tag a file that doesn't exist
-    let nonexistent_key = "definitely/does/not/exist/file.json";
-    let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
-
-    let result = storage.tag_object(nonexistent_key, &tags).await;
-
-    // Should return an error (the specific error type depends on S3)
-    assert!(result.is_err(), "Tagging non-existent object should return error");
-
-    // Verify we got an error - the specific message varies by S3 implementation
-    // LocalStack may return "service error" while real S3 returns "NoSuchKey"
-    let error_msg = result.unwrap_err().to_string();
-    assert!(!error_msg.is_empty(), "Error message should not be empty: {}", error_msg);
-
-    Ok(())
-}
-
-// =============================================================================
-// Helper Functions
-// =============================================================================
-
-/// Simple struct to hold lifecycle rule info for testing
-struct LifecycleRuleInfo {
-    id: String,
-    enabled: bool,
-    tag_key: Option<String>,
-    tag_value: Option<String>,
-    expiration_days: Option<i32>,
-}
-
-/// Helper to get bucket lifecycle configuration
-async fn get_bucket_lifecycle_config(
-    provider_config: &Arc<crate::core::cloud::CloudProvider>,
-    bucket_name: &str,
-) -> Result<Vec<LifecycleRuleInfo>, Box<dyn Error>> {
-    let aws_config = provider_config.get_aws_client_or_panic();
-
-    let mut s3_config_builder = aws_sdk_s3::config::Builder::from(aws_config);
-    s3_config_builder.set_force_path_style(Some(true));
-    let client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
-
-    let lifecycle_output = client.get_bucket_lifecycle_configuration().bucket(bucket_name).send().await?;
-
-    let rules: Vec<LifecycleRuleInfo> = lifecycle_output
-        .rules()
-        .iter()
-        .map(|rule| {
-            let (tag_key, tag_value) = if let Some(filter) = rule.filter() {
-                if let Some(tag) = filter.tag() {
-                    (Some(tag.key().to_string()), Some(tag.value().to_string()))
-                } else {
-                    (None, None)
-                }
-            } else {
-                (None, None)
-            };
-
-            LifecycleRuleInfo {
-                id: rule.id().unwrap_or_default().to_string(),
-                enabled: *rule.status() == aws_sdk_s3::types::ExpirationStatus::Enabled,
-                tag_key,
-                tag_value,
-                expiration_days: rule.expiration().and_then(|e| e.days()),
-            }
-        })
-        .collect();
-
-    Ok(rules)
-}
-
-/// Helper to get object tags from S3
-async fn get_object_tags(
-    provider_config: &Arc<crate::core::cloud::CloudProvider>,
-    bucket_name: &str,
-    key: &str,
-) -> Result<Vec<(String, String)>, Box<dyn Error>> {
-    let aws_config = provider_config.get_aws_client_or_panic();
-
-    let mut s3_config_builder = aws_sdk_s3::config::Builder::from(aws_config);
-    s3_config_builder.set_force_path_style(Some(true));
-    let client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
-
-    let tagging_output = client.get_object_tagging().bucket(bucket_name).key(key).send().await?;
-
-    let tags: Vec<(String, String)> =
-        tagging_output.tag_set().iter().map(|tag| (tag.key().to_string(), tag.value().to_string())).collect();
-
-    Ok(tags)
-}
-
-// =============================================================================
-// Integration Happy Path Test
-// =============================================================================
-
-/// Integration test for the complete storage cleanup happy path.
-/// This test verifies the full flow with real LocalStack (S3) and MongoDB:
-/// 1. Create artifacts in S3 for a job
-/// 2. Create a completed StateTransition job in MongoDB
-/// 3. Run StorageCleanupTrigger
-/// 4. Verify artifacts are tagged with expiration tags
-/// 5. Verify job is updated with storage_artifacts_tagged_at timestamp
+/// Full integration test: Creates S3 artifacts + MongoDB job, runs worker, verifies tagging
 #[rstest]
 #[tokio::test]
 async fn test_storage_cleanup_happy_path_integration() -> Result<(), Box<dyn Error>> {
-    // Build config with actual storage, database and lock client (LocalStack + MongoDB)
     let services = TestConfigBuilder::new()
         .configure_storage_client(ConfigType::Actual)
         .configure_database(ConfigType::Actual)
@@ -488,28 +171,21 @@ async fn test_storage_cleanup_happy_path_integration() -> Result<(), Box<dyn Err
         .await;
 
     let config = &services.config;
-    let job_id: u64 = 99999; // Use a unique job ID to avoid conflicts
+    let job_id: u64 = 99999;
     let test_data = Bytes::from(r#"{"test": "happy_path_integration"}"#);
 
-    // Step 1: Create artifacts in S3 for this job
-    // Create files in the artifact locations that storage cleanup will look for
+    // Step 1: Create artifacts in S3
     let artifact_file = get_batch_artifact_file(job_id, "proof.json");
-    config.storage().put_data(test_data.clone(), &artifact_file).await?;
-
     let blob_file = get_batch_blob_file(job_id, 0);
-    config.storage().put_data(test_data.clone(), &blob_file).await?;
-
     let snos_file = format!("{}/snos_output.json", get_snos_legacy_dir(job_id));
-    config.storage().put_data(test_data.clone(), &snos_file).await?;
-
     let state_update_file = get_batch_state_update_file(job_id);
+
+    config.storage().put_data(test_data.clone(), &artifact_file).await?;
+    config.storage().put_data(test_data.clone(), &blob_file).await?;
+    config.storage().put_data(test_data.clone(), &snos_file).await?;
     config.storage().put_data(test_data.clone(), &state_update_file).await?;
 
-    // Step 2: Create a completed StateTransition job in MongoDB
-    // The job must have:
-    // - job_type = StateTransition
-    // - status = Completed
-    // - metadata.specific.storage_artifacts_tagged_at = None
+    // Step 2: Create completed StateTransition job in MongoDB
     let job = JobItem {
         id: uuid::Uuid::new_v4(),
         internal_id: job_id,
@@ -525,53 +201,222 @@ async fn test_storage_cleanup_happy_path_integration() -> Result<(), Box<dyn Err
                 da_segment_path: None,
                 tx_hash: Some("0x123".to_string()),
                 context: SettlementContext::Batch(SettlementContextData { to_settle: job_id, last_failed: None }),
-                storage_artifacts_tagged_at: None, // This is the key - not yet tagged
+                storage_artifacts_tagged_at: None,
             }),
         },
         version: 0,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),
     };
-
     config.database().create_job(job.clone()).await?;
 
-    // Verify the job was created and is returned by get_jobs_without_storage_artifacts_tagged
+    // Verify job is in untagged list
     let untagged_jobs = config.database().get_jobs_without_storage_artifacts_tagged(Some(100)).await?;
-    assert!(
-        untagged_jobs.iter().any(|j| j.internal_id == job_id),
-        "Job should be in the list of jobs without storage artifacts tagged"
-    );
+    assert!(untagged_jobs.iter().any(|j| j.internal_id == job_id), "Job should be in untagged list");
 
-    // Step 3: Run the StorageCleanupTrigger
+    // Step 3: Run StorageCleanupTrigger
     let result = StorageCleanupTrigger.run_worker(config.clone()).await;
-    assert!(result.is_ok(), "StorageCleanupTrigger should complete successfully: {:?}", result.err());
+    assert!(result.is_ok(), "StorageCleanupTrigger should complete: {:?}", result.err());
 
-    // Step 4: Verify artifacts are tagged with expiration tags
-    // Use the actual bucket name from test config (includes UUID for test isolation)
+    // Step 4: Verify artifacts are tagged
     let bucket_name = services.storage_params.bucket_identifier.to_string();
-
-    // Check tags on the artifact file
     let artifact_tags = get_object_tags(&services.provider_config, &bucket_name, &artifact_file).await?;
     assert!(
         artifact_tags.iter().any(|(k, v)| k == STORAGE_EXPIRATION_TAG_KEY && v == STORAGE_EXPIRATION_TAG_VALUE),
-        "Artifact file should have expiration tag. Tags found: {:?}",
+        "Artifact should have expiration tag: {:?}",
         artifact_tags
     );
 
-    // Check tags on the blob file
-    let blob_tags = get_object_tags(&services.provider_config, &bucket_name, &blob_file).await?;
-    assert!(
-        blob_tags.iter().any(|(k, v)| k == STORAGE_EXPIRATION_TAG_KEY && v == STORAGE_EXPIRATION_TAG_VALUE),
-        "Blob file should have expiration tag. Tags found: {:?}",
-        blob_tags
-    );
-
-    // Step 5: Verify job is updated with storage_artifacts_tagged_at timestamp
+    // Step 5: Verify job is no longer in untagged list
     let untagged_jobs_after = config.database().get_jobs_without_storage_artifacts_tagged(Some(100)).await?;
-    assert!(
-        !untagged_jobs_after.iter().any(|j| j.internal_id == job_id),
-        "Job should no longer be in the list of untagged jobs (it should have been marked as tagged)"
-    );
+    assert!(!untagged_jobs_after.iter().any(|j| j.internal_id == job_id), "Job should be marked as tagged");
 
     Ok(())
+}
+
+// =============================================================================
+// S3 Storage Client Unit Tests
+// =============================================================================
+
+/// Tests: tag_object applies tags correctly + tag_nonexistent_object returns error
+#[rstest]
+#[tokio::test]
+async fn test_tag_object_success_and_error_cases() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+    let storage = services.config.storage();
+
+    // Setup: create a test object
+    let test_key = "test_tagging/object.json";
+    storage.put_data(Bytes::from(r#"{"test": "tagging"}"#), test_key).await?;
+
+    // Test 1: tag_object applies tags correctly
+    let tags = [(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
+    storage.tag_object(test_key, &tags).await?;
+
+    let bucket_name = services.storage_params.bucket_identifier.to_string();
+    let applied_tags = get_object_tags(&services.provider_config, &bucket_name, test_key).await?;
+    assert!(
+        applied_tags.iter().any(|(k, v)| k == STORAGE_EXPIRATION_TAG_KEY && v == STORAGE_EXPIRATION_TAG_VALUE),
+        "Tag should be applied: {:?}",
+        applied_tags
+    );
+
+    // Test 2: tag_nonexistent_object returns error
+    let result = storage.tag_object("nonexistent/path/file.json", &tags).await;
+    assert!(result.is_err(), "Tagging nonexistent object should return error");
+
+    Ok(())
+}
+
+/// Tests: list_files_in_dir returns all files in directory
+#[rstest]
+#[tokio::test]
+async fn test_list_files_in_dir_returns_all_files() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+    let storage = services.config.storage();
+
+    // Setup: create multiple files in a directory
+    let test_dir = "test_list_dir_12345";
+    let files = ["file1.json", "file2.json", "nested/file3.json"];
+    for file in &files {
+        let key = format!("{}/{}", test_dir, file);
+        storage.put_data(Bytes::from(r#"{"test": "list"}"#), &key).await?;
+    }
+
+    // Test: list_files_in_dir returns all files
+    let listed_files = storage.list_files_in_dir(test_dir).await?;
+    assert_eq!(listed_files.len(), 3, "Should list all 3 files");
+    for file in &files {
+        let expected_key = format!("{}/{}", test_dir, file);
+        assert!(listed_files.contains(&expected_key), "Should contain {}", expected_key);
+    }
+
+    // Test: empty directory returns empty list
+    let empty_result = storage.list_files_in_dir("nonexistent_dir_xyz").await?;
+    assert!(empty_result.is_empty(), "Nonexistent dir should return empty list");
+
+    Ok(())
+}
+
+/// Tests: setup_lifecycle_rule creates correct configuration
+#[rstest]
+#[tokio::test]
+async fn test_setup_lifecycle_rule_creates_correct_config() -> Result<(), Box<dyn Error>> {
+    use crate::types::constant::STORAGE_LIFECYCLE_RULE_ID;
+
+    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
+    let bucket_name = services.storage_params.bucket_identifier.to_string();
+    let aws_config = services.provider_config.get_aws_client_or_panic();
+
+    let mut s3_config_builder = aws_sdk_s3::config::Builder::from(aws_config);
+    s3_config_builder.set_force_path_style(Some(true));
+    let client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
+
+    // Lifecycle rule is created during TestConfigBuilder setup, verify it exists
+    let lifecycle = client.get_bucket_lifecycle_configuration().bucket(&bucket_name).send().await?;
+    let rules = lifecycle.rules();
+
+    let cleanup_rule = rules.iter().find(|r| r.id() == Some(STORAGE_LIFECYCLE_RULE_ID));
+    assert!(cleanup_rule.is_some(), "Lifecycle rule should exist");
+
+    let rule = cleanup_rule.unwrap();
+    assert_eq!(*rule.status(), aws_sdk_s3::types::ExpirationStatus::Enabled);
+    assert!(rule.expiration().is_some(), "Rule should have expiration configured");
+
+    // Verify tag filter
+    if let Some(filter) = rule.filter() {
+        if let Some(tag) = filter.tag() {
+            assert_eq!(tag.key(), STORAGE_EXPIRATION_TAG_KEY);
+            assert_eq!(tag.value(), STORAGE_EXPIRATION_TAG_VALUE);
+        } else {
+            panic!("Rule should have tag filter");
+        }
+    }
+
+    Ok(())
+}
+
+/// Tests: collect_and_tag_artifacts integration (full worker flow for single job)
+#[rstest]
+#[tokio::test]
+async fn test_collect_and_tag_artifacts_integration() -> Result<(), Box<dyn Error>> {
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(ConfigType::Actual)
+        .configure_database(ConfigType::Actual)
+        .configure_lock_client(ConfigType::Actual)
+        .build()
+        .await;
+
+    let config = &services.config;
+    let job_id: u64 = 88888;
+    let test_data = Bytes::from(r#"{"test": "collect_and_tag"}"#);
+
+    // Create artifacts in multiple directories
+    let artifact_file = get_batch_artifact_file(job_id, "test_proof.json");
+    let blob_file = get_batch_blob_file(job_id, 0);
+    let state_update_file = get_batch_state_update_file(job_id);
+
+    config.storage().put_data(test_data.clone(), &artifact_file).await?;
+    config.storage().put_data(test_data.clone(), &blob_file).await?;
+    config.storage().put_data(test_data.clone(), &state_update_file).await?;
+
+    // Create job in database
+    let job = JobItem {
+        id: uuid::Uuid::new_v4(),
+        internal_id: job_id,
+        job_type: JobType::StateTransition,
+        status: JobStatus::Completed,
+        external_id: crate::types::jobs::external_id::ExternalId::Number(job_id as usize),
+        metadata: JobMetadata {
+            common: CommonMetadata::default(),
+            specific: JobSpecificMetadata::StateUpdate(StateUpdateMetadata {
+                snos_output_path: None,
+                program_output_path: None,
+                blob_data_path: Some(blob_file.clone()),
+                da_segment_path: None,
+                tx_hash: Some("0xabc".to_string()),
+                context: SettlementContext::Batch(SettlementContextData { to_settle: job_id, last_failed: None }),
+                storage_artifacts_tagged_at: None,
+            }),
+        },
+        version: 0,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+    config.database().create_job(job).await?;
+
+    // Run worker
+    StorageCleanupTrigger.run_worker(config.clone()).await?;
+
+    // Verify all artifacts are tagged
+    let bucket_name = services.storage_params.bucket_identifier.to_string();
+    for key in [&artifact_file, &blob_file, &state_update_file] {
+        let tags = get_object_tags(&services.provider_config, &bucket_name, key).await?;
+        assert!(
+            tags.iter().any(|(k, v)| k == STORAGE_EXPIRATION_TAG_KEY && v == STORAGE_EXPIRATION_TAG_VALUE),
+            "File {} should be tagged: {:?}",
+            key,
+            tags
+        );
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+async fn get_object_tags(
+    provider_config: &Arc<crate::core::cloud::CloudProvider>,
+    bucket_name: &str,
+    key: &str,
+) -> Result<Vec<(String, String)>, Box<dyn Error>> {
+    let aws_config = provider_config.get_aws_client_or_panic();
+    let mut s3_config_builder = aws_sdk_s3::config::Builder::from(aws_config);
+    s3_config_builder.set_force_path_style(Some(true));
+    let client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
+
+    let tagging_output = client.get_object_tagging().bucket(bucket_name).key(key).send().await?;
+    Ok(tagging_output.tag_set().iter().map(|tag| (tag.key().to_string(), tag.value().to_string())).collect())
 }

--- a/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/orchestrator/src/tests/workers/update_state/mod.rs
@@ -163,6 +163,7 @@ async fn update_state_worker_continues_from_previous_state_update() {
         da_segment_path: None,
         tx_hash: None,
         context: SettlementContext::Block(SettlementContextData { to_settle: 4, last_failed: None }),
+        storage_artifacts_tagged_at: None,
     };
 
     job_item.metadata =
@@ -219,6 +220,7 @@ async fn update_state_worker_next_block_missing() {
         da_segment_path: None,
         tx_hash: None,
         context: SettlementContext::Block(SettlementContextData { to_settle: 4, last_failed: None }),
+        storage_artifacts_tagged_at: None,
     };
 
     job_item.metadata =

--- a/orchestrator/src/tests/workers/utils/mod.rs
+++ b/orchestrator/src/tests/workers/utils/mod.rs
@@ -138,6 +138,7 @@ fn create_metadata_for_job_type(job_type: JobType, block_number: u64) -> JobMeta
                 da_segment_path: None,
                 tx_hash: None,
                 context: SettlementContext::Block(SettlementContextData { to_settle: block_number, last_failed: None }),
+                storage_artifacts_tagged_at: None,
             }),
         },
         // For any other job types, use a default metadata structure

--- a/orchestrator/src/types/batch.rs
+++ b/orchestrator/src/types/batch.rs
@@ -1,5 +1,5 @@
 use crate::core::config::StarknetVersion;
-use crate::types::constant::{STORAGE_BLOB_DIR, STORAGE_STATE_UPDATE_DIR};
+use crate::types::constant::{get_batch_blob_dir, get_batch_blob_file, get_batch_state_update_file};
 use blockifier::bouncer::BouncerWeights;
 use chrono::{DateTime, SubsecRound, Utc};
 #[cfg(feature = "with_mongodb")]
@@ -241,15 +241,15 @@ impl AggregatorBatch {
     }
 
     pub fn get_blob_file_path(batch_index: u64, blob_index: u64) -> String {
-        format!("{}/{}.txt", Self::get_blob_dir_path(batch_index), blob_index)
+        get_batch_blob_file(batch_index, blob_index)
     }
 
     fn get_state_update_file_path(batch_index: u64) -> String {
-        format!("{}/batch/{}.json", STORAGE_STATE_UPDATE_DIR, batch_index)
+        get_batch_state_update_file(batch_index)
     }
 
     fn get_blob_dir_path(batch_index: u64) -> String {
-        format!("{}/batch/{}", STORAGE_BLOB_DIR, batch_index)
+        get_batch_blob_dir(batch_index)
     }
 }
 

--- a/orchestrator/src/types/constant.rs
+++ b/orchestrator/src/types/constant.rs
@@ -14,6 +14,58 @@ pub const DA_SEGMENT_FILE_NAME: &str = "da_blob.json";
 pub const STORAGE_STATE_UPDATE_DIR: &str = "state_update";
 pub const STORAGE_BLOB_DIR: &str = "blob";
 pub const STORAGE_ARTIFACTS_DIR: &str = "artifacts";
+pub const STORAGE_BATCH_SUBDIR: &str = "batch";
+
+// ============================================================================
+// Storage Path Helper Functions
+// ============================================================================
+
+/// Returns the directory path for batch artifacts: `artifacts/batch/{batch_index}`
+pub fn get_batch_artifacts_dir(batch_index: u64) -> String {
+    format!("{}/{}/{}", STORAGE_ARTIFACTS_DIR, STORAGE_BATCH_SUBDIR, batch_index)
+}
+
+/// Returns the full path for a specific artifact file: `artifacts/batch/{batch_index}/{filename}`
+pub fn get_batch_artifact_file(batch_index: u64, filename: &str) -> String {
+    format!("{}/{}", get_batch_artifacts_dir(batch_index), filename)
+}
+
+/// Returns the directory path for batch blob data: `blob/batch/{batch_index}`
+pub fn get_batch_blob_dir(batch_index: u64) -> String {
+    format!("{}/{}/{}", STORAGE_BLOB_DIR, STORAGE_BATCH_SUBDIR, batch_index)
+}
+
+/// Returns the full path for a specific blob file: `blob/batch/{batch_index}/{blob_index}.txt`
+pub fn get_batch_blob_file(batch_index: u64, blob_index: u64) -> String {
+    format!("{}/{}.txt", get_batch_blob_dir(batch_index), blob_index)
+}
+
+/// Returns the path for a batch state update file: `state_update/batch/{batch_index}.json`
+pub fn get_batch_state_update_file(batch_index: u64) -> String {
+    format!("{}/{}/{}.json", STORAGE_STATE_UPDATE_DIR, STORAGE_BATCH_SUBDIR, batch_index)
+}
+
+/// Returns the legacy SNOS directory path (at root level): `{job_id}`
+/// This is for backwards compatibility with old format SNOS artifacts
+pub fn get_snos_legacy_dir(job_id: u64) -> String {
+    format!("{}", job_id)
+}
+
+// Storage cleanup constants
+/// Tag key used to mark objects for expiration
+pub const STORAGE_EXPIRATION_TAG_KEY: &str = "expire-after-settlement";
+/// Tag value used to mark objects for expiration
+pub const STORAGE_EXPIRATION_TAG_VALUE: &str = "true";
+/// Number of days after object creation before S3 deletes the object
+pub const STORAGE_EXPIRATION_DAYS: i32 = 14;
+/// Lifecycle rule ID for S3
+pub const STORAGE_LIFECYCLE_RULE_ID: &str = "expire-settled-artifacts";
+/// Worker key for distributed locking
+pub const STORAGE_CLEANUP_WORKER_KEY: &str = "StorageCleanupWorker";
+/// Maximum number of jobs to process per cleanup run, empirically determined
+pub const STORAGE_CLEANUP_MAX_JOBS_PER_RUN: usize = 200;
+/// Lock duration in seconds for storage cleanup worker (5 minutes)
+pub const STORAGE_CLEANUP_LOCK_DURATION: u64 = 300;
 pub const BLOB_LEN: usize = 4096;
 pub const MAX_BLOBS: usize = 6; // TODO: This should be configurable via ENV or config file
 pub const MAX_BLOB_SIZE: usize = BLOB_LEN * MAX_BLOBS; // This represents the maximum size of data that you can use in a single transaction

--- a/orchestrator/src/types/constant.rs
+++ b/orchestrator/src/types/constant.rs
@@ -56,8 +56,6 @@ pub fn get_snos_legacy_dir(job_id: u64) -> String {
 pub const STORAGE_EXPIRATION_TAG_KEY: &str = "expire-after-settlement";
 /// Tag value used to mark objects for expiration
 pub const STORAGE_EXPIRATION_TAG_VALUE: &str = "true";
-/// Number of days after object creation before S3 deletes the object
-pub const STORAGE_EXPIRATION_DAYS: i32 = 14;
 /// Lifecycle rule ID for S3
 pub const STORAGE_LIFECYCLE_RULE_ID: &str = "expire-settled-artifacts";
 /// Worker key for distributed locking

--- a/orchestrator/src/types/constant.rs
+++ b/orchestrator/src/types/constant.rs
@@ -16,54 +16,39 @@ pub const STORAGE_BLOB_DIR: &str = "blob";
 pub const STORAGE_ARTIFACTS_DIR: &str = "artifacts";
 pub const STORAGE_BATCH_SUBDIR: &str = "batch";
 
-// ============================================================================
-// Storage Path Helper Functions
-// ============================================================================
-
-/// Returns the directory path for batch artifacts: `artifacts/batch/{batch_index}`
+// Storage path helpers
 pub fn get_batch_artifacts_dir(batch_index: u64) -> String {
     format!("{}/{}/{}", STORAGE_ARTIFACTS_DIR, STORAGE_BATCH_SUBDIR, batch_index)
 }
 
-/// Returns the full path for a specific artifact file: `artifacts/batch/{batch_index}/{filename}`
 pub fn get_batch_artifact_file(batch_index: u64, filename: &str) -> String {
     format!("{}/{}", get_batch_artifacts_dir(batch_index), filename)
 }
 
-/// Returns the directory path for batch blob data: `blob/batch/{batch_index}`
 pub fn get_batch_blob_dir(batch_index: u64) -> String {
     format!("{}/{}/{}", STORAGE_BLOB_DIR, STORAGE_BATCH_SUBDIR, batch_index)
 }
 
-/// Returns the full path for a specific blob file: `blob/batch/{batch_index}/{blob_index}.txt`
 pub fn get_batch_blob_file(batch_index: u64, blob_index: u64) -> String {
     format!("{}/{}.txt", get_batch_blob_dir(batch_index), blob_index)
 }
 
-/// Returns the path for a batch state update file: `state_update/batch/{batch_index}.json`
 pub fn get_batch_state_update_file(batch_index: u64) -> String {
     format!("{}/{}/{}.json", STORAGE_STATE_UPDATE_DIR, STORAGE_BATCH_SUBDIR, batch_index)
 }
 
-/// Returns the legacy SNOS directory path (at root level): `{job_id}`
-/// This is for backwards compatibility with old format SNOS artifacts
+/// Legacy SNOS directory at root level for backwards compatibility
 pub fn get_snos_legacy_dir(job_id: u64) -> String {
     format!("{}", job_id)
 }
 
 // Storage cleanup constants
-/// Tag key used to mark objects for expiration
 pub const STORAGE_EXPIRATION_TAG_KEY: &str = "expire-after-settlement";
-/// Tag value used to mark objects for expiration
 pub const STORAGE_EXPIRATION_TAG_VALUE: &str = "true";
-/// Lifecycle rule ID for S3
 pub const STORAGE_LIFECYCLE_RULE_ID: &str = "expire-settled-artifacts";
-/// Worker key for distributed locking
 pub const STORAGE_CLEANUP_WORKER_KEY: &str = "StorageCleanupWorker";
-/// Maximum number of jobs to process per cleanup run, empirically determined
 pub const STORAGE_CLEANUP_MAX_JOBS_PER_RUN: usize = 200;
-/// Lock duration in seconds for storage cleanup worker (5 minutes)
-pub const STORAGE_CLEANUP_LOCK_DURATION: u64 = 300;
+pub const STORAGE_CLEANUP_LOCK_DURATION: u64 = 300; // 5 minutes
 pub const BLOB_LEN: usize = 4096;
 pub const MAX_BLOBS: usize = 6; // TODO: This should be configurable via ENV or config file
 pub const MAX_BLOB_SIZE: usize = BLOB_LEN * MAX_BLOBS; // This represents the maximum size of data that you can use in a single transaction

--- a/orchestrator/src/types/jobs/metadata/mod.rs
+++ b/orchestrator/src/types/jobs/metadata/mod.rs
@@ -215,6 +215,13 @@ pub struct StateUpdateMetadata {
     pub tx_hash: Option<String>,
 
     pub context: SettlementContext,
+
+    // Storage cleanup tracking
+    /// Timestamp when storage artifacts were tagged for expiration.
+    /// Used by StorageCleanupTrigger to track which jobs have been processed.
+    /// When None, the job's artifacts have not yet been tagged for cleanup.
+    #[serde(default)]
+    pub storage_artifacts_tagged_at: Option<DateTime<Utc>>,
 }
 
 /// Enum containing all possible job-specific metadata types.

--- a/orchestrator/src/types/jobs/mod.rs
+++ b/orchestrator/src/types/jobs/mod.rs
@@ -21,6 +21,7 @@ pub enum WorkerTriggerType {
     Aggregator,
     AggregatorBatching,
     SnosBatching,
+    StorageCleanup,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/orchestrator/src/types/params/mod.rs
+++ b/orchestrator/src/types/params/mod.rs
@@ -103,6 +103,8 @@ impl fmt::Display for AWSResourceIdentifier {
 #[derive(Debug, Clone)]
 pub struct StorageArgs {
     pub bucket_identifier: AWSResourceIdentifier,
+    /// Number of days before S3 automatically deletes objects tagged for expiration
+    pub storage_expiration_days: i32,
 }
 
 impl StorageArgs {
@@ -187,7 +189,10 @@ impl TryFrom<SetupCmd> for StorageArgs {
                 AWSResourceIdentifier::Name(name)
             });
 
-            Ok(Self { bucket_identifier: identifier })
+            Ok(Self {
+                bucket_identifier: identifier,
+                storage_expiration_days: setup_cmd.aws_s3_args.storage_expiration_days,
+            })
         } else {
             Err(OrchestratorError::SetupCommandError("Missing bucket name".to_string()))
         }
@@ -209,7 +214,10 @@ impl TryFrom<RunCmd> for StorageArgs {
                 AWSResourceIdentifier::Name(name)
             });
 
-            Ok(Self { bucket_identifier: identifier })
+            Ok(Self {
+                bucket_identifier: identifier,
+                storage_expiration_days: run_cmd.aws_s3_args.storage_expiration_days,
+            })
         } else {
             Err(OrchestratorError::RunCommandError("Missing bucket name".to_string()))
         }

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -28,6 +28,7 @@ use crate::worker::event_handler::triggers::proof_registration::ProofRegistratio
 use crate::worker::event_handler::triggers::proving::ProvingJobTrigger;
 use crate::worker::event_handler::triggers::snos::SnosJobTrigger;
 use crate::worker::event_handler::triggers::snos_batching::SnosBatchingTrigger;
+use crate::worker::event_handler::triggers::storage_cleanup::StorageCleanupTrigger;
 use crate::worker::event_handler::triggers::update_state::UpdateStateJobTrigger;
 use crate::worker::event_handler::triggers::JobTrigger;
 use crate::worker::service::JobService;
@@ -875,6 +876,7 @@ impl JobHandlerService {
             WorkerTriggerType::ProofRegistration => Box::new(ProofRegistrationJobTrigger),
             WorkerTriggerType::Aggregator => Box::new(AggregatorJobTrigger),
             WorkerTriggerType::UpdateState => Box::new(UpdateStateJobTrigger),
+            WorkerTriggerType::StorageCleanup => Box::new(StorageCleanupTrigger),
         }
     }
 }

--- a/orchestrator/src/worker/event_handler/triggers/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/aggregator.rs
@@ -1,8 +1,8 @@
 use crate::core::config::Config;
 use crate::types::batch::{AggregatorBatch, AggregatorBatchStatus};
 use crate::types::constant::{
-    CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, ORCHESTRATOR_VERSION, PROGRAM_OUTPUT_FILE_NAME, PROOF_FILE_NAME,
-    SNOS_OUTPUT_FILE_NAME, STORAGE_ARTIFACTS_DIR, STORAGE_BLOB_DIR,
+    get_batch_artifact_file, get_batch_blob_dir, CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, ORCHESTRATOR_VERSION,
+    PROGRAM_OUTPUT_FILE_NAME, PROOF_FILE_NAME, SNOS_OUTPUT_FILE_NAME,
 };
 use crate::types::jobs::metadata::{AggregatorMetadata, CommonMetadata, JobMetadata, JobSpecificMetadata};
 use crate::types::jobs::types::{JobStatus, JobType};
@@ -59,24 +59,15 @@ impl JobTrigger for AggregatorJobTrigger {
                     batch_num: batch.index,
                     bucket_id: batch.bucket_id,
                     download_proof: if config.params.store_audit_artifacts {
-                        Some(format!("{}/batch/{}/{}", STORAGE_ARTIFACTS_DIR, batch.index, PROOF_FILE_NAME))
+                        Some(get_batch_artifact_file(batch.index, PROOF_FILE_NAME))
                     } else {
                         None
                     },
-                    blob_data_path: format!("{}/batch/{}", STORAGE_BLOB_DIR, batch.index),
-                    da_segment_path: format!(
-                        "{}/batch/{}/{}",
-                        STORAGE_ARTIFACTS_DIR, batch.index, DA_SEGMENT_FILE_NAME
-                    ),
-                    cairo_pie_path: format!("{}/batch/{}/{}", STORAGE_ARTIFACTS_DIR, batch.index, CAIRO_PIE_FILE_NAME),
-                    snos_output_path: format!(
-                        "{}/batch/{}/{}",
-                        STORAGE_ARTIFACTS_DIR, batch.index, SNOS_OUTPUT_FILE_NAME
-                    ),
-                    program_output_path: format!(
-                        "{}/batch/{}/{}",
-                        STORAGE_ARTIFACTS_DIR, batch.index, PROGRAM_OUTPUT_FILE_NAME
-                    ),
+                    blob_data_path: get_batch_blob_dir(batch.index),
+                    da_segment_path: get_batch_artifact_file(batch.index, DA_SEGMENT_FILE_NAME),
+                    cairo_pie_path: get_batch_artifact_file(batch.index, CAIRO_PIE_FILE_NAME),
+                    snos_output_path: get_batch_artifact_file(batch.index, SNOS_OUTPUT_FILE_NAME),
+                    program_output_path: get_batch_artifact_file(batch.index, PROGRAM_OUTPUT_FILE_NAME),
                     ..AggregatorMetadata::default()
                 }),
             };

--- a/orchestrator/src/worker/event_handler/triggers/mod.rs
+++ b/orchestrator/src/worker/event_handler/triggers/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod proof_registration;
 pub(crate) mod proving;
 pub(crate) mod snos;
 pub(crate) mod snos_batching;
+pub(crate) mod storage_cleanup;
 pub(crate) mod update_state;
 
 use crate::core::config::Config;

--- a/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
+++ b/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
@@ -186,13 +186,12 @@ impl StorageCleanupTrigger {
     /// Tag artifacts for expiration. Returns (tagged_count, all_succeeded).
     /// Handles non-existent files gracefully (counts as success).
     async fn tag_artifacts(&self, config: &Arc<Config>, job_id: u64, paths: &[String]) -> (usize, bool) {
-        let tag_key = STORAGE_EXPIRATION_TAG_KEY.to_string();
-        let tag_value = STORAGE_EXPIRATION_TAG_VALUE.to_string();
+        // Create tags once outside the loop - only a reference is passed, avoiding Vec clones
+        let tags = vec![(STORAGE_EXPIRATION_TAG_KEY.to_string(), STORAGE_EXPIRATION_TAG_VALUE.to_string())];
         let mut tagged_count = 0;
 
         for path in paths {
-            let tags = vec![(tag_key.clone(), tag_value.clone())];
-            match config.storage().tag_object(path, tags).await {
+            match config.storage().tag_object(path, &tags).await {
                 Ok(_) => {
                     tagged_count += 1;
                     debug!(job_id = %job_id, path = %path, "Tagged artifact for expiration");

--- a/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
+++ b/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
@@ -1,0 +1,175 @@
+use crate::core::client::lock::LockValue;
+use crate::core::config::Config;
+use crate::types::jobs::job_updates::JobItemUpdates;
+use crate::types::jobs::metadata::{JobMetadata, JobSpecificMetadata, StateUpdateMetadata};
+use crate::types::jobs::types::{JobStatus, JobType};
+use crate::worker::event_handler::triggers::JobTrigger;
+use async_trait::async_trait;
+use chrono::Utc;
+use std::sync::Arc;
+use tracing::{debug, error, info, warn};
+
+/// Worker key for distributed locking
+pub const STORAGE_CLEANUP_WORKER_KEY: &str = "StorageCleanupWorker";
+
+/// Tag key used to mark objects for expiration
+const EXPIRATION_TAG_KEY: &str = "expire-after-settlement";
+const EXPIRATION_TAG_VALUE: &str = "true";
+
+/// Maximum number of jobs to process per run
+const MAX_JOBS_PER_RUN: usize = 20;
+
+/// Lock duration in seconds (5 minutes)
+const CLEANUP_WORKER_LOCK_DURATION: u64 = 300;
+
+pub struct StorageCleanupTrigger;
+
+#[async_trait]
+impl JobTrigger for StorageCleanupTrigger {
+    async fn run_worker(&self, config: Arc<Config>) -> color_eyre::Result<()> {
+        // Try to acquire distributed lock
+        match config
+            .lock()
+            .acquire_lock(STORAGE_CLEANUP_WORKER_KEY, LockValue::Boolean(false), CLEANUP_WORKER_LOCK_DURATION, None)
+            .await
+        {
+            Ok(_) => {
+                debug!("{} acquired lock", STORAGE_CLEANUP_WORKER_KEY);
+            }
+            Err(err) => {
+                debug!("{} failed to acquire lock, returning safely: {}", STORAGE_CLEANUP_WORKER_KEY, err);
+                return Ok(());
+            }
+        }
+
+        // Execute main work and ensure lock is released
+        let result = self.process_completed_jobs(&config).await;
+
+        // Always release the lock
+        if let Err(e) = config.lock().release_lock(STORAGE_CLEANUP_WORKER_KEY, None).await {
+            error!("Failed to release {} lock: {}", STORAGE_CLEANUP_WORKER_KEY, e);
+            if result.is_ok() {
+                return Err(e.into());
+            }
+        }
+
+        result
+    }
+
+    /// Storage cleanup should always run, regardless of failed jobs
+    async fn is_worker_enabled(&self, _config: Arc<Config>) -> color_eyre::Result<bool> {
+        Ok(true)
+    }
+}
+
+impl StorageCleanupTrigger {
+    /// Process completed StateTransition jobs that haven't had their artifacts tagged
+    async fn process_completed_jobs(&self, config: &Arc<Config>) -> color_eyre::Result<()> {
+        // Get completed StateTransition jobs
+        let completed_jobs = config
+            .database()
+            .get_jobs_by_types_and_statuses(
+                vec![JobType::StateTransition],
+                vec![JobStatus::Completed],
+                Some(MAX_JOBS_PER_RUN as i64),
+                None, // Don't filter by orchestrator version - clean up all completed jobs
+            )
+            .await?;
+
+        if completed_jobs.is_empty() {
+            debug!("No completed StateTransition jobs found");
+            return Ok(());
+        }
+
+        // Filter to jobs that haven't been tagged yet
+        let jobs_to_tag: Vec<_> = completed_jobs
+            .into_iter()
+            .filter(|job| {
+                let metadata_result: Result<StateUpdateMetadata, _> = job.metadata.specific.clone().try_into();
+                if let Ok(metadata) = metadata_result {
+                    metadata.storage_artifacts_tagged_at.is_none()
+                } else {
+                    false
+                }
+            })
+            .take(MAX_JOBS_PER_RUN)
+            .collect();
+
+        if jobs_to_tag.is_empty() {
+            debug!("No StateTransition jobs need artifact tagging");
+            return Ok(());
+        }
+
+        info!("Processing {} StateTransition jobs for storage cleanup", jobs_to_tag.len());
+
+        for job in jobs_to_tag {
+            let job_id = job.internal_id;
+
+            // Get the metadata to find artifact paths
+            let state_metadata: StateUpdateMetadata = match job.metadata.specific.clone().try_into() {
+                Ok(m) => m,
+                Err(e) => {
+                    error!(job_id = %job_id, error = %e, "Failed to parse StateUpdateMetadata");
+                    continue;
+                }
+            };
+
+            // Collect all artifact paths to tag
+            let mut paths_to_tag = Vec::new();
+
+            if let Some(path) = &state_metadata.snos_output_path {
+                paths_to_tag.push(path.clone());
+            }
+            if let Some(path) = &state_metadata.program_output_path {
+                paths_to_tag.push(path.clone());
+            }
+            if let Some(path) = &state_metadata.blob_data_path {
+                paths_to_tag.push(path.clone());
+            }
+            if let Some(path) = &state_metadata.da_segment_path {
+                paths_to_tag.push(path.clone());
+            }
+
+            if paths_to_tag.is_empty() {
+                warn!(job_id = %job_id, "No artifact paths found in StateTransition job metadata");
+                continue;
+            }
+
+            // Tag all artifacts
+            let tags = vec![(EXPIRATION_TAG_KEY.to_string(), EXPIRATION_TAG_VALUE.to_string())];
+            let mut all_tagged = true;
+
+            for path in &paths_to_tag {
+                if let Err(e) = config.storage().tag_object(path, tags.clone()).await {
+                    error!(job_id = %job_id, path = %path, error = %e, "Failed to tag artifact");
+                    all_tagged = false;
+                    break;
+                }
+                debug!(job_id = %job_id, path = %path, "Tagged artifact for expiration");
+            }
+
+            if !all_tagged {
+                // If any tagging failed, skip updating the job and try again next run
+                continue;
+            }
+
+            // Update job metadata to mark artifacts as tagged
+            let mut updated_metadata = state_metadata;
+            updated_metadata.storage_artifacts_tagged_at = Some(Utc::now());
+
+            let job_update = JobItemUpdates::new().update_metadata(JobMetadata {
+                common: job.metadata.common.clone(),
+                specific: JobSpecificMetadata::StateUpdate(updated_metadata),
+            });
+
+            if let Err(e) = config.database().update_job(&job, job_update).await {
+                error!(job_id = %job_id, error = %e, "Failed to update job metadata after tagging");
+                continue;
+            }
+
+            info!(job_id = %job_id, artifact_count = paths_to_tag.len(), "Successfully tagged artifacts for expiration");
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
# PR: Automatic Storage Cleanup for Settled Artifacts

## Pull Request type

- [x] Feature

## What is the current behavior?

S3 storage grows continuously with no cleanup mechanism. Artifacts from completed jobs (cairo_pie.zip, snos_output.json, program_output.txt, blob data, etc.) remain indefinitely after StateTransition jobs complete.

- PC Devnet reached **1.4 TB** storage consumption
- Growth rate: **>100 GB/day**
- No TTL or lifecycle policies exist
- Files remain indefinitely, causing unnecessary storage costs

Resolves: #NA

## What is the new behavior?

Implements automatic storage cleanup using S3 Lifecycle Rules with object tagging:

- **S3 Lifecycle Rule**: On setup, configures lifecycle rule to auto-delete objects tagged with `expire-after-settlement=true` after 14 days from creation
- **StorageCleanupTrigger**: New worker that runs via EventBridge (every 10 mins), tags artifacts from completed StateTransition jobs
- **Tracking**: `storage_artifacts_tagged_at` field in StateUpdateMetadata prevents re-processing
- **Batch Limiter**: Processes max 200 jobs per run to avoid overwhelming S3 API
- **Distributed Lock**: Uses MongoDB locks collection to prevent concurrent runs
- **Fast Cleanup**: Old artifacts (>14 days) get deleted within 24h of tagging

## ⚠️ Required IAM Permissions

This feature requires the following IAM permissions to be added to the orchestrator's IAM role/policy:

```json
{
    "Effect": "Allow",
    "Action": [
        "s3:PutObjectTagging",
        "s3:PutLifecycleConfiguration",
        "s3:GeLifecycleConfiguration"
    ],
    "Resource": [
        "arn:aws:s3:::<bucket-name>",
        "arn:aws:s3:::<bucket-name>/*"
    ]
}
```

**Permission breakdown:**
- **`s3:PutObjectTagging`** (Required): Allows the StorageCleanup worker to tag artifacts for expiration. Without this, the worker will fail with a "service error" when tagging objects.
- **`s3:PutLifecycleConfiguration`** (Required): Allows the setup phase to configure the lifecycle rule that auto-deletes tagged objects after 14 days. Without this, the `setup` command will fail.
- **`s3:GetLifecycleConfiguration`** (Recommended): Best practice for checking existing lifecycle rules before applying new ones to avoid overwriting other configurations.

## Storage Paths Covered

The worker discovers and tags **ALL files** in these directories using `list_files_in_dir()`:

| Path Pattern | Description | Example Files |
|--------------|-------------|---------------|
| `artifacts/batch/{job_id}/` | Aggregator artifacts (new format) | `cairo_pie.zip`, `program_output.txt`, `snos_output.json`, `da_segment.json`, `proof.json` |
| `blob/batch/{job_id}/` | Blob data files | `1.txt`, `2.txt`, etc. |
| `{job_id}/` | SNOS artifacts (old format, root level) | `cairo_pie.zip`, `program_output.txt`, `snos_output.json`, `blob_data.txt`, `onchain_data.json`, `proof.json`, `proof_part2.json` |
| `state_update/batch/{job_id}.json` | State update JSON file | Single JSON file per job |

**Key point**: The worker uses `list_files_in_dir()` to discover files dynamically, so ALL files in each directory are tagged - not just hardcoded filenames. This ensures complete cleanup even if new file types are added.

## Does this introduce a breaking change?

No

The new field `storage_artifacts_tagged_at` in `StateUpdateMetadata` uses `#[serde(default)]`, so existing jobs will deserialize with `None` (untagged). The cleanup worker will process them on subsequent runs.

## Deployment Steps

1. **Add IAM permissions** (see Required IAM Permissions section above) to orchestrator's role
2. Deploy the code changes
3. Run setup to apply lifecycle rule to existing bucket (idempotent)
4. EventBridge rule is auto-created for StorageCleanup trigger

## How It Works

```
StateTransition completes
        ↓
StorageCleanupTrigger runs (every 10 min via EventBridge)
        ↓
Acquires distributed lock (MongoDB)
        ↓
Query: completed StateTransition jobs WHERE storage_artifacts_tagged_at IS NULL LIMIT 200
        ↓
For each job:
  - List all files in artifacts/batch/{id}/, blob/batch/{id}/, {id}/
  - Tag all discovered files with "expire-after-settlement=true"
  - Tag state_update/batch/{id}.json
  - Update metadata: storage_artifacts_tagged_at = now()
        ↓
Release lock
        ↓
AWS S3 Lifecycle (runs daily)
        ↓
Delete objects where tag exists AND creation_date > 14 days ago
```

## Design Decisions

- **Provider-agnostic naming**: `StorageCleanup` not `S3Cleanup`
- **Tag-based expiration**: AWS handles deletion, minimal code
- **14-day retention**: Buffer for debugging before deletion
- **Creation date basis**: Old artifacts deleted within 24h of tagging
- **Dynamic file discovery**: Uses `list_files_in_dir()` instead of hardcoded paths
- **Efficient DB query**: New `get_jobs_without_storage_artifacts_tagged()` method queries directly for untagged jobs
- **Graceful error handling**: Non-existent files (NoSuchKey) are skipped without failing the job
