### PR TITLE
perf: remove redundant L1Handler clone in gateway block

### DIFF
--- a/madara/crates/primitives/gateway/src/block.rs
+++ b/madara/crates/primitives/gateway/src/block.rs
@@ -92,7 +92,7 @@ impl ProviderBlock {
             .map(|(index, tx)| {
                 let l1_to_l2_consumed_message = match &tx.transaction {
                     mp_block::Transaction::L1Handler(l1_handler) => {
-                        mp_receipt::MsgToL2::try_from(&l1_handler.clone()).ok()
+                        mp_receipt::MsgToL2::try_from(l1_handler).ok()
                     }
                     _ => None,
                 };
@@ -217,7 +217,7 @@ impl ProviderBlockPreConfirmed {
             .map(|(index, (tx, state_diff))| {
                 let l1_to_l2_consumed_message = match &tx.transaction {
                     mp_block::Transaction::L1Handler(l1_handler) => {
-                        mp_receipt::MsgToL2::try_from(&l1_handler.clone()).ok()
+                        mp_receipt::MsgToL2::try_from(l1_handler).ok()
                     }
                     _ => None,
                 };


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

- [x] Other (please describe): optimization

## What is the current behavior?

Before these changes, we were cloning L1HandlerTransaction before calling MsgToL2::try_from, even though the conversion only needs an immutable reference. This caused unnecessary struct cloning and Arc refcount operations for every L1 handler transaction without any behavioral benefit.

## What is the new behavior?

This change passes the existing &L1HandlerTransaction directly to MsgToL2::try_from in ProviderBlock::new and ProviderBlockPreConfirmed::new, avoiding the extra clone while keeping the logic and output fully unchanged.

-
-
-

