### PR TITLE
feat: add comprehensive close block and block production metrics

### DIFF
--- a/madara/Cargo.lock
+++ b/madara/Cargo.lock
@@ -6589,6 +6589,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "prometheus",
+ "serde_json",
  "time",
  "tokio",
  "tracing",

--- a/madara/Cargo.lock
+++ b/madara/Cargo.lock
@@ -7308,6 +7308,7 @@ dependencies = [
  "bitvec",
  "blockifier",
  "bonsai-trie",
+ "mc-analytics",
  "mp-chain-config",
  "mp-convert",
  "mp-receipt",

--- a/madara/crates/client/analytics/Cargo.toml
+++ b/madara/crates/client/analytics/Cargo.toml
@@ -33,6 +33,7 @@ opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry-stdout = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "logs"] }
 prometheus = { workspace = true }
+serde_json = { workspace = true }
 time = { workspace = true, features = ["formatting", "local-offset", "macros"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/madara/crates/client/analytics/src/formatter.rs
+++ b/madara/crates/client/analytics/src/formatter.rs
@@ -209,7 +209,8 @@ impl Visit for CloseBlockEventVisitor {
             self.message = formatted.trim_matches('"').to_string();
         } else {
             let formatted = format!("{:?}", value);
-            self.fields.push((field.name().to_string(), serde_json::Value::String(formatted.trim_matches('"').to_string())));
+            self.fields
+                .push((field.name().to_string(), serde_json::Value::String(formatted.trim_matches('"').to_string())));
         }
     }
 }
@@ -584,8 +585,7 @@ impl CustomFormatter {
             json_obj.insert(key, value);
         }
 
-        let json_str = serde_json::to_string(&serde_json::Value::Object(json_obj))
-            .unwrap_or_else(|_| "{}".to_string());
+        let json_str = serde_json::to_string(&serde_json::Value::Object(json_obj)).unwrap_or_else(|_| "{}".to_string());
 
         writeln!(writer, "{}", json_str)
     }

--- a/madara/crates/client/block_production/src/executor/tests.rs
+++ b/madara/crates/client/block_production/src/executor/tests.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 use super::*;
+use crate::metrics::BlockProductionMetrics;
 use crate::tests::{make_declare_tx, make_udc_call, DevnetSetup};
 use crate::{tests::devnet_setup, util::AdditionalTxInfo};
 use assert_matches::assert_matches;
