### PR TITLE
fix(db): disable RocksDB snapshots by default

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -99,7 +99,7 @@ ETHEREUM_SETTLEMENT_TXN_WAIT_SLEEP_DELAY_SECS=60
 
 #### SERVICE ####
 
-MADARA_ORCHESTRATOR_MADARA_RPC_URL=https://pathfinder-madara-ci.d.karnot.xyz
+MADARA_ORCHESTRATOR_MADARA_RPC_URL=https://pathfinder-sepolia.d.karnot.xyz
 # It's fine to use dummy for tests as it's not being used.
 MADARA_ORCHESTRATOR_MADARA_FEEDER_GATEWAY_URL=http://localhost:8080
 

--- a/.github/workflows/task-test-cli.yml
+++ b/.github/workflows/task-test-cli.yml
@@ -20,16 +20,16 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: madara-${{ runner.os }}
       - name: Run cli without arguments
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           CARGO_TARGET_DIR=target cargo run --manifest-path madara/Cargo.toml --bin madara --release -- --no-l1-sync --devnet &
           MADARA_PID=$!
-          while ! echo exit | nc localhost 9944; do sleep 1; done
+          while ! curl -s -X POST http://localhost:9944 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"starknet_chainId","params":[],"id":1}' | grep -q result; do sleep 1; done
           kill $MADARA_PID
       - name: Run cli pointing to a file
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           CARGO_TARGET_DIR=target cargo run --manifest-path madara/Cargo.toml --bin madara --release -- --no-l1-sync --devnet --config-file ./configs/args/config.json &
           MADARA_PID=$!
-          while ! echo exit | nc localhost 9944; do sleep 1; done
+          while ! curl -s -X POST http://localhost:9944 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"starknet_chainId","params":[],"id":1}' | grep -q result; do sleep 1; done
           kill $MADARA_PID

--- a/madara/crates/client/db/src/rocksdb/options.rs
+++ b/madara/crates/client/db/src/rocksdb/options.rs
@@ -251,7 +251,7 @@ impl Default for RocksDBConfig {
             memtable_other_budget_bytes: 128 * MiB,
             memtable_prefix_bloom_filter_ratio: 0.0,
             max_saved_trie_logs: None,
-            max_kept_snapshots: None,
+            max_kept_snapshots: Some(0),
             snapshot_interval: 5,
             backup_dir: None,
             restore_from_latest_backup: false,

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -198,5 +198,4 @@ mod tests {
             assert_eq!(block_n, Some(expected_block), "Snapshot at block {} should exist", expected_block);
         }
     }
-
 }

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -199,35 +199,4 @@ mod tests {
         }
     }
 
-    /// Verify snapshot_interval behavior: snapshots are only created at interval boundaries.
-    #[test]
-    fn test_snapshot_interval_behavior() {
-        let (_temp_dir, db) = create_test_db();
-
-        // Create snapshots with max_kept_snapshots = None, interval = 10
-        let snapshots = Snapshots::new(db, None, None, 10);
-
-        // Add blocks 0-35
-        for block_n in 0..36 {
-            snapshots.set_new_head(block_n);
-        }
-
-        // Should have 4 snapshots (at 0, 10, 20, 30)
-        assert_eq!(
-            snapshots.inner.read().expect("Poisoned lock").historical.len(),
-            4,
-            "Snapshots should only be created at interval boundaries"
-        );
-
-        // Verify snapshots at exact intervals
-        let (block_n, _) = snapshots.get_closest(0);
-        assert_eq!(block_n, Some(0));
-
-        let (block_n, _) = snapshots.get_closest(10);
-        assert_eq!(block_n, Some(10));
-
-        // Block 15 should return snapshot at 20 (closest >= 15)
-        let (block_n, _) = snapshots.get_closest(15);
-        assert_eq!(block_n, Some(20), "get_closest should return the next available snapshot");
-    }
 }

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -45,6 +45,13 @@ impl Snapshots {
         }
     }
 
+    /// Returns the number of historical snapshots currently stored.
+    /// This is primarily useful for testing snapshot limit behavior.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn historical_count(&self) -> usize {
+        self.inner.read().expect("Poisoned lock").historical.len()
+    }
+
     /// Called when a new block has been added in the database. This will make a snapshot
     /// on top of the new block, and it will store that snapshot in the snapshot history every
     /// `snapshot_interval` blocks.
