### PR TITLE
fix: restore L1->L2 messages with correct fee during chain revert

### DIFF
--- a/madara/crates/client/db/src/rocksdb/blocks.rs
+++ b/madara/crates/client/db/src/rocksdb/blocks.rs
@@ -395,11 +395,11 @@ impl RocksDBStorageInner {
                 );
             }
 
-            // TODO: No sure how to implement the same for the L2 Network
-            // self.message_to_l2_remove_txns(
-            //     transactions.iter().filter_map(|v| v.transaction.as_l1_handler()).map(|tx| tx.nonce),
-            //     &mut batch,
-            // )?;
+            // Restore L1->L2 messages to pending and remove their consumed mapping.
+            self.messages_to_l2_restore_pending(
+                transactions.iter().filter_map(|v| v.transaction.as_l1_handler()),
+                &mut batch,
+            )?;
 
             tracing::debug!(
                 "📦 REORG [block_db_revert]: Removing {} transactions from block {}",

--- a/madara/crates/client/db/src/rocksdb/column.rs
+++ b/madara/crates/client/db/src/rocksdb/column.rs
@@ -31,6 +31,7 @@ pub const ALL_COLUMNS: &[Column] = &[
     super::meta::PRECONFIRMED_COLUMN,
     super::l1_to_l2_messages::L1_TO_L2_PENDING_MESSAGE_BY_NONCE,
     super::l1_to_l2_messages::L1_TO_L2_TXN_HASH_BY_NONCE,
+    super::l1_to_l2_messages::L1_TO_L2_PAID_FEE_BY_NONCE,
     super::mempool::MEMPOOL_TRANSACTIONS_COLUMN,
     super::trie::BONSAI_CONTRACT_FLAT_COLUMN,
     super::trie::BONSAI_CONTRACT_TRIE_COLUMN,

--- a/madara/crates/client/db/src/rocksdb/l1_to_l2_messages.rs
+++ b/madara/crates/client/db/src/rocksdb/l1_to_l2_messages.rs
@@ -12,19 +12,34 @@ pub const L1_TO_L2_PENDING_MESSAGE_BY_NONCE: Column =
     Column::new("l1_to_l2_pending_message_by_nonce").set_point_lookup();
 /// <core_contract_nonce 8 bytes> => txn hash
 pub const L1_TO_L2_TXN_HASH_BY_NONCE: Column = Column::new("l1_to_l2_txn_hash_by_nonce").set_point_lookup();
+/// <core_contract_nonce 8 bytes> => paid_fee_on_l1 (u128 as 16 bytes big-endian)
+pub const L1_TO_L2_PAID_FEE_BY_NONCE: Column = Column::new("l1_to_l2_paid_fee_by_nonce").set_point_lookup();
+
+// Fallback fee used when re-inserting pending L1->L2 messages during a revert
+// when the fee is not found in storage (for messages confirmed before this fix).
+const REVERT_PENDING_FEE_ON_L1_FALLBACK: u128 = 1_000_000_000_000;
 
 impl RocksDBStorageInner {
     /// Also removed the given txns from the pending column.
-    pub(super) fn messages_to_l2_write_trasactions<'a>(
+    /// Stores the paid_fee_on_l1 from pending messages so it can be recovered during revert.
+    pub(super) fn messages_to_l2_write_transactions<'a>(
         &self,
         txs: impl IntoIterator<Item = (&'a L1HandlerTransaction, &'a L1HandlerTransactionReceipt)>,
     ) -> Result<()> {
         let mut batch = WriteBatchWithTransaction::default();
         let pending_cf = self.get_column(L1_TO_L2_PENDING_MESSAGE_BY_NONCE);
         let on_l2_cf = self.get_column(L1_TO_L2_TXN_HASH_BY_NONCE);
+        let fee_cf = self.get_column(L1_TO_L2_PAID_FEE_BY_NONCE);
 
         for (txn, receipt) in txs {
             let key = txn.nonce.to_be_bytes();
+
+            // Read the pending message to get the paid_fee_on_l1 before deleting
+            if let Some(pending_msg) = self.get_pending_message_to_l2(txn.nonce)? {
+                // Store the fee so we can recover it during revert
+                batch.put_cf(&fee_cf, key, pending_msg.paid_fee_on_l1.to_be_bytes());
+            }
+
             batch.delete_cf(&pending_cf, key);
             batch.put_cf(&on_l2_cf, key, receipt.transaction_hash.to_bytes_be());
         }
@@ -79,6 +94,52 @@ impl RocksDBStorageInner {
     pub(super) fn write_l1_handler_txn_hash_by_nonce(&self, core_contract_nonce: u64, txn_hash: &Felt) -> Result<()> {
         let on_l2_cf = self.get_column(L1_TO_L2_TXN_HASH_BY_NONCE);
         self.db.put_cf_opt(&on_l2_cf, core_contract_nonce.to_be_bytes(), txn_hash.to_bytes_be(), &self.writeopts)?;
+        Ok(())
+    }
+
+    /// Get the paid_fee_on_l1 for a confirmed L1 handler transaction by its nonce.
+    pub(super) fn get_l1_handler_paid_fee_by_nonce(&self, core_contract_nonce: u64) -> Result<Option<u128>> {
+        let fee_cf = self.get_column(L1_TO_L2_PAID_FEE_BY_NONCE);
+        let Some(res) = self.db.get_pinned_cf(&fee_cf, core_contract_nonce.to_be_bytes())? else {
+            return Ok(None);
+        };
+        let bytes: [u8; 16] = res[..].try_into().context("Deserializing paid_fee_on_l1")?;
+        Ok(Some(u128::from_be_bytes(bytes)))
+    }
+
+    /// Restore L1->L2 messages as pending during a revert.
+    ///
+    /// This removes the consumed mapping (nonce -> tx hash) and re-inserts the
+    /// message into the pending column so it can be re-processed if still valid on L1.
+    /// Uses the stored paid_fee_on_l1 if available, otherwise falls back to a default value.
+    pub(super) fn messages_to_l2_restore_pending<'a>(
+        &self,
+        txs: impl IntoIterator<Item = &'a L1HandlerTransaction>,
+        batch: &mut WriteBatchWithTransaction,
+    ) -> Result<()> {
+        let pending_cf = self.get_column(L1_TO_L2_PENDING_MESSAGE_BY_NONCE);
+        let on_l2_cf = self.get_column(L1_TO_L2_TXN_HASH_BY_NONCE);
+        let fee_cf = self.get_column(L1_TO_L2_PAID_FEE_BY_NONCE);
+
+        for tx in txs {
+            let nonce_bytes = tx.nonce.to_be_bytes();
+
+            // Get the stored paid_fee_on_l1, falling back to default if not found
+            // (for messages confirmed before this fix was implemented)
+            let paid_fee_on_l1 =
+                self.get_l1_handler_paid_fee_by_nonce(tx.nonce)?.unwrap_or(REVERT_PENDING_FEE_ON_L1_FALLBACK);
+
+            // Remove consumed mapping (nonce -> tx hash)
+            batch.delete_cf(&on_l2_cf, nonce_bytes);
+
+            // Remove the stored fee (it will be re-stored when confirmed again)
+            batch.delete_cf(&fee_cf, nonce_bytes);
+
+            // Re-insert as pending with the actual paid_fee_on_l1
+            let pending = L1HandlerTransactionWithFee::new(tx.clone(), paid_fee_on_l1);
+            batch.put_cf(&pending_cf, nonce_bytes, super::serialize(&pending)?);
+        }
+
         Ok(())
     }
 

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -380,7 +380,7 @@ impl MadaraStorageWrite for RocksDBStorage {
         tracing::debug!("Writing transactions {block_n}");
         // Save l1 core contract nonce to tx mapping.
         self.inner
-            .messages_to_l2_write_trasactions(
+            .messages_to_l2_write_transactions(
                 txs.iter().filter_map(|v| v.transaction.as_l1_handler().zip(v.receipt.as_l1_handler())),
             )
             .with_context(|| format!("Updating L1 state when storing transactions for block_n={block_n}"))?;

--- a/madara/crates/client/db/src/tests/mod.rs
+++ b/madara/crates/client/db/src/tests/mod.rs
@@ -1,3 +1,4 @@
 #![cfg(any(test, feature = "testing"))]
 pub mod test_migration;
 pub mod test_open;
+pub mod test_revert_l1_messages;

--- a/madara/crates/client/db/src/tests/test_block.rs
+++ b/madara/crates/client/db/src/tests/test_block.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-#[tokio::test]
-async fn test_chain_info() {
-    let db = MadaraBackend::open_for_testing(ChainConfig::madara_test().into());
-    let chain_config = db.chain_config();
-    assert_eq!(chain_config.chain_id, ChainConfig::madara_test().chain_id);
-}

--- a/madara/crates/client/db/src/tests/test_revert_l1_messages.rs
+++ b/madara/crates/client/db/src/tests/test_revert_l1_messages.rs
@@ -1,0 +1,145 @@
+#![cfg(test)]
+
+use anyhow::Result;
+use mp_block::header::{BlockTimestamp, GasPrices, PreconfirmedHeader};
+use mp_block::FullBlockWithoutCommitments;
+use mp_block::TransactionWithReceipt;
+use mp_chain_config::ChainConfig;
+use mp_convert::{Felt, ToFelt};
+use mp_receipt::{Hash256, L1HandlerTransactionReceipt};
+use mp_transactions::{L1HandlerTransaction, L1HandlerTransactionWithFee, Transaction};
+use std::sync::Arc;
+
+use crate::{storage::MadaraStorageRead, ChainTip, MadaraBackend};
+
+fn make_l1_handler_tx(nonce: u64) -> L1HandlerTransaction {
+    L1HandlerTransaction {
+        version: Felt::ZERO,
+        nonce,
+        contract_address: Felt::from(123u128),
+        entry_point_selector: Felt::from(456u128),
+        calldata: vec![Felt::from(789u128)].into(),
+    }
+}
+
+fn make_l1_handler_tx_with_receipt(
+    chain_id: Felt,
+    protocol_version: mp_chain_config::StarknetVersion,
+    nonce: u64,
+) -> TransactionWithReceipt {
+    let tx = make_l1_handler_tx(nonce);
+
+    let tx_hash = Transaction::L1Handler(tx.clone()).compute_hash(chain_id, protocol_version, false);
+
+    let receipt = L1HandlerTransactionReceipt {
+        message_hash: Hash256::from_bytes([0u8; 32]),
+        transaction_hash: tx_hash,
+        actual_fee: Default::default(),
+        messages_sent: vec![],
+        events: vec![],
+        execution_resources: Default::default(),
+        execution_result: Default::default(),
+    };
+
+    TransactionWithReceipt { transaction: Transaction::L1Handler(tx), receipt: receipt.into() }
+}
+
+fn make_block(
+    chain_config: &ChainConfig,
+    block_number: u64,
+    transactions: Vec<TransactionWithReceipt>,
+) -> FullBlockWithoutCommitments {
+    FullBlockWithoutCommitments {
+        header: PreconfirmedHeader {
+            block_number,
+            sequencer_address: Felt::ZERO,
+            block_timestamp: BlockTimestamp(0),
+            protocol_version: chain_config.latest_protocol_version,
+            gas_prices: GasPrices::default(),
+            l1_da_mode: chain_config.l1_da_mode,
+        },
+        state_diff: Default::default(),
+        transactions,
+        events: vec![],
+    }
+}
+
+#[test]
+fn test_revert_restores_l1_to_l2_messages() -> Result<()> {
+    let chain_config = Arc::new(ChainConfig::madara_test());
+    let backend = MadaraBackend::open_for_testing(chain_config.clone());
+
+    let chain_id = chain_config.chain_id.to_felt();
+    let protocol_version = chain_config.latest_protocol_version;
+
+    let block0 = make_block(&chain_config, 0, vec![make_l1_handler_tx_with_receipt(chain_id, protocol_version, 1)]);
+    let block0_hash = backend.write_access().add_full_block_with_classes(&block0, &[], false)?.block_hash;
+
+    let block1 = make_block(&chain_config, 1, vec![make_l1_handler_tx_with_receipt(chain_id, protocol_version, 2)]);
+    backend.write_access().add_full_block_with_classes(&block1, &[], false)?;
+
+    assert!(backend.get_l1_handler_txn_hash_by_nonce(1)?.is_some());
+    assert!(backend.get_l1_handler_txn_hash_by_nonce(2)?.is_some());
+    assert!(backend.get_pending_message_to_l2(2)?.is_none());
+
+    backend.revert_to(&block0_hash)?;
+    let fresh_chain_tip = backend.db.get_chain_tip()?;
+    backend.chain_tip.send_replace(ChainTip::from_storage(fresh_chain_tip));
+
+    assert!(backend.get_l1_handler_txn_hash_by_nonce(2)?.is_none());
+    let pending = backend.get_pending_message_to_l2(2)?.expect("pending L1->L2 message should be restored");
+    assert_eq!(pending.tx.nonce, 2);
+
+    assert!(backend.get_l1_handler_txn_hash_by_nonce(1)?.is_some());
+    assert!(backend.get_pending_message_to_l2(1)?.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn test_revert_restores_l1_to_l2_messages_with_correct_fee() -> Result<()> {
+    let chain_config = Arc::new(ChainConfig::madara_test());
+    let backend = MadaraBackend::open_for_testing(chain_config.clone());
+
+    let chain_id = chain_config.chain_id.to_felt();
+    let protocol_version = chain_config.latest_protocol_version;
+
+    // First, write pending messages with specific fees (simulating L1 event processing)
+    let fee_for_nonce_1 = 1_000_000_000_u128; // 1 gwei
+    let fee_for_nonce_2 = 2_500_000_000_u128; // 2.5 gwei
+
+    let msg1 = L1HandlerTransactionWithFee::new(make_l1_handler_tx(1), fee_for_nonce_1);
+    let msg2 = L1HandlerTransactionWithFee::new(make_l1_handler_tx(2), fee_for_nonce_2);
+
+    backend.write_pending_message_to_l2(&msg1)?;
+    backend.write_pending_message_to_l2(&msg2)?;
+
+    // Add blocks which will confirm the messages and store their fees
+    let block0 = make_block(&chain_config, 0, vec![make_l1_handler_tx_with_receipt(chain_id, protocol_version, 1)]);
+    let block0_hash = backend.write_access().add_full_block_with_classes(&block0, &[], false)?.block_hash;
+
+    let block1 = make_block(&chain_config, 1, vec![make_l1_handler_tx_with_receipt(chain_id, protocol_version, 2)]);
+    backend.write_access().add_full_block_with_classes(&block1, &[], false)?;
+
+    // Verify messages are confirmed and no longer pending
+    assert!(backend.get_l1_handler_txn_hash_by_nonce(1)?.is_some());
+    assert!(backend.get_l1_handler_txn_hash_by_nonce(2)?.is_some());
+    assert!(backend.get_pending_message_to_l2(1)?.is_none());
+    assert!(backend.get_pending_message_to_l2(2)?.is_none());
+
+    // Revert to block0
+    backend.revert_to(&block0_hash)?;
+    let fresh_chain_tip = backend.db.get_chain_tip()?;
+    backend.chain_tip.send_replace(ChainTip::from_storage(fresh_chain_tip));
+
+    // Verify message 2 is restored as pending with the CORRECT fee
+    let pending = backend.get_pending_message_to_l2(2)?.expect("pending L1->L2 message should be restored");
+    assert_eq!(pending.tx.nonce, 2);
+    assert_eq!(pending.paid_fee_on_l1, fee_for_nonce_2, "Fee should be restored to original value");
+
+    // Message 1 should still be confirmed
+    assert!(backend.get_l1_handler_txn_hash_by_nonce(1)?.is_some());
+    assert!(backend.get_pending_message_to_l2(1)?.is_none());
+
+    Ok(())
+}

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -11,7 +11,7 @@
 //!
 //! The Madara node follows the [Starknet RPC specs] as well as the [Starknet P2P specs] in the
 //! implementations of its various components. Where seems fit, some extensions might be added to
-//! the specs, in particular in regards to any potential admin or privileged endpoints which might
+//! the specs, in particular in regard to any potential admin or privileged endpoints which might
 //! prove to be useful in prod.
 //!
 //! # Core Crates
@@ -38,7 +38,7 @@
 //! # Primitives Crates
 //! > `mp-*`
 //!
-//! Crates which are responsible for modelling the data in use by the node. These mostly don't
+//! Crates which are responsible for modeling the data in use by the node. These mostly don't
 //! contain any business logic (though some helper functions might be included) and instead focus on
 //! data types as well as serialization and deserialization. These crates answer the question of
 //! _what_ data the node transforms.
@@ -177,7 +177,7 @@ async fn main() -> anyhow::Result<()> {
     // Setting up analytics
     let mut service_analytics = AnalyticsService::new(run_cmd.analytics_params.as_analytics_config())
         .context("Initializing analytics service")?;
-    service_analytics.setup().context("Setting-up analystics service")?;
+    service_analytics.setup().context("Setting-up analytics service")?;
 
     // If it's a sequencer or a devnet we set the mandatory chain config. If it's a full node we set the chain config from the network or the custom chain config.
     let chain_config = if run_cmd.is_sequencer() {


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Testing
- [ ] Other (please describe):

## What is the current behavior?

When reverting the chain to a previous block (during reorgs), consumed L1->L2 messages were not being restored to the pending state. Additionally, if they were restored, the `paid_fee_on_l1` was lost because it was not persisted after the message moved from pending to confirmed.

Resolves: #NA

## What is the new behavior?

- L1 handler transactions are now restored to pending state during chain reverts
- Added a new RocksDB column (`l1_to_l2_paid_fee_by_nonce`) to persist the `paid_fee_on_l1` when messages are confirmed
- During revert, messages are restored with the correct fee from storage
- Falls back to a default fee for messages confirmed before this fix was deployed
- Added comprehensive tests for revert functionality

## Does this introduce a breaking change?

No

This adds a new RocksDB column which will be automatically created on startup. Existing confirmed messages that predate this change will use a fallback fee value if reverted.

## Other information

### Database Schema Changes

New column added:
- `l1_to_l2_paid_fee_by_nonce`: Maps `core_contract_nonce (8 bytes)` → `paid_fee_on_l1 (u128 as 16 bytes big-endian)`

This column stores the fee paid on L1 when a message is confirmed, so it can be recovered during reverts.