@@ -70,7 +71,8 @@ async fn l1_handler_setup(
     let setup = devnet_setup.await;
 
     let (commands_sender, commands) = mpsc::unbounded_channel();
-    let mut handle = start_executor_thread(setup.backend.clone(), commands).unwrap();
+    let mut handle =
+        start_executor_thread(setup.backend.clone(), commands, Arc::new(BlockProductionMetrics::register())).unwrap();
 
     let (tx, additional_info) = make_tx(
         &setup.backend,

--- a/madara/crates/client/block_production/src/executor/thread.rs
+++ b/madara/crates/client/block_production/src/executor/thread.rs
@@ -9,7 +9,6 @@ use mc_db::MadaraBackend;
 use mc_exec::metrics::{context_label, metrics as exec_metrics, tx_type_to_label};
 use mc_exec::{execution::TxInfo, LayeredStateAdapter};
 use mp_convert::{Felt, ToFelt};
-use opentelemetry::KeyValue;
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::ClassHash;
 use std::{
@@ -306,12 +305,8 @@ impl ExecutorThread {
                                 match execution_state.executor.finalize() {
                                     Ok(block_exec_summary) => {
                                         let finalize_secs = finalize_start.elapsed().as_secs_f64();
-                                        let attributes = [KeyValue::new(
-                                            "block_number",
-                                            execution_state.exec_ctx.block_number.to_string(),
-                                        )];
                                         self.metrics.executor_finalize_duration.record(finalize_secs, &[]);
-                                        self.metrics.executor_finalize_last.record(finalize_secs, &attributes);
+                                        self.metrics.executor_finalize_last.record(finalize_secs, &[]);
 
                                         // Send EndFinalBlock message so main loop can close the block during shutdown
                                         if self
@@ -509,9 +504,8 @@ impl ExecutorThread {
                 let finalize_start = Instant::now();
                 let block_exec_summary = execution_state.executor.finalize()?;
                 let finalize_secs = finalize_start.elapsed().as_secs_f64();
-                let attributes = [KeyValue::new("block_number", execution_state.exec_ctx.block_number.to_string())];
                 self.metrics.executor_finalize_duration.record(finalize_secs, &[]);
-                self.metrics.executor_finalize_last.record(finalize_secs, &attributes);
+                self.metrics.executor_finalize_last.record(finalize_secs, &[]);
 
                 if self
                     .replies_sender

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -847,7 +847,7 @@ impl BlockProductionTask {
             .record(block_exec_summary.bouncer_weights.l1_gas as u64, &block_number_attributes);
         self.metrics
             .block_bouncer_sierra_gas
-            .record(block_exec_summary.bouncer_weights.sierra_gas.0 as u64, &block_number_attributes);
+            .record(block_exec_summary.bouncer_weights.sierra_gas.0, &block_number_attributes);
         self.metrics
             .block_bouncer_n_events
             .record(block_exec_summary.bouncer_weights.n_events as u64, &block_number_attributes);

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -444,13 +444,14 @@ impl BlockProductionTask {
 
     /// Helper function to close a preconfirmed block with the given state_diff and bouncer weights.
     /// This is used both during normal block closing (EndBlock case) and during restart recovery.
+    /// Returns the result including timing information from the DB layer.
     async fn close_preconfirmed_block_with_state_diff(
         backend: Arc<MadaraBackend>,
         block_number: u64,
         consumed_core_contract_nonces: HashSet<u64>,
         bouncer_weights: &blockifier::bouncer::BouncerWeights,
         state_diff: mp_state_update::StateDiff,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<mc_db::AddFullBlockResult> {
         // Copy bouncer_weights to move into the closure (BouncerWeights implements Copy)
         let bouncer_weights = *bouncer_weights;
         global_spawn_rayon_task(move || {
@@ -468,12 +469,12 @@ impl BlockProductionTask {
                 .context("Saving Bouncer Weights for SNOS")?;
 
             // Close the preconfirmed block with state_diff
-            backend
+            let result = backend
                 .write_access()
                 .close_preconfirmed(/* pre_v0_13_2_hash_override */ true, Some(state_diff))
                 .context("Closing preconfirmed block")?;
 
-            anyhow::Ok(())
+            anyhow::Ok(result)
         })
         .await
     }
@@ -706,7 +707,7 @@ impl BlockProductionTask {
         let state_diff =
             mp_state_update::StateDiff::from_blockifier(block_exec_summary.state_diff, &migration_v2_hashes);
 
-        Self::close_preconfirmed_block_with_state_diff(
+        let _db_result = Self::close_preconfirmed_block_with_state_diff(
             self.backend.clone(),
             block_number,
             consumed_core_contract_nonces,
@@ -829,42 +830,47 @@ impl BlockProductionTask {
 
         let block_number_attributes = [KeyValue::new("block_number", state.block_number.to_string())];
 
+        // Capture state diff counts before moving state_diff
+        let declared_classes_count = state_diff.declared_classes.len();
+        let deployed_contracts_count = state_diff.deployed_contracts.len();
+        let storage_diffs_count = state_diff.storage_diffs.len();
+        let nonce_updates_count = state_diff.nonces.len();
+        let state_diff_len = state_diff.len();
+        let consumed_l1_nonces_count = state.consumed_core_contract_nonces.len();
+
+        // Capture bouncer weights before moving
+        let bouncer_l1_gas = block_exec_summary.bouncer_weights.l1_gas;
+        let bouncer_sierra_gas = block_exec_summary.bouncer_weights.sierra_gas.0;
+        let bouncer_n_events = block_exec_summary.bouncer_weights.n_events;
+        let bouncer_message_segment_length = block_exec_summary.bouncer_weights.message_segment_length;
+        let bouncer_state_diff_size = block_exec_summary.bouncer_weights.state_diff_size;
+
         // Record state diff data gauges before moving state_diff
         self.metrics
             .block_declared_classes_count
-            .record(state_diff.declared_classes.len() as u64, &block_number_attributes);
+            .record(declared_classes_count as u64, &block_number_attributes);
         self.metrics
             .block_deployed_contracts_count
-            .record(state_diff.deployed_contracts.len() as u64, &block_number_attributes);
-        self.metrics.block_storage_diffs_count.record(state_diff.storage_diffs.len() as u64, &block_number_attributes);
-        self.metrics.block_nonce_updates_count.record(state_diff.nonces.len() as u64, &block_number_attributes);
-        self.metrics.block_state_diff_length.record(state_diff.len() as u64, &block_number_attributes);
+            .record(deployed_contracts_count as u64, &block_number_attributes);
+        self.metrics.block_storage_diffs_count.record(storage_diffs_count as u64, &block_number_attributes);
+        self.metrics.block_nonce_updates_count.record(nonce_updates_count as u64, &block_number_attributes);
+        self.metrics.block_state_diff_length.record(state_diff_len as u64, &block_number_attributes);
         self.metrics.block_event_count.record(event_count, &block_number_attributes);
 
         // Record bouncer weights gauges
-        self.metrics
-            .block_bouncer_l1_gas
-            .record(block_exec_summary.bouncer_weights.l1_gas as u64, &block_number_attributes);
-        self.metrics
-            .block_bouncer_sierra_gas
-            .record(block_exec_summary.bouncer_weights.sierra_gas.0, &block_number_attributes);
-        self.metrics
-            .block_bouncer_n_events
-            .record(block_exec_summary.bouncer_weights.n_events as u64, &block_number_attributes);
+        self.metrics.block_bouncer_l1_gas.record(bouncer_l1_gas as u64, &block_number_attributes);
+        self.metrics.block_bouncer_sierra_gas.record(bouncer_sierra_gas, &block_number_attributes);
+        self.metrics.block_bouncer_n_events.record(bouncer_n_events as u64, &block_number_attributes);
         self.metrics
             .block_bouncer_message_segment_length
-            .record(block_exec_summary.bouncer_weights.message_segment_length as u64, &block_number_attributes);
-        self.metrics
-            .block_bouncer_state_diff_size
-            .record(block_exec_summary.bouncer_weights.state_diff_size as u64, &block_number_attributes);
+            .record(bouncer_message_segment_length as u64, &block_number_attributes);
+        self.metrics.block_bouncer_state_diff_size.record(bouncer_state_diff_size as u64, &block_number_attributes);
 
         // Record consumed L1 nonces count
-        self.metrics
-            .block_consumed_l1_nonces_count
-            .record(state.consumed_core_contract_nonces.len() as u64, &block_number_attributes);
+        self.metrics.block_consumed_l1_nonces_count.record(consumed_l1_nonces_count as u64, &block_number_attributes);
 
         let close_preconfirmed_start = Instant::now();
-        Self::close_preconfirmed_block_with_state_diff(
+        let db_result = Self::close_preconfirmed_block_with_state_diff(
             self.backend.clone(),
             state.block_number,
             state.consumed_core_contract_nonces,
@@ -873,12 +879,52 @@ impl BlockProductionTask {
         )
         .await
         .context("Closing block")?;
-        self.metrics.close_preconfirmed_duration.record(close_preconfirmed_start.elapsed().as_secs_f64(), &[]);
-        self.metrics
-            .close_preconfirmed_last
-            .record(close_preconfirmed_start.elapsed().as_secs_f64(), &block_number_attributes);
+        let close_preconfirmed_duration = close_preconfirmed_start.elapsed();
+        self.metrics.close_preconfirmed_duration.record(close_preconfirmed_duration.as_secs_f64(), &[]);
+        self.metrics.close_preconfirmed_last.record(close_preconfirmed_duration.as_secs_f64(), &block_number_attributes);
 
         let time_to_close = start_time.elapsed();
+        let block_production_time = state.block_start_time.elapsed();
+
+        // Emit structured log event for Loki querying (close_block_complete)
+        // All timing values converted to milliseconds for human-readability
+        let timings = &db_result.timings;
+        tracing::info!(
+            target: "close_block",
+            block_number = state.block_number,
+            tx_count = n_txs,
+            event_count = event_count,
+            // High-level timing
+            close_block_total_ms = time_to_close.as_secs_f64() * 1000.0,
+            close_preconfirmed_ms = close_preconfirmed_duration.as_secs_f64() * 1000.0,
+            block_production_ms = block_production_time.as_secs_f64() * 1000.0,
+            // State diff counts
+            state_diff_len = state_diff_len,
+            declared_classes = declared_classes_count,
+            deployed_contracts = deployed_contracts_count,
+            storage_diffs = storage_diffs_count,
+            nonce_updates = nonce_updates_count,
+            consumed_l1_nonces = consumed_l1_nonces_count,
+            // Bouncer weights
+            bouncer_l1_gas = bouncer_l1_gas,
+            bouncer_sierra_gas = bouncer_sierra_gas,
+            bouncer_n_events = bouncer_n_events,
+            bouncer_message_segment_length = bouncer_message_segment_length,
+            bouncer_state_diff_size = bouncer_state_diff_size,
+            // DB timing breakdown (all in ms)
+            get_full_block_ms = timings.get_full_block_with_classes.as_secs_f64() * 1000.0,
+            commitments_ms = timings.block_commitments_compute.as_secs_f64() * 1000.0,
+            merklization_ms = timings.merklization.as_secs_f64() * 1000.0,
+            contract_trie_ms = timings.contract_trie_root.as_secs_f64() * 1000.0,
+            class_trie_ms = timings.class_trie_root.as_secs_f64() * 1000.0,
+            contract_storage_trie_commit_ms = timings.contract_storage_trie_commit.as_secs_f64() * 1000.0,
+            contract_trie_commit_ms = timings.contract_trie_commit.as_secs_f64() * 1000.0,
+            class_trie_commit_ms = timings.class_trie_commit.as_secs_f64() * 1000.0,
+            block_hash_ms = timings.block_hash_compute.as_secs_f64() * 1000.0,
+            db_write_ms = timings.db_write_block_parts.as_secs_f64() * 1000.0,
+            "close_block_complete"
+        );
+
         tracing::info!("⛏️  Closed block #{} with {n_txs} transactions - {time_to_close:?}", state.block_number);
 
         // Record timing metrics
@@ -895,10 +941,8 @@ impl BlockProductionTask {
         self.metrics.block_counter.add(1, &block_number_attributes);
         self.metrics.block_gauge.record(state.block_number, &attributes);
         self.metrics.transaction_counter.add(n_txs as u64, &block_number_attributes);
-        self.metrics.block_production_time.record(state.block_start_time.elapsed().as_secs_f64(), &[]);
-        self.metrics
-            .block_production_time_last
-            .record(state.block_start_time.elapsed().as_secs_f64(), &block_number_attributes);
+        self.metrics.block_production_time.record(block_production_time.as_secs_f64(), &[]);
+        self.metrics.block_production_time_last.record(block_production_time.as_secs_f64(), &block_number_attributes);
         self.metrics.block_close_time.record(time_to_close.as_secs_f64(), &[]);
         self.metrics.block_close_time_last.record(time_to_close.as_secs_f64(), &block_number_attributes);
 

--- a/madara/crates/client/block_production/src/metrics.rs
+++ b/madara/crates/client/block_production/src/metrics.rs
@@ -19,6 +19,27 @@ pub struct BlockProductionMetrics {
     pub txs_rejected: Counter<u64>,
     pub classes_declared: Counter<u64>,
     pub l2_gas_consumed: Counter<u64>,
+
+    // Close block timing metrics
+    pub close_block_total_duration: Histogram<f64>,
+    pub close_preconfirmed_duration: Histogram<f64>,
+    pub executor_finalize_duration: Histogram<f64>,
+
+    // Block data gauges
+    pub block_event_count: Gauge<u64>,
+    pub block_state_diff_length: Gauge<u64>,
+    pub block_declared_classes_count: Gauge<u64>,
+    pub block_deployed_contracts_count: Gauge<u64>,
+    pub block_storage_diffs_count: Gauge<u64>,
+    pub block_nonce_updates_count: Gauge<u64>,
+    pub block_consumed_l1_nonces_count: Gauge<u64>,
+
+    // Bouncer weights gauges
+    pub block_bouncer_l1_gas: Gauge<u64>,
+    pub block_bouncer_sierra_gas: Gauge<u64>,
+    pub block_bouncer_n_events: Gauge<u64>,
+    pub block_bouncer_message_segment_length: Gauge<u64>,
+    pub block_bouncer_state_diff_size: Gauge<u64>,
 }
 
 impl BlockProductionMetrics {
@@ -99,6 +120,102 @@ impl BlockProductionMetrics {
             "gas".to_string(),
         );
 
+        // Close block timing metrics
+        let close_block_total_duration = register_histogram_metric_instrument(
+            &meter,
+            "close_block_total_duration_seconds".to_string(),
+            "Total time to close a block".to_string(),
+            "s".to_string(),
+        );
+        let close_preconfirmed_duration = register_histogram_metric_instrument(
+            &meter,
+            "close_preconfirmed_duration_seconds".to_string(),
+            "Time to close preconfirmed block with state diff".to_string(),
+            "s".to_string(),
+        );
+        let executor_finalize_duration = register_histogram_metric_instrument(
+            &meter,
+            "executor_finalize_duration_seconds".to_string(),
+            "Time for executor.finalize() to complete".to_string(),
+            "s".to_string(),
+        );
+
+        // Block data gauges
+        let block_event_count = register_gauge_metric_instrument(
+            &meter,
+            "block_event_count".to_string(),
+            "Number of events in the closed block".to_string(),
+            "events".to_string(),
+        );
+        let block_state_diff_length = register_gauge_metric_instrument(
+            &meter,
+            "block_state_diff_length".to_string(),
+            "State diff length of the closed block".to_string(),
+            "entries".to_string(),
+        );
+        let block_declared_classes_count = register_gauge_metric_instrument(
+            &meter,
+            "block_declared_classes_count".to_string(),
+            "Number of declared classes in the closed block".to_string(),
+            "classes".to_string(),
+        );
+        let block_deployed_contracts_count = register_gauge_metric_instrument(
+            &meter,
+            "block_deployed_contracts_count".to_string(),
+            "Number of deployed contracts in the closed block".to_string(),
+            "contracts".to_string(),
+        );
+        let block_storage_diffs_count = register_gauge_metric_instrument(
+            &meter,
+            "block_storage_diffs_count".to_string(),
+            "Number of storage diff entries in the closed block".to_string(),
+            "entries".to_string(),
+        );
+        let block_nonce_updates_count = register_gauge_metric_instrument(
+            &meter,
+            "block_nonce_updates_count".to_string(),
+            "Number of nonce updates in the closed block".to_string(),
+            "updates".to_string(),
+        );
+        let block_consumed_l1_nonces_count = register_gauge_metric_instrument(
+            &meter,
+            "block_consumed_l1_nonces_count".to_string(),
+            "Number of L1 to L2 nonces consumed in the closed block".to_string(),
+            "nonces".to_string(),
+        );
+
+        // Bouncer weights gauges
+        let block_bouncer_l1_gas = register_gauge_metric_instrument(
+            &meter,
+            "block_bouncer_l1_gas".to_string(),
+            "L1 gas consumed from bouncer weights".to_string(),
+            "gas".to_string(),
+        );
+        let block_bouncer_sierra_gas = register_gauge_metric_instrument(
+            &meter,
+            "block_bouncer_sierra_gas".to_string(),
+            "Sierra gas consumed from bouncer weights".to_string(),
+            "gas".to_string(),
+        );
+        let block_bouncer_n_events = register_gauge_metric_instrument(
+            &meter,
+            "block_bouncer_n_events".to_string(),
+            "Number of events from bouncer weights".to_string(),
+            "events".to_string(),
+        );
+        let block_bouncer_message_segment_length = register_gauge_metric_instrument(
+            &meter,
+            "block_bouncer_message_segment_length".to_string(),
+            "Message segment length from bouncer weights".to_string(),
+            "length".to_string(),
+        );
+        let block_bouncer_state_diff_size = register_gauge_metric_instrument(
+            &meter,
+            "block_bouncer_state_diff_size".to_string(),
+            "State diff size from bouncer weights".to_string(),
+            "size".to_string(),
+        );
+
         Self {
             block_gauge,
             block_counter,
@@ -111,6 +228,21 @@ impl BlockProductionMetrics {
             txs_rejected,
             classes_declared,
             l2_gas_consumed,
+            close_block_total_duration,
+            close_preconfirmed_duration,
+            executor_finalize_duration,
+            block_event_count,
+            block_state_diff_length,
+            block_declared_classes_count,
+            block_deployed_contracts_count,
+            block_storage_diffs_count,
+            block_nonce_updates_count,
+            block_consumed_l1_nonces_count,
+            block_bouncer_l1_gas,
+            block_bouncer_sierra_gas,
+            block_bouncer_n_events,
+            block_bouncer_message_segment_length,
+            block_bouncer_state_diff_size,
         }
     }
 

--- a/madara/crates/client/block_production/src/metrics.rs
+++ b/madara/crates/client/block_production/src/metrics.rs
@@ -294,14 +294,13 @@ impl BlockProductionMetrics {
         }
     }
 
-    pub fn record_execution_stats(&self, block_number: u64, stats: &ExecutionStats) {
-        let attributes = [KeyValue::new("block_number", block_number.to_string())];
-        self.batches_executed.add(stats.n_batches as u64, &attributes);
-        self.txs_added_to_block.add(stats.n_added_to_block as u64, &attributes);
-        self.txs_executed.add(stats.n_executed as u64, &attributes);
-        self.txs_reverted.add(stats.n_reverted as u64, &attributes);
-        self.txs_rejected.add(stats.n_rejected as u64, &attributes);
-        self.classes_declared.add(stats.declared_classes as u64, &attributes);
+    pub fn record_execution_stats(&self, stats: &ExecutionStats) {
+        self.batches_executed.add(stats.n_batches as u64, &[]);
+        self.txs_added_to_block.add(stats.n_added_to_block as u64, &[]);
+        self.txs_executed.add(stats.n_executed as u64, &[]);
+        self.txs_reverted.add(stats.n_reverted as u64, &[]);
+        self.txs_rejected.add(stats.n_rejected as u64, &[]);
+        self.classes_declared.add(stats.declared_classes as u64, &[]);
 
         // Safely convert u128 to u64 for metrics, logging if truncation occurs
         let gas_consumed_u64 = stats.l2_gas_consumed.try_into().unwrap_or_else(|_| {
@@ -312,6 +311,6 @@ impl BlockProductionMetrics {
             );
             u64::MAX
         });
-        self.l2_gas_consumed.add(gas_consumed_u64, &attributes);
+        self.l2_gas_consumed.add(gas_consumed_u64, &[]);
     }
 }

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -132,7 +132,6 @@ use mp_receipt::EventWithTransactionHash;
 use mp_state_update::StateDiff;
 use mp_transactions::validated::ValidatedTransaction;
 use mp_transactions::L1HandlerTransactionWithFee;
-use opentelemetry::KeyValue;
 use prelude::*;
 use starknet_types_core::felt::Felt;
 use std::path::Path;
@@ -716,9 +715,8 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         let (mut block, classes) = preconfirmed_view.get_full_block_with_classes()?;
         let fetch_duration = fetch_start.elapsed();
         let fetch_secs = fetch_duration.as_secs_f64();
-        let block_number_attributes = [KeyValue::new("block_number", block.header.block_number.to_string())];
         metrics().get_full_block_with_classes_duration.record(fetch_secs, &[]);
-        metrics().get_full_block_with_classes_last.record(fetch_secs, &block_number_attributes);
+        metrics().get_full_block_with_classes_last.record(fetch_secs, &[]);
 
         if let Some(mut state_diff) = state_diff {
             state_diff.old_declared_contracts =
@@ -800,9 +798,8 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         );
         timings.block_commitments_compute = commitments_start.elapsed();
         let commitments_secs = timings.block_commitments_compute.as_secs_f64();
-        let block_number_attributes = [KeyValue::new("block_number", block.header.block_number.to_string())];
         metrics().block_commitments_compute_duration.record(commitments_secs, &[]);
-        metrics().block_commitments_compute_last.record(commitments_secs, &block_number_attributes);
+        metrics().block_commitments_compute_last.record(commitments_secs, &[]);
 
         let (global_state_root, merklization_timings) =
             self.apply_to_global_trie(block.header.block_number, [&block.state_diff])?;
@@ -823,7 +820,7 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         timings.block_hash_compute = hash_start.elapsed();
         let hash_secs = timings.block_hash_compute.as_secs_f64();
         metrics().block_hash_compute_duration.record(hash_secs, &[]);
-        metrics().block_hash_compute_last.record(hash_secs, &block_number_attributes);
+        metrics().block_hash_compute_last.record(hash_secs, &[]);
 
         tracing::info!("Block hash {block_hash:#x} computed for #{}", block.header.block_number);
 
@@ -845,7 +842,7 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         timings.db_write_block_parts = write_start.elapsed();
         let write_secs = timings.db_write_block_parts.as_secs_f64();
         metrics().db_write_block_parts_duration.record(write_secs, &[]);
-        metrics().db_write_block_parts_last.record(write_secs, &block_number_attributes);
+        metrics().db_write_block_parts_last.record(write_secs, &[]);
 
         Ok(AddFullBlockResult { new_state_root: global_state_root, commitments, block_hash, parent_block_hash, timings })
     }

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -844,7 +844,13 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         metrics().db_write_block_parts_duration.record(write_secs, &[]);
         metrics().db_write_block_parts_last.record(write_secs, &[]);
 
-        Ok(AddFullBlockResult { new_state_root: global_state_root, commitments, block_hash, parent_block_hash, timings })
+        Ok(AddFullBlockResult {
+            new_state_root: global_state_root,
+            commitments,
+            block_hash,
+            parent_block_hash,
+            timings,
+        })
     }
 
     /// Lower level access to writing primitives. This is only used by the sync process, which

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -137,7 +137,7 @@ use prelude::*;
 use starknet_types_core::felt::Felt;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 pub mod metrics;
 use metrics::metrics;
 pub mod migration;
@@ -153,11 +153,38 @@ pub mod tests;
 pub mod view;
 
 use blockifier::bouncer::BouncerWeights;
+pub use rocksdb::global_trie::MerklizationTimings;
 pub use storage::{
     DevnetPredeployedContractAccount, DevnetPredeployedKeys, EventFilter, MadaraStorage, MadaraStorageRead,
     MadaraStorageWrite, StorageTxIndex,
 };
 pub use view::{MadaraBlockView, MadaraConfirmedBlockView, MadaraPreconfirmedBlockView, MadaraStateView};
+
+/// Timing information collected during the close_block DB operations.
+/// All durations are captured for structured logging.
+#[derive(Debug, Clone, Default)]
+pub struct CloseBlockTimings {
+    /// Time to fetch full block with classes
+    pub get_full_block_with_classes: Duration,
+    /// Time to compute block commitments
+    pub block_commitments_compute: Duration,
+    /// Total time for global trie merklization (apply_to_global_trie)
+    pub merklization: Duration,
+    /// Time to compute contract trie root (parallel with class trie)
+    pub contract_trie_root: Duration,
+    /// Time to compute class trie root (parallel with contract trie)
+    pub class_trie_root: Duration,
+    /// Time to commit contract storage trie
+    pub contract_storage_trie_commit: Duration,
+    /// Time to commit contract trie
+    pub contract_trie_commit: Duration,
+    /// Time to commit class trie
+    pub class_trie_commit: Duration,
+    /// Time to compute block hash
+    pub block_hash_compute: Duration,
+    /// Time to write block parts to database
+    pub db_write_block_parts: Duration,
+}
 
 /// Current chain tip.
 #[derive(Default, Clone)]
@@ -553,6 +580,8 @@ pub struct AddFullBlockResult {
     pub commitments: BlockCommitments,
     pub block_hash: Felt,
     pub parent_block_hash: Felt,
+    /// Timing information from the close_block DB operations.
+    pub timings: CloseBlockTimings,
 }
 
 impl<D: MadaraStorageRead> MadaraBackend<D> {
@@ -685,7 +714,8 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         let preconfirmed_view =
             self.inner.block_view_on_preconfirmed().context("There is no current preconfirmed block")?;
         let (mut block, classes) = preconfirmed_view.get_full_block_with_classes()?;
-        let fetch_secs = fetch_start.elapsed().as_secs_f64();
+        let fetch_duration = fetch_start.elapsed();
+        let fetch_secs = fetch_duration.as_secs_f64();
         let block_number_attributes = [KeyValue::new("block_number", block.header.block_number.to_string())];
         metrics().get_full_block_with_classes_duration.record(fetch_secs, &[]);
         metrics().get_full_block_with_classes_last.record(fetch_secs, &block_number_attributes);
@@ -698,7 +728,7 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
 
         // Write the block & apply to global trie
 
-        let result = self.write_new_confirmed_inner(&block, &classes, pre_v0_13_2_hash_override)?;
+        let result = self.write_new_confirmed_inner(&block, &classes, pre_v0_13_2_hash_override, fetch_duration)?;
 
         self.new_confirmed_block(block.header.block_number)?;
 
@@ -730,20 +760,28 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         pre_v0_13_2_hash_override: bool,
     ) -> Result<AddFullBlockResult> {
         let block_n = block.header.block_number;
-        let result = self.write_new_confirmed_inner(block, classes, pre_v0_13_2_hash_override)?;
+        // For add_full_block_with_classes, no get_full_block_with_classes is needed as block is already provided
+        let result = self.write_new_confirmed_inner(block, classes, pre_v0_13_2_hash_override, Duration::ZERO)?;
 
         self.new_confirmed_block(block_n)?;
         Ok(result)
     }
 
     /// Does not change the chain tip. Performs merkelization (global tries update) and block hash computation, and saves
-    /// all the block parts. Returns the block hash.
+    /// all the block parts. Returns the block hash and timing information.
+    /// Note: The `get_full_block_with_classes` timing must be provided by the caller.
     fn write_new_confirmed_inner(
         &self,
         block: &FullBlockWithoutCommitments,
         classes: &[ConvertedClass],
         pre_v0_13_2_hash_override: bool,
+        get_full_block_with_classes_duration: Duration,
     ) -> Result<AddFullBlockResult> {
+        let mut timings = CloseBlockTimings {
+            get_full_block_with_classes: get_full_block_with_classes_duration,
+            ..Default::default()
+        };
+
         let parent_block_hash = if let Some(last_block) = self.inner.block_view_on_last_confirmed() {
             last_block.get_block_info()?.block_hash
         } else {
@@ -760,19 +798,30 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
             &block.state_diff,
             &block.events,
         );
-        let commitments_secs = commitments_start.elapsed().as_secs_f64();
+        timings.block_commitments_compute = commitments_start.elapsed();
+        let commitments_secs = timings.block_commitments_compute.as_secs_f64();
         let block_number_attributes = [KeyValue::new("block_number", block.header.block_number.to_string())];
         metrics().block_commitments_compute_duration.record(commitments_secs, &[]);
         metrics().block_commitments_compute_last.record(commitments_secs, &block_number_attributes);
 
-        let global_state_root = self.apply_to_global_trie(block.header.block_number, [&block.state_diff])?;
+        let (global_state_root, merklization_timings) =
+            self.apply_to_global_trie(block.header.block_number, [&block.state_diff])?;
+
+        // Copy merklization timings
+        timings.merklization = merklization_timings.total;
+        timings.contract_trie_root = merklization_timings.contract_trie_root;
+        timings.class_trie_root = merklization_timings.class_trie_root;
+        timings.contract_storage_trie_commit = merklization_timings.contract_trie.storage_commit;
+        timings.contract_trie_commit = merklization_timings.contract_trie.trie_commit;
+        timings.class_trie_commit = merklization_timings.class_trie.trie_commit;
 
         let header =
             block.header.clone().into_confirmed_header(parent_block_hash, commitments.clone(), global_state_root);
 
         let hash_start = Instant::now();
         let block_hash = header.compute_hash(self.inner.chain_config.chain_id.to_felt(), pre_v0_13_2_hash_override);
-        let hash_secs = hash_start.elapsed().as_secs_f64();
+        timings.block_hash_compute = hash_start.elapsed();
+        let hash_secs = timings.block_hash_compute.as_secs_f64();
         metrics().block_hash_compute_duration.record(hash_secs, &[]);
         metrics().block_hash_compute_last.record(hash_secs, &block_number_attributes);
 
@@ -793,11 +842,12 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         self.write_state_diff(block.header.block_number, &block.state_diff)?;
         self.write_events(block.header.block_number, &block.events)?;
         self.write_classes(block.header.block_number, classes)?;
-        let write_secs = write_start.elapsed().as_secs_f64();
+        timings.db_write_block_parts = write_start.elapsed();
+        let write_secs = timings.db_write_block_parts.as_secs_f64();
         metrics().db_write_block_parts_duration.record(write_secs, &[]);
         metrics().db_write_block_parts_last.record(write_secs, &block_number_attributes);
 
-        Ok(AddFullBlockResult { new_state_root: global_state_root, commitments, block_hash, parent_block_hash })
+        Ok(AddFullBlockResult { new_state_root: global_state_root, commitments, block_hash, parent_block_hash, timings })
     }
 
     /// Lower level access to writing primitives. This is only used by the sync process, which
@@ -872,7 +922,7 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         &self,
         start_block_n: u64,
         state_diffs: impl IntoIterator<Item = &'a StateDiff>,
-    ) -> Result<Felt> {
+    ) -> Result<(Felt, rocksdb::global_trie::MerklizationTimings)> {
         self.inner.db.apply_to_global_trie(start_block_n, state_diffs)
     }
 

--- a/madara/crates/client/db/src/metrics.rs
+++ b/madara/crates/client/db/src/metrics.rs
@@ -1,0 +1,119 @@
+use mc_analytics::register_histogram_metric_instrument;
+use opentelemetry::metrics::Histogram;
+use opentelemetry::{global, InstrumentationScope, KeyValue};
+use std::sync::LazyLock;
+
+/// Database metrics for close_block operations
+pub struct DbMetrics {
+    // Merklization timing (Priority 1)
+    pub apply_to_global_trie_duration: Histogram<f64>,
+    pub contract_trie_root_duration: Histogram<f64>,
+    pub class_trie_root_duration: Histogram<f64>,
+    pub contract_storage_trie_commit_duration: Histogram<f64>,
+    pub contract_trie_commit_duration: Histogram<f64>,
+    pub class_trie_commit_duration: Histogram<f64>,
+
+    // Block hash calculation (Priority 2)
+    pub block_commitments_compute_duration: Histogram<f64>,
+    pub block_hash_compute_duration: Histogram<f64>,
+
+    // Data fetching (Priority 3)
+    pub get_full_block_with_classes_duration: Histogram<f64>,
+    pub db_write_block_parts_duration: Histogram<f64>,
+}
+
+impl DbMetrics {
+    pub fn register() -> Self {
+        let meter = global::meter_with_scope(
+            InstrumentationScope::builder("crates.db.opentelemetry")
+                .with_attributes([KeyValue::new("crate", "db")])
+                .build(),
+        );
+
+        // Merklization timing (Priority 1)
+        let apply_to_global_trie_duration = register_histogram_metric_instrument(
+            &meter,
+            "apply_to_global_trie_duration_seconds".to_string(),
+            "Total time for global trie merklization".to_string(),
+            "s".to_string(),
+        );
+        let contract_trie_root_duration = register_histogram_metric_instrument(
+            &meter,
+            "contract_trie_root_duration_seconds".to_string(),
+            "Time to compute contract trie root".to_string(),
+            "s".to_string(),
+        );
+        let class_trie_root_duration = register_histogram_metric_instrument(
+            &meter,
+            "class_trie_root_duration_seconds".to_string(),
+            "Time to compute class trie root".to_string(),
+            "s".to_string(),
+        );
+        let contract_storage_trie_commit_duration = register_histogram_metric_instrument(
+            &meter,
+            "contract_storage_trie_commit_duration_seconds".to_string(),
+            "Time to commit contract storage trie".to_string(),
+            "s".to_string(),
+        );
+        let contract_trie_commit_duration = register_histogram_metric_instrument(
+            &meter,
+            "contract_trie_commit_duration_seconds".to_string(),
+            "Time to commit contract trie".to_string(),
+            "s".to_string(),
+        );
+        let class_trie_commit_duration = register_histogram_metric_instrument(
+            &meter,
+            "class_trie_commit_duration_seconds".to_string(),
+            "Time to commit class trie".to_string(),
+            "s".to_string(),
+        );
+
+        // Block hash calculation (Priority 2)
+        let block_commitments_compute_duration = register_histogram_metric_instrument(
+            &meter,
+            "block_commitments_compute_duration_seconds".to_string(),
+            "Total time to compute block commitments".to_string(),
+            "s".to_string(),
+        );
+        let block_hash_compute_duration = register_histogram_metric_instrument(
+            &meter,
+            "block_hash_compute_duration_seconds".to_string(),
+            "Time to compute block hash".to_string(),
+            "s".to_string(),
+        );
+
+        // Data fetching (Priority 3)
+        let get_full_block_with_classes_duration = register_histogram_metric_instrument(
+            &meter,
+            "get_full_block_with_classes_duration_seconds".to_string(),
+            "Time to fetch full block with classes".to_string(),
+            "s".to_string(),
+        );
+        let db_write_block_parts_duration = register_histogram_metric_instrument(
+            &meter,
+            "db_write_block_parts_duration_seconds".to_string(),
+            "Time to write block parts to database".to_string(),
+            "s".to_string(),
+        );
+
+        Self {
+            apply_to_global_trie_duration,
+            contract_trie_root_duration,
+            class_trie_root_duration,
+            contract_storage_trie_commit_duration,
+            contract_trie_commit_duration,
+            class_trie_commit_duration,
+            block_commitments_compute_duration,
+            block_hash_compute_duration,
+            get_full_block_with_classes_duration,
+            db_write_block_parts_duration,
+        }
+    }
+}
+
+static METRICS: LazyLock<DbMetrics> = LazyLock::new(DbMetrics::register);
+
+/// Get the global database metrics instance
+pub fn metrics() -> &'static DbMetrics {
+    &METRICS
+}

--- a/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
@@ -62,7 +62,9 @@ pub fn class_trie_root(
     tracing::trace!("class_trie committing");
     let class_commit_start = Instant::now();
     class_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
-    metrics().class_trie_commit_duration.record(class_commit_start.elapsed().as_secs_f64(), &[]);
+    let class_commit_secs = class_commit_start.elapsed().as_secs_f64();
+    metrics().class_trie_commit_duration.record(class_commit_secs, &[]);
+    metrics().class_trie_commit_last.record(class_commit_secs, &[]);
 
     let root_hash = class_trie.root_hash(super::bonsai_identifier::CLASS).map_err(WrappedBonsaiError)?;
 

--- a/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
@@ -7,7 +7,6 @@ use bitvec::vec::BitVec;
 use bitvec::view::AsBits;
 use bonsai_trie::id::BasicId;
 use mp_state_update::{DeclaredClassItem, MigratedClassItem};
-use opentelemetry::KeyValue;
 use rayon::prelude::*;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Poseidon, StarkHash};
@@ -67,9 +66,8 @@ pub fn class_trie_root(
     class_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
     timings.trie_commit = class_commit_start.elapsed();
     let class_commit_secs = timings.trie_commit.as_secs_f64();
-    let block_number_attributes = [KeyValue::new("block_number", block_number.to_string())];
     metrics().class_trie_commit_duration.record(class_commit_secs, &[]);
-    metrics().class_trie_commit_last.record(class_commit_secs, &block_number_attributes);
+    metrics().class_trie_commit_last.record(class_commit_secs, &[]);
 
     let root_hash = class_trie.root_hash(super::bonsai_identifier::CLASS).map_err(WrappedBonsaiError)?;
 

--- a/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
@@ -1,3 +1,4 @@
+use crate::metrics::metrics;
 use crate::rocksdb::trie::WrappedBonsaiError;
 use crate::{prelude::*, rocksdb::RocksDBStorage};
 use bitvec::order::Msb0;
@@ -8,6 +9,7 @@ use mp_state_update::{DeclaredClassItem, MigratedClassItem};
 use rayon::prelude::*;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Poseidon, StarkHash};
+use std::time::Instant;
 
 // "CONTRACT_CLASS_LEAF_V0"
 const CONTRACT_CLASS_HASH_VERSION: Felt = Felt::from_hex_unchecked("0x434f4e54524143545f434c4153535f4c4541465f5630");
@@ -58,7 +60,9 @@ pub fn class_trie_root(
     }
 
     tracing::trace!("class_trie committing");
+    let class_commit_start = Instant::now();
     class_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
+    metrics().class_trie_commit_duration.record(class_commit_start.elapsed().as_secs_f64(), &[]);
 
     let root_hash = class_trie.root_hash(super::bonsai_identifier::CLASS).map_err(WrappedBonsaiError)?;
 

--- a/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
@@ -6,6 +6,7 @@ use bitvec::vec::BitVec;
 use bitvec::view::AsBits;
 use bonsai_trie::id::BasicId;
 use mp_state_update::{DeclaredClassItem, MigratedClassItem};
+use opentelemetry::KeyValue;
 use rayon::prelude::*;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Poseidon, StarkHash};
@@ -63,8 +64,9 @@ pub fn class_trie_root(
     let class_commit_start = Instant::now();
     class_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
     let class_commit_secs = class_commit_start.elapsed().as_secs_f64();
+    let block_number_attributes = [KeyValue::new("block_number", block_number.to_string())];
     metrics().class_trie_commit_duration.record(class_commit_secs, &[]);
-    metrics().class_trie_commit_last.record(class_commit_secs, &[]);
+    metrics().class_trie_commit_last.record(class_commit_secs, &block_number_attributes);
 
     let root_hash = class_trie.root_hash(super::bonsai_identifier::CLASS).map_err(WrappedBonsaiError)?;
 

--- a/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/classes.rs
@@ -149,7 +149,8 @@ mod tests {
         let block_number = 1;
 
         // Call the class_trie_root function with both declared and migrated classes
-        let (result, _timings) = class_trie_root(&backend.db, &declared_classes, &migrated_classes, block_number).unwrap();
+        let (result, _timings) =
+            class_trie_root(&backend.db, &declared_classes, &migrated_classes, block_number).unwrap();
 
         // The result should incorporate both declared and migrated classes.
         // The expected hash is computed by inserting both class leaf hashes into the trie.

--- a/madara/crates/client/db/src/rocksdb/global_trie/contracts.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/contracts.rs
@@ -7,7 +7,6 @@ use bitvec::vec::BitVec;
 use bitvec::view::AsBits;
 use bonsai_trie::id::BasicId;
 use mp_state_update::{ContractStorageDiffItem, DeployedContractItem, NonceUpdate, ReplacedClassItem, StorageEntry};
-use opentelemetry::KeyValue;
 use rayon::prelude::*;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Pedersen, StarkHash};
@@ -64,9 +63,8 @@ pub fn contract_trie_root(
     contract_storage_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
     timings.storage_commit = storage_commit_start.elapsed();
     let storage_commit_secs = timings.storage_commit.as_secs_f64();
-    let block_number_attributes = [KeyValue::new("block_number", block_number.to_string())];
     metrics().contract_storage_trie_commit_duration.record(storage_commit_secs, &[]);
-    metrics().contract_storage_trie_commit_last.record(storage_commit_secs, &block_number_attributes);
+    metrics().contract_storage_trie_commit_last.record(storage_commit_secs, &[]);
 
     for NonceUpdate { contract_address, nonce } in nonces {
         contract_leafs.entry(*contract_address).or_default().nonce = Some(*nonce);
@@ -106,7 +104,7 @@ pub fn contract_trie_root(
     timings.trie_commit = contract_commit_start.elapsed();
     let contract_commit_secs = timings.trie_commit.as_secs_f64();
     metrics().contract_trie_commit_duration.record(contract_commit_secs, &[]);
-    metrics().contract_trie_commit_last.record(contract_commit_secs, &block_number_attributes);
+    metrics().contract_trie_commit_last.record(contract_commit_secs, &[]);
     let root_hash = contract_trie.root_hash(super::bonsai_identifier::CONTRACT).map_err(WrappedBonsaiError)?;
 
     tracing::trace!("contract_trie committed");

--- a/madara/crates/client/db/src/rocksdb/global_trie/contracts.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/contracts.rs
@@ -1,3 +1,4 @@
+use crate::metrics::metrics;
 use crate::rocksdb::trie::WrappedBonsaiError;
 use crate::{prelude::*, rocksdb::RocksDBStorage};
 use bitvec::order::Msb0;
@@ -9,6 +10,7 @@ use rayon::prelude::*;
 use starknet_types_core::felt::Felt;
 use starknet_types_core::hash::{Pedersen, StarkHash};
 use std::collections::HashMap;
+use std::time::Instant;
 
 #[derive(Debug, Default)]
 struct ContractLeaf {
@@ -55,7 +57,9 @@ pub fn contract_trie_root(
     tracing::trace!("contract_storage_trie commit");
 
     // Then we commit them
+    let storage_commit_start = Instant::now();
     contract_storage_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
+    metrics().contract_storage_trie_commit_duration.record(storage_commit_start.elapsed().as_secs_f64(), &[]);
 
     for NonceUpdate { contract_address, nonce } in nonces {
         contract_leafs.entry(*contract_address).or_default().nonce = Some(*nonce);
@@ -90,7 +94,9 @@ pub fn contract_trie_root(
 
     tracing::trace!("contract_trie committing");
 
+    let contract_commit_start = Instant::now();
     contract_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
+    metrics().contract_trie_commit_duration.record(contract_commit_start.elapsed().as_secs_f64(), &[]);
     let root_hash = contract_trie.root_hash(super::bonsai_identifier::CONTRACT).map_err(WrappedBonsaiError)?;
 
     tracing::trace!("contract_trie committed");

--- a/madara/crates/client/db/src/rocksdb/global_trie/contracts.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/contracts.rs
@@ -59,7 +59,9 @@ pub fn contract_trie_root(
     // Then we commit them
     let storage_commit_start = Instant::now();
     contract_storage_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
-    metrics().contract_storage_trie_commit_duration.record(storage_commit_start.elapsed().as_secs_f64(), &[]);
+    let storage_commit_secs = storage_commit_start.elapsed().as_secs_f64();
+    metrics().contract_storage_trie_commit_duration.record(storage_commit_secs, &[]);
+    metrics().contract_storage_trie_commit_last.record(storage_commit_secs, &[]);
 
     for NonceUpdate { contract_address, nonce } in nonces {
         contract_leafs.entry(*contract_address).or_default().nonce = Some(*nonce);
@@ -96,7 +98,9 @@ pub fn contract_trie_root(
 
     let contract_commit_start = Instant::now();
     contract_trie.commit(BasicId::new(block_number)).map_err(WrappedBonsaiError)?;
-    metrics().contract_trie_commit_duration.record(contract_commit_start.elapsed().as_secs_f64(), &[]);
+    let contract_commit_secs = contract_commit_start.elapsed().as_secs_f64();
+    metrics().contract_trie_commit_duration.record(contract_commit_secs, &[]);
+    metrics().contract_trie_commit_last.record(contract_commit_secs, &[]);
     let root_hash = contract_trie.root_hash(super::bonsai_identifier::CONTRACT).map_err(WrappedBonsaiError)?;
 
     tracing::trace!("contract_trie committed");

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -1,3 +1,4 @@
+use crate::metrics::metrics;
 use crate::rocksdb::trie::WrappedBonsaiError;
 use crate::{prelude::*, rocksdb::RocksDBStorage};
 use mp_state_update::StateDiff;
@@ -5,6 +6,7 @@ use starknet_types_core::{
     felt::Felt,
     hash::{Poseidon, StarkHash},
 };
+use std::time::Instant;
 
 mod classes;
 mod contracts;
@@ -23,33 +25,46 @@ pub fn apply_to_global_trie<'a>(
     start_block_n: u64,
     state_diffs: impl IntoIterator<Item = &'a StateDiff>,
 ) -> Result<Felt> {
+    let total_start = Instant::now();
     let mut state_root = None;
     for (block_n, state_diff) in (start_block_n..).zip(state_diffs) {
         tracing::debug!("applying state_diff block_n={block_n}");
 
-        let (contract_trie_root, class_trie_root) = rayon::join(
+        let ((contract_trie_root, contract_duration), (class_trie_root, class_duration)) = rayon::join(
             || {
-                contracts::contract_trie_root(
+                let start = Instant::now();
+                let result = contracts::contract_trie_root(
                     backend,
                     &state_diff.deployed_contracts,
                     &state_diff.replaced_classes,
                     &state_diff.nonces,
                     &state_diff.storage_diffs,
                     block_n,
-                )
+                );
+                (result, start.elapsed())
             },
             || {
-                classes::class_trie_root(
+                let start = Instant::now();
+                let result = classes::class_trie_root(
                     backend,
                     &state_diff.declared_classes,
                     &state_diff.migrated_compiled_classes,
                     block_n,
-                )
+                );
+                (result, start.elapsed())
             },
         );
 
+        // Record individual trie durations
+        metrics().contract_trie_root_duration.record(contract_duration.as_secs_f64(), &[]);
+        metrics().class_trie_root_duration.record(class_duration.as_secs_f64(), &[]);
+
         state_root = Some(calculate_state_root(contract_trie_root?, class_trie_root?));
     }
+
+    // Record total merklization duration
+    metrics().apply_to_global_trie_duration.record(total_start.elapsed().as_secs_f64(), &[]);
+
     state_root.context("Applying an empty batch to the global trie")
 }
 

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -55,15 +55,21 @@ pub fn apply_to_global_trie<'a>(
             },
         );
 
-        // Record individual trie durations
-        metrics().contract_trie_root_duration.record(contract_duration.as_secs_f64(), &[]);
-        metrics().class_trie_root_duration.record(class_duration.as_secs_f64(), &[]);
+        // Record individual trie durations (histogram + gauge)
+        let contract_secs = contract_duration.as_secs_f64();
+        let class_secs = class_duration.as_secs_f64();
+        metrics().contract_trie_root_duration.record(contract_secs, &[]);
+        metrics().contract_trie_root_last.record(contract_secs, &[]);
+        metrics().class_trie_root_duration.record(class_secs, &[]);
+        metrics().class_trie_root_last.record(class_secs, &[]);
 
         state_root = Some(calculate_state_root(contract_trie_root?, class_trie_root?));
     }
 
-    // Record total merklization duration
-    metrics().apply_to_global_trie_duration.record(total_start.elapsed().as_secs_f64(), &[]);
+    // Record total merklization duration (histogram + gauge)
+    let total_secs = total_start.elapsed().as_secs_f64();
+    metrics().apply_to_global_trie_duration.record(total_secs, &[]);
+    metrics().apply_to_global_trie_last.record(total_secs, &[]);
 
     state_root.context("Applying an empty batch to the global trie")
 }

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -63,10 +63,7 @@ pub fn apply_to_global_trie<'a>(
         tracing::debug!("applying state_diff block_n={block_n}");
         let block_start = Instant::now();
 
-        let (
-            (contract_result, contract_duration),
-            (class_result, class_duration),
-        ) = rayon::join(
+        let ((contract_result, contract_duration), (class_result, class_duration)) = rayon::join(
             || {
                 let start = Instant::now();
                 let result = contracts::contract_trie_root(

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -2,7 +2,6 @@ use crate::metrics::metrics;
 use crate::rocksdb::trie::WrappedBonsaiError;
 use crate::{prelude::*, rocksdb::RocksDBStorage};
 use mp_state_update::StateDiff;
-use opentelemetry::KeyValue;
 use starknet_types_core::{
     felt::Felt,
     hash::{Poseidon, StarkHash},
@@ -95,11 +94,10 @@ pub fn apply_to_global_trie<'a>(
         // Record individual trie durations (histogram + gauge)
         let contract_secs = contract_duration.as_secs_f64();
         let class_secs = class_duration.as_secs_f64();
-        let block_number_attributes = [KeyValue::new("block_number", block_n.to_string())];
         metrics().contract_trie_root_duration.record(contract_secs, &[]);
-        metrics().contract_trie_root_last.record(contract_secs, &block_number_attributes);
+        metrics().contract_trie_root_last.record(contract_secs, &[]);
         metrics().class_trie_root_duration.record(class_secs, &[]);
-        metrics().class_trie_root_last.record(class_secs, &block_number_attributes);
+        metrics().class_trie_root_last.record(class_secs, &[]);
 
         // Extract root hashes and sub-timings
         let (contract_trie_root, contract_trie_timings) = contract_result?;
@@ -117,7 +115,7 @@ pub fn apply_to_global_trie<'a>(
         timings.total = block_start.elapsed();
         let block_secs = timings.total.as_secs_f64();
         metrics().apply_to_global_trie_duration.record(block_secs, &[]);
-        metrics().apply_to_global_trie_last.record(block_secs, &block_number_attributes);
+        metrics().apply_to_global_trie_last.record(block_secs, &[]);
     }
 
     let root = state_root.context("Applying an empty batch to the global trie")?;

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -4,8 +4,7 @@ use crate::{
     rocksdb::{
         backup::BackupManager,
         column::{Column, ALL_COLUMNS},
-        global_trie::apply_to_global_trie,
-        global_trie::get_state_root,
+        global_trie::{apply_to_global_trie, get_state_root, MerklizationTimings},
         meta::StoredChainTipWithoutContent,
         metrics::DbMetrics,
         options::rocksdb_global_options,
@@ -518,7 +517,7 @@ impl MadaraStorageWrite for RocksDBStorage {
         &self,
         start_block_n: u64,
         state_diffs: impl IntoIterator<Item = &'a StateDiff>,
-    ) -> Result<Felt> {
+    ) -> Result<(Felt, MerklizationTimings)> {
         tracing::debug!("Applying state diff to global trie start_block_n={start_block_n}");
         apply_to_global_trie(self, start_block_n, state_diffs).context("Applying state diff to global trie")
     }

--- a/madara/crates/client/db/src/storage.rs
+++ b/madara/crates/client/db/src/storage.rs
@@ -1,5 +1,6 @@
 use crate::preconfirmed::PreconfirmedExecutedTransaction;
 use crate::prelude::*;
+use crate::rocksdb::global_trie::MerklizationTimings;
 use blockifier::bouncer::BouncerWeights;
 use mp_block::{
     header::PreconfirmedHeader, BlockHeaderWithSignatures, EventWithInfo, MadaraBlockInfo, TransactionWithReceipt,
@@ -179,12 +180,12 @@ pub trait MadaraStorageWrite: Send + Sync + 'static {
     fn write_mempool_transaction(&self, tx: &ValidatedTransaction) -> Result<()>;
 
     /// Write a state diff to the global tries.
-    /// Returns the new state root.
+    /// Returns the new state root and timing information.
     fn apply_to_global_trie<'a>(
         &self,
         start_block_n: u64,
         state_diffs: impl IntoIterator<Item = &'a StateDiff>,
-    ) -> Result<Felt>;
+    ) -> Result<(Felt, MerklizationTimings)>;
 
     fn flush(&self) -> Result<()>;
 

--- a/madara/crates/client/sync/src/apply_state.rs
+++ b/madara/crates/client/sync/src/apply_state.rs
@@ -181,7 +181,7 @@ impl ApplyStateSteps {
                 // latest_block is block_range.end (exclusive), so actual last processed block is latest_block - 1
                 // This ensures fallback DB queries in contract_state_leaf_hash fetch state at the correct block number
                 let trie_block_number = latest_block.saturating_sub(1);
-                let global_state_root =
+                let (global_state_root, _timings) =
                     backend.write_access().apply_to_global_trie(trie_block_number, [accumulated_state_diff].iter())?;
 
                 let block_number = &latest_block.checked_sub(1);

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -584,7 +584,7 @@ impl BlockImporterCtx {
 
         tracing::debug!("🔄 Applying state diff for blocks {:?} to global trie", block_range);
 
-        let got =
+        let (got, _timings) =
             self.backend.write_access().apply_to_global_trie(block_range.start, state_diffs).map_err(|error| {
                 BlockImportError::InternalDb { error, context: "Applying state diff to global trie".into() }
             })?;
@@ -685,7 +685,7 @@ mod tests {
         let importer = BlockImporter::new(backend, validation);
 
         // WHEN: We call update_tries with these parameters
-        let result = importer.ctx().apply_to_global_trie(0..1, vec![state_diff]);
+        let result = importer.ctx().apply_to_global_trie(0..1, vec![state_diff]).map(|_| ());
 
         assert_eq!(expected_result.map_err(|e| format!("{e:#}")), result.map_err(|e| format!("{e:#}")),)
     }

--- a/madara/crates/primitives/block/Cargo.toml
+++ b/madara/crates/primitives/block/Cargo.toml
@@ -21,6 +21,7 @@ num-traits = { workspace = true }
 # Madara
 bitvec = { workspace = true }
 bonsai-trie = { workspace = true }
+mc-analytics = { workspace = true }
 mp-chain-config = { workspace = true }
 mp-convert = { workspace = true }
 mp-receipt = { workspace = true }

--- a/madara/crates/primitives/block/src/lib.rs
+++ b/madara/crates/primitives/block/src/lib.rs
@@ -13,6 +13,7 @@ use starknet_types_core::felt::Felt;
 pub mod commitments;
 pub mod event_with_info;
 pub mod header;
+pub mod metrics;
 pub mod to_rpc;
 
 pub use event_with_info::EventWithInfo;

--- a/madara/crates/primitives/block/src/metrics.rs
+++ b/madara/crates/primitives/block/src/metrics.rs
@@ -1,0 +1,53 @@
+use mc_analytics::register_histogram_metric_instrument;
+use opentelemetry::metrics::Histogram;
+use opentelemetry::{global, InstrumentationScope, KeyValue};
+use std::sync::LazyLock;
+
+/// Commitment computation metrics
+pub struct CommitmentMetrics {
+    pub transaction_commitment_duration: Histogram<f64>,
+    pub state_diff_commitment_duration: Histogram<f64>,
+    pub events_commitment_duration: Histogram<f64>,
+}
+
+impl CommitmentMetrics {
+    pub fn register() -> Self {
+        let meter = global::meter_with_scope(
+            InstrumentationScope::builder("crates.block.opentelemetry")
+                .with_attributes([KeyValue::new("crate", "block")])
+                .build(),
+        );
+
+        let transaction_commitment_duration = register_histogram_metric_instrument(
+            &meter,
+            "transaction_commitment_duration_seconds".to_string(),
+            "Time to compute transaction and receipt commitments".to_string(),
+            "s".to_string(),
+        );
+        let state_diff_commitment_duration = register_histogram_metric_instrument(
+            &meter,
+            "state_diff_commitment_duration_seconds".to_string(),
+            "Time to compute state diff commitment".to_string(),
+            "s".to_string(),
+        );
+        let events_commitment_duration = register_histogram_metric_instrument(
+            &meter,
+            "events_commitment_duration_seconds".to_string(),
+            "Time to compute events commitment".to_string(),
+            "s".to_string(),
+        );
+
+        Self {
+            transaction_commitment_duration,
+            state_diff_commitment_duration,
+            events_commitment_duration,
+        }
+    }
+}
+
+static METRICS: LazyLock<CommitmentMetrics> = LazyLock::new(CommitmentMetrics::register);
+
+/// Get the global commitment metrics instance
+pub fn metrics() -> &'static CommitmentMetrics {
+    &METRICS
+}

--- a/madara/crates/primitives/block/src/metrics.rs
+++ b/madara/crates/primitives/block/src/metrics.rs
@@ -37,11 +37,7 @@ impl CommitmentMetrics {
             "s".to_string(),
         );
 
-        Self {
-            transaction_commitment_duration,
-            state_diff_commitment_duration,
-            events_commitment_duration,
-        }
+        Self { transaction_commitment_duration, state_diff_commitment_duration, events_commitment_duration }
     }
 }
 

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4585,10 +4585,10 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "type": "loki",
+        "uid": "${DS_LOKI}"
       },
-      "description": "Total time to close a block (P50, P95, P99). Note: Bucket boundaries may cause interpolation artifacts.",
+      "description": "Total time to close a block (P50, P95, P99) computed from per-block logs.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4636,7 +4636,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -4666,28 +4666,28 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [${__interval}])",
           "legendFormat": "Close Block p50",
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [${__interval}])",
           "legendFormat": "Close Block p95",
           "refId": "B"
         },
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [${__interval}])",
           "legendFormat": "Close Block p99",
           "refId": "C"
         }
@@ -4697,10 +4697,10 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "type": "loki",
+        "uid": "${DS_LOKI}"
       },
-      "description": "Full block production time from start to close (P50, P95, P99)",
+      "description": "Full block production time from start to close (P50, P95, P99) computed from per-block logs.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4748,7 +4748,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -4778,28 +4778,28 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_production_ms [${__interval}])",
           "legendFormat": "Block Production p50",
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_production_ms [${__interval}])",
           "legendFormat": "Block Production p95",
           "refId": "B"
         },
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_production_ms [${__interval}])",
           "legendFormat": "Block Production p99",
           "refId": "C"
         }
@@ -5604,7 +5604,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\"",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap $log_field",
           "queryType": "range",
           "refId": "A"
         }
@@ -5826,65 +5826,7 @@
         "overrides": []
       },
       "pluginVersion": 39,
-      "transformations": [
-        {
-          "id": "extractFields",
-          "options": {
-            "source": "Line",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "timestamp",
-                "path": "timestamp"
-              }
-            ]
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "pattern": "^(timestamp|Time|__time|$log_field)$"
-            }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "targetField": "timestamp",
-                "destinationType": "time"
-              },
-              {
-                "targetField": "Time",
-                "destinationType": "time"
-              },
-              {
-                "targetField": "__time",
-                "destinationType": "time"
-              },
-              {
-                "targetField": "$log_field",
-                "destinationType": "number"
-              }
-            ]
-          }
-        },
-        {
-          "id": "renameByName",
-          "options": {
-            "renames": {
-              "__time": "Time",
-              "timestamp": "Time"
-            }
-          }
-        },
-        {
-          "id": "prepareTimeSeries",
-          "options": {}
-        }
-      ]
+      "transformations": []
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4442,7 +4442,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5545,239 +5545,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 146
-      },
-      "id": 309,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "block_number"
-          }
-        ]
-      },
-      "pluginVersion": "11.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
-          },
-          "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json",
-          "queryType": "range",
-          "refId": "A"
-        }
-      ],
-      "title": "Close Block Events (Loki)",
-      "transformations": [
-        {
-          "id": "extractFields",
-          "options": {
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "block_number",
-                "path": "block_number"
-              },
-              {
-                "alias": "tx_count",
-                "path": "tx_count"
-              },
-              {
-                "alias": "event_count",
-                "path": "event_count"
-              },
-              {
-                "alias": "close_block_total_ms",
-                "path": "close_block_total_ms"
-              },
-              {
-                "alias": "block_close_ms",
-                "path": "block_close_ms"
-              },
-              {
-                "alias": "close_preconfirmed_ms",
-                "path": "close_preconfirmed_ms"
-              },
-              {
-                "alias": "block_production_ms",
-                "path": "block_production_ms"
-              },
-              {
-                "alias": "get_full_block_ms",
-                "path": "get_full_block_ms"
-              },
-              {
-                "alias": "commitments_ms",
-                "path": "commitments_ms"
-              },
-              {
-                "alias": "merklization_ms",
-                "path": "merklization_ms"
-              },
-              {
-                "alias": "contract_trie_ms",
-                "path": "contract_trie_ms"
-              },
-              {
-                "alias": "class_trie_ms",
-                "path": "class_trie_ms"
-              },
-              {
-                "alias": "contract_storage_trie_commit_ms",
-                "path": "contract_storage_trie_commit_ms"
-              },
-              {
-                "alias": "contract_trie_commit_ms",
-                "path": "contract_trie_commit_ms"
-              },
-              {
-                "alias": "class_trie_commit_ms",
-                "path": "class_trie_commit_ms"
-              },
-              {
-                "alias": "block_hash_ms",
-                "path": "block_hash_ms"
-              },
-              {
-                "alias": "db_write_ms",
-                "path": "db_write_ms"
-              },
-              {
-                "alias": "state_diff_len",
-                "path": "state_diff_len"
-              },
-              {
-                "alias": "declared_classes",
-                "path": "declared_classes"
-              },
-              {
-                "alias": "deployed_contracts",
-                "path": "deployed_contracts"
-              },
-              {
-                "alias": "storage_diffs",
-                "path": "storage_diffs"
-              },
-              {
-                "alias": "nonce_updates",
-                "path": "nonce_updates"
-              },
-              {
-                "alias": "consumed_l1_nonces",
-                "path": "consumed_l1_nonces"
-              },
-              {
-                "alias": "bouncer_l1_gas",
-                "path": "bouncer_l1_gas"
-              },
-              {
-                "alias": "bouncer_sierra_gas",
-                "path": "bouncer_sierra_gas"
-              },
-              {
-                "alias": "bouncer_n_events",
-                "path": "bouncer_n_events"
-              },
-              {
-                "alias": "bouncer_message_segment_length",
-                "path": "bouncer_message_segment_length"
-              },
-              {
-                "alias": "bouncer_state_diff_size",
-                "path": "bouncer_state_diff_size"
-              },
-              {
-                "alias": "batches_executed",
-                "path": "batches_executed"
-              },
-              {
-                "alias": "txs_added_to_block",
-                "path": "txs_added_to_block"
-              },
-              {
-                "alias": "txs_executed",
-                "path": "txs_executed"
-              },
-              {
-                "alias": "txs_reverted",
-                "path": "txs_reverted"
-              },
-              {
-                "alias": "txs_rejected",
-                "path": "txs_rejected"
-              },
-              {
-                "alias": "classes_declared",
-                "path": "classes_declared"
-              },
-              {
-                "alias": "l2_gas_consumed",
-                "path": "l2_gas_consumed"
-              }
-            ],
-            "source": "Line"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Line": true,
-              "Time": false,
-              "id": true,
-              "labels": true,
-              "tsNs": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
       "id": 310,
       "type": "timeseries",
       "title": "Close Block Timing Breakdown (Loki)",
@@ -5843,6 +5610,55 @@
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
           "legendFormat": "Block Hash",
           "refId": "E"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_preconfirmed_ms [$__interval]) by ()",
