### PR TITLE
chore: updated trie log value from 100 to 10000

### DIFF
--- a/madara/node/src/cli/backend.rs
+++ b/madara/node/src/cli/backend.rs
@@ -71,8 +71,8 @@ pub struct BackendParams {
 
     /// This is the number of blocks for which you can get storage proofs using the storage proof endpoints.
     /// Blocks older than this limit will not be stored for retrieving historical merkle trie state. By default,
-    /// the historical merkle trie state access is limited to 100 blocks by default.
-    #[clap(env = "MADARA_DB_MAX_SAVED_TRIE_LOGS", long, default_value = Some("100"))]
+    /// the historical merkle trie state access is limited to 10000 blocks by default.
+    #[clap(env = "MADARA_DB_MAX_SAVED_TRIE_LOGS", long, default_value = Some("10000"))]
     pub db_max_saved_trie_logs: Option<usize>,
 
     /// This affects the performance of the storage proof endpoint.


### PR DESCRIPTION
by default we are keeping the trie logs of 100 blocks, updating it to 10000 for better reorg adaptability! 

notion update: https://www.notion.so/karnot/Deployment-CHANGELOGS-2f52948ec45180078906f381b5023210?source=copy_link#2f62948ec45180399045fe7a6c110a45