### PR TITLE
fix: improve blob transaction gas price retry logic

### DIFF
--- a/orchestrator/crates/settlement-clients/ethereum/src/error.rs
+++ b/orchestrator/crates/settlement-clients/ethereum/src/error.rs
@@ -6,6 +6,10 @@ pub enum SendTransactionError {
     #[error("Replacement transaction underpriced: {0}")]
     #[allow(dead_code)]
     ReplacementTransactionUnderpriced(RpcError<TransportErrorKind>),
+
+    #[error("Transaction retry limit reached: next multiplier ({next_mul:.2}x) exceeds maximum ({max_mul:.2}x)")]
+    RetryLimitExceeded { next_mul: f64, max_mul: f64 },
+
     #[error("Error: {0}")]
     Other(#[from] RpcError<TransportErrorKind>),
 }

--- a/orchestrator/crates/settlement-clients/ethereum/src/error.rs
+++ b/orchestrator/crates/settlement-clients/ethereum/src/error.rs
@@ -7,9 +7,6 @@ pub enum SendTransactionError {
     #[allow(dead_code)]
     ReplacementTransactionUnderpriced(RpcError<TransportErrorKind>),
 
-    #[error("Transaction retry limit reached: next multiplier ({next_mul:.2}x) exceeds maximum ({max_mul:.2}x)")]
-    RetryLimitExceeded { next_mul: f64, max_mul: f64 },
-
     #[error("Error: {0}")]
     Other(#[from] RpcError<TransportErrorKind>),
 }

--- a/orchestrator/crates/settlement-clients/ethereum/src/lib.rs
+++ b/orchestrator/crates/settlement-clients/ethereum/src/lib.rs
@@ -298,7 +298,7 @@ impl SettlementClient for EthereumSettlementClient {
             let pending_transaction = match self.send_transaction(tx_envelope).await {
                 Result::Ok(pending_transaction) => pending_transaction,
                 Result::Err(SendTransactionError::ReplacementTransactionUnderpriced(rpc_err)) => {
-                    match self.get_next_mul_factor(mul_factor) {
+                    match calculate_next_gas_mul_factor(mul_factor, self.max_gas_price_mul_factor) {
                         Some(next_mul_factor) => {
                             info!(attempt = attempt, "Transaction underpriced, sending replacement transaction");
                             debug!(
@@ -553,10 +553,6 @@ impl EthereumSettlementClient {
     // add a safety margin to the gas price to handle fluctuations
     fn add_safety_margin(&self, value: u128, mul_factor: f64) -> u128 {
         (value as f64 * mul_factor) as u128
-    }
-
-    fn get_next_mul_factor(&self, mul_factor: f64) -> Option<f64> {
-        calculate_next_gas_mul_factor(mul_factor, self.max_gas_price_mul_factor)
     }
 
     /// Method to send blob transaction (standard EIP4844)

--- a/orchestrator/crates/settlement-clients/ethereum/src/lib.rs
+++ b/orchestrator/crates/settlement-clients/ethereum/src/lib.rs
@@ -68,10 +68,7 @@ const GAS_LIMIT_STATE_UPDATE: u64 = 5_500_000;
 
 /// Calculates the next gas price multiplier for transaction retry.
 /// Returns an error if the next multiplier would exceed the maximum allowed.
-fn calculate_next_gas_mul_factor(
-    current_mul: f64,
-    max_mul: f64,
-) -> std::result::Result<f64, SendTransactionError> {
+fn calculate_next_gas_mul_factor(current_mul: f64, max_mul: f64) -> std::result::Result<f64, SendTransactionError> {
     let next_mul = GAS_PRICE_INCREMENT_FACTOR * current_mul;
     if next_mul > max_mul {
         Err(SendTransactionError::RetryLimitExceeded { next_mul, max_mul })

--- a/orchestrator/crates/settlement-clients/ethereum/src/lib.rs
+++ b/orchestrator/crates/settlement-clients/ethereum/src/lib.rs
@@ -311,17 +311,11 @@ impl SettlementClient for EthereumSettlementClient {
                                 attempt += 1;
                                 continue;
                             }
-                            Err(retry_err) => {
-                                bail!("{}", retry_err);
-                            }
+                            Err(retry_err) => return Err(retry_err.into()),
                         }
                     }
-                    SendTransactionError::RetryLimitExceeded { .. } => {
-                        bail!("{}", e);
-                    }
-                    SendTransactionError::Other(_) => {
-                        bail!("Failed to send blob transaction: {:?}", e);
-                    }
+                    SendTransactionError::RetryLimitExceeded { .. } => return Err(e.into()),
+                    SendTransactionError::Other(_) => return Err(e.into()),
                 },
             };
 

--- a/orchestrator/src/cli/settlement/ethereum.rs
+++ b/orchestrator/src/cli/settlement/ethereum.rs
@@ -29,7 +29,10 @@ pub struct EthereumSettlementCliArgs {
     #[arg(env = "MADARA_ORCHESTRATOR_ETHEREUM_FINALITY_RETRY_WAIT_IN_SECS", long, default_value = "60")]
     pub ethereum_finality_retry_wait_in_secs: Option<u64>,
 
-    #[arg(env = "MADARA_ORCHESTRATOR_EIP1559_MAX_GAS_MUL_FACTOR", long, default_value = "1.5")]
+    /// Maximum gas price multiplier for blob transaction retries.
+    /// Blob transactions require 100% (2x) price bump to replace stuck transactions.
+    /// With start=1.1x and 2.0x increment: 1.1 → 2.2 → fail. Max 2 attempts to avoid overpaying.
+    #[arg(env = "MADARA_ORCHESTRATOR_EIP1559_MAX_GAS_MUL_FACTOR", long, default_value = "2.5")]
     pub max_gas_price_mul_factor: f64,
 
     /// Disable PeerDAS (PeerDAS is a feature introduced in Fusaka upgrade which changes the way we settle on Ethereum).


### PR DESCRIPTION
## Problem

The orchestrator was failing with the error "Gas price multiplier is too high" for StateTransition jobs. This error message was misleading and the retry logic had incorrect parameters for blob transactions.

## Root Cause

EIP-4844 blob transactions require a 100% price bump (2x multiplier) to replace a stuck transaction in the blobpool. This is different from regular transactions which only need a 10% bump.

**References:**
- [Geth blobpool config](https://github.com/ethereum/go-ethereum/blob/d0af257aa20fe9d3e244570ee4abb9a78ff3b9c4/core/txpool/blobpool/config.go#L34)
- [Reth transaction pool config](https://github.com/paradigmxyz/reth/blob/c2435ff6f8265088b9ded0014051c9a97d0d7b84/crates/transaction-pool/src/config.rs#L29)
- [Nethermind blob tx comparison](https://github.com/NethermindEth/nethermind/blob/471bcb95bac677d2ffde5bb2e882e20186841b24/src/Nethermind/Nethermind.TxPool/Comparison/CompareReplacedBlobTx.cs#L40)

## Solution

- Updated gas price multiplier constants: start at 1.1x, increment by 2.0x
- Simplified retry logic to allow max 2 attempts (1.1x -> 2.2x -> fail)
- Replaced generic `bail!` with typed `SendTransactionError::RetryLimitExceeded` for clearer error messages
- Replaced `bail!` calls with proper error propagation using `.into()` to preserve error chain
- Added structured logging:
  - **Info level**: Transaction events (sending replacement, submission, finalization)
  - **Debug level**: Multiplier details (current, next, max values)

## Testing

Unit tests added for the gas multiplier calculation logic. Full integration tests would require complex Anvil setup with blob transaction simulation.

---
Generated with [Claude Code](https://claude.ai/code)