+          "legendFormat": "Close Preconfirmed",
+          "refId": "F"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap get_full_block_ms [$__interval]) by ()",
+          "legendFormat": "Get Full Block",
+          "refId": "G"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_trie_ms [$__interval]) by ()",
+          "legendFormat": "Contract Trie",
+          "refId": "H"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap class_trie_ms [$__interval]) by ()",
+          "legendFormat": "Class Trie",
+          "refId": "I"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_storage_trie_commit_ms [$__interval]) by ()",
+          "legendFormat": "Contract Storage Trie Commit",
+          "refId": "J"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_trie_commit_ms [$__interval]) by ()",
+          "legendFormat": "Contract Trie Commit",
+          "refId": "K"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap class_trie_commit_ms [$__interval]) by ()",
+          "legendFormat": "Class Trie Commit",
+          "refId": "L"
         }
       ],
       "fieldConfig": {
@@ -5980,6 +5796,55 @@
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
           "legendFormat": "State Diff Length",
           "refId": "E"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap batches_executed [$__interval]) by ()",
+          "legendFormat": "Batches Executed",
+          "refId": "F"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_added_to_block [$__interval]) by ()",
+          "legendFormat": "Txs Added to Block",
+          "refId": "G"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_rejected [$__interval]) by ()",
+          "legendFormat": "Txs Rejected",
+          "refId": "H"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap classes_declared [$__interval]) by ()",
+          "legendFormat": "Classes Declared",
+          "refId": "I"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap deployed_contracts [$__interval]) by ()",
+          "legendFormat": "Deployed Contracts",
+          "refId": "J"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap storage_diffs [$__interval]) by ()",
+          "legendFormat": "Storage Diffs",
+          "refId": "K"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap nonce_updates [$__interval]) by ()",
+          "legendFormat": "Nonce Updates",
+          "refId": "L"
         }
       ],
       "fieldConfig": {
@@ -5998,6 +5863,128 @@
       },
       "pluginVersion": 39,
       "transformations": []