@@ -84,5 +91,134 @@ impl Snapshots {
             // If none was found, this means that we are asking for a block that's between the last snapshot and the current latest block, or
             // snapshots are disabled. In these cases we want to return the snapshot for the current latest block.
             .unwrap_or_else(|| (inner.head_block_n, Arc::clone(&inner.head)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rocksdb::{column::ALL_COLUMNS, options::rocksdb_global_options, RocksDBConfig};
+    use rocksdb::{ColumnFamilyDescriptor, DBWithThreadMode, MultiThreaded, WriteOptions};
+
+    /// Helper to create a test RocksDBStorageInner with a temporary directory.
+    fn create_test_db() -> (tempfile::TempDir, Arc<RocksDBStorageInner>) {
+        let temp_dir = tempfile::TempDir::with_prefix("snapshot-test").unwrap();
+        let config = RocksDBConfig::default();
+        let opts = rocksdb_global_options(&config).unwrap();
+        let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
+            &opts,
+            temp_dir.path(),
+            ALL_COLUMNS.iter().map(|col| ColumnFamilyDescriptor::new(col.rocksdb_name, col.rocksdb_options(&config))),
+        )
+        .unwrap();
+        let writeopts = WriteOptions::default();
+        let inner = Arc::new(RocksDBStorageInner { db, writeopts, config });
+        (temp_dir, inner)
+    }
+
+    /// When `max_kept_snapshots = Some(0)`, no snapshots should be created in historical.
+    /// This verifies that snapshots are effectively disabled with the new default.
+    #[test]
+    fn test_snapshots_disabled_when_zero() {
+        let (_temp_dir, db) = create_test_db();
+
+        // Create snapshots with max_kept_snapshots = Some(0) (disabled)
+        let snapshots = Snapshots::new(db, None, Some(0), 5);
+
+        // Simulate adding blocks at snapshot intervals
+        for block_n in 0..20 {
+            snapshots.set_new_head(block_n);
+        }
+
+        // No historical snapshots should be created when max_kept_snapshots is 0
+        assert_eq!(snapshots.historical_count(), 0, "No historical snapshots should exist when max_kept_snapshots=0");
+
+        // get_closest should still return the head snapshot
+        let (block_n, _snapshot) = snapshots.get_closest(10);
+        assert_eq!(block_n, Some(19), "Should return head block when snapshots are disabled");
+    }
+
+    /// When `max_kept_snapshots = Some(n)`, only n snapshots should be kept.
+    /// Oldest snapshots are removed first (FIFO behavior).
+    #[test]
+    fn test_snapshots_limited_to_max() {
+        let (_temp_dir, db) = create_test_db();
+
+        // Create snapshots with max_kept_snapshots = Some(3), interval = 5
+        let snapshots = Snapshots::new(db, None, Some(3), 5);
+
+        // Add blocks 0-24 (snapshots at 0, 5, 10, 15, 20)
+        for block_n in 0..25 {
+            snapshots.set_new_head(block_n);
+        }
+
+        // Should have exactly 3 snapshots (the limit)
+        assert_eq!(snapshots.historical_count(), 3, "Should have exactly max_kept_snapshots historical snapshots");
+
+        // The oldest snapshots (0, 5) should have been removed, keeping 10, 15, 20
+        let (block_n, _) = snapshots.get_closest(0);
+        // Since snapshot at 0 is removed, get_closest(0) should return the next available (10)
+        assert_eq!(block_n, Some(10), "Oldest snapshots should be removed first");
+
+        // Verify the kept snapshots
+        let (block_n, _) = snapshots.get_closest(10);
+        assert_eq!(block_n, Some(10), "Snapshot at block 10 should exist");
+
+        let (block_n, _) = snapshots.get_closest(15);
+        assert_eq!(block_n, Some(15), "Snapshot at block 15 should exist");
+
+        let (block_n, _) = snapshots.get_closest(20);
+        assert_eq!(block_n, Some(20), "Snapshot at block 20 should exist");
+    }
+
+    /// When `max_kept_snapshots = None`, snapshots accumulate without limit.
+    #[test]
+    fn test_snapshots_unlimited_when_none() {
+        let (_temp_dir, db) = create_test_db();
+
+        // Create snapshots with max_kept_snapshots = None (unlimited), interval = 5
+        let snapshots = Snapshots::new(db, None, None, 5);
+
+        // Add blocks 0-49 (snapshots at 0, 5, 10, 15, 20, 25, 30, 35, 40, 45)
+        for block_n in 0..50 {
+            snapshots.set_new_head(block_n);
+        }
+
+        // Should have 10 snapshots (one every 5 blocks from 0 to 45)
+        assert_eq!(snapshots.historical_count(), 10, "All snapshots should be retained when max_kept_snapshots=None");
+
+        // All snapshots should be accessible
+        for expected_block in (0..50).step_by(5) {
+            let (block_n, _) = snapshots.get_closest(expected_block);
+            assert_eq!(block_n, Some(expected_block), "Snapshot at block {} should exist", expected_block);
+        }
+    }
+
+    /// Verify snapshot_interval behavior: snapshots are only created at interval boundaries.
+    #[test]
+    fn test_snapshot_interval_behavior() {
+        let (_temp_dir, db) = create_test_db();
+
+        // Create snapshots with max_kept_snapshots = None, interval = 10
+        let snapshots = Snapshots::new(db, None, None, 10);
+
+        // Add blocks 0-35
+        for block_n in 0..36 {
+            snapshots.set_new_head(block_n);
+        }
+
+        // Should have 4 snapshots (at 0, 10, 20, 30)
+        assert_eq!(snapshots.historical_count(), 4, "Snapshots should only be created at interval boundaries");
+
+        // Verify snapshots at exact intervals
+        let (block_n, _) = snapshots.get_closest(0);
+        assert_eq!(block_n, Some(0));
+
+        let (block_n, _) = snapshots.get_closest(10);
+        assert_eq!(block_n, Some(10));
+
+        // Block 15 should return snapshot at 20 (closest >= 15)
+        let (block_n, _) = snapshots.get_closest(15);
+        assert_eq!(block_n, Some(20), "get_closest should return the next available snapshot");
     }
 }

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -45,13 +45,6 @@ impl Snapshots {
         }
     }
 
