### PR TITLE
test: stabilize events bloom filter proptest

### DIFF
--- a/madara/crates/client/db/src/rocksdb/events_bloom_filter.rs
+++ b/madara/crates/client/db/src/rocksdb/events_bloom_filter.rs
@@ -412,9 +412,7 @@ mod tests {
         let range = 100..1000usize;
         range.prop_flat_map(|size| {
             prop::collection::vec(
-                (0..u64::MAX).prop_map(|from| {
-                    // Generate 1 to 10 keys for each event
-                    let num_keys = rand::random::<usize>() % 10 + 1;
+                (any::<u64>(), 1usize..=10usize).prop_map(|(from, num_keys)| {
                     let keys = (0..num_keys).map(|i| from + i as u64).collect();
                     create_test_event(from, keys)
                 }),


### PR DESCRIPTION
## What / Why

`events_bloom_filter` has a proptest that generates large sets of events to exercise the Bloom filter implementation.

That strategy previously used `rand::random()` **inside** the proptest generator to pick the number of keys per event. This bypasses proptest's RNG/shrinker, which means:
- failures are harder to reproduce (seeding via proptest doesn't fully capture the input), and
- shrinking/debugging is less reliable (part of the input isn't shrinkable).

## Changes

- Generate `num_keys` as part of the proptest strategy (`1..=10`) instead of using `rand::random()`.
- No production behavior changes (tests-only).

## Testing

```bash
cd madara
cargo fmt
cargo clippy --workspace --all-features --no-deps -- -D warnings
cargo clippy --workspace --all-features --tests --no-deps -- -D warnings
cargo test -p mc-db rocksdb::events_bloom_filter::tests::test_bloom_key_creation
```