+    },
+    {
+      "id": 313,
+      "type": "timeseries",
+      "title": "Bouncer Weights (Loki)",
+      "description": "Bouncer weights and gas consumption from structured logs",
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 177
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "mean", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap l2_gas_consumed [$__interval]) by ()",
+          "legendFormat": "L2 Gas Consumed",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_l1_gas [$__interval]) by ()",
+          "legendFormat": "Bouncer L1 Gas",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_sierra_gas [$__interval]) by ()",
+          "legendFormat": "Bouncer Sierra Gas",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_n_events [$__interval]) by ()",
+          "legendFormat": "Bouncer Events",
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_message_segment_length [$__interval]) by ()",
+          "legendFormat": "Bouncer Msg Segment Len",
+          "refId": "E"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_state_diff_size [$__interval]) by ()",
+          "legendFormat": "Bouncer State Diff Size",
+          "refId": "F"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "pluginVersion": 39,
+      "transformations": []
+    },
+    {
+      "id": 314,
+      "type": "logs",
+      "title": "Close Block Logs",
+      "description": "Raw close_block_complete log entries",
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 187
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1,5 +1,7 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "description": "Madara Starknet Node - Comprehensive Overview",
   "editable": true,
   "fiscalYearStartMonth": 0,
@@ -10,1479 +12,5318 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 50,
       "panels": [],
       "title": "Block Production",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#37872D", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
       "id": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(block_produced_no{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Chain Height", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(block_produced_no{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Chain Height",
+          "refId": "A"
+        }
+      ],
       "title": "Chain Height",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#8F3BB8", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8F3BB8",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
       "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "1 / sum(rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))", "legendFormat": "Block Interval", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "1 / sum(rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "Block Interval",
+          "refId": "A"
+        }
+      ],
       "title": "Block Interval",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "decimals": 0,
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#73BF69", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#73BF69",
+                "value": null
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
       "id": 60,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(tx_execution_time_ms_milliseconds_sum{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])) / sum(rate(tx_execution_time_ms_milliseconds_count{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m]))", "legendFormat": "Avg Tx Exec", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(tx_execution_time_ms_milliseconds_sum{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])) / sum(rate(tx_execution_time_ms_milliseconds_count{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m]))",