-    /// Returns the number of historical snapshots currently stored.
-    /// This is primarily useful for testing snapshot limit behavior.
-    #[cfg(any(test, feature = "testing"))]
-    pub fn historical_count(&self) -> usize {
-        self.inner.read().expect("Poisoned lock").historical.len()
-    }
-
     /// Called when a new block has been added in the database. This will make a snapshot
     /// on top of the new block, and it will store that snapshot in the snapshot history every
     /// `snapshot_interval` blocks.
@@ -131,7 +124,11 @@ mod tests {
         }
 
         // No historical snapshots should be created when max_kept_snapshots is 0
-        assert_eq!(snapshots.historical_count(), 0, "No historical snapshots should exist when max_kept_snapshots=0");
+        assert_eq!(
+            snapshots.inner.read().expect("Poisoned lock").historical.len(),
+            0,
+            "No historical snapshots should exist when max_kept_snapshots=0"
+        );
 
         // get_closest should still return the head snapshot
         let (block_n, _snapshot) = snapshots.get_closest(10);
@@ -153,7 +150,11 @@ mod tests {
         }
 
         // Should have exactly 3 snapshots (the limit)
-        assert_eq!(snapshots.historical_count(), 3, "Should have exactly max_kept_snapshots historical snapshots");
+        assert_eq!(
+            snapshots.inner.read().expect("Poisoned lock").historical.len(),
+            3,
+            "Should have exactly max_kept_snapshots historical snapshots"
+        );
 
         // The oldest snapshots (0, 5) should have been removed, keeping 10, 15, 20
         let (block_n, _) = snapshots.get_closest(0);
@@ -185,7 +186,11 @@ mod tests {
         }
 
         // Should have 10 snapshots (one every 5 blocks from 0 to 45)
