### PR TITLE
feat: make Atlantic artifacts bucket configurable through CLI/ENV

### DIFF
--- a/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/client.rs
@@ -846,17 +846,12 @@ impl AtlanticClient {
             format!("{}/queries/{}/proof.json", self.artifacts_base_url.as_str().trim_end_matches('/'), task_id);
 
         let context = format!("task_id: {}, url: {}", task_id, proof_path);
-        let task_id_clone = task_id.to_string();
-        let artifacts_base_url = self.artifacts_base_url.clone();
+        let task_id_owned = task_id.to_string();
 
         let result = self
             .retry_request("get_proof_by_task_id", &context, || {
-                let proof_path = format!(
-                    "{}/queries/{}/proof.json",
-                    artifacts_base_url.as_str().trim_end_matches('/'),
-                    &task_id_clone
-                );
-                let task_id = task_id_clone.clone();
+                let proof_path = proof_path.clone();
+                let task_id = task_id_owned.clone();
 
                 async move {
                     debug!(

--- a/orchestrator/crates/prover-clients/atlantic-service/src/constants.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/constants.rs
@@ -1,13 +1,7 @@
-/// Endpoint to fetch the artifacts from the herodotus service
-pub(crate) const ATLANTIC_FETCH_ARTIFACTS_BASE_URL: &str = "https://storage.googleapis.com/hero-atlantic";
-
 // File names of the artifacts that are downloaded from the herodotus service
 pub const CAIRO_PIE_FILE_NAME: &str = "pie.cairo0.zip";
 pub const SNOS_OUTPUT_FILE_NAME: &str = "snos_output.json";
 pub const PROOF_FILE_NAME: &str = "proof.json";
-
-/// Endpoint to download the proof from the herodotus service
-pub(crate) const ATLANTIC_PROOF_URL: &str = "https://storage.googleapis.com/hero-atlantic/queries/{}/proof.json";
 
 // Aggregator job configurations
 pub(crate) const AGGREGATOR_USE_KZG_DA: bool = true;

--- a/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
@@ -34,6 +34,7 @@ async fn atlantic_client_submit_task_when_mock_works() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
         atlantic_sharp_prover: AtlanticSharpProver::default(),
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
     };
     // Start a mock server
     let mock_server = MockServer::start();
@@ -102,6 +103,7 @@ async fn atlantic_client_does_not_resubmit_when_job_exists() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
         atlantic_sharp_prover: AtlanticSharpProver::default(),
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
     };
 
     let mock_server = MockServer::start();
@@ -205,6 +207,7 @@ async fn atlantic_client_get_query_by_dedup_id_found() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
         atlantic_sharp_prover: AtlanticSharpProver::default(),
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
     };
     let api_key = get_env_var_or_panic("MADARA_ORCHESTRATOR_ATLANTIC_API_KEY");
     let atlantic_service =
@@ -238,6 +241,7 @@ async fn atlantic_client_get_query_by_dedup_id_not_found() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
         atlantic_sharp_prover: AtlanticSharpProver::default(),
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
     };
     let api_key = get_env_var_or_panic("MADARA_ORCHESTRATOR_ATLANTIC_API_KEY");
     let atlantic_service =
@@ -272,6 +276,7 @@ async fn atlantic_client_get_task_status_works() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
         atlantic_sharp_prover: AtlanticSharpProver::default(),
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
     };
     let atlantic_service =
         AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None, None);
@@ -300,6 +305,7 @@ async fn atlantic_client_get_bucket_status_works() {
         atlantic_cairo_vm: AtlanticCairoVm::Python,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
         atlantic_sharp_prover: AtlanticSharpProver::default(),
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
     };
     let atlantic_service =
         AtlanticProverService::new_with_args(&atlantic_params, &LayoutName::dynamic, None, None, None);
@@ -330,6 +336,7 @@ async fn atlantic_client_submit_task_and_get_job_status_with_mock_fact_hash() {
         atlantic_cairo_vm: AtlanticCairoVm::Rust,
         atlantic_result: AtlanticQueryStep::ProofGeneration,
         atlantic_sharp_prover: AtlanticSharpProver::default(),
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
     };
 
     // Create the Atlantic service with actual configuration

--- a/orchestrator/src/cli/prover/atlantic.rs
+++ b/orchestrator/src/cli/prover/atlantic.rs
@@ -70,4 +70,12 @@ pub struct AtlanticCliArgs {
     /// The SHARP prover backend to use (stone or stwo).
     #[arg(env = "MADARA_ORCHESTRATOR_ATLANTIC_SHARP_PROVER", long, default_value = "stone")]
     pub atlantic_sharp_prover: Option<AtlanticSharpProver>,
+
+    /// The base URL for fetching artifacts from the Atlantic service (e.g., proofs, SNOS outputs).
+    #[arg(
+        env = "MADARA_ORCHESTRATOR_ATLANTIC_ARTIFACTS_BASE_URL",
+        long,
+        default_value = "https://storage.googleapis.com/hero-atlantic-bucket"
+    )]
+    pub atlantic_artifacts_base_url: Option<Url>,
 }

--- a/orchestrator/src/types/params/prover.rs
+++ b/orchestrator/src/types/params/prover.rs
@@ -99,6 +99,9 @@ impl TryFrom<RunCmd> for ProverConfig {
                     atlantic_sharp_prover: atlantic_args.atlantic_sharp_prover.ok_or_else(|| {
                         OrchestratorError::RunCommandError("Atlantic sharp prover is required".to_string())
                     })?,
+                    atlantic_artifacts_base_url: atlantic_args.atlantic_artifacts_base_url.ok_or_else(|| {
+                        OrchestratorError::RunCommandError("Atlantic artifacts base URL is required".to_string())
+                    })?,
                 }))
             }
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

Atlantic artifacts bucket is hard coded in the codebase.

## What is the new behavior?

The bucket to fetch Atlantic artifacts from is configurable from ENV/CLI

## Does this introduce a breaking change?

YES.
The default value for Atlantic's S3 bucket has changed. You can configure it via ENV to use prev value still.

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