+          "legendFormat": "Avg Tx Exec",
+          "refId": "A"
+        }
+      ],
       "title": "Avg Tx Exec",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "decimals": 2,
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#FF9830", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FF9830",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
       "id": 4,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(transaction_counter_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]))", "legendFormat": "TPS (1m)", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(transaction_counter_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]))",
+          "legendFormat": "TPS (1m)",
+          "refId": "A"
+        }
+      ],
       "title": "TPS (1m)",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "decimals": 2,
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#C4162A", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#C4162A",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
       "id": 5,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["max"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(transaction_counter_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]))", "legendFormat": "Max TPS", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(transaction_counter_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]))",
+          "legendFormat": "Max TPS",
+          "refId": "A"
+        }
+      ],
       "title": "Max TPS",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#56A64B", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#56A64B",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 1 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
       "id": 6,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(mempool_current_size{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Pending Txs", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(mempool_current_size{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Pending Txs",
+          "refId": "A"
+        }
+      ],
       "title": "Mempool",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 25, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
-        "overrides": [{ "matcher": { "id": "byName", "options": "Chain Height" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] }]
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Chain Height"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#37872D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "id": 7,
-      "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(block_produced_no{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Chain Height", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(block_produced_no{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Chain Height",
+          "refId": "A"
+        }
+      ],
       "title": "Block Height",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 25, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "TPS" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Blocks/min" }, "properties": [{ "id": "color", "value": { "fixedColor": "#3274D9", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "TPS"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Blocks/min"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3274D9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "id": 8,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(transaction_counter_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]))", "legendFormat": "TPS", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) * 60", "legendFormat": "Blocks/min", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(transaction_counter_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]))",
+          "legendFormat": "TPS",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) * 60",
+          "legendFormat": "Blocks/min",
+          "refId": "B"
+        }
       ],
       "title": "Throughput",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 60, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "p50" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "p90" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "p99" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#37872D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C4162A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
       "id": 61,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(tx_execution_time_ms_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])))", "legendFormat": "p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(tx_execution_time_ms_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])))", "legendFormat": "p90", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(tx_execution_time_ms_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])))", "legendFormat": "p99", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tx_execution_time_ms_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(tx_execution_time_ms_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(tx_execution_time_ms_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\", context=\"production\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
       ],
       "title": "Tx Execution Time",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
       "id": 100,
       "panels": [],
       "title": "RPC Overview",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#37872D", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 23 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 23
+      },
       "id": 101,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Total Calls", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Total Calls",
+          "refId": "A"
+        }
+      ],
       "title": "Total Calls",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#FF9830", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FF9830",
+                "value": null
+              }
+            ]
+          },
           "unit": "reqps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 23 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 23
+      },
       "id": 102,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))", "legendFormat": "RPS (5m)", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "RPS (5m)",
+          "refId": "A"
+        }
+      ],
       "title": "RPS (5m)",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#3274D9", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3274D9",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 23 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 23
+      },
       "id": 103,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "WS Sessions", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "WS Sessions",
+          "refId": "A"
+        }
+      ],
       "title": "WS Sessions",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 100 }, { "color": "red", "value": 500 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 23 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 23
+      },
       "id": 104,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Latency p50", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Latency p50",
+          "refId": "A"
+        }
+      ],
       "title": "Latency p50",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 200 }, { "color": "red", "value": 1000 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 23 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 23
+      },
       "id": 105,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Latency p99", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Latency p99",
+          "refId": "A"
+        }
+      ],
       "title": "Latency p99",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#8F3BB8", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8F3BB8",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 23 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 23
+      },
       "id": 106,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_started_total{namespace=~\"$namespace\", pod=~\"$pod\"}) - sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "In-Flight", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(calls_started_total{namespace=~\"$namespace\", pod=~\"$pod\"}) - sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "In-Flight",
+          "refId": "A"
+        }
+      ],
       "title": "In-Flight",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "reqps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 27 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
       "id": 107,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))", "legendFormat": "Requests/s", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "Requests/s",
+          "refId": "A"
+        }
       ],
       "title": "RPC Request Rate",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "p50" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "p90" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "p99" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#37872D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C4162A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 27 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
       "id": 108,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "p50 (all methods)", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "p90 (all methods)", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "p99 (all methods)", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "p50 (all methods)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "p90 (all methods)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "p99 (all methods)",
+          "refId": "C"
+        }
       ],
       "title": "RPC Latency Percentiles",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "percentunit"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Success Rate" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Error Rate" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success Rate"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#37872D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error Rate"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C4162A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 35 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 35
+      },
       "id": 109,
-      "options": { "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", success=\"true\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))", "legendFormat": "Success Rate", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", success=\"false\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))", "legendFormat": "Error Rate", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", success=\"true\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "Success Rate",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", success=\"false\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "Error Rate",
+          "refId": "B"
+        }
       ],
       "title": "RPC Success/Error Rate",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "reqps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 35 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 35
+      },
       "id": 110,
-      "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
       "title": "Top RPC Methods",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 35 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 35
+      },
       "id": 111,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Active Sessions", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Active Sessions",
+          "refId": "A"
+        }
+      ],
       "title": "Active WebSocket Sessions",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 35 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 35
+      },
       "id": 112,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(5, histogram_quantile(0.50, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))))", "legendFormat": "{{method}} p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(5, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))))", "legendFormat": "{{method}} p90", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(5, histogram_quantile(0.50, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))))",
+          "legendFormat": "{{method}} p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(5, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))))",
+          "legendFormat": "{{method}} p90",
+          "refId": "B"
+        }
       ],
       "title": "Top Methods Latency",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
       "id": 51,
       "panels": [],
       "title": "Database & Storage",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#37872D", "value": null }, { "color": "yellow", "value": 53687091200 }, { "color": "red", "value": 107374182400 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 53687091200
+              },
+              {
+                "color": "red",
+                "value": 107374182400
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 44 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 44
+      },
       "id": 10,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_size{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "DB Size", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_size{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "DB Size",
+          "refId": "A"
+        }
+      ],
       "title": "DB Size",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#3274D9", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3274D9",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 44 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 44
+      },
       "id": 11,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_mem_table_total{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "MemTable Allocated", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_mem_table_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "MemTable Allocated",
+          "refId": "A"
+        }
+      ],
       "title": "MemTable Allocated",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#8F3BB8", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8F3BB8",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 44 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 44
+      },
       "id": 12,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_cache_total{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Block Cache", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_cache_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Block Cache",
+          "refId": "A"
+        }
+      ],
       "title": "Block Cache",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#FF9830", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#FF9830",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 44 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 44
+      },
       "id": 13,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_mem_table_unflushed{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Unflushed", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_mem_table_unflushed{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Unflushed",
+          "refId": "A"
+        }
+      ],
       "title": "Unflushed",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#56A64B", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#56A64B",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 44 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 44
+      },
       "id": 14,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_mem_table_readers_total{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Table Readers", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_mem_table_readers_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Table Readers",
+          "refId": "A"
+        }
+      ],
       "title": "Table Readers",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "Bps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 44 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 44
+      },
       "id": 15,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(db_size{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))", "legendFormat": "Growth Rate", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(db_size{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "Growth Rate",
+          "refId": "A"
+        }
+      ],
       "title": "Growth Rate",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 49 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
       "id": 16,
-      "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_size{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Total Size", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_mem_table_total{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "MemTable Allocated", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_cache_total{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Cache", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_size{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Total Size",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_mem_table_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "MemTable Allocated",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_cache_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Cache",
+          "refId": "C"
+        }
       ],
       "title": "Storage Over Time",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 49 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
       "id": 17,
-      "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "column_sizes{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "{{column}}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "column_sizes{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{column}}",
+          "refId": "A"
+        }
+      ],
       "title": "Column Family Sizes",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
       "id": 70,
       "panels": [],
       "title": "RocksDB Write Stall Detection",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [{ "options": { "0": { "color": "green", "index": 0, "text": "Running" }, "1": { "color": "red", "index": 1, "text": "STOPPED" } }, "type": "value" }],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Running"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "STOPPED"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 71 },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 71
+      },
       "id": 71,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(db_is_write_stopped{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Write Status", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max(db_is_write_stopped{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Write Status",
+          "refId": "A"
+        }
+      ],
       "title": "Write Status",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 34359738368 }, { "color": "red", "value": 68719476736 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 34359738368
+              },
+              {
+                "color": "red",
+                "value": 68719476736
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 5, "x": 4, "y": 71 },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 4,
+        "y": 71
+      },
       "id": 72,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_pending_compaction_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Pending Compaction", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_pending_compaction_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Pending Compaction",
+          "refId": "A"
+        }
+      ],
       "title": "Pending Compaction",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 15 }, { "color": "red", "value": 20 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 15
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 5, "x": 9, "y": 71 },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 9,
+        "y": 71
+      },
       "id": 73,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_level_files_count{namespace=~\"$namespace\", pod=~\"$pod\", level=\"L0\"})", "legendFormat": "L0 Files", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_level_files_count{namespace=~\"$namespace\", pod=~\"$pod\", level=\"L0\"})",
+          "legendFormat": "L0 Files",
+          "refId": "A"
+        }
+      ],
       "title": "L0 Files",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 3 }, { "color": "red", "value": 4 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 4
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 5, "x": 14, "y": 71 },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 71
+      },
       "id": 74,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_num_immutable_memtables{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Immutable MemTables", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_num_immutable_memtables{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Immutable MemTables",
+          "refId": "A"
+        }
+      ],
       "title": "Immutable MemTables",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "#3274D9", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3274D9",
+                "value": null
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 5, "w": 5, "x": 19, "y": 71 },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 71
+      },
       "id": 75,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_memtable_size_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "MemTable Data", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_memtable_size_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "MemTable Data",