-        assert_eq!(snapshots.historical_count(), 10, "All snapshots should be retained when max_kept_snapshots=None");
+        assert_eq!(
+            snapshots.inner.read().expect("Poisoned lock").historical.len(),
+            10,
+            "All snapshots should be retained when max_kept_snapshots=None"
+        );
 
         // All snapshots should be accessible
         for expected_block in (0..50).step_by(5) {
@@ -208,7 +213,11 @@ mod tests {
         }
 
         // Should have 4 snapshots (at 0, 10, 20, 30)
-        assert_eq!(snapshots.historical_count(), 4, "Snapshots should only be created at interval boundaries");
+        assert_eq!(
+            snapshots.inner.read().expect("Poisoned lock").historical.len(),
+            4,
+            "Snapshots should only be created at interval boundaries"
+        );
 
         // Verify snapshots at exact intervals
         let (block_n, _) = snapshots.get_closest(0);

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -89,49 +89,36 @@ impl Snapshots {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::rocksdb::{column::ALL_COLUMNS, options::rocksdb_global_options, RocksDBConfig};
-    use rocksdb::{ColumnFamilyDescriptor, DBWithThreadMode, MultiThreaded, WriteOptions};
+    use crate::rocksdb::{RocksDBConfig, RocksDBStorage};
 
-    /// Helper to create a test RocksDBStorageInner with a temporary directory.
-    fn create_test_db() -> (tempfile::TempDir, Arc<RocksDBStorageInner>) {
+    fn create_test_storage(config: RocksDBConfig) -> (tempfile::TempDir, RocksDBStorage) {
         let temp_dir = tempfile::TempDir::with_prefix("snapshot-test").unwrap();
-        let config = RocksDBConfig::default();
-        let opts = rocksdb_global_options(&config).unwrap();
-        let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
-            &opts,
-            temp_dir.path(),
-            ALL_COLUMNS.iter().map(|col| ColumnFamilyDescriptor::new(col.rocksdb_name, col.rocksdb_options(&config))),
-        )
-        .unwrap();
-        let writeopts = WriteOptions::default();
-        let inner = Arc::new(RocksDBStorageInner { db, writeopts, config });
-        (temp_dir, inner)
+        let storage = RocksDBStorage::open(temp_dir.path(), config).unwrap();
+        (temp_dir, storage)
     }
 
     /// When `max_kept_snapshots = Some(0)`, no snapshots should be created in historical.
     /// This verifies that snapshots are effectively disabled with the new default.
     #[test]
     fn test_snapshots_disabled_when_zero() {
-        let (_temp_dir, db) = create_test_db();
-
-        // Create snapshots with max_kept_snapshots = Some(0) (disabled)
-        let snapshots = Snapshots::new(db, None, Some(0), 5);
+        let config = RocksDBConfig::default();
+        assert_eq!(config.max_kept_snapshots, Some(0), "Default config should disable snapshots");
+        let (_temp_dir, storage) = create_test_storage(config);
 
         // Simulate adding blocks at snapshot intervals
         for block_n in 0..20 {
-            snapshots.set_new_head(block_n);
+            storage.snapshots.set_new_head(block_n);
         }
 
         // No historical snapshots should be created when max_kept_snapshots is 0
         assert_eq!(
-            snapshots.inner.read().expect("Poisoned lock").historical.len(),
+            storage.snapshots.inner.read().expect("Poisoned lock").historical.len(),
             0,
             "No historical snapshots should exist when max_kept_snapshots=0"
         );
 
         // get_closest should still return the head snapshot
-        let (block_n, _snapshot) = snapshots.get_closest(10);
+        let (block_n, _snapshot) = storage.snapshots.get_closest(10);
         assert_eq!(block_n, Some(19), "Should return head block when snapshots are disabled");
     }
 
@@ -139,62 +126,58 @@ mod tests {
     /// Oldest snapshots are removed first (FIFO behavior).
     #[test]
     fn test_snapshots_limited_to_max() {
-        let (_temp_dir, db) = create_test_db();
-
-        // Create snapshots with max_kept_snapshots = Some(3), interval = 5
-        let snapshots = Snapshots::new(db, None, Some(3), 5);
+        let config = RocksDBConfig { max_kept_snapshots: Some(3), snapshot_interval: 5, ..Default::default() };
+        let (_temp_dir, storage) = create_test_storage(config);
 
         // Add blocks 0-24 (snapshots at 0, 5, 10, 15, 20)
         for block_n in 0..25 {
-            snapshots.set_new_head(block_n);
+            storage.snapshots.set_new_head(block_n);
         }
 
         // Should have exactly 3 snapshots (the limit)
         assert_eq!(
-            snapshots.inner.read().expect("Poisoned lock").historical.len(),
+            storage.snapshots.inner.read().expect("Poisoned lock").historical.len(),
             3,
             "Should have exactly max_kept_snapshots historical snapshots"
         );
 
         // The oldest snapshots (0, 5) should have been removed, keeping 10, 15, 20
-        let (block_n, _) = snapshots.get_closest(0);
+        let (block_n, _) = storage.snapshots.get_closest(0);
         // Since snapshot at 0 is removed, get_closest(0) should return the next available (10)
         assert_eq!(block_n, Some(10), "Oldest snapshots should be removed first");
 
         // Verify the kept snapshots
-        let (block_n, _) = snapshots.get_closest(10);
+        let (block_n, _) = storage.snapshots.get_closest(10);
         assert_eq!(block_n, Some(10), "Snapshot at block 10 should exist");
 
-        let (block_n, _) = snapshots.get_closest(15);
+        let (block_n, _) = storage.snapshots.get_closest(15);
         assert_eq!(block_n, Some(15), "Snapshot at block 15 should exist");
 
-        let (block_n, _) = snapshots.get_closest(20);
+        let (block_n, _) = storage.snapshots.get_closest(20);
         assert_eq!(block_n, Some(20), "Snapshot at block 20 should exist");
     }
 
     /// When `max_kept_snapshots = None`, snapshots accumulate without limit.
     #[test]
     fn test_snapshots_unlimited_when_none() {
-        let (_temp_dir, db) = create_test_db();
-
-        // Create snapshots with max_kept_snapshots = None (unlimited), interval = 5
-        let snapshots = Snapshots::new(db, None, None, 5);
+        let config = RocksDBConfig { max_kept_snapshots: None, snapshot_interval: 5, ..Default::default() };
+        let (_temp_dir, storage) = create_test_storage(config);
 
         // Add blocks 0-49 (snapshots at 0, 5, 10, 15, 20, 25, 30, 35, 40, 45)
         for block_n in 0..50 {
-            snapshots.set_new_head(block_n);
+            storage.snapshots.set_new_head(block_n);
         }
 
         // Should have 10 snapshots (one every 5 blocks from 0 to 45)
         assert_eq!(
-            snapshots.inner.read().expect("Poisoned lock").historical.len(),
+            storage.snapshots.inner.read().expect("Poisoned lock").historical.len(),
             10,
             "All snapshots should be retained when max_kept_snapshots=None"
         );
 
         // All snapshots should be accessible
         for expected_block in (0..50).step_by(5) {
-            let (block_n, _) = snapshots.get_closest(expected_block);
+            let (block_n, _) = storage.snapshots.get_closest(expected_block);
             assert_eq!(block_n, Some(expected_block), "Snapshot at block {} should exist", expected_block);
         }
     }


### PR DESCRIPTION
## Summary

- Change `max_kept_snapshots` default from `None` (unlimited) to `Some(0)` (disabled)
- Prevents unbounded memory growth from accumulating snapshots

## Problem

With the previous default of `None`:
- Snapshots were created every `snapshot_interval` blocks (default: 5)
- Snapshots were **never cleaned up** (cleanup only runs when `is_some_and()` returns true)
- For a node syncing from genesis with 600k+ blocks: **120,000+ snapshots** would accumulate in memory

## Solution

Setting default to `Some(0)` disables snapshot creation entirely. Users who need snapshots for storage proofs can explicitly enable them via `--db-max-kept-snapshots`.

## Behavior Summary

| `max_kept_snapshots` | Snapshot Creation | Cleanup | Result |
|---------------------|-------------------|---------|--------|
| `None` (old default) | ✅ Yes | ❌ Never | **Unlimited accumulation** |
| `Some(0)` (new default) | ❌ No | N/A | **Disabled** |
| `Some(n)` where n > 0 | ✅ Yes | ✅ When > n | **Limited to n** |

## CI

- `test-cli`: increase step timeout to 20 minutes and wait for JSON-RPC `starknet_chainId` to return before killing the process.

## Test plan

- [ ] Verify node starts without snapshots by default
- [ ] Verify `--db-max-kept-snapshots N` enables snapshots with limit

🤖 Generated with [Claude Code](https://claude.ai/code)
