### PR TITLE
test(cairo-native): make memory cache timeout deterministic

### DIFF
--- a/madara/crates/client/cairo_native/src/cache.rs
+++ b/madara/crates/client/cairo_native/src/cache.rs
@@ -304,7 +304,7 @@ pub(crate) fn try_get_from_memory_cache(
     let thread_handle = thread::spawn(move || {
         let start = Instant::now();
 
-        if let Some(cached_entry) = NATIVE_CACHE.get(&class_hash_for_log) {
+        let result = if let Some(cached_entry) = NATIVE_CACHE.get(&class_hash_for_log) {
             // Retrieve the cached class (Arc clone is cheap - just increments reference count, doesn't copy data)
             let cached_class = cached_entry.value().0.clone();
             drop(cached_entry); // Release shard lock before expensive operations below
@@ -338,15 +338,7 @@ pub(crate) fn try_get_from_memory_cache(
                 cache_size = cache_size,
                 "memory_hit"
             );
-
-            #[cfg(test)]
-            {
-                let delay = test_memory_cache_send_delay();
-                if !delay.is_zero() {
-                    std::thread::sleep(delay);
-                }
-            }
-            let _ = tx.send(Some(runnable));
+            Some(runnable)
         } else {
             // Memory cache miss - log it
             let lookup_elapsed = start.elapsed();
@@ -360,15 +352,17 @@ pub(crate) fn try_get_from_memory_cache(
                 cache_size = cache_size,
                 "memory_cache_miss"
             );
-            #[cfg(test)]
-            {
-                let delay = test_memory_cache_send_delay();
-                if !delay.is_zero() {
-                    std::thread::sleep(delay);
-                }
+            None
+        };
+
+        #[cfg(test)]
+        {
+            let delay = test_memory_cache_send_delay();
+            if !delay.is_zero() {
+                std::thread::sleep(delay);
             }
-            let _ = tx.send(None);
         }
+        let _ = tx.send(result);
     });
 
     let exec_config = config


### PR DESCRIPTION
## What / Why

`test_handle_sierra_class_memory_cache_timeout` in `mc-class-exec` is intended to validate the behavior when the cairo-native memory-cache worker is slow and a request times out.

The test was flaky because the worker thread and the timeout are racing: depending on scheduling, the worker could send its response before the timeout trips, making the test outcome non-deterministic.

## Changes

- Add a **test-only** delay hook in the memory-cache worker send path (`#[cfg(test)]`) so the test can deterministically force the timeout.
- Add a small guard in the test module to always reset the delay back to `0ms`, preventing cross-test contamination.
- No production behavior changes (the delay code is compiled only for tests).

## Testing

```bash
cd madara
cargo test -p mc-class-exec test_handle_sierra_class_memory_cache_timeout -- --nocapture
cargo clippy -p mc-class-exec --all-features --tests --no-deps -- -D warnings
```