+          "refId": "A"
+        }
+      ],
       "title": "MemTable Data",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "line+area" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 15 }, { "color": "red", "value": 20 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 15
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "L0 Files" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Immutable MemTables" }, "properties": [{ "id": "color", "value": { "fixedColor": "#8F3BB8", "mode": "fixed" } }, { "id": "custom.thresholdsStyle", "value": { "mode": "off" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "L0 Files"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Immutable MemTables"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8F3BB8",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "off"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 76 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 76
+      },
       "id": 76,
       "description": "Monitors RocksDB write stall risk.\n\n**L0 Files Thresholds:**\n- Yellow line (15): Warning - approaching slowdown\n- Red line (20): Critical - RocksDB throttles writes\n- Stop at 36 files\n\n**Immutable MemTables:**\n- Stall when >= max_write_buffer_number (default 5)",
-      "options": { "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_level_files_count{namespace=~\"$namespace\", pod=~\"$pod\", level=\"L0\"})", "legendFormat": "L0 Files", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_num_immutable_memtables{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Immutable MemTables", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_level_files_count{namespace=~\"$namespace\", pod=~\"$pod\", level=\"L0\"})",
+          "legendFormat": "L0 Files",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_num_immutable_memtables{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Immutable MemTables",
+          "refId": "B"
+        }
       ],
       "title": "Write Stall Indicators",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "line+area" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 34359738368 }, { "color": "red", "value": 68719476736 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 34359738368
+              },
+              {
+                "color": "red",
+                "value": 68719476736
+              }
+            ]
+          },
           "unit": "bytes"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Pending Compaction" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "MemTable Data" }, "properties": [{ "id": "color", "value": { "fixedColor": "#3274D9", "mode": "fixed" } }, { "id": "custom.thresholdsStyle", "value": { "mode": "off" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pending Compaction"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C4162A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MemTable Data"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3274D9",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "off"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 76 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 76
+      },
       "id": 77,
       "description": "Monitors compaction backlog and memtable data size.\n\n**Pending Compaction Thresholds:**\n- Yellow line (32 GiB): Warning - compaction falling behind\n- Red line (64 GiB): Critical - risk of write stalls\n\n**MemTable Data:**\n- Current data stored in memtables (before flush to SST files)",
-      "options": { "legend": { "calcs": ["last", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_pending_compaction_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Pending Compaction", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(db_memtable_size_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "MemTable Data", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_pending_compaction_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "Pending Compaction",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(db_memtable_size_bytes{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "legendFormat": "MemTable Data",
+          "refId": "B"
+        }
       ],
       "title": "Compaction & MemTable Data",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 76 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 76
+      },
       "id": 78,
       "description": "Shows the distribution of SST files across LSM tree levels.\n\n- **L0**: Recently flushed files (uncompacted, overlapping keys)\n- **L1-L6**: Compacted files (sorted, non-overlapping)\n\nA healthy database has few/no L0 files with data distributed across deeper levels.",
-      "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_level_files_count{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "{{level}}", "refId": "A" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "db_level_files_count{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "{{level}}",
+          "refId": "A"
+        }
       ],
       "title": "LSM Tree Level Distribution",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 84 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 84
+      },
       "id": 200,
       "panels": [],
       "title": "Cairo Native Execution",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 85
+      },
       "id": 201,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_cache_size_class{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_cache_size_class{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "Cache Size",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 85
+      },
       "id": 202,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_cache_hits_memory_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_cache_hits_memory_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "Memory Hits",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 85
+      },
       "id": 203,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_cache_hits_disk_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_cache_hits_disk_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "Disk Hits",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "orange", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 85
+      },
       "id": 204,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_cache_evictions_eviction_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_cache_evictions_eviction_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "Evictions",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "yellow", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 85
+      },
       "id": 205,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_vm_fallbacks_fallback_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_vm_fallbacks_fallback_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "VM Fallbacks",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 85
+      },
       "id": 206,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_current_compilations_compilation{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_current_compilations_compilation{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "Active Compilations",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "red", "value": 1 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 85
+      },
       "id": 212,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_compilations_failed_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_compilations_failed_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "Compilation Failures",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "orange", "value": null }, { "color": "orange", "value": 1 }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 3, "x": 21, "y": 85 },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 85
+      },
       "id": 213,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "cairo_native_compilations_timeout_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}", "refId": "A" }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "cairo_native_compilations_timeout_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "refId": "A"
+        }
+      ],
       "title": "Compilation Timeouts",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "percentunit"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 89 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 89
+      },
       "id": 207,
-      "options": { "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_cache_hits_memory_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(cairo_native_cache_hits_memory_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(cairo_native_cache_memory_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + 0.001)", "legendFormat": "Memory Hit Rate", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_cache_hits_disk_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(cairo_native_cache_hits_disk_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(cairo_native_cache_disk_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + 0.001)", "legendFormat": "Disk Hit Rate", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_hits_memory_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(cairo_native_cache_hits_memory_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(cairo_native_cache_memory_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + 0.001)",
+          "legendFormat": "Memory Hit Rate",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_hits_disk_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(cairo_native_cache_hits_disk_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(cairo_native_cache_disk_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + 0.001)",
+          "legendFormat": "Disk Hit Rate",
+          "refId": "B"
+        }
       ],
       "title": "Cache Hit Rate",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ops"
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Failed/s" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Timeout/s" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed/s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Timeout/s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 89 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 89
+      },
       "id": 208,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_compilations_started_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Started/s", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_compilations_succeeded_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Succeeded/s", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_compilations_failed_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Failed/s", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_compilations_timeout_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Timeout/s", "refId": "D" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_compilations_started_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Started/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_compilations_succeeded_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Succeeded/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_compilations_failed_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Failed/s",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_compilations_timeout_compilation_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Timeout/s",
+          "refId": "D"
+        }
       ],
       "title": "Compilation Rate",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ms"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 89 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 89
+      },
       "id": 209,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_compilation_time_milliseconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / rate(cairo_native_compilation_time_milliseconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "avg", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(cairo_native_compilation_time_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(cairo_native_compilation_time_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "p90", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(cairo_native_compilation_time_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "p99", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_compilation_time_milliseconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / rate(cairo_native_compilation_time_milliseconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "avg",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cairo_native_compilation_time_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(cairo_native_compilation_time_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cairo_native_compilation_time_milliseconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
       ],
       "title": "Compilation Time",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ops"
         },
         "overrides": [
-          { "matcher": { "id": "byRegexp", "options": ".*Timeout.*|.*Error.*" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Timeout.*|.*Error.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 97 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 97
+      },
       "id": 210,
-      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_cache_memory_timeout_timeout_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Memory Timeout/s", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_cache_disk_load_timeout_timeout_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Disk Load Timeout/s", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_cache_disk_load_error_error_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Disk Load Error/s", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_memory_timeout_timeout_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Memory Timeout/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_disk_load_timeout_timeout_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Disk Load Timeout/s",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_disk_load_error_error_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Disk Load Error/s",
+          "refId": "C"
+        }
       ],
       "title": "Cache Errors",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 97 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 97
+      },
       "id": 211,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_vm_fallbacks_fallback_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "VM Fallbacks/s", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(cairo_native_compilation_in_progress_skip_skip_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "In-Progress Skip/s", "refId": "B" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_vm_fallbacks_fallback_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "VM Fallbacks/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_compilation_in_progress_skip_skip_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "In-Progress Skip/s",
+          "refId": "B"
+        }
       ],
       "title": "Fallback & Skip Rate",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 105 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 105
+      },
       "id": 300,
       "panels": [],
       "title": "Close Block Metrics",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 106 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 106
+      },
       "id": 301,
-      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Fetch Block",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Commitments",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Merklization",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Block Hash",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Write Block to DB",
+          "refId": "E"
+        }
       ],
       "title": "Close Block Timing Breakdown (Stacked)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 106 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 106
+      },
       "id": 302,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(get_full_block_with_classes_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Fetch Block p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(get_full_block_with_classes_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Fetch Block p95", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Commitments p50", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Commitments p95", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Merklization p50", "refId": "E" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Merklization p95", "refId": "F" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Hash p50", "refId": "G" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Hash p95", "refId": "H" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(db_write_block_parts_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Write to DB p50", "refId": "I" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(db_write_block_parts_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Write to DB p95", "refId": "J" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(get_full_block_with_classes_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Fetch Block p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(get_full_block_with_classes_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Fetch Block p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Commitments p50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Commitments p95",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Merklization p50",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Merklization p95",
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Block Hash p50",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Block Hash p95",
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(db_write_block_parts_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Write to DB p50",
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(db_write_block_parts_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Write to DB p95",
+          "refId": "J"
+        }
       ],
       "title": "Close Block Percentiles (p50, p95)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Total time to close a block (P50, P95, P99). Note: Bucket boundaries may cause interpolation artifacts.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 114 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 114
+      },
       "id": 307,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Close Block p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Close Block p95", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Close Block p99", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Close Block p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Close Block p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Close Block p99",
+          "refId": "C"
+        }
       ],
       "title": "Close Block Total Duration (P50, P95, P99)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Full block production time from start to close (P50, P95, P99)",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 114 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 114
+      },
       "id": 308,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Production p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Production p95", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Production p99", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Block Production p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Block Production p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "legendFormat": "Block Production p99",
+          "refId": "C"
+        }
       ],
       "title": "Block Production Time (P50, P95, P99)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 122 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 122
+      },
       "id": 303,
-      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_state_diff_length{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "State Diff Length", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_declared_classes_count{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Declared Classes", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_deployed_contracts_count{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Deployed Contracts", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_storage_diffs_count{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Storage Diffs", "refId": "D" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_state_diff_length{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "State Diff Length",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_declared_classes_count{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Declared Classes",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_deployed_contracts_count{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Deployed Contracts",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_storage_diffs_count{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Storage Diffs",
+          "refId": "D"
+        }
       ],
       "title": "Block State Diff Stats",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "none"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 114 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 114
+      },
       "id": 304,
-      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_l1_gas{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "L1 Gas", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_sierra_gas{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Sierra Gas", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_n_events{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Events", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_state_diff_size{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "State Diff Size", "refId": "D" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_bouncer_l1_gas{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "L1 Gas",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_bouncer_sierra_gas{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Sierra Gas",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_bouncer_n_events{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Events",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_bouncer_state_diff_size{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "State Diff Size",
+          "refId": "D"
+        }
       ],
       "title": "Bouncer Weights",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 122 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 122
+      },
       "id": 305,
-      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Fetch Block",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Commitments",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Merklization",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Block Hash",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Write Block to DB",
+          "refId": "E"
+        }
       ],
       "title": "Close Block Timing (Latest Values)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 122 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 122
+      },
       "id": 306,
-      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Total Merklization", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Root", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Root", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Storage Trie Commit", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Commit", "refId": "E" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Commit", "refId": "F" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Total Merklization",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Contract Trie Root",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Class Trie Root",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Storage Trie Commit",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "contract_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Contract Trie Commit",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "class_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Class Trie Commit",
+          "refId": "F"
+        }
       ],
       "title": "Merklization Deep Dive",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -1493,41 +5334,111 @@
             "drawStyle": "bars",
             "fillOpacity": 60,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineStyle": { "fill": "solid" },
+            "lineStyle": {
+              "fill": "solid"
+            },
             "lineWidth": 1,
             "pointSize": 4,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 130 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 130
+      },
       "id": 307,
-      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum(rate(block_close_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum(rate(block_close_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p95", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_close_time_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Latest", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(block_close_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(block_close_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "block_close_time_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Latest",
+          "refId": "C"
+        }
       ],
       "title": "Block Close Time (Histogram Trends)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -1538,58 +5449,160 @@
             "drawStyle": "bars",
             "fillOpacity": 60,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineStyle": { "fill": "solid" },
+            "lineStyle": {
+              "fill": "solid"
+            },
             "lineWidth": 1,
             "pointSize": 4,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 138 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 138
+      },
       "id": 308,
-      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum(rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum(rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p95", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Latest", "refId": "C" }
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Latest",
+          "refId": "C"
+        }
       ],
       "title": "Merklization (Histogram Trends)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
           "mappings": [],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 146 },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 146
+      },
       "id": 309,
       "options": {
         "cellHeight": "sm",
-        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
-        "sortBy": [{ "desc": true, "displayName": "block_number" }]
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "block_number"
+          }
+        ]
       },
       "pluginVersion": "11.4.0",
       "targets": [
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | __error__=\"\"",
           "queryType": "range",
@@ -1603,14 +5616,146 @@
           "options": {
             "format": "json",
             "jsonPaths": [
-              { "alias": "block_number", "path": "block_number" },
-              { "alias": "tx_count", "path": "tx_count" },
-              { "alias": "event_count", "path": "event_count" },
-              { "alias": "close_block_total_ms", "path": "close_block_total_ms" },
-              { "alias": "merklization_ms", "path": "merklization_ms" },
-              { "alias": "block_hash_ms", "path": "block_hash_ms" },
-              { "alias": "db_write_ms", "path": "db_write_ms" },
-              { "alias": "state_diff_len", "path": "state_diff_len" }
+              {
+                "alias": "block_number",
+                "path": "block_number"
+              },
+              {
+                "alias": "tx_count",
+                "path": "tx_count"
+              },
+              {
+                "alias": "event_count",
+                "path": "event_count"
+              },
+              {
+                "alias": "close_block_total_ms",
+                "path": "close_block_total_ms"
+              },
+              {
+                "alias": "block_close_ms",
+                "path": "block_close_ms"
+              },
+              {
+                "alias": "close_preconfirmed_ms",
+                "path": "close_preconfirmed_ms"
+              },
+              {
+                "alias": "block_production_ms",
+                "path": "block_production_ms"
+              },
+              {
+                "alias": "get_full_block_ms",
+                "path": "get_full_block_ms"
+              },
+              {
+                "alias": "commitments_ms",
+                "path": "commitments_ms"
+              },
+              {
+                "alias": "merklization_ms",
+                "path": "merklization_ms"
+              },
+              {
+                "alias": "contract_trie_ms",
+                "path": "contract_trie_ms"
+              },
+              {
+                "alias": "class_trie_ms",
+                "path": "class_trie_ms"
+              },
+              {
+                "alias": "contract_storage_trie_commit_ms",
+                "path": "contract_storage_trie_commit_ms"
+              },
+              {
+                "alias": "contract_trie_commit_ms",
+                "path": "contract_trie_commit_ms"
+              },
+              {
+                "alias": "class_trie_commit_ms",
+                "path": "class_trie_commit_ms"
+              },
+              {
+                "alias": "block_hash_ms",
+                "path": "block_hash_ms"
+              },
+              {
+                "alias": "db_write_ms",
+                "path": "db_write_ms"
+              },
+              {
+                "alias": "state_diff_len",
+                "path": "state_diff_len"
+              },
+              {
+                "alias": "declared_classes",
+                "path": "declared_classes"
+              },
+              {
+                "alias": "deployed_contracts",
+                "path": "deployed_contracts"
+              },
+              {
+                "alias": "storage_diffs",
+                "path": "storage_diffs"
+              },
+              {
+                "alias": "nonce_updates",
+                "path": "nonce_updates"
+              },
+              {
+                "alias": "consumed_l1_nonces",
+                "path": "consumed_l1_nonces"
+              },
+              {
+                "alias": "bouncer_l1_gas",
+                "path": "bouncer_l1_gas"
+              },
+              {
+                "alias": "bouncer_sierra_gas",
+                "path": "bouncer_sierra_gas"
+              },
+              {
+                "alias": "bouncer_n_events",
+                "path": "bouncer_n_events"
+              },
+              {
+                "alias": "bouncer_message_segment_length",
+                "path": "bouncer_message_segment_length"
+              },
+              {
+                "alias": "bouncer_state_diff_size",
+                "path": "bouncer_state_diff_size"
+              },
+              {
+                "alias": "batches_executed",
+                "path": "batches_executed"
+              },
+              {
+                "alias": "txs_added_to_block",
+                "path": "txs_added_to_block"
+              },
+              {
+                "alias": "txs_executed",
+                "path": "txs_executed"
+              },
+              {
+                "alias": "txs_reverted",
+                "path": "txs_reverted"
+              },
+              {
+                "alias": "txs_rejected",
+                "path": "txs_rejected"
+              },
+              {
+                "alias": "classes_declared",
+                "path": "classes_declared"
+              },
+              {
+                "alias": "l2_gas_consumed",
+                "path": "l2_gas_consumed"
+              }
             ],
             "source": "Line"
           }
@@ -1618,27 +5763,194 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": { "Line": true, "Time": false, "id": true, "labels": true, "tsNs": true },
+            "excludeByName": {
+              "Line": true,
+              "Time": false,
+              "id": true,
+              "labels": true,
+              "tsNs": true
+            },
             "indexByName": {},
             "renameByName": {}
           }
         }
       ],
       "type": "table"
+    },
+    {
+      "id": 310,
+      "type": "timeseries",
+      "title": "Close Block Metrics (Loki)",
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 157
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap $log_field",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "pluginVersion": 39
     }
   ],
   "refresh": "5s",
   "schemaVersion": 39,
-  "tags": ["madara", "starknet", "overview"],
+  "tags": [
+    "madara",
+    "starknet",
+    "overview"
+  ],
   "templating": {
     "list": [
-      { "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" }, "hide": 0, "includeAll": false, "multi": false, "name": "DS_PROMETHEUS", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" },
-      { "current": { "selected": false, "text": "Loki", "value": "Loki" }, "hide": 0, "includeAll": false, "multi": false, "name": "DS_LOKI", "options": [], "query": "loki", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" },
-      { "allValue": ".*", "current": { "selected": true, "text": "All", "value": "$__all" }, "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "definition": "label_values(block_produced_no, namespace)", "hide": 0, "includeAll": true, "label": "Namespace", "multi": true, "name": "namespace", "options": [], "query": { "query": "label_values(block_produced_no, namespace)", "refId": "StandardVariableQuery" }, "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query" },
-      { "allValue": ".*", "current": { "selected": true, "text": "All", "value": "$__all" }, "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "definition": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)", "hide": 0, "includeAll": true, "label": "Pod", "multi": true, "name": "pod", "options": [], "query": { "query": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)", "refId": "StandardVariableQuery" }, "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query" }
+      {
+        "name": "log_field",
+        "type": "custom",
+        "label": "Log Field",
+        "hide": 0,
+        "query": "close_block_total_ms,block_close_ms,close_preconfirmed_ms,block_production_ms,get_full_block_ms,commitments_ms,merklization_ms,contract_trie_ms,class_trie_ms,contract_storage_trie_commit_ms,contract_trie_commit_ms,class_trie_commit_ms,block_hash_ms,db_write_ms,state_diff_len,declared_classes,deployed_contracts,storage_diffs,nonce_updates,consumed_l1_nonces,bouncer_l1_gas,bouncer_sierra_gas,bouncer_n_events,bouncer_message_segment_length,bouncer_state_diff_size,batches_executed,txs_added_to_block,txs_executed,txs_reverted,txs_rejected,classes_declared,l2_gas_consumed",
+        "current": {
+          "selected": false,
+          "text": "close_block_total_ms",
+          "value": "close_block_total_ms"
+        },
+        "options": [],
+        "multi": false,
+        "includeAll": false,
+        "skipUrlSync": false,
+        "allValue": null,
+        "refresh": 0
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Loki",
+          "value": "Loki"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_LOKI",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(block_produced_no, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(block_produced_no, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
     ]
   },
-  "time": { "from": "now-15m", "to": "now" },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
   "title": "Madara Overview",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1386,13 +1386,13 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(apply_to_global_trie_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(apply_to_global_trie_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Total Merklization", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(contract_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(contract_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Contract Trie", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(class_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(class_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Class Trie", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(block_commitments_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(block_commitments_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Commitments", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(block_hash_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(block_hash_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Block Hash", "refId": "E" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(apply_to_global_trie_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(apply_to_global_trie_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Total Merklization", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(contract_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(contract_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Contract Trie", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(class_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(class_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Class Trie", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(block_commitments_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(block_commitments_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Commitments", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(block_hash_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(block_hash_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Block Hash", "refId": "E" }
       ],
-      "title": "Close Block Timing (Avg per Block)",
+      "title": "Close Block Timing (Per Block)",
       "type": "timeseries"
     },
     {
@@ -1412,14 +1412,14 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(close_block_total_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(close_block_total_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Total Close Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(contract_storage_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(contract_storage_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Storage Trie Commit", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(contract_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(contract_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Contract Trie Commit", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(class_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(class_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Class Trie Commit", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(get_full_block_with_classes_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(get_full_block_with_classes_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Fetch Block+Classes", "refId": "E" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(db_write_block_parts_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(db_write_block_parts_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "DB Write", "refId": "F" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(close_block_total_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(close_block_total_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Total Close Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(contract_storage_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(contract_storage_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Storage Trie Commit", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(contract_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(contract_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Contract Trie Commit", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(class_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(class_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Class Trie Commit", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(get_full_block_with_classes_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(get_full_block_with_classes_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Fetch Block+Classes", "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(db_write_block_parts_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(db_write_block_parts_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "DB Write", "refId": "F" }
       ],
-      "title": "Close Block Detailed Timing (Avg)",
+      "title": "Close Block Detailed Timing (Per Block)",
       "type": "timeseries"
     }
   ],

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1259,6 +1259,115 @@
       ],
       "title": "Fallback & Skip Rate",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 105 },
+      "id": 300,
+      "panels": [],
+      "title": "Close Block Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 106 },
+      "id": 301,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Total Merklization p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(contract_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Contract Trie p50", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(class_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Class Trie p50", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Commitments p50", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Hash p50", "refId": "E" }
+      ],
+      "title": "Close Block Timing Breakdown (p50)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 106 },
+      "id": 302,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Total Merklization p99", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(contract_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Contract Trie p99", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(class_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Class Trie p99", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Total Close Block p99", "refId": "D" }
+      ],
+      "title": "Close Block Timing (p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 114 },
+      "id": 303,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_state_diff_length{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "State Diff Length", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_declared_classes_count{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Declared Classes", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_deployed_contracts_count{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Deployed Contracts", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_storage_diffs_count{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Storage Diffs", "refId": "D" }
+      ],
+      "title": "Block State Diff Stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 114 },
+      "id": 304,
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_l1_gas{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "L1 Gas", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_sierra_gas{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Sierra Gas", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_n_events{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Events", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_bouncer_state_diff_size{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "State Diff Size", "refId": "D" }
+      ],
+      "title": "Bouncer Weights",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5604,7 +5604,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | __error__=\"\"",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\"",
           "queryType": "range",
           "refId": "A"
         }
@@ -5814,7 +5814,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap $log_field",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\"",
           "queryType": "range",
           "refId": "A"
         }
@@ -5825,7 +5825,40 @@
         },
         "overrides": []
       },
-      "pluginVersion": 39
+      "pluginVersion": 39,
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "Line",
+            "format": "json",
+            "jsonPaths": []
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "^$log_field$"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "targetField": "$log_field",
+                "destinationType": "number"
+              }
+            ]
+          }
+        },
+        {
+          "id": "prepareTimeSeries",
+          "options": {}
+        }
+      ]
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4669,7 +4669,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p50",
           "refId": "A"
         },
@@ -4678,7 +4678,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p95",
           "refId": "B"
         },
@@ -4687,7 +4687,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p99",
           "refId": "C"
         }
@@ -4781,7 +4781,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p50",
           "refId": "A"
         },
@@ -4790,7 +4790,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p95",
           "refId": "B"
         },
@@ -4799,7 +4799,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p99",
           "refId": "C"
         }
@@ -5604,7 +5604,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json",
+          "expr": "{namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json",
           "queryType": "range",
           "refId": "A"
         }
@@ -5812,35 +5812,35 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Total Close Block",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap merklization_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap merklization_ms [$__interval]) by ()",
           "legendFormat": "Merklization",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap commitments_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap commitments_ms [$__interval]) by ()",
           "legendFormat": "Commitments",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap db_write_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap db_write_ms [$__interval]) by ()",
           "legendFormat": "DB Write",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
           "legendFormat": "Block Hash",
           "refId": "E"
         }
@@ -5892,7 +5892,7 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block Total (p50)",
           "refId": "A"
         }
@@ -5947,35 +5947,35 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap tx_count [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap tx_count [$__interval]) by ()",
           "legendFormat": "Tx Count",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap event_count [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap event_count [$__interval]) by ()",
           "legendFormat": "Event Count",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_executed [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap txs_executed [$__interval]) by ()",
           "legendFormat": "Txs Executed",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_reverted [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap txs_reverted [$__interval]) by ()",
           "legendFormat": "Txs Reverted",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
           "legendFormat": "State Diff Length",
           "refId": "E"
         }

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5839,7 +5839,7 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "^(Time|$log_field)$"
+              "pattern": "^(__time|Time|$log_field)$"
             }
           }
         },
@@ -5852,6 +5852,14 @@
                 "destinationType": "number"
               }
             ]
+          }
+        },
+        {
+          "id": "renameByName",
+          "options": {
+            "renames": {
+              "__time": "Time"
+            }
           }
         },
         {

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4585,10 +4585,10 @@
     },
     {
       "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Total time to close a block (P50, P95, P99) computed from per-block logs.",
+      "description": "Total time to close a block (P50, P95, P99) from Prometheus histogram.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4636,7 +4636,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -4666,28 +4666,28 @@
       "targets": [
         {
           "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Close Block p50",
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Close Block p95",
           "refId": "B"
         },
         {
           "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Close Block p99",
           "refId": "C"
         }
@@ -4697,10 +4697,10 @@
     },
     {
       "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Full block production time from start to close (P50, P95, P99) computed from per-block logs.",
+      "description": "Full block production time from start to close (P50, P95, P99) from Prometheus histogram.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4748,7 +4748,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -4778,28 +4778,28 @@
       "targets": [
         {
           "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(block_production_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Block Production p50",
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(block_production_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Block Production p95",
           "refId": "B"
         },
         {
           "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(block_production_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Block Production p99",
           "refId": "C"
         }
@@ -5869,7 +5869,7 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 177
       },

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5832,14 +5832,19 @@
           "options": {
             "source": "Line",
             "format": "json",
-            "jsonPaths": []
+            "jsonPaths": [
+              {
+                "alias": "timestamp",
+                "path": "timestamp"
+              }
+            ]
           }
         },
         {
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "^(__time|Time|$log_field)$"
+              "pattern": "^(timestamp|Time|__time|$log_field)$"
             }
           }
         },
@@ -5847,6 +5852,10 @@
           "id": "convertFieldType",
           "options": {
             "conversions": [
+              {
+                "targetField": "timestamp",
+                "destinationType": "time"
+              },
               {
                 "targetField": "Time",
                 "destinationType": "time"
@@ -5866,7 +5875,8 @@
           "id": "renameByName",
           "options": {
             "renames": {
-              "__time": "Time"
+              "__time": "Time",
+              "timestamp": "Time"
             }
           }
         },

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1368,6 +1368,59 @@
       ],
       "title": "Bouncer Weights",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 122 },
+      "id": 305,
+      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(apply_to_global_trie_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(apply_to_global_trie_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Total Merklization", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(contract_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(contract_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Contract Trie", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(class_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(class_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Class Trie", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(block_commitments_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(block_commitments_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Commitments", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(block_hash_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(block_hash_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Block Hash", "refId": "E" }
+      ],
+      "title": "Close Block Timing (Avg per Block)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 122 },
+      "id": 306,
+      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(close_block_total_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(close_block_total_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Total Close Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(contract_storage_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(contract_storage_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Storage Trie Commit", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(contract_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(contract_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Contract Trie Commit", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(class_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(class_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Class Trie Commit", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(get_full_block_with_classes_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(get_full_block_with_classes_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "Fetch Block+Classes", "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(db_write_block_parts_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) / rate(db_write_block_parts_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])", "legendFormat": "DB Write", "refId": "F" }
+      ],
+      "title": "Close Block Detailed Timing (Avg)",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4669,7 +4669,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p50",
           "refId": "A"
         },
@@ -4678,7 +4678,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p95",
           "refId": "B"
         },
@@ -4687,7 +4687,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p99",
           "refId": "C"
         }
@@ -4781,7 +4781,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p50",
           "refId": "A"
         },
@@ -4790,7 +4790,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p95",
           "refId": "B"
         },
@@ -4799,7 +4799,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p99",
           "refId": "C"
         }
@@ -5604,7 +5604,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json",
           "queryType": "range",
           "refId": "A"
         }
@@ -5812,35 +5812,35 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Total Close Block",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap merklization_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap merklization_ms [$__interval]) by ()",
           "legendFormat": "Merklization",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap commitments_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap commitments_ms [$__interval]) by ()",
           "legendFormat": "Commitments",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap db_write_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap db_write_ms [$__interval]) by ()",
           "legendFormat": "DB Write",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
           "legendFormat": "Block Hash",
           "refId": "E"
         }
@@ -5853,7 +5853,8 @@
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "fillOpacity": 10,
-            "showPoints": "never"
+            "showPoints": "never",
+            "spanNulls": true
           }
         },
         "overrides": []
@@ -5892,7 +5893,7 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block Total (p50)",
           "refId": "A"
         }
@@ -5905,7 +5906,8 @@
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "fillOpacity": 10,
-            "showPoints": "auto"
+            "showPoints": "never",
+            "spanNulls": true
           }
         },
         "overrides": []
@@ -5947,35 +5949,35 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap tx_count [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap tx_count [$__interval]) by ()",
           "legendFormat": "Tx Count",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap event_count [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap event_count [$__interval]) by ()",
           "legendFormat": "Event Count",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap txs_executed [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_executed [$__interval]) by ()",
           "legendFormat": "Txs Executed",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap txs_reverted [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_reverted [$__interval]) by ()",
           "legendFormat": "Txs Reverted",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", namespace=~\".+\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
           "legendFormat": "State Diff Length",
           "refId": "E"
         }
@@ -5988,7 +5990,8 @@
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "fillOpacity": 10,
-            "showPoints": "never"
+            "showPoints": "never",
+            "spanNulls": true
           }
         },
         "overrides": []

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -644,8 +644,8 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 60,
+            "drawStyle": "line",
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -660,7 +660,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -4617,7 +4617,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -4729,7 +4729,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -5331,8 +5331,8 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 60,
+            "drawStyle": "line",
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -5340,17 +5340,14 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
             "pointSize": 4,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -5375,7 +5372,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 130
       },
@@ -5446,8 +5443,8 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 60,
+            "drawStyle": "line",
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -5455,17 +5452,14 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
             "pointSize": 4,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -5490,9 +5484,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 138
+        "w": 12,
+        "x": 12,
+        "y": 130
       },
       "id": 308,
       "options": {
@@ -5555,7 +5549,7 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 157
       },
@@ -5741,9 +5735,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 12,
-        "x": 12,
-        "y": 157
+        "w": 24,
+        "x": 0,
+        "y": 167
       },
       "options": {
         "legend": {
@@ -5951,40 +5945,6 @@
       },
       "pluginVersion": 39,
       "transformations": []
-    },
-    {
-      "id": 314,
-      "type": "logs",
-      "title": "Close Block Logs",
-      "description": "Raw close_block_complete log entries",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 187
-      },
-      "options": {
-        "showTime": true,
-        "showLabels": false,
-        "showCommonLabels": false,
-        "wrapLogMessage": true,
-        "prettifyLogMessage": true,
-        "enableLogDetails": true,
-        "sortOrder": "Descending",
-        "dedupStrategy": "none"
-      },
-      "targets": [
-        {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
-          "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json",
-          "refId": "A"
-        }
-      ]
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1285,10 +1285,10 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Fetch Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Commitments", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Merklization", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Block Hash", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
       ],
       "title": "Close Block Timing Breakdown (Stacked)",
@@ -1468,7 +1468,7 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Total Merklization", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Total Merklization", "refId": "A" },
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Root", "refId": "B" },
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Root", "refId": "C" },
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Storage Trie Commit", "refId": "D" },

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5862,6 +5862,57 @@
       "transformations": []
     },
     {
+      "id": 312,
+      "type": "timeseries",
+      "title": "Close Block Metrics (Loki)",
+      "description": "Close block timing metrics from structured logs (p50)",
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 167
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["lastNotNull", "mean", "max"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "legendFormat": "Close Block Total (p50)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "transformations": []
+    },
+    {
       "id": 311,
       "type": "timeseries",
       "title": "Block Execution Stats (Loki)",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5839,7 +5839,7 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "^$log_field$"
+              "pattern": "^(Time|$log_field)$"
             }
           }
         },

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1285,11 +1285,11 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Fetch Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Commitments", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Merklization", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Block Hash", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Write Block to DB", "refId": "E" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Fetch Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Commitments", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Merklization", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Block Hash", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
       ],
       "title": "Close Block Timing Breakdown (Stacked)",
       "type": "timeseries"
@@ -1442,13 +1442,13 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Fetch Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Commitments", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Merklization", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Block Hash", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Write Block to DB", "refId": "E" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
       ],
-      "title": "Per-Block Exact Timing",
+      "title": "Close Block Timing (Latest Values)",
       "type": "timeseries"
     },
     {
@@ -1468,12 +1468,12 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Total Merklization", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Contract Trie Root", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Class Trie Root", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Storage Trie Commit", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (contract_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Contract Trie Commit", "refId": "E" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (class_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Class Trie Commit", "refId": "F" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Total Merklization", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Root", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Root", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Storage Trie Commit", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Commit", "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Commit", "refId": "F" }
       ],
       "title": "Merklization Deep Dive",
       "type": "timeseries"
@@ -1516,9 +1516,11 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_close_time_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}}", "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum(rate(block_close_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum(rate(block_close_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p95", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_close_time_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Latest", "refId": "C" }
       ],
-      "title": "Block Close Time (per block)",
+      "title": "Block Close Time (Histogram Trends)",
       "type": "timeseries"
     },
     {
@@ -1559,10 +1561,70 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}}", "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum(rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum(rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (le))", "legendFormat": "p95", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Latest", "refId": "C" }
       ],
-      "title": "Merklization (per block)",
+      "title": "Merklization (Histogram Trends)",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 146 },
+      "id": 309,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "block_number" }]
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | __error__=\"\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Close Block Events (Loki)",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "json",
+            "jsonPaths": [
+              { "alias": "block_number", "path": "block_number" },
+              { "alias": "tx_count", "path": "tx_count" },
+              { "alias": "event_count", "path": "event_count" },
+              { "alias": "close_block_total_ms", "path": "close_block_total_ms" },
+              { "alias": "merklization_ms", "path": "merklization_ms" },
+              { "alias": "block_hash_ms", "path": "block_hash_ms" },
+              { "alias": "db_write_ms", "path": "db_write_ms" },
+              { "alias": "state_diff_len", "path": "state_diff_len" }
+            ],
+            "source": "Line"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Line": true, "Time": false, "id": true, "labels": true, "tsNs": true },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "refresh": "5s",
@@ -1571,6 +1633,7 @@
   "templating": {
     "list": [
       { "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" }, "hide": 0, "includeAll": false, "multi": false, "name": "DS_PROMETHEUS", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" },
+      { "current": { "selected": false, "text": "Loki", "value": "Loki" }, "hide": 0, "includeAll": false, "multi": false, "name": "DS_LOKI", "options": [], "query": "loki", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" },
       { "allValue": ".*", "current": { "selected": true, "text": "All", "value": "$__all" }, "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "definition": "label_values(block_produced_no, namespace)", "hide": 0, "includeAll": true, "label": "Namespace", "multi": true, "name": "namespace", "options": [], "query": { "query": "label_values(block_produced_no, namespace)", "refId": "StandardVariableQuery" }, "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query" },
       { "allValue": ".*", "current": { "selected": true, "text": "All", "value": "$__all" }, "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "definition": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)", "hide": 0, "includeAll": true, "label": "Pod", "multi": true, "name": "pod", "options": [], "query": { "query": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)", "refId": "StandardVariableQuery" }, "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query" }
     ]

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1327,6 +1327,56 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Total time to close a block (P50, P95, P99). Note: Bucket boundaries may cause interpolation artifacts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 114 },
+      "id": 307,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Close Block p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Close Block p95", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Close Block p99", "refId": "C" }
+      ],
+      "title": "Close Block Total Duration (P50, P95, P99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Full block production time from start to close (P50, P95, P99)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 114 },
+      "id": 308,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Production p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Production p95", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Production p99", "refId": "C" }
+      ],
+      "title": "Block Production Time (P50, P95, P99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -1337,7 +1387,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 114 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 122 },
       "id": 303,
       "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -64,7 +64,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "1 / rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])", "legendFormat": "Block Interval", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "1 / sum(rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))", "legendFormat": "Block Interval", "refId": "A" }],
       "title": "Block Interval",
       "type": "stat"
     },
@@ -216,7 +216,7 @@
       "pluginVersion": "11.4.0",
       "targets": [
         { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(transaction_counter_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]))", "legendFormat": "TPS", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m]) * 60", "legendFormat": "Blocks/min", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(block_produced_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) * 60", "legendFormat": "Blocks/min", "refId": "B" }
       ],
       "title": "Throughput",
       "type": "timeseries"
@@ -226,7 +226,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 60, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
           "mappings": [],
           "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
           "unit": "ms"
@@ -1285,11 +1285,11 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Fetch Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Commitments", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Merklization", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Block Hash", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Write Block to DB", "refId": "E" }
       ],
       "title": "Close Block Timing Breakdown (Stacked)",
       "type": "timeseries"
@@ -1442,11 +1442,11 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Fetch Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Commitments", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Merklization", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Block Hash", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}} - Write Block to DB", "refId": "E" }
       ],
       "title": "Per-Block Exact Timing",
       "type": "timeseries"
@@ -1468,14 +1468,100 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Total Merklization", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Root", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Root", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Storage Trie Commit", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Commit", "refId": "E" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Commit", "refId": "F" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Total Merklization", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Contract Trie Root", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Class Trie Root", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Storage Trie Commit", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (contract_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Contract Trie Commit", "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max without (block_number) (class_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"})", "legendFormat": "Class Trie Commit", "refId": "F" }
       ],
       "title": "Merklization Deep Dive",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": { "fill": "solid" },
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 130 },
+      "id": 307,
+      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_close_time_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}}", "refId": "A" }
+      ],
+      "title": "Block Close Time (per block)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": { "fill": "solid" },
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 138 },
+      "id": 308,
+      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block {{block_number}}", "refId": "A" }
+      ],
+      "title": "Merklization (per block)",
       "type": "timeseries"
     }
   ],

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4669,7 +4669,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [${__interval}])",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p50",
           "refId": "A"
         },
@@ -4678,7 +4678,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [${__interval}])",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p95",
           "refId": "B"
         },
@@ -4687,7 +4687,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [${__interval}])",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block p99",
           "refId": "C"
         }
@@ -4781,7 +4781,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_production_ms [${__interval}])",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p50",
           "refId": "A"
         },
@@ -4790,7 +4790,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_production_ms [${__interval}])",
+          "expr": "quantile_over_time(0.95, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p95",
           "refId": "B"
         },
@@ -4799,7 +4799,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_production_ms [${__interval}])",
+          "expr": "quantile_over_time(0.99, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_production_ms [$__interval]) by ()",
           "legendFormat": "Block Production p99",
           "refId": "C"
         }
@@ -5604,7 +5604,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap $log_field",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json",
           "queryType": "range",
           "refId": "A"
         }
@@ -5812,35 +5812,35 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Total Close Block",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap merklization_ms [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap merklization_ms [$__interval]) by ()",
           "legendFormat": "Merklization",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap commitments_ms [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap commitments_ms [$__interval]) by ()",
           "legendFormat": "Commitments",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap db_write_ms [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap db_write_ms [$__interval]) by ()",
           "legendFormat": "DB Write",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_hash_ms [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
           "legendFormat": "Block Hash",
           "refId": "E"
         }
@@ -5896,35 +5896,35 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap tx_count [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap tx_count [$__interval]) by ()",
           "legendFormat": "Tx Count",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap event_count [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap event_count [$__interval]) by ()",
           "legendFormat": "Event Count",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap txs_executed [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_executed [$__interval]) by ()",
           "legendFormat": "Txs Executed",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap txs_reverted [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_reverted [$__interval]) by ()",
           "legendFormat": "Txs Reverted",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap state_diff_len [$__interval])",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
           "legendFormat": "State Diff Length",
           "refId": "E"
         }

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -1273,7 +1273,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
           "mappings": [],
           "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
           "unit": "s"
@@ -1282,16 +1282,16 @@
       },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 106 },
       "id": 301,
-      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Total Merklization p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(contract_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Contract Trie p50", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(class_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Class Trie p50", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Commitments p50", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Hash p50", "refId": "E" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
       ],
-      "title": "Close Block Timing Breakdown (p50)",
+      "title": "Close Block Timing Breakdown (Stacked)",
       "type": "timeseries"
     },
     {
@@ -1311,12 +1311,18 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Total Merklization p99", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(contract_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Contract Trie p99", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(class_trie_root_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Class Trie p99", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(close_block_total_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Total Close Block p99", "refId": "D" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(get_full_block_with_classes_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Fetch Block p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(get_full_block_with_classes_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Fetch Block p95", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Commitments p50", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(block_commitments_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Commitments p95", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Merklization p50", "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(apply_to_global_trie_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Merklization p95", "refId": "F" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Hash p50", "refId": "G" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(block_hash_compute_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Block Hash p95", "refId": "H" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(db_write_block_parts_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Write to DB p50", "refId": "I" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(db_write_block_parts_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))", "legendFormat": "Write to DB p95", "refId": "J" }
       ],
-      "title": "Close Block Timing (p99)",
+      "title": "Close Block Percentiles (p50, p95)",
       "type": "timeseries"
     },
     {
@@ -1386,13 +1392,13 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(apply_to_global_trie_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(apply_to_global_trie_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Total Merklization", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(contract_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(contract_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Contract Trie", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(class_trie_root_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(class_trie_root_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Class Trie", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(block_commitments_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(block_commitments_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Commitments", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(block_hash_compute_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(block_hash_compute_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Block Hash", "refId": "E" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "get_full_block_with_classes_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Fetch Block", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_commitments_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Commitments", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Merklization", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "block_hash_compute_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Block Hash", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "db_write_block_parts_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Write Block to DB", "refId": "E" }
       ],
-      "title": "Close Block Timing (Per Block)",
+      "title": "Per-Block Exact Timing",
       "type": "timeseries"
     },
     {
@@ -1412,14 +1418,14 @@
       "options": { "legend": { "calcs": ["lastNotNull", "mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(close_block_total_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(close_block_total_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Total Close Block", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(contract_storage_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(contract_storage_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Storage Trie Commit", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(contract_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(contract_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Contract Trie Commit", "refId": "C" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(class_trie_commit_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(class_trie_commit_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Class Trie Commit", "refId": "D" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(get_full_block_with_classes_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(get_full_block_with_classes_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "Fetch Block+Classes", "refId": "E" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "increase(db_write_block_parts_duration_seconds_sum{namespace=~\"$namespace\", pod=~\"$pod\"}[30s]) / increase(db_write_block_parts_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[30s])", "legendFormat": "DB Write", "refId": "F" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "apply_to_global_trie_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Total Merklization", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Root", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_root_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Root", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_storage_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Storage Trie Commit", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "contract_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Contract Trie Commit", "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "class_trie_commit_last_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}", "legendFormat": "Class Trie Commit", "refId": "F" }
       ],
-      "title": "Close Block Detailed Timing (Per Block)",
+      "title": "Merklization Deep Dive",
       "type": "timeseries"
     }
   ],

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4781,7 +4781,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(block_production_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Block Production p50",
           "refId": "A"
         },
@@ -4790,7 +4790,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(block_production_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Block Production p95",
           "refId": "B"
         },
@@ -4799,7 +4799,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(block_production_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(block_production_time_seconds_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
           "legendFormat": "Block Production p99",
           "refId": "C"
         }

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5848,6 +5848,14 @@
           "options": {
             "conversions": [
               {
+                "targetField": "Time",
+                "destinationType": "time"
+              },
+              {
+                "targetField": "__time",
+                "destinationType": "time"
+              },
+              {
                 "targetField": "$log_field",
                 "destinationType": "number"
               }

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5780,14 +5780,15 @@
     {
       "id": 310,
       "type": "timeseries",
-      "title": "Close Block Metrics (Loki)",
+      "title": "Close Block Timing Breakdown (Loki)",
+      "description": "Per-block timing breakdown extracted from structured logs",
       "datasource": {
         "type": "loki",
         "uid": "${DS_LOKI}"
       },
       "gridPos": {
         "h": 10,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 157
       },
@@ -5809,19 +5810,135 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "loki",
-            "uid": "${DS_LOKI}"
-          },
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\"",
-          "queryType": "range",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap close_block_total_ms [$__interval])",
+          "legendFormat": "Total Close Block",
           "refId": "A"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap merklization_ms [$__interval])",
+          "legendFormat": "Merklization",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap commitments_ms [$__interval])",
+          "legendFormat": "Commitments",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap db_write_ms [$__interval])",
+          "legendFormat": "DB Write",
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap block_hash_ms [$__interval])",
+          "legendFormat": "Block Hash",
+          "refId": "E"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "none"
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "pluginVersion": 39,
+      "transformations": []
+    },
+    {
+      "id": 311,
+      "type": "timeseries",
+      "title": "Block Execution Stats (Loki)",
+      "description": "Per-block execution statistics extracted from structured logs",
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 157
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap tx_count [$__interval])",
+          "legendFormat": "Tx Count",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap event_count [$__interval])",
+          "legendFormat": "Event Count",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap txs_executed [$__interval])",
+          "legendFormat": "Txs Executed",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap txs_reverted [$__interval])",
+          "legendFormat": "Txs Reverted",
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "editorMode": "code",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\", app=~\".+\"} |= \"close_block_complete\" | json | __error__=\"\" | unwrap state_diff_len [$__interval])",
+          "legendFormat": "State Diff Length",
+          "refId": "E"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
         },
         "overrides": []
       },


### PR DESCRIPTION
## Summary
- Add close_block RPC timing metrics with block_number attribute
- Add gauge metrics for exact per-block timing values
- Add comprehensive Grafana dashboards for monitoring

## Metrics Added

### Close Block Timing (with block_number attribute)
- `close_block_total_duration_seconds`
- `apply_to_global_trie_duration_seconds`
- `block_commitments_compute_duration_seconds`
- `block_hash_compute_duration_seconds`
- `db_write_block_parts_duration_seconds`
- `get_full_block_with_classes_duration_seconds`

### Per-Block Exact Values (gauge metrics)
- `*_last_seconds` variants for real-time per-block tracking

### Block Data Gauges (with block_number attribute)
- `block_state_diff_length`, `block_event_count`
- `block_bouncer_*` metrics (l1_gas, sierra_gas, n_events, state_diff_size)
- `block_declared_classes_count`, `block_deployed_contracts_count`, `block_storage_diffs_count`

### Grafana Dashboards
- Close Block Timing Breakdown (Stacked)
- Close Block Percentiles (p50, p95)
- Close Block Total Duration (P50, P95, P99)
- Block Production Time (P50, P95, P99)
- Per-Block Exact Timing
- Merklization Deep Dive
- Block State Diff Stats
- Bouncer Weights

Checkout the grafana at: https://grafana-central.karnot.xyz/d/madara-overview-04/madara-overview?orgId=1&from=now-15m&to=now&timezone=browser&var-log_field=close_block_total_ms&var-DS_PROMETHEUS=P4169E866C3094E38&var-DS_LOKI=aes0yh8jjc7i8b&var-namespace=madara-full-node&var-pod=paradex-testnet-madara-dev-0

PS: ensure your VPN is connected!

changelog: https://www.notion.so/karnot/Deployment-CHANGELOGS-2f52948ec45180078906f381b5023210?source=copy_link#2f52948ec451809494bac15f8d9b9300

🤖 Generated with [Claude Code](https://claude.com/claude-code)