### PR TITLE
feat(parallel-merkle): add block-production finalizer orchestration

### DIFF
--- a/madara/crates/client/block_production/src/finalizer.rs
+++ b/madara/crates/client/block_production/src/finalizer.rs
@@ -10,6 +10,11 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 use tokio::{sync::mpsc, task::JoinSet};
 
+/// Finalized block payload handed off from block production to the parallel finalizer.
+///
+/// This contains all data required by both finalizer lanes:
+/// - DB staging lane (block/classes/weights/consumed nonces)
+/// - Root compute lane (state diff for cumulative merklization)
 #[derive(Debug)]
 pub struct FinalizedBlockPayload {
     pub block_n: u64,
@@ -26,6 +31,9 @@ pub struct ParallelMerkleFinalizerHandle {
 }
 
 impl ParallelMerkleFinalizerHandle {
+    /// Enqueue a block for parallel finalization.
+    ///
+    /// Queue backpressure is controlled by `parallel_merkle.max_inflight`.
     pub async fn submit(&self, payload: FinalizedBlockPayload) -> anyhow::Result<()> {
         self.sender.send(payload).await.context("sending finalized block payload to parallel-merkle finalizer")
     }
@@ -121,6 +129,26 @@ struct ParallelMerkleFinalizerWorker {
 }
 
 impl ParallelMerkleFinalizerWorker {
+    /// Main worker loop that coordinates ingestion, lane completion, and ordered confirmation.
+    ///
+    /// Flow:
+    /// ```text
+    /// +------------------- loop -------------------+
+    /// | select!                                  |
+    /// | 1) recv payload (if inflight < limit)    |
+    /// |      -> schedule_block()                 |
+    /// | 2) db_staging job finished               |
+    /// |      -> mark persisted_ready OR failure  |
+    /// | 3) root_compute job finished             |
+    /// |      -> mark roots_ready OR failure      |
+    /// +--------------------+----------------------+
+    ///                      |
+    ///                      v
+    ///               try_confirm_ready()
+    ///                  (strictly next_confirm)
+    /// ```
+    ///
+    /// The loop exits only when the input channel is closed and both job sets are empty.
     async fn run(&mut self, mut receiver: mpsc::Receiver<FinalizedBlockPayload>) -> anyhow::Result<()> {
         loop {
             tokio::select! {
@@ -167,6 +195,18 @@ impl ParallelMerkleFinalizerWorker {
         Ok(())
     }
 
+    /// Schedule both lanes for a single block.
+    ///
+    /// Flow:
+    /// ```text
+    /// payload(block_n)
+    ///   -> db_staging_jobs.spawn(...)
+    ///        writes staged block parts to DB
+    ///   -> root_compute_jobs.spawn(...)
+    ///        computes state root from snapshot base + cumulative state diff
+    /// ```
+    ///
+    /// A duplicate `block_n` is rejected and recorded as a scheduler failure.
     fn schedule_block(&mut self, payload: FinalizedBlockPayload) {
         let block_n = payload.block_n;
         if !self.scheduled_blocks.insert(block_n) {
@@ -229,6 +269,22 @@ impl ParallelMerkleFinalizerWorker {
         });
     }
 
+    /// Confirm all currently-ready blocks in strict sequence (`next_confirm` only).
+    ///
+    /// Flow per block:
+    /// ```text
+    /// if failure[next_confirm] -> bail
+    /// if persisted_ready && roots_ready for next_confirm:
+    ///   confirm staged block with precomputed root
+    ///   if boundary:
+    ///     flush overlay + checkpoint
+    ///     advance snapshot base and drop committed cumulative diffs
+    ///   next_confirm += 1
+    /// else:
+    ///   stop
+    /// ```
+    ///
+    /// This guarantees in-order DB confirmation even if lane completions arrive out-of-order.
     async fn try_confirm_ready(&mut self) -> anyhow::Result<()> {
         if let Some(failure) = Self::next_confirm_failure(self.next_confirm, &self.failed_blocks) {
             anyhow::bail!(
@@ -246,9 +302,6 @@ impl ParallelMerkleFinalizerWorker {
             let Some(root_ready) = self.roots_ready.get(&self.next_confirm).cloned() else {
                 break;
             };
-
-            self.persisted_ready.remove(&self.next_confirm);
-            self.roots_ready.remove(&self.next_confirm);
 
             self.backend
                 .write_access()
@@ -276,6 +329,9 @@ impl ParallelMerkleFinalizerWorker {
                 self.pending_epoch_diffs = self.pending_epoch_diffs.split_off(&(self.next_confirm + 1));
             }
 
+            // Consume readiness only after all DB side effects for this block succeeded.
+            self.persisted_ready.remove(&self.next_confirm);
+            self.roots_ready.remove(&self.next_confirm);
             self.scheduled_blocks.remove(&self.next_confirm);
             self.next_confirm += 1;
         }
@@ -302,6 +358,7 @@ impl ParallelMerkleFinalizerWorker {
         persisted_ready.contains(&next_confirm) && roots_ready.contains_key(&next_confirm)
     }
 
+    /// Returns whether worker can accept another payload based on inflight block count.
     fn can_schedule_more(max_inflight_blocks: usize, scheduled_blocks: &BTreeSet<u64>) -> bool {
         scheduled_blocks.len() < max_inflight_blocks
     }
@@ -319,27 +376,33 @@ impl ParallelMerkleFinalizerWorker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn boundary_rule_respects_flush_interval() {
-        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 0));
-        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 1));
-        assert!(ParallelMerkleFinalizerWorker::is_boundary_for(3, 2));
-        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 3));
-        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 4));
-        assert!(ParallelMerkleFinalizerWorker::is_boundary_for(3, 5));
+    #[rstest]
+    #[case(3, 0, false)]
+    #[case(3, 1, false)]
+    #[case(3, 2, true)]
+    #[case(3, 3, false)]
+    #[case(3, 4, false)]
+    #[case(3, 5, true)]
+    fn boundary_rule_respects_flush_interval(
+        #[case] flush_interval: u64,
+        #[case] block_n: u64,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(ParallelMerkleFinalizerWorker::is_boundary_for(flush_interval, block_n), expected);
     }
 
-    #[test]
-    fn cumulative_start_includes_block_zero_without_confirmed_tip() {
-        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(0, 0), 0);
-        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(10, 0), 0);
-    }
-
-    #[test]
-    fn cumulative_start_skips_persisted_snapshot_base_after_confirmed_tip() {
-        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(0, 1), 1);
-        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(9, 10), 10);
+    #[rstest]
+    #[case(0, 0, 0)]
+    #[case(10, 0, 0)]
+    #[case(0, 1, 1)]
+    #[case(9, 10, 10)]
+    fn cumulative_start_cases(#[case] snapshot_base_block_n: u64, #[case] next_confirm: u64, #[case] expected: u64) {
+        assert_eq!(
+            ParallelMerkleFinalizerWorker::cumulative_range_start(snapshot_base_block_n, next_confirm),
+            expected
+        );
     }
 
     #[test]
@@ -360,38 +423,47 @@ mod tests {
         assert!(ParallelMerkleFinalizerWorker::is_confirm_ready(5, &persisted_ready, &roots_ready));
     }
 
-    #[test]
-    fn can_schedule_more_respects_inflight_bound() {
+    #[rstest]
+    #[case(2, 0, true)]
+    #[case(2, 1, true)]
+    #[case(2, 2, false)]
+    fn can_schedule_more_respects_inflight_bound(
+        #[case] max_inflight_blocks: usize,
+        #[case] scheduled_count: u64,
+        #[case] expected: bool,
+    ) {
         let mut scheduled = BTreeSet::new();
-        assert!(ParallelMerkleFinalizerWorker::can_schedule_more(2, &scheduled));
-
-        scheduled.insert(10);
-        scheduled.insert(11);
-        assert!(!ParallelMerkleFinalizerWorker::can_schedule_more(2, &scheduled));
+        for n in 0..scheduled_count {
+            scheduled.insert(10 + n);
+        }
+        assert_eq!(ParallelMerkleFinalizerWorker::can_schedule_more(max_inflight_blocks, &scheduled), expected);
     }
 
-    #[test]
-    fn next_confirm_failure_only_blocks_matching_height() {
+    #[rstest]
+    #[case(6, false)]
+    #[case(7, true)]
+    fn next_confirm_failure_only_blocks_matching_height(#[case] next_confirm: u64, #[case] should_find: bool) {
         let mut failed_blocks = BTreeMap::new();
         failed_blocks.insert(7, LaneFailure { lane: "root-compute", message: "boom".to_string() });
-        assert!(ParallelMerkleFinalizerWorker::next_confirm_failure(6, &failed_blocks).is_none());
-
-        let failure = ParallelMerkleFinalizerWorker::next_confirm_failure(7, &failed_blocks)
-            .expect("failure for next confirm block should be returned");
-        assert_eq!(failure.lane, "root-compute");
-        assert!(failure.message.contains("boom"));
+        let failure = ParallelMerkleFinalizerWorker::next_confirm_failure(next_confirm, &failed_blocks);
+        assert_eq!(failure.is_some(), should_find);
+        if let Some(failure) = failure {
+            assert_eq!(failure.lane, "root-compute");
+            assert!(failure.message.contains("boom"));
+        }
     }
 
-    #[test]
-    fn initial_snapshot_base_prefers_latest_confirmed_when_present() {
-        assert_eq!(initial_snapshot_base(Some(10), Some(9)), 10);
-        assert_eq!(initial_snapshot_base(Some(10), Some(15)), 10);
-        assert_eq!(initial_snapshot_base(Some(10), None), 10);
-    }
-
-    #[test]
-    fn initial_snapshot_base_falls_back_to_checkpoint_or_zero() {
-        assert_eq!(initial_snapshot_base(None, Some(8)), 8);
-        assert_eq!(initial_snapshot_base(None, None), 0);
+    #[rstest]
+    #[case(Some(10), Some(9), 10)]
+    #[case(Some(10), Some(15), 10)]
+    #[case(Some(10), None, 10)]
+    #[case(None, Some(8), 8)]
+    #[case(None, None, 0)]
+    fn initial_snapshot_base_cases(
+        #[case] latest_confirmed: Option<u64>,
+        #[case] latest_checkpoint: Option<u64>,
+        #[case] expected: u64,
+    ) {
+        assert_eq!(initial_snapshot_base(latest_confirmed, latest_checkpoint), expected);
     }
 }

--- a/madara/crates/client/block_production/src/finalizer.rs
+++ b/madara/crates/client/block_production/src/finalizer.rs
@@ -1,4 +1,4 @@
-use crate::{ParallelMerkleConfig, ParallelMerkleTrieLogMode};
+use crate::{remove_consumed_core_contract_nonces, ParallelMerkleConfig, ParallelMerkleTrieLogMode};
 use anyhow::Context;
 use blockifier::bouncer::BouncerWeights;
 use mc_db::{BonsaiOverlay, MadaraBackend, ParallelMerkleInMemoryTrieLogMode};
@@ -149,11 +149,11 @@ impl ParallelMerkleFinalizerWorker {
                 let mut block = payload.block;
                 block.state_diff = payload.state_diff;
 
-                for l1_nonce in payload.consumed_core_contract_nonces {
-                    backend_for_path_a
-                        .remove_pending_message_to_l2(l1_nonce)
-                        .context("removing consumed l1->l2 nonce in parallel finalizer")?;
-                }
+                remove_consumed_core_contract_nonces(
+                    backend_for_path_a.as_ref(),
+                    payload.consumed_core_contract_nonces,
+                    "parallel finalizer",
+                )?;
 
                 backend_for_path_a.write_access().write_parallel_merkle_staged_block_data(
                     &block,

--- a/madara/crates/client/block_production/src/finalizer.rs
+++ b/madara/crates/client/block_production/src/finalizer.rs
@@ -1,3 +1,4 @@
+use crate::util::ExecutionStats;
 use crate::{ParallelMerkleConfig, ParallelMerkleTrieLogMode};
 use anyhow::Context;
 use blockifier::bouncer::BouncerWeights;
@@ -6,8 +7,9 @@ use mp_block::FullBlockWithoutCommitments;
 use mp_class::ConvertedClass;
 use mp_convert::Felt;
 use mp_state_update::StateDiff;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::{sync::mpsc, task::JoinSet};
 
 /// Finalized block payload handed off from block production to the parallel finalizer.
@@ -15,6 +17,7 @@ use tokio::{sync::mpsc, task::JoinSet};
 /// This contains all data required by both finalizer lanes:
 /// - DB staging lane (block/classes/weights/consumed nonces)
 /// - Root compute lane (state diff for cumulative merklization)
+/// - Observability context used to emit `close_block_complete` on parallel confirm
 #[derive(Debug)]
 pub struct FinalizedBlockPayload {
     pub block_n: u64,
@@ -23,6 +26,8 @@ pub struct FinalizedBlockPayload {
     pub state_diff: StateDiff,
     pub consumed_core_contract_nonces: HashSet<u64>,
     pub bouncer_weights: BouncerWeights,
+    pub execution_stats: ExecutionStats,
+    pub block_production_duration: Duration,
 }
 
 #[derive(Clone)]
@@ -50,6 +55,45 @@ struct RootReady {
 struct LaneFailure {
     lane: &'static str,
     message: String,
+}
+
+#[derive(Debug, Clone)]
+struct BlockCloseLogContext {
+    queued_at: Instant,
+    block_production_duration: Duration,
+    execution_stats: ExecutionStats,
+    tx_count: u64,
+    event_count: u64,
+    state_diff_len: usize,
+    declared_classes_count: usize,
+    deployed_contracts_count: usize,
+    storage_diffs_count: usize,
+    nonce_updates_count: usize,
+    consumed_l1_nonces_count: usize,
+    bouncer_weights: BouncerWeights,
+    db_staging_ms: Option<f64>,
+    root_compute_ms: Option<f64>,
+}
+
+impl BlockCloseLogContext {
+    fn from_payload(payload: &FinalizedBlockPayload) -> Self {
+        Self {
+            queued_at: Instant::now(),
+            block_production_duration: payload.block_production_duration,
+            execution_stats: payload.execution_stats.clone(),
+            tx_count: payload.block.transactions.len() as u64,
+            event_count: payload.block.events.len() as u64,
+            state_diff_len: payload.state_diff.len(),
+            declared_classes_count: payload.state_diff.declared_classes.len(),
+            deployed_contracts_count: payload.state_diff.deployed_contracts.len(),
+            storage_diffs_count: payload.state_diff.storage_diffs.len(),
+            nonce_updates_count: payload.state_diff.nonces.len(),
+            consumed_l1_nonces_count: payload.consumed_core_contract_nonces.len(),
+            bouncer_weights: payload.bouncer_weights,
+            db_staging_ms: None,
+            root_compute_ms: None,
+        }
+    }
 }
 
 pub fn spawn_parallel_merkle_finalizer(
@@ -86,6 +130,7 @@ pub fn spawn_parallel_merkle_finalizer(
         pending_epoch_diffs: BTreeMap::new(),
         persisted_ready: BTreeSet::new(),
         roots_ready: BTreeMap::new(),
+        close_block_logs: BTreeMap::new(),
         db_staging_jobs: JoinSet::new(),
         root_compute_jobs: JoinSet::new(),
         max_inflight_blocks: max_inflight,
@@ -94,7 +139,11 @@ pub fn spawn_parallel_merkle_finalizer(
     };
     tokio::spawn(async move {
         if let Err(error) = worker.run(receiver).await {
-            tracing::error!(%error, "parallel merkle finalizer worker terminated with error");
+            tracing::error!(
+                target: "close_block",
+                error = %error,
+                "parallel_finalizer_worker_terminated"
+            );
         }
     });
 
@@ -121,8 +170,9 @@ struct ParallelMerkleFinalizerWorker {
     pending_epoch_diffs: BTreeMap<u64, StateDiff>,
     persisted_ready: BTreeSet<u64>,
     roots_ready: BTreeMap<u64, RootReady>,
-    db_staging_jobs: JoinSet<(u64, anyhow::Result<()>)>,
-    root_compute_jobs: JoinSet<(u64, anyhow::Result<RootReady>)>,
+    close_block_logs: BTreeMap<u64, BlockCloseLogContext>,
+    db_staging_jobs: JoinSet<(u64, anyhow::Result<Duration>)>,
+    root_compute_jobs: JoinSet<(u64, anyhow::Result<(RootReady, Duration)>)>,
     max_inflight_blocks: usize,
     scheduled_blocks: BTreeSet<u64>,
     failed_blocks: BTreeMap<u64, LaneFailure>,
@@ -165,8 +215,11 @@ impl ParallelMerkleFinalizerWorker {
                 Some(joined) = self.db_staging_jobs.join_next(), if !self.db_staging_jobs.is_empty() => {
                     let (block_n, db_staging_result) = joined.context("joining db-staging persistence job")?;
                     match db_staging_result {
-                        Ok(()) => {
+                        Ok(duration) => {
                             self.persisted_ready.insert(block_n);
+                            if let Some(log_ctx) = self.close_block_logs.get_mut(&block_n) {
+                                log_ctx.db_staging_ms = Some(duration.as_secs_f64() * 1000.0);
+                            }
                         }
                         Err(error) => {
                             self.record_block_failure(block_n, "db-staging", error);
@@ -176,8 +229,11 @@ impl ParallelMerkleFinalizerWorker {
                 Some(joined) = self.root_compute_jobs.join_next(), if !self.root_compute_jobs.is_empty() => {
                     let (block_n, root_result) = joined.context("joining root-compute job")?;
                     match root_result {
-                        Ok(root_ready) => {
+                        Ok((root_ready, duration)) => {
                             self.roots_ready.insert(block_n, root_ready);
+                            if let Some(log_ctx) = self.close_block_logs.get_mut(&block_n) {
+                                log_ctx.root_compute_ms = Some(duration.as_secs_f64() * 1000.0);
+                            }
                         }
                         Err(error) => {
                             self.record_block_failure(block_n, "root-compute", error);
@@ -217,6 +273,7 @@ impl ParallelMerkleFinalizerWorker {
             );
             return;
         }
+        self.close_block_logs.insert(block_n, BlockCloseLogContext::from_payload(&payload));
 
         let is_boundary = Self::is_boundary_for(self.flush_interval, block_n);
 
@@ -231,6 +288,7 @@ impl ParallelMerkleFinalizerWorker {
         let backend_for_root_compute = Arc::clone(&self.backend);
 
         self.db_staging_jobs.spawn(async move {
+            let started_at = Instant::now();
             let db_staging_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
                 let mut block = payload.block;
                 block.state_diff = payload.state_diff;
@@ -245,11 +303,13 @@ impl ParallelMerkleFinalizerWorker {
             })
             .await
             .context("joining blocking db-staging worker")
-            .and_then(|result| result);
+            .and_then(|result| result)
+            .map(|()| started_at.elapsed());
             (block_n, db_staging_result)
         });
 
         self.root_compute_jobs.spawn(async move {
+            let started_at = Instant::now();
             let root_result = tokio::task::spawn_blocking(move || -> anyhow::Result<RootReady> {
                 let computed =
                     backend_for_root_compute.write_access().compute_parallel_merkle_root_from_snapshot_base(
@@ -264,7 +324,8 @@ impl ParallelMerkleFinalizerWorker {
             })
             .await
             .context("joining blocking root-compute worker")
-            .and_then(|result| result);
+            .and_then(|result| result)
+            .map(|root_ready| (root_ready, started_at.elapsed()));
             (block_n, root_result)
         });
     }
@@ -303,7 +364,9 @@ impl ParallelMerkleFinalizerWorker {
                 break;
             };
 
-            self.backend
+            let confirm_started_at = Instant::now();
+            let confirm_result = self
+                .backend
                 .write_access()
                 .confirm_parallel_merkle_staged_block_with_root(
                     self.next_confirm,
@@ -311,22 +374,75 @@ impl ParallelMerkleFinalizerWorker {
                     /* pre_v0_13_2_hash_override */ true,
                 )
                 .with_context(|| format!("confirming staged block #{} in parallel finalizer", self.next_confirm))?;
+            let parallel_confirm_ms = confirm_started_at.elapsed().as_secs_f64() * 1000.0;
 
+            let mut parallel_boundary_flush_ms = 0.0;
             if root_ready.is_boundary {
                 let overlay = root_ready
                     .overlay
                     .as_ref()
                     .with_context(|| format!("missing boundary overlay for block #{}", self.next_confirm))?;
 
+                let flush_started_at = Instant::now();
                 self.backend
                     .write_access()
                     .flush_parallel_merkle_overlay_and_checkpoint(self.next_confirm, overlay, self.trie_log_mode)
                     .with_context(|| {
                         format!("flushing boundary overlay/checkpoint for block #{}", self.next_confirm)
                     })?;
+                parallel_boundary_flush_ms = flush_started_at.elapsed().as_secs_f64() * 1000.0;
 
                 self.snapshot_base_block_n = self.next_confirm;
                 self.pending_epoch_diffs = self.pending_epoch_diffs.split_off(&(self.next_confirm + 1));
+            }
+
+            if let Some(log_ctx) = self.close_block_logs.remove(&self.next_confirm) {
+                let timings = &confirm_result.timings;
+                let close_block_total_ms = log_ctx.queued_at.elapsed().as_secs_f64() * 1000.0;
+                let close_preconfirmed_ms = log_ctx.db_staging_ms.unwrap_or_default();
+                tracing::info!(
+                    target: "close_block",
+                    block_number = self.next_confirm,
+                    tx_count = log_ctx.tx_count,
+                    event_count = log_ctx.event_count,
+                    close_block_total_ms = close_block_total_ms,
+                    block_close_ms = close_block_total_ms,
+                    close_preconfirmed_ms = close_preconfirmed_ms,
+                    block_production_ms = log_ctx.block_production_duration.as_secs_f64() * 1000.0,
+                    batches_executed = log_ctx.execution_stats.n_batches,
+                    txs_added_to_block = log_ctx.execution_stats.n_added_to_block,
+                    txs_executed = log_ctx.execution_stats.n_executed,
+                    txs_reverted = log_ctx.execution_stats.n_reverted,
+                    txs_rejected = log_ctx.execution_stats.n_rejected,
+                    classes_declared = log_ctx.execution_stats.declared_classes,
+                    l2_gas_consumed = log_ctx.execution_stats.l2_gas_consumed,
+                    state_diff_len = log_ctx.state_diff_len,
+                    declared_classes = log_ctx.declared_classes_count,
+                    deployed_contracts = log_ctx.deployed_contracts_count,
+                    storage_diffs = log_ctx.storage_diffs_count,
+                    nonce_updates = log_ctx.nonce_updates_count,
+                    consumed_l1_nonces = log_ctx.consumed_l1_nonces_count,
+                    bouncer_l1_gas = log_ctx.bouncer_weights.l1_gas,
+                    bouncer_sierra_gas = log_ctx.bouncer_weights.sierra_gas.0,
+                    bouncer_n_events = log_ctx.bouncer_weights.n_events,
+                    bouncer_message_segment_length = log_ctx.bouncer_weights.message_segment_length,
+                    bouncer_state_diff_size = log_ctx.bouncer_weights.state_diff_size,
+                    get_full_block_ms = timings.get_full_block_with_classes.as_secs_f64() * 1000.0,
+                    commitments_ms = timings.block_commitments_compute.as_secs_f64() * 1000.0,
+                    merklization_ms = timings.merklization.as_secs_f64() * 1000.0,
+                    contract_trie_ms = timings.contract_trie_root.as_secs_f64() * 1000.0,
+                    class_trie_ms = timings.class_trie_root.as_secs_f64() * 1000.0,
+                    contract_storage_trie_commit_ms = timings.contract_storage_trie_commit.as_secs_f64() * 1000.0,
+                    contract_trie_commit_ms = timings.contract_trie_commit.as_secs_f64() * 1000.0,
+                    class_trie_commit_ms = timings.class_trie_commit.as_secs_f64() * 1000.0,
+                    block_hash_ms = timings.block_hash_compute.as_secs_f64() * 1000.0,
+                    db_write_ms = timings.db_write_block_parts.as_secs_f64() * 1000.0,
+                    parallel_db_staging_ms = close_preconfirmed_ms,
+                    parallel_root_compute_ms = log_ctx.root_compute_ms.unwrap_or_default(),
+                    parallel_confirm_ms = parallel_confirm_ms,
+                    parallel_boundary_flush_ms = parallel_boundary_flush_ms,
+                    "close_block_complete"
+                );
             }
 
             // Consume readiness only after all DB side effects for this block succeeded.
@@ -369,7 +485,19 @@ impl ParallelMerkleFinalizerWorker {
 
     fn record_block_failure(&mut self, block_n: u64, lane: &'static str, error: anyhow::Error) {
         let message = format!("{error:#}");
-        self.failed_blocks.entry(block_n).or_insert(LaneFailure { lane, message });
+        match self.failed_blocks.entry(block_n) {
+            Entry::Occupied(_) => {}
+            Entry::Vacant(entry) => {
+                tracing::error!(
+                    target: "close_block",
+                    block_number = block_n,
+                    lane = lane,
+                    error = %message,
+                    "parallel_finalizer_lane_failed"
+                );
+                entry.insert(LaneFailure { lane, message });
+            }
+        }
     }
 }
 

--- a/madara/crates/client/block_production/src/finalizer.rs
+++ b/madara/crates/client/block_production/src/finalizer.rs
@@ -1,0 +1,293 @@
+use crate::{ParallelMerkleConfig, ParallelMerkleTrieLogMode};
+use anyhow::Context;
+use blockifier::bouncer::BouncerWeights;
+use mc_db::{BonsaiOverlay, MadaraBackend, ParallelMerkleInMemoryTrieLogMode};
+use mp_block::FullBlockWithoutCommitments;
+use mp_class::ConvertedClass;
+use mp_convert::Felt;
+use mp_state_update::StateDiff;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::Arc;
+use tokio::{sync::mpsc, task::JoinSet};
+
+#[derive(Debug)]
+pub struct FinalizedBlockPayload {
+    pub block_n: u64,
+    pub block: FullBlockWithoutCommitments,
+    pub classes: Vec<ConvertedClass>,
+    pub state_diff: StateDiff,
+    pub consumed_core_contract_nonces: HashSet<u64>,
+    pub bouncer_weights: BouncerWeights,
+}
+
+#[derive(Clone)]
+pub struct ParallelMerkleFinalizerHandle {
+    sender: mpsc::Sender<FinalizedBlockPayload>,
+}
+
+impl ParallelMerkleFinalizerHandle {
+    pub async fn submit(&self, payload: FinalizedBlockPayload) -> anyhow::Result<()> {
+        self.sender.send(payload).await.context("sending finalized block payload to parallel-merkle finalizer")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RootReady {
+    root: Felt,
+    overlay: Option<BonsaiOverlay>,
+    is_boundary: bool,
+}
+
+pub fn spawn_parallel_merkle_finalizer(
+    backend: Arc<MadaraBackend>,
+    config: ParallelMerkleConfig,
+) -> anyhow::Result<ParallelMerkleFinalizerHandle> {
+    let max_inflight =
+        usize::try_from(config.max_inflight).context("parallel_merkle.max_inflight does not fit usize")?;
+    let max_inflight = max_inflight.max(1);
+    let (sender, receiver) = mpsc::channel(max_inflight);
+
+    let latest_confirmed = backend.latest_confirmed_block_n();
+    let next_confirm = latest_confirmed.map(|n| n + 1).unwrap_or(0);
+    let snapshot_base_block_n = backend
+        .get_parallel_merkle_latest_checkpoint()
+        .context("reading parallel merkle latest checkpoint")?
+        .or(latest_confirmed)
+        .unwrap_or(0);
+
+    let trie_log_mode = map_trie_log_mode(config.trie_log_mode);
+    let mut worker = ParallelMerkleFinalizerWorker {
+        backend,
+        flush_interval: config.flush_interval.max(2),
+        trie_log_mode,
+        next_confirm,
+        snapshot_base_block_n,
+        pending_epoch_diffs: BTreeMap::new(),
+        persisted_ready: BTreeSet::new(),
+        roots_ready: BTreeMap::new(),
+        path_a_jobs: JoinSet::new(),
+        path_b_jobs: JoinSet::new(),
+    };
+    tokio::spawn(async move {
+        if let Err(error) = worker.run(receiver).await {
+            tracing::error!(%error, "parallel merkle finalizer worker terminated with error");
+        }
+    });
+
+    Ok(ParallelMerkleFinalizerHandle { sender })
+}
+
+fn map_trie_log_mode(mode: ParallelMerkleTrieLogMode) -> ParallelMerkleInMemoryTrieLogMode {
+    match mode {
+        ParallelMerkleTrieLogMode::Off => ParallelMerkleInMemoryTrieLogMode::Off,
+        ParallelMerkleTrieLogMode::Checkpoint => ParallelMerkleInMemoryTrieLogMode::Checkpoint,
+    }
+}
+
+struct ParallelMerkleFinalizerWorker {
+    backend: Arc<MadaraBackend>,
+    flush_interval: u64,
+    trie_log_mode: ParallelMerkleInMemoryTrieLogMode,
+    next_confirm: u64,
+    snapshot_base_block_n: u64,
+    pending_epoch_diffs: BTreeMap<u64, StateDiff>,
+    persisted_ready: BTreeSet<u64>,
+    roots_ready: BTreeMap<u64, RootReady>,
+    path_a_jobs: JoinSet<anyhow::Result<u64>>,
+    path_b_jobs: JoinSet<anyhow::Result<(u64, RootReady)>>,
+}
+
+impl ParallelMerkleFinalizerWorker {
+    async fn run(&mut self, mut receiver: mpsc::Receiver<FinalizedBlockPayload>) -> anyhow::Result<()> {
+        loop {
+            tokio::select! {
+                maybe_payload = receiver.recv() => {
+                    match maybe_payload {
+                        Some(payload) => self.schedule_block(payload),
+                        None => {
+                            if self.path_a_jobs.is_empty() && self.path_b_jobs.is_empty() {
+                                break;
+                            }
+                        }
+                    }
+                }
+                Some(joined) = self.path_a_jobs.join_next(), if !self.path_a_jobs.is_empty() => {
+                    let block_n = joined.context("joining path-a persistence job")??;
+                    self.persisted_ready.insert(block_n);
+                }
+                Some(joined) = self.path_b_jobs.join_next(), if !self.path_b_jobs.is_empty() => {
+                    let (block_n, root_ready) = joined.context("joining path-b root job")??;
+                    self.roots_ready.insert(block_n, root_ready);
+                }
+                else => break,
+            }
+
+            self.try_confirm_ready().await?;
+        }
+
+        // Drain any last ready confirmations after channel close.
+        self.try_confirm_ready().await?;
+        Ok(())
+    }
+
+    fn schedule_block(&mut self, payload: FinalizedBlockPayload) {
+        let block_n = payload.block_n;
+        let is_boundary = Self::is_boundary_for(self.flush_interval, block_n);
+
+        self.pending_epoch_diffs.insert(block_n, payload.state_diff.clone());
+        let cumulative_start = Self::cumulative_range_start(self.snapshot_base_block_n, self.next_confirm);
+        let cumulative_state_diff = mc_db::rocksdb::global_trie::in_memory::squash_state_diffs(
+            self.pending_epoch_diffs.range(cumulative_start..=block_n).map(|(_, diff)| diff),
+        );
+        let snapshot_base_block_n = self.snapshot_base_block_n;
+        let trie_log_mode = self.trie_log_mode;
+        let backend_for_path_a = Arc::clone(&self.backend);
+        let backend_for_path_b = Arc::clone(&self.backend);
+
+        self.path_a_jobs.spawn(async move {
+            tokio::task::spawn_blocking(move || -> anyhow::Result<u64> {
+                let mut block = payload.block;
+                block.state_diff = payload.state_diff;
+
+                for l1_nonce in payload.consumed_core_contract_nonces {
+                    backend_for_path_a
+                        .remove_pending_message_to_l2(l1_nonce)
+                        .context("removing consumed l1->l2 nonce in parallel finalizer")?;
+                }
+
+                backend_for_path_a.write_access().write_parallel_merkle_staged_block_data(
+                    &block,
+                    &payload.classes,
+                    Some(&payload.bouncer_weights),
+                )?;
+                Ok(block_n)
+            })
+            .await
+            .context("joining blocking path-a worker")?
+        });
+
+        self.path_b_jobs.spawn(async move {
+            tokio::task::spawn_blocking(move || -> anyhow::Result<(u64, RootReady)> {
+                let root_result = backend_for_path_b.write_access().compute_parallel_merkle_root_from_snapshot_base(
+                    snapshot_base_block_n,
+                    block_n,
+                    &cumulative_state_diff,
+                    is_boundary,
+                    trie_log_mode,
+                )?;
+
+                Ok((block_n, RootReady { root: root_result.state_root, overlay: root_result.overlay, is_boundary }))
+            })
+            .await
+            .context("joining blocking path-b worker")?
+        });
+    }
+
+    async fn try_confirm_ready(&mut self) -> anyhow::Result<()> {
+        loop {
+            if !Self::is_confirm_ready(self.next_confirm, &self.persisted_ready, &self.roots_ready) {
+                break;
+            }
+            let Some(root_ready) = self.roots_ready.get(&self.next_confirm).cloned() else {
+                break;
+            };
+
+            self.persisted_ready.remove(&self.next_confirm);
+            self.roots_ready.remove(&self.next_confirm);
+
+            self.backend
+                .write_access()
+                .confirm_parallel_merkle_staged_block_with_root(
+                    self.next_confirm,
+                    root_ready.root,
+                    /* pre_v0_13_2_hash_override */ true,
+                )
+                .with_context(|| format!("confirming staged block #{} in parallel finalizer", self.next_confirm))?;
+
+            if root_ready.is_boundary {
+                let overlay = root_ready
+                    .overlay
+                    .as_ref()
+                    .with_context(|| format!("missing boundary overlay for block #{}", self.next_confirm))?;
+
+                self.backend
+                    .write_access()
+                    .flush_parallel_merkle_overlay_and_checkpoint(self.next_confirm, overlay, self.trie_log_mode)
+                    .with_context(|| {
+                        format!("flushing boundary overlay/checkpoint for block #{}", self.next_confirm)
+                    })?;
+
+                self.snapshot_base_block_n = self.next_confirm;
+                self.pending_epoch_diffs = self.pending_epoch_diffs.split_off(&(self.next_confirm + 1));
+            }
+
+            self.next_confirm += 1;
+        }
+        Ok(())
+    }
+
+    fn is_boundary_for(flush_interval: u64, block_n: u64) -> bool {
+        (block_n + 1) % flush_interval == 0
+    }
+
+    fn cumulative_range_start(snapshot_base_block_n: u64, next_confirm: u64) -> u64 {
+        if next_confirm == 0 {
+            0
+        } else {
+            snapshot_base_block_n.saturating_add(1)
+        }
+    }
+
+    fn is_confirm_ready(
+        next_confirm: u64,
+        persisted_ready: &BTreeSet<u64>,
+        roots_ready: &BTreeMap<u64, RootReady>,
+    ) -> bool {
+        persisted_ready.contains(&next_confirm) && roots_ready.contains_key(&next_confirm)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boundary_rule_respects_flush_interval() {
+        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 0));
+        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 1));
+        assert!(ParallelMerkleFinalizerWorker::is_boundary_for(3, 2));
+        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 3));
+        assert!(!ParallelMerkleFinalizerWorker::is_boundary_for(3, 4));
+        assert!(ParallelMerkleFinalizerWorker::is_boundary_for(3, 5));
+    }
+
+    #[test]
+    fn cumulative_start_includes_block_zero_without_confirmed_tip() {
+        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(0, 0), 0);
+        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(10, 0), 0);
+    }
+
+    #[test]
+    fn cumulative_start_skips_persisted_snapshot_base_after_confirmed_tip() {
+        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(0, 1), 1);
+        assert_eq!(ParallelMerkleFinalizerWorker::cumulative_range_start(9, 10), 10);
+    }
+
+    #[test]
+    fn confirm_ready_requires_both_paths_for_next_block() {
+        let mut persisted_ready = BTreeSet::new();
+        let mut roots_ready = BTreeMap::new();
+        let root_ready = RootReady { root: Felt::ONE, overlay: None, is_boundary: false };
+
+        assert!(!ParallelMerkleFinalizerWorker::is_confirm_ready(5, &persisted_ready, &roots_ready));
+
+        persisted_ready.insert(5);
+        assert!(!ParallelMerkleFinalizerWorker::is_confirm_ready(5, &persisted_ready, &roots_ready));
+
+        roots_ready.insert(6, root_ready.clone());
+        assert!(!ParallelMerkleFinalizerWorker::is_confirm_ready(5, &persisted_ready, &roots_ready));
+
+        roots_ready.insert(5, root_ready);
+        assert!(ParallelMerkleFinalizerWorker::is_confirm_ready(5, &persisted_ready, &roots_ready));
+    }
+}

--- a/madara/crates/client/block_production/src/finalizer.rs
+++ b/madara/crates/client/block_production/src/finalizer.rs
@@ -1,4 +1,4 @@
-use crate::{remove_consumed_core_contract_nonces, ParallelMerkleConfig, ParallelMerkleTrieLogMode};
+use crate::{ParallelMerkleConfig, ParallelMerkleTrieLogMode};
 use anyhow::Context;
 use blockifier::bouncer::BouncerWeights;
 use mc_db::{BonsaiOverlay, MadaraBackend, ParallelMerkleInMemoryTrieLogMode};
@@ -38,6 +38,12 @@ struct RootReady {
     is_boundary: bool,
 }
 
+#[derive(Debug, Clone)]
+struct LaneFailure {
+    lane: &'static str,
+    message: String,
+}
+
 pub fn spawn_parallel_merkle_finalizer(
     backend: Arc<MadaraBackend>,
     config: ParallelMerkleConfig,
@@ -49,11 +55,18 @@ pub fn spawn_parallel_merkle_finalizer(
 
     let latest_confirmed = backend.latest_confirmed_block_n();
     let next_confirm = latest_confirmed.map(|n| n + 1).unwrap_or(0);
-    let snapshot_base_block_n = backend
-        .get_parallel_merkle_latest_checkpoint()
-        .context("reading parallel merkle latest checkpoint")?
-        .or(latest_confirmed)
-        .unwrap_or(0);
+    let latest_checkpoint =
+        backend.get_parallel_merkle_latest_checkpoint().context("reading parallel merkle latest checkpoint")?;
+    if let (Some(checkpoint), Some(confirmed)) = (latest_checkpoint, latest_confirmed) {
+        if checkpoint < confirmed {
+            tracing::warn!(
+                latest_checkpoint = checkpoint,
+                latest_confirmed = confirmed,
+                "parallel finalizer bootstrap prefers latest confirmed as snapshot base to avoid stale checkpoint base"
+            );
+        }
+    }
+    let snapshot_base_block_n = initial_snapshot_base(latest_confirmed, latest_checkpoint);
 
     let trie_log_mode = map_trie_log_mode(config.trie_log_mode);
     let mut worker = ParallelMerkleFinalizerWorker {
@@ -65,8 +78,11 @@ pub fn spawn_parallel_merkle_finalizer(
         pending_epoch_diffs: BTreeMap::new(),
         persisted_ready: BTreeSet::new(),
         roots_ready: BTreeMap::new(),
-        path_a_jobs: JoinSet::new(),
-        path_b_jobs: JoinSet::new(),
+        db_staging_jobs: JoinSet::new(),
+        root_compute_jobs: JoinSet::new(),
+        max_inflight_blocks: max_inflight,
+        scheduled_blocks: BTreeSet::new(),
+        failed_blocks: BTreeMap::new(),
     };
     tokio::spawn(async move {
         if let Err(error) = worker.run(receiver).await {
@@ -75,6 +91,10 @@ pub fn spawn_parallel_merkle_finalizer(
     });
 
     Ok(ParallelMerkleFinalizerHandle { sender })
+}
+
+fn initial_snapshot_base(latest_confirmed: Option<u64>, latest_checkpoint: Option<u64>) -> u64 {
+    latest_confirmed.or(latest_checkpoint).unwrap_or(0)
 }
 
 fn map_trie_log_mode(mode: ParallelMerkleTrieLogMode) -> ParallelMerkleInMemoryTrieLogMode {
@@ -93,31 +113,48 @@ struct ParallelMerkleFinalizerWorker {
     pending_epoch_diffs: BTreeMap<u64, StateDiff>,
     persisted_ready: BTreeSet<u64>,
     roots_ready: BTreeMap<u64, RootReady>,
-    path_a_jobs: JoinSet<anyhow::Result<u64>>,
-    path_b_jobs: JoinSet<anyhow::Result<(u64, RootReady)>>,
+    db_staging_jobs: JoinSet<(u64, anyhow::Result<()>)>,
+    root_compute_jobs: JoinSet<(u64, anyhow::Result<RootReady>)>,
+    max_inflight_blocks: usize,
+    scheduled_blocks: BTreeSet<u64>,
+    failed_blocks: BTreeMap<u64, LaneFailure>,
 }
 
 impl ParallelMerkleFinalizerWorker {
     async fn run(&mut self, mut receiver: mpsc::Receiver<FinalizedBlockPayload>) -> anyhow::Result<()> {
         loop {
             tokio::select! {
-                maybe_payload = receiver.recv() => {
+                maybe_payload = receiver.recv(), if Self::can_schedule_more(self.max_inflight_blocks, &self.scheduled_blocks) => {
                     match maybe_payload {
                         Some(payload) => self.schedule_block(payload),
                         None => {
-                            if self.path_a_jobs.is_empty() && self.path_b_jobs.is_empty() {
+                            if self.db_staging_jobs.is_empty() && self.root_compute_jobs.is_empty() {
                                 break;
                             }
                         }
                     }
                 }
-                Some(joined) = self.path_a_jobs.join_next(), if !self.path_a_jobs.is_empty() => {
-                    let block_n = joined.context("joining path-a persistence job")??;
-                    self.persisted_ready.insert(block_n);
+                Some(joined) = self.db_staging_jobs.join_next(), if !self.db_staging_jobs.is_empty() => {
+                    let (block_n, db_staging_result) = joined.context("joining db-staging persistence job")?;
+                    match db_staging_result {
+                        Ok(()) => {
+                            self.persisted_ready.insert(block_n);
+                        }
+                        Err(error) => {
+                            self.record_block_failure(block_n, "db-staging", error);
+                        }
+                    }
                 }
-                Some(joined) = self.path_b_jobs.join_next(), if !self.path_b_jobs.is_empty() => {
-                    let (block_n, root_ready) = joined.context("joining path-b root job")??;
-                    self.roots_ready.insert(block_n, root_ready);
+                Some(joined) = self.root_compute_jobs.join_next(), if !self.root_compute_jobs.is_empty() => {
+                    let (block_n, root_result) = joined.context("joining root-compute job")?;
+                    match root_result {
+                        Ok(root_ready) => {
+                            self.roots_ready.insert(block_n, root_ready);
+                        }
+                        Err(error) => {
+                            self.record_block_failure(block_n, "root-compute", error);
+                        }
+                    }
                 }
                 else => break,
             }
@@ -132,6 +169,15 @@ impl ParallelMerkleFinalizerWorker {
 
     fn schedule_block(&mut self, payload: FinalizedBlockPayload) {
         let block_n = payload.block_n;
+        if !self.scheduled_blocks.insert(block_n) {
+            self.record_block_failure(
+                block_n,
+                "scheduler",
+                anyhow::anyhow!("duplicate finalizer payload for block #{block_n}"),
+            );
+            return;
+        }
+
         let is_boundary = Self::is_boundary_for(self.flush_interval, block_n);
 
         self.pending_epoch_diffs.insert(block_n, payload.state_diff.clone());
@@ -141,49 +187,58 @@ impl ParallelMerkleFinalizerWorker {
         );
         let snapshot_base_block_n = self.snapshot_base_block_n;
         let trie_log_mode = self.trie_log_mode;
-        let backend_for_path_a = Arc::clone(&self.backend);
-        let backend_for_path_b = Arc::clone(&self.backend);
+        let backend_for_db_staging = Arc::clone(&self.backend);
+        let backend_for_root_compute = Arc::clone(&self.backend);
 
-        self.path_a_jobs.spawn(async move {
-            tokio::task::spawn_blocking(move || -> anyhow::Result<u64> {
+        self.db_staging_jobs.spawn(async move {
+            let db_staging_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
                 let mut block = payload.block;
                 block.state_diff = payload.state_diff;
 
-                remove_consumed_core_contract_nonces(
-                    backend_for_path_a.as_ref(),
-                    payload.consumed_core_contract_nonces,
-                    "parallel finalizer",
-                )?;
-
-                backend_for_path_a.write_access().write_parallel_merkle_staged_block_data(
+                backend_for_db_staging.write_access().write_parallel_merkle_staged_block_data_with_consumed_nonces(
                     &block,
                     &payload.classes,
                     Some(&payload.bouncer_weights),
+                    payload.consumed_core_contract_nonces,
                 )?;
-                Ok(block_n)
+                Ok(())
             })
             .await
-            .context("joining blocking path-a worker")?
+            .context("joining blocking db-staging worker")
+            .and_then(|result| result);
+            (block_n, db_staging_result)
         });
 
-        self.path_b_jobs.spawn(async move {
-            tokio::task::spawn_blocking(move || -> anyhow::Result<(u64, RootReady)> {
-                let root_result = backend_for_path_b.write_access().compute_parallel_merkle_root_from_snapshot_base(
-                    snapshot_base_block_n,
-                    block_n,
-                    &cumulative_state_diff,
-                    is_boundary,
-                    trie_log_mode,
-                )?;
+        self.root_compute_jobs.spawn(async move {
+            let root_result = tokio::task::spawn_blocking(move || -> anyhow::Result<RootReady> {
+                let computed =
+                    backend_for_root_compute.write_access().compute_parallel_merkle_root_from_snapshot_base(
+                        snapshot_base_block_n,
+                        block_n,
+                        &cumulative_state_diff,
+                        is_boundary,
+                        trie_log_mode,
+                    )?;
 
-                Ok((block_n, RootReady { root: root_result.state_root, overlay: root_result.overlay, is_boundary }))
+                Ok(RootReady { root: computed.state_root, overlay: computed.overlay, is_boundary })
             })
             .await
-            .context("joining blocking path-b worker")?
+            .context("joining blocking root-compute worker")
+            .and_then(|result| result);
+            (block_n, root_result)
         });
     }
 
     async fn try_confirm_ready(&mut self) -> anyhow::Result<()> {
+        if let Some(failure) = Self::next_confirm_failure(self.next_confirm, &self.failed_blocks) {
+            anyhow::bail!(
+                "parallel finalizer cannot progress at block #{}: {} lane failed: {}",
+                self.next_confirm,
+                failure.lane,
+                failure.message
+            );
+        }
+
         loop {
             if !Self::is_confirm_ready(self.next_confirm, &self.persisted_ready, &self.roots_ready) {
                 break;
@@ -221,6 +276,7 @@ impl ParallelMerkleFinalizerWorker {
                 self.pending_epoch_diffs = self.pending_epoch_diffs.split_off(&(self.next_confirm + 1));
             }
 
+            self.scheduled_blocks.remove(&self.next_confirm);
             self.next_confirm += 1;
         }
         Ok(())
@@ -244,6 +300,19 @@ impl ParallelMerkleFinalizerWorker {
         roots_ready: &BTreeMap<u64, RootReady>,
     ) -> bool {
         persisted_ready.contains(&next_confirm) && roots_ready.contains_key(&next_confirm)
+    }
+
+    fn can_schedule_more(max_inflight_blocks: usize, scheduled_blocks: &BTreeSet<u64>) -> bool {
+        scheduled_blocks.len() < max_inflight_blocks
+    }
+
+    fn next_confirm_failure(next_confirm: u64, failed_blocks: &BTreeMap<u64, LaneFailure>) -> Option<LaneFailure> {
+        failed_blocks.get(&next_confirm).cloned()
+    }
+
+    fn record_block_failure(&mut self, block_n: u64, lane: &'static str, error: anyhow::Error) {
+        let message = format!("{error:#}");
+        self.failed_blocks.entry(block_n).or_insert(LaneFailure { lane, message });
     }
 }
 
@@ -289,5 +358,40 @@ mod tests {
 
         roots_ready.insert(5, root_ready);
         assert!(ParallelMerkleFinalizerWorker::is_confirm_ready(5, &persisted_ready, &roots_ready));
+    }
+
+    #[test]
+    fn can_schedule_more_respects_inflight_bound() {
+        let mut scheduled = BTreeSet::new();
+        assert!(ParallelMerkleFinalizerWorker::can_schedule_more(2, &scheduled));
+
+        scheduled.insert(10);
+        scheduled.insert(11);
+        assert!(!ParallelMerkleFinalizerWorker::can_schedule_more(2, &scheduled));
+    }
+
+    #[test]
+    fn next_confirm_failure_only_blocks_matching_height() {
+        let mut failed_blocks = BTreeMap::new();
+        failed_blocks.insert(7, LaneFailure { lane: "root-compute", message: "boom".to_string() });
+        assert!(ParallelMerkleFinalizerWorker::next_confirm_failure(6, &failed_blocks).is_none());
+
+        let failure = ParallelMerkleFinalizerWorker::next_confirm_failure(7, &failed_blocks)
+            .expect("failure for next confirm block should be returned");
+        assert_eq!(failure.lane, "root-compute");
+        assert!(failure.message.contains("boom"));
+    }
+
+    #[test]
+    fn initial_snapshot_base_prefers_latest_confirmed_when_present() {
+        assert_eq!(initial_snapshot_base(Some(10), Some(9)), 10);
+        assert_eq!(initial_snapshot_base(Some(10), Some(15)), 10);
+        assert_eq!(initial_snapshot_base(Some(10), None), 10);
+    }
+
+    #[test]
+    fn initial_snapshot_base_falls_back_to_checkpoint_or_zero() {
+        assert_eq!(initial_snapshot_base(None, Some(8)), 8);
+        assert_eq!(initial_snapshot_base(None, None), 0);
     }
 }

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -202,6 +202,20 @@ pub(crate) struct CurrentBlockState {
     pub accumulated_stats: util::ExecutionStats,
 }
 
+pub(crate) fn remove_consumed_core_contract_nonces(
+    backend: &MadaraBackend,
+    consumed_core_contract_nonces: impl IntoIterator<Item = u64>,
+    operation: &str,
+) -> anyhow::Result<()> {
+    for l1_nonce in consumed_core_contract_nonces {
+        backend
+            .remove_pending_message_to_l2(l1_nonce)
+            .with_context(|| format!("removing consumed l1->l2 nonce during {operation}"))?;
+    }
+
+    Ok(())
+}
+
 impl CurrentBlockState {
     pub fn new(backend: Arc<MadaraBackend>, block_number: u64) -> Self {
         Self {
@@ -489,12 +503,11 @@ impl BlockProductionTask {
         // Copy bouncer_weights to move into the closure (BouncerWeights implements Copy)
         let bouncer_weights = *bouncer_weights;
         global_spawn_rayon_task(move || {
-            // Remove consumed L1 to L2 message nonces
-            for l1_nonce in consumed_core_contract_nonces {
-                backend
-                    .remove_pending_message_to_l2(l1_nonce)
-                    .context("Removing pending message to l2 from database")?;
-            }
+            remove_consumed_core_contract_nonces(
+                backend.as_ref(),
+                consumed_core_contract_nonces,
+                "preconfirmed block close",
+            )?;
 
             // Save bouncer weights
             backend

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -377,10 +377,19 @@ impl BlockProductionTask {
         l1_client: Arc<dyn SettlementClient>,
         no_charge_fee: bool,
         parallel_merkle: ParallelMerkleConfig,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let (sender, recv) = mpsc::unbounded_channel();
         let (bypass_input_sender, bypass_tx_input) = mpsc::channel(16);
-        Self {
+        let parallel_merkle_finalizer = if parallel_merkle.enabled {
+            Some(
+                spawn_parallel_merkle_finalizer(backend.clone(), parallel_merkle.clone())
+                    .context("spawning parallel merkle finalizer")?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Self {
             backend: backend.clone(),
             mempool,
             current_state: None,
@@ -392,8 +401,8 @@ impl BlockProductionTask {
             bypass_tx_input: Some(bypass_tx_input),
             no_charge_fee,
             parallel_merkle,
-            parallel_merkle_finalizer: None,
-        }
+            parallel_merkle_finalizer,
+        })
     }
 
     pub fn handle(&self) -> BlockProductionHandle {
@@ -1056,13 +1065,10 @@ impl BlockProductionTask {
         // initial state
         let latest_block_n = self.backend.latest_confirmed_block_n();
         self.current_state = Some(TaskState::NotExecuting { latest_block_n });
-
-        if self.parallel_merkle.enabled {
-            self.parallel_merkle_finalizer = Some(
-                spawn_parallel_merkle_finalizer(self.backend.clone(), self.parallel_merkle.clone())
-                    .context("spawning parallel merkle finalizer")?,
-            );
-        }
+        debug_assert!(
+            !self.parallel_merkle.enabled || self.parallel_merkle_finalizer.is_some(),
+            "parallel merkle finalizer must be initialized in BlockProductionTask::new when enabled"
+        );
 
         Ok(())
     }
@@ -1219,6 +1225,7 @@ pub(crate) mod tests {
                 false, /* no_charge_fee = false */
                 ParallelMerkleConfig::default(),
             )
+            .expect("creating block production task")
         }
     }
 
@@ -2059,7 +2066,8 @@ pub(crate) mod tests {
             Arc::new(original_devnet_setup.l1_client.clone()),
             initial_no_charge_fee,
             ParallelMerkleConfig::default(),
-        );
+        )
+        .expect("creating initial block production task");
 
         let mut notifications = block_production_task.subscribe_state_notifications();
         let restart_task =
@@ -2090,7 +2098,8 @@ pub(crate) mod tests {
             Arc::new(original_devnet_setup.l1_client.clone()),
             restart_no_charge_fee, // Current config: no_charge_fee = false
             ParallelMerkleConfig::default(),
-        );
+        )
+        .expect("creating restart block production task");
 
         // Start the block production task.
         // This will call setup_initial_state() which calls close_preconfirmed_block_if_exists().

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -957,8 +957,18 @@ impl BlockProductionTask {
                 state_diff,
                 consumed_core_contract_nonces: state.consumed_core_contract_nonces,
                 bouncer_weights: block_exec_summary.bouncer_weights,
+                execution_stats: state.accumulated_stats.clone(),
+                block_production_duration: state.block_start_time.elapsed(),
             };
             finalizer.submit(payload).await.context("queueing block in parallel finalizer")?;
+            tracing::info!(
+                target: "close_block",
+                block_number = state.block_number,
+                tx_count = n_txs,
+                event_count = event_count,
+                close_preconfirmed_ms = close_preconfirmed_start.elapsed().as_secs_f64() * 1000.0,
+                "close_block_queued_for_parallel_finalizer"
+            );
         } else {
             let db_result = Self::close_preconfirmed_block_with_state_diff(
                 self.backend.clone(),

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -125,6 +125,7 @@
 //! [`process_reply`]: BlockProductionTask::process_reply
 
 use crate::batcher::Batcher;
+use crate::finalizer::{spawn_parallel_merkle_finalizer, FinalizedBlockPayload, ParallelMerkleFinalizerHandle};
 use crate::metrics::BlockProductionMetrics;
 use crate::util::BlockExecutionContext;
 use anyhow::Context;
@@ -154,6 +155,7 @@ use tokio::sync::mpsc;
 
 mod batcher;
 mod executor;
+mod finalizer;
 mod handle;
 pub mod metrics;
 mod util;
@@ -342,8 +344,8 @@ pub struct BlockProductionTask {
     l1_client: Arc<dyn SettlementClient>,
     bypass_tx_input: Option<mpsc::Receiver<ValidatedTransaction>>,
     no_charge_fee: bool,
-    #[allow(dead_code)] // Will be consumed by finalizer orchestration in follow-up PRs.
     parallel_merkle: ParallelMerkleConfig,
+    parallel_merkle_finalizer: Option<ParallelMerkleFinalizerHandle>,
 }
 
 impl BlockProductionTask {
@@ -376,6 +378,7 @@ impl BlockProductionTask {
             bypass_tx_input: Some(bypass_tx_input),
             no_charge_fee,
             parallel_merkle,
+            parallel_merkle_finalizer: None,
         }
     }
 
@@ -915,15 +918,88 @@ impl BlockProductionTask {
         self.metrics.block_consumed_l1_nonces_count.record(consumed_l1_nonces_count as u64, &[]);
 
         let close_preconfirmed_start = Instant::now();
-        let db_result = Self::close_preconfirmed_block_with_state_diff(
-            self.backend.clone(),
-            state.block_number,
-            state.consumed_core_contract_nonces,
-            &block_exec_summary.bouncer_weights,
-            state_diff,
-        )
-        .await
-        .context("Closing block")?;
+        if self.parallel_merkle.enabled {
+            let finalizer = self
+                .parallel_merkle_finalizer
+                .as_ref()
+                .context("parallel merkle is enabled but finalizer handle is missing")?;
+
+            let (mut block_without_state_diff, classes) =
+                preconfirmed_view.get_full_block_without_state_diff().context("building finalizer payload block")?;
+            block_without_state_diff.state_diff = state_diff.clone();
+
+            let payload = FinalizedBlockPayload {
+                block_n: state.block_number,
+                block: block_without_state_diff,
+                classes,
+                state_diff,
+                consumed_core_contract_nonces: state.consumed_core_contract_nonces,
+                bouncer_weights: block_exec_summary.bouncer_weights,
+            };
+            finalizer.submit(payload).await.context("queueing block in parallel finalizer")?;
+        } else {
+            let db_result = Self::close_preconfirmed_block_with_state_diff(
+                self.backend.clone(),
+                state.block_number,
+                state.consumed_core_contract_nonces,
+                &block_exec_summary.bouncer_weights,
+                state_diff,
+            )
+            .await
+            .context("Closing block")?;
+
+            // Emit structured log event for Loki querying (close_block_complete)
+            // All timing values converted to milliseconds for human-readability
+            let timings = &db_result.timings;
+            let exec_stats = &state.accumulated_stats;
+            let time_to_close = start_time.elapsed();
+            let block_production_time = state.block_start_time.elapsed();
+            tracing::info!(
+                target: "close_block",
+                block_number = state.block_number,
+                tx_count = n_txs,
+                event_count = event_count,
+                // High-level timing
+                close_block_total_ms = time_to_close.as_secs_f64() * 1000.0,
+                block_close_ms = time_to_close.as_secs_f64() * 1000.0,
+                close_preconfirmed_ms = close_preconfirmed_start.elapsed().as_secs_f64() * 1000.0,
+                block_production_ms = block_production_time.as_secs_f64() * 1000.0,
+                // Execution stats
+                batches_executed = exec_stats.n_batches,
+                txs_added_to_block = exec_stats.n_added_to_block,
+                txs_executed = exec_stats.n_executed,
+                txs_reverted = exec_stats.n_reverted,
+                txs_rejected = exec_stats.n_rejected,
+                classes_declared = exec_stats.declared_classes,
+                l2_gas_consumed = exec_stats.l2_gas_consumed,
+                // State diff counts
+                state_diff_len = state_diff_len,
+                declared_classes = declared_classes_count,
+                deployed_contracts = deployed_contracts_count,
+                storage_diffs = storage_diffs_count,
+                nonce_updates = nonce_updates_count,
+                consumed_l1_nonces = consumed_l1_nonces_count,
+                // Bouncer weights
+                bouncer_l1_gas = bouncer_l1_gas,
+                bouncer_sierra_gas = bouncer_sierra_gas,
+                bouncer_n_events = bouncer_n_events,
+                bouncer_message_segment_length = bouncer_message_segment_length,
+                bouncer_state_diff_size = bouncer_state_diff_size,
+                // DB timing breakdown (all in ms)
+                get_full_block_ms = timings.get_full_block_with_classes.as_secs_f64() * 1000.0,
+                commitments_ms = timings.block_commitments_compute.as_secs_f64() * 1000.0,
+                merklization_ms = timings.merklization.as_secs_f64() * 1000.0,
+                contract_trie_ms = timings.contract_trie_root.as_secs_f64() * 1000.0,
+                class_trie_ms = timings.class_trie_root.as_secs_f64() * 1000.0,
+                contract_storage_trie_commit_ms = timings.contract_storage_trie_commit.as_secs_f64() * 1000.0,
+                contract_trie_commit_ms = timings.contract_trie_commit.as_secs_f64() * 1000.0,
+                class_trie_commit_ms = timings.class_trie_commit.as_secs_f64() * 1000.0,
+                block_hash_ms = timings.block_hash_compute.as_secs_f64() * 1000.0,
+                db_write_ms = timings.db_write_block_parts.as_secs_f64() * 1000.0,
+                "close_block_complete"
+            );
+        }
+
         let close_preconfirmed_duration = close_preconfirmed_start.elapsed();
         self.metrics.close_preconfirmed_duration.record(close_preconfirmed_duration.as_secs_f64(), &[]);
         self.metrics.close_preconfirmed_last.record(close_preconfirmed_duration.as_secs_f64(), &[]);
@@ -931,56 +1007,14 @@ impl BlockProductionTask {
         let time_to_close = start_time.elapsed();
         let block_production_time = state.block_start_time.elapsed();
 
-        // Emit structured log event for Loki querying (close_block_complete)
-        // All timing values converted to milliseconds for human-readability
-        let timings = &db_result.timings;
-        let exec_stats = &state.accumulated_stats;
-        tracing::info!(
-            target: "close_block",
-            block_number = state.block_number,
-            tx_count = n_txs,
-            event_count = event_count,
-            // High-level timing
-            close_block_total_ms = time_to_close.as_secs_f64() * 1000.0,
-            block_close_ms = time_to_close.as_secs_f64() * 1000.0,
-            close_preconfirmed_ms = close_preconfirmed_duration.as_secs_f64() * 1000.0,
-            block_production_ms = block_production_time.as_secs_f64() * 1000.0,
-            // Execution stats
-            batches_executed = exec_stats.n_batches,
-            txs_added_to_block = exec_stats.n_added_to_block,
-            txs_executed = exec_stats.n_executed,
-            txs_reverted = exec_stats.n_reverted,
-            txs_rejected = exec_stats.n_rejected,
-            classes_declared = exec_stats.declared_classes,
-            l2_gas_consumed = exec_stats.l2_gas_consumed,
-            // State diff counts
-            state_diff_len = state_diff_len,
-            declared_classes = declared_classes_count,
-            deployed_contracts = deployed_contracts_count,
-            storage_diffs = storage_diffs_count,
-            nonce_updates = nonce_updates_count,
-            consumed_l1_nonces = consumed_l1_nonces_count,
-            // Bouncer weights
-            bouncer_l1_gas = bouncer_l1_gas,
-            bouncer_sierra_gas = bouncer_sierra_gas,
-            bouncer_n_events = bouncer_n_events,
-            bouncer_message_segment_length = bouncer_message_segment_length,
-            bouncer_state_diff_size = bouncer_state_diff_size,
-            // DB timing breakdown (all in ms)
-            get_full_block_ms = timings.get_full_block_with_classes.as_secs_f64() * 1000.0,
-            commitments_ms = timings.block_commitments_compute.as_secs_f64() * 1000.0,
-            merklization_ms = timings.merklization.as_secs_f64() * 1000.0,
-            contract_trie_ms = timings.contract_trie_root.as_secs_f64() * 1000.0,
-            class_trie_ms = timings.class_trie_root.as_secs_f64() * 1000.0,
-            contract_storage_trie_commit_ms = timings.contract_storage_trie_commit.as_secs_f64() * 1000.0,
-            contract_trie_commit_ms = timings.contract_trie_commit.as_secs_f64() * 1000.0,
-            class_trie_commit_ms = timings.class_trie_commit.as_secs_f64() * 1000.0,
-            block_hash_ms = timings.block_hash_compute.as_secs_f64() * 1000.0,
-            db_write_ms = timings.db_write_block_parts.as_secs_f64() * 1000.0,
-            "close_block_complete"
-        );
-
-        tracing::info!("⛏️  Closed block #{} with {n_txs} transactions - {time_to_close:?}", state.block_number);
+        if self.parallel_merkle.enabled {
+            tracing::info!(
+                "⛏️  Queued block #{} with {n_txs} transactions for parallel finalizer - {time_to_close:?}",
+                state.block_number
+            );
+        } else {
+            tracing::info!("⛏️  Closed block #{} with {n_txs} transactions - {time_to_close:?}", state.block_number);
+        }
 
         // Record timing metrics
         self.metrics.close_block_total_duration.record(time_to_close.as_secs_f64(), &[]);
@@ -1009,6 +1043,13 @@ impl BlockProductionTask {
         // initial state
         let latest_block_n = self.backend.latest_confirmed_block_n();
         self.current_state = Some(TaskState::NotExecuting { latest_block_n });
+
+        if self.parallel_merkle.enabled {
+            self.parallel_merkle_finalizer = Some(
+                spawn_parallel_merkle_finalizer(self.backend.clone(), self.parallel_merkle.clone())
+                    .context("spawning parallel merkle finalizer")?,
+            );
+        }
 
         Ok(())
     }

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -158,6 +158,9 @@ pub mod view;
 
 use blockifier::bouncer::BouncerWeights;
 pub use rocksdb::external_outbox::{ExternalOutboxEntry, ExternalOutboxId};
+pub use rocksdb::global_trie::in_memory::{
+    BonsaiOverlay, InMemoryRootComputation, TrieLogMode as ParallelMerkleInMemoryTrieLogMode,
+};
 pub use rocksdb::global_trie::MerklizationTimings;
 pub use storage::{
     DevnetPredeployedContractAccount, DevnetPredeployedKeys, EventFilter, MadaraStorage, MadaraStorageRead,
@@ -1114,6 +1117,36 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
     // pub fn update_metrics(&self) -> u64 {
     //     self.db_metrics.update(&self.db)
     // }
+}
+
+impl MadaraBackendWriter<RocksDBStorage> {
+    /// Compute state root for a cumulative state diff from a specific persisted snapshot base.
+    pub fn compute_parallel_merkle_root_from_snapshot_base(
+        &self,
+        snapshot_base_block_n: u64,
+        block_n: u64,
+        cumulative_state_diff: &StateDiff,
+        include_overlay: bool,
+        trie_log_mode: ParallelMerkleInMemoryTrieLogMode,
+    ) -> Result<InMemoryRootComputation> {
+        self.inner.db.compute_parallel_merkle_root_from_snapshot_base(
+            snapshot_base_block_n,
+            block_n,
+            cumulative_state_diff,
+            include_overlay,
+            trie_log_mode,
+        )
+    }
+
+    /// Flush a boundary overlay and atomically persist checkpoint metadata.
+    pub fn flush_parallel_merkle_overlay_and_checkpoint(
+        &self,
+        block_n: u64,
+        overlay: &BonsaiOverlay,
+        trie_log_mode: ParallelMerkleInMemoryTrieLogMode,
+    ) -> Result<()> {
+        self.inner.db.flush_parallel_merkle_overlay_and_checkpoint(block_n, overlay, trie_log_mode)
+    }
 }
 
 // Delegate these db reads/writes. These are related to specific services, and are not specific to a block view / the chain tip writer handle.

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -1120,6 +1120,22 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
 }
 
 impl MadaraBackendWriter<RocksDBStorage> {
+    pub fn write_parallel_merkle_staged_block_data_with_consumed_nonces(
+        &self,
+        block: &FullBlockWithoutCommitments,
+        classes: &[ConvertedClass],
+        bouncer_weights: Option<&BouncerWeights>,
+        consumed_core_contract_nonces: impl IntoIterator<Item = u64>,
+    ) -> Result<()> {
+        self.inner.db.write_parallel_merkle_staged_block_data_with_consumed_nonces(
+            block,
+            classes,
+            bouncer_weights,
+            consumed_core_contract_nonces,
+            self.inner.chain_config.chain_id.to_felt(),
+        )
+    }
+
     /// Compute state root for a cumulative state diff from a specific persisted snapshot base.
     pub fn compute_parallel_merkle_root_from_snapshot_base(
         &self,

--- a/madara/crates/client/db/src/rocksdb/l1_to_l2_messages.rs
+++ b/madara/crates/client/db/src/rocksdb/l1_to_l2_messages.rs
@@ -200,6 +200,17 @@ impl RocksDBStorageInner {
         Ok(())
     }
 
+    pub(super) fn remove_pending_messages_to_l2_in_batch(
+        &self,
+        core_contract_nonces: impl IntoIterator<Item = u64>,
+        batch: &mut WriteBatchWithTransaction,
+    ) {
+        let pending_cf = self.get_column(L1_TO_L2_PENDING_MESSAGE_BY_NONCE);
+        for core_contract_nonce in core_contract_nonces {
+            batch.delete_cf(&pending_cf, core_contract_nonce.to_be_bytes());
+        }
+    }
+
     pub(super) fn get_pending_message_to_l2(
         &self,
         core_contract_nonce: u64,

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -179,6 +179,28 @@ impl RocksDBStorageInner {
         Ok(())
     }
 
+    /// Persist staged data for a block in resumable multi-stage commits.
+    ///
+    /// Flow:
+    /// ```text
+    /// Stage 1 (atomic batch):
+    ///   remove pending L1->L2 nonces
+    ///   + write staged header
+    ///   + write txs + tx indices
+    ///   + STAGED_STATE = Txns
+    ///
+    /// Stage 2 (existing writers):
+    ///   materialize events into receipts
+    ///   + compute/store commitments + staged block info
+    ///   + write state diff + state/class updates + bouncer weights
+    ///   + STAGED_STATE = Diff
+    ///
+    /// Stage 3:
+    ///   store events bloom
+    ///   + STAGED_STATE = Final
+    /// ```
+    ///
+    /// Resume rule: stage state in META is the only progress marker and is updated last in each stage.
     fn write_parallel_merkle_staged_block_data(
         &self,
         block: &FullBlockWithoutCommitments,
@@ -258,6 +280,9 @@ impl RocksDBStorageInner {
         Ok(())
     }
 
+    /// Confirm a block only after staged state is `Final`.
+    ///
+    /// This atomically writes confirmed header info, advances chain tip, and clears staged metadata.
     fn confirm_parallel_merkle_staged_block(&self, header: &BlockHeaderWithSignatures) -> Result<()> {
         let block_n = header.header.block_number;
         if !self.parallel_merkle_has_staged_block(block_n)? {

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -4,7 +4,11 @@ use crate::{
     rocksdb::{
         backup::BackupManager,
         column::{Column, ALL_COLUMNS},
-        global_trie::{apply_to_global_trie, get_state_root, MerklizationTimings},
+        global_trie::{
+            apply_to_global_trie, get_state_root,
+            in_memory::{self, BonsaiOverlay, InMemoryRootComputation, TrieLogMode},
+            MerklizationTimings,
+        },
         meta::{ParallelMerkleStagedState, StoredChainTipWithoutContent},
         metrics::DbMetrics,
         options::rocksdb_global_options,
@@ -331,6 +335,33 @@ impl RocksDBStorage {
     /// carefully. This should only be used by the migration system.
     pub fn inner_db(&self) -> &DB {
         &self.inner.db
+    }
+
+    pub fn compute_parallel_merkle_root_from_snapshot_base(
+        &self,
+        snapshot_base_block_n: u64,
+        block_n: u64,
+        state_diff: &StateDiff,
+        include_overlay: bool,
+        trie_log_mode: TrieLogMode,
+    ) -> Result<InMemoryRootComputation> {
+        let (_, snapshot) = self.snapshots.get_closest(snapshot_base_block_n);
+        in_memory::compute_root_from_snapshot(self, snapshot, block_n, state_diff, include_overlay, trie_log_mode)
+            .with_context(|| {
+                format!(
+                    "Computing parallel merkle root from snapshot_base_block_n={snapshot_base_block_n} for block_n={block_n}"
+                )
+            })
+    }
+
+    pub fn flush_parallel_merkle_overlay_and_checkpoint(
+        &self,
+        block_n: u64,
+        overlay: &BonsaiOverlay,
+        trie_log_mode: TrieLogMode,
+    ) -> Result<()> {
+        in_memory::flush_overlay_and_checkpoint(self, block_n, overlay, trie_log_mode)
+            .with_context(|| format!("Flushing parallel merkle overlay and checkpointing block_n={block_n}"))
     }
 }
 

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -184,6 +184,7 @@ impl RocksDBStorageInner {
         block: &FullBlockWithoutCommitments,
         classes: &[ConvertedClass],
         bouncer_weights: Option<&BouncerWeights>,
+        consumed_core_contract_nonces: impl IntoIterator<Item = u64>,
         chain_id: Felt,
     ) -> Result<()> {
         let block_n = block.header.block_number;
@@ -204,9 +205,10 @@ impl RocksDBStorageInner {
         // A single per-block staged-state key in META_COLUMN allows idempotent resume.
         let staged_state = self.parallel_merkle_get_staged_state(block_n)?;
 
-        // Stage 1: Transactions + indices + staged header + txns marker (single atomic batch).
+        // Stage 1: Pending L1->L2 nonce removals + transactions + indices + staged header + txns marker (single atomic batch).
         if staged_state.is_none() {
             let mut batch = WriteBatchWithTransaction::default();
+            self.remove_pending_messages_to_l2_in_batch(consumed_core_contract_nonces, &mut batch);
             self.parallel_merkle_set_staged_header(block_n, &block.header, &mut batch)?;
             self.parallel_merkle_set_staged_state(block_n, ParallelMerkleStagedState::Txns, &mut batch)?;
             self.blocks_store_transactions_with_indices_to_batch(block_n, &block.transactions, &mut batch)?;
@@ -337,6 +339,23 @@ impl RocksDBStorage {
         &self.inner.db
     }
 
+    pub fn write_parallel_merkle_staged_block_data_with_consumed_nonces(
+        &self,
+        block: &FullBlockWithoutCommitments,
+        classes: &[ConvertedClass],
+        bouncer_weights: Option<&BouncerWeights>,
+        consumed_core_contract_nonces: impl IntoIterator<Item = u64>,
+        chain_id: Felt,
+    ) -> Result<()> {
+        self.inner.write_parallel_merkle_staged_block_data(
+            block,
+            classes,
+            bouncer_weights,
+            consumed_core_contract_nonces,
+            chain_id,
+        )
+    }
+
     pub fn compute_parallel_merkle_root_from_snapshot_base(
         &self,
         snapshot_base_block_n: u64,
@@ -345,11 +364,14 @@ impl RocksDBStorage {
         include_overlay: bool,
         trie_log_mode: TrieLogMode,
     ) -> Result<InMemoryRootComputation> {
-        let (_, snapshot) = self.snapshots.get_closest(snapshot_base_block_n);
+        let (snapshot_block_n, snapshot) =
+            self.snapshots.get_at_or_before(snapshot_base_block_n).with_context(|| {
+                format!("No compatible snapshot at-or-before requested snapshot_base_block_n={snapshot_base_block_n}")
+            })?;
         in_memory::compute_root_from_snapshot(self, snapshot, block_n, state_diff, include_overlay, trie_log_mode)
             .with_context(|| {
                 format!(
-                    "Computing parallel merkle root from snapshot_base_block_n={snapshot_base_block_n} for block_n={block_n}"
+                    "Computing parallel merkle root from snapshot_base_block_n={snapshot_base_block_n} using snapshot_at={snapshot_block_n:?} for block_n={block_n}"
                 )
             })
     }
@@ -570,9 +592,14 @@ impl MadaraStorageWrite for RocksDBStorage {
         chain_id: Felt,
     ) -> Result<()> {
         tracing::debug!("Writing parallel merkle staged block data block_n={}", block.header.block_number);
-        self.inner
-            .write_parallel_merkle_staged_block_data(block, classes, bouncer_weights, chain_id)
-            .with_context(|| format!("Writing parallel merkle staged block data block_n={}", block.header.block_number))
+        self.write_parallel_merkle_staged_block_data_with_consumed_nonces(
+            block,
+            classes,
+            bouncer_weights,
+            std::iter::empty(),
+            chain_id,
+        )
+        .with_context(|| format!("Writing parallel merkle staged block data block_n={}", block.header.block_number))
     }
 
     fn confirm_parallel_merkle_staged_block(&self, header: BlockHeaderWithSignatures) -> Result<()> {

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -85,6 +85,25 @@ impl Snapshots {
             // snapshots are disabled. In these cases we want to return the snapshot for the current latest block.
             .unwrap_or_else(|| (inner.head_block_n, Arc::clone(&inner.head)))
     }
+
+    /// Get the closest snapshot at or before the provided `block_n`.
+    ///
+    /// Returns `None` if the only available persisted snapshot is strictly newer than `block_n`.
+    /// For an empty chain (`head_block_n == None`), this returns the current head snapshot.
+    #[tracing::instrument(skip(self))]
+    pub fn get_at_or_before(&self, block_n: u64) -> Option<(Option<u64>, SnapshotRef)> {
+        let inner = self.inner.read().expect("Poisoned lock");
+
+        if let Some((snapshot_block_n, snapshot)) = inner.historical.range(..=block_n).next_back() {
+            return Some((Some(*snapshot_block_n), Arc::clone(snapshot)));
+        }
+
+        match inner.head_block_n {
+            Some(head_block_n) if head_block_n <= block_n => Some((Some(head_block_n), Arc::clone(&inner.head))),
+            Some(_) => None,
+            None => Some((None, Arc::clone(&inner.head))),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -180,5 +199,44 @@ mod tests {
             let (block_n, _) = storage.snapshots.get_closest(expected_block);
             assert_eq!(block_n, Some(expected_block), "Snapshot at block {} should exist", expected_block);
         }
+    }
+
+    #[test]
+    fn test_get_at_or_before_rejects_newer_only_head_snapshot() {
+        let config = RocksDBConfig::default();
+        let (_temp_dir, storage) = create_test_storage(config);
+
+        storage.snapshots.set_new_head(10);
+        assert!(
+            storage.snapshots.get_at_or_before(5).is_none(),
+            "newer head-only snapshot must not satisfy older snapshot base request"
+        );
+    }
+
+    #[test]
+    fn test_get_at_or_before_returns_head_for_equal_or_newer_request() {
+        let config = RocksDBConfig::default();
+        let (_temp_dir, storage) = create_test_storage(config);
+
+        storage.snapshots.set_new_head(10);
+        let (snapshot_block_n, _) = storage.snapshots.get_at_or_before(10).expect("equal head should be returned");
+        assert_eq!(snapshot_block_n, Some(10));
+
+        let (snapshot_block_n, _) =
+            storage.snapshots.get_at_or_before(11).expect("head should be returned for newer request");
+        assert_eq!(snapshot_block_n, Some(10));
+    }
+
+    #[test]
+    fn test_get_at_or_before_prefers_historical_snapshot_when_available() {
+        let config = RocksDBConfig { max_kept_snapshots: Some(5), snapshot_interval: 5, ..Default::default() };
+        let (_temp_dir, storage) = create_test_storage(config);
+
+        for block_n in 0..=20 {
+            storage.snapshots.set_new_head(block_n);
+        }
+
+        let (snapshot_block_n, _) = storage.snapshots.get_at_or_before(17).expect("historical snapshot should exist");
+        assert_eq!(snapshot_block_n, Some(15));
     }
 }

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -109,6 +109,7 @@ impl Snapshots {
 #[cfg(test)]
 mod tests {
     use crate::rocksdb::{RocksDBConfig, RocksDBStorage};
+    use rstest::rstest;
 
     fn create_test_storage(config: RocksDBConfig) -> (tempfile::TempDir, RocksDBStorage) {
         let temp_dir = tempfile::TempDir::with_prefix("snapshot-test").unwrap();
@@ -213,18 +214,22 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_get_at_or_before_returns_head_for_equal_or_newer_request() {
+    #[rstest]
+    #[case(10, Some(10))]
+    #[case(11, Some(10))]
+    fn test_get_at_or_before_returns_head_for_equal_or_newer_request(
+        #[case] requested_block_n: u64,
+        #[case] expected_snapshot_n: Option<u64>,
+    ) {
         let config = RocksDBConfig::default();
         let (_temp_dir, storage) = create_test_storage(config);
 
         storage.snapshots.set_new_head(10);
-        let (snapshot_block_n, _) = storage.snapshots.get_at_or_before(10).expect("equal head should be returned");
-        assert_eq!(snapshot_block_n, Some(10));
-
-        let (snapshot_block_n, _) =
-            storage.snapshots.get_at_or_before(11).expect("head should be returned for newer request");
-        assert_eq!(snapshot_block_n, Some(10));
+        let (snapshot_block_n, _) = storage
+            .snapshots
+            .get_at_or_before(requested_block_n)
+            .expect("head should be returned for equal/newer request");
+        assert_eq!(snapshot_block_n, expected_snapshot_n);
     }
 
     #[test]

--- a/madara/crates/client/db/src/tests/test_parallel_merkle_staged.rs
+++ b/madara/crates/client/db/src/tests/test_parallel_merkle_staged.rs
@@ -16,7 +16,7 @@ use mp_class::ClassInfo;
 use mp_convert::{Felt, ToFelt};
 use mp_receipt::{Event, EventWithTransactionHash, InvokeTransactionReceipt};
 use mp_state_update::{ContractStorageDiffItem, MigratedClassItem, NonceUpdate, StateDiff, StorageEntry};
-use mp_transactions::{validated::TxTimestamp, InvokeTransactionV0};
+use mp_transactions::{validated::TxTimestamp, InvokeTransactionV0, L1HandlerTransaction, L1HandlerTransactionWithFee};
 
 fn make_staged_block(block_n: u64, tx_hash: Felt) -> FullBlockWithoutCommitments {
     let header = PreconfirmedHeader { block_number: block_n, ..Default::default() };
@@ -66,6 +66,18 @@ fn make_preconfirmed_executed_tx(tx_hash: Felt) -> PreconfirmedExecutedTransacti
         arrived_at: TxTimestamp::now(),
         paid_fee_on_l1: None,
     }
+}
+
+fn make_pending_l1_to_l2_message(core_contract_nonce: u64) -> L1HandlerTransactionWithFee {
+    L1HandlerTransactionWithFee::new(
+        L1HandlerTransaction {
+            nonce: core_contract_nonce,
+            contract_address: Felt::from_hex_unchecked("0x1234"),
+            entry_point_selector: Felt::from_hex_unchecked("0x99"),
+            ..Default::default()
+        },
+        10,
+    )
 }
 
 #[tokio::test]
@@ -132,6 +144,38 @@ async fn write_parallel_merkle_staged_block_data_rejects_confirmed_block() {
         .write_parallel_merkle_staged_block_data(&block, &[], None)
         .expect_err("confirmed block should not be staged again");
     assert!(format!("{err:#}").contains("already confirmed"));
+}
+
+#[tokio::test]
+async fn write_parallel_merkle_staged_block_data_stage_one_is_atomic_with_nonce_removals() {
+    let backend = MadaraBackend::open_for_testing(ChainConfig::madara_test().into());
+    let consumed_nonce = 77_u64;
+    let pending = make_pending_l1_to_l2_message(consumed_nonce);
+    backend.write_pending_message_to_l2(&pending).expect("pending message should be stored");
+
+    // Use an overflowed block number so stage-1 fails before batch commit.
+    let block = make_staged_block(u64::MAX, Felt::from_hex_unchecked("0xdead"));
+    let err = backend
+        .write_access()
+        .write_parallel_merkle_staged_block_data_with_consumed_nonces(&block, &[], None, [consumed_nonce])
+        .expect_err("staged write should fail for overflowed block number");
+    assert!(format!("{err:#}").contains("Converting block_n to u32"));
+
+    // Stage-1 is atomic: nonce removal and staged metadata must not be committed on failure.
+    assert_eq!(
+        backend.get_pending_message_to_l2(consumed_nonce).unwrap(),
+        Some(pending),
+        "nonce removal must rollback when stage-1 fails"
+    );
+    assert!(
+        !backend.has_parallel_merkle_staged_block(block.header.block_number).unwrap(),
+        "staged marker must not be written on stage-1 failure"
+    );
+    assert_eq!(
+        backend.get_parallel_merkle_staged_block_header(block.header.block_number).unwrap(),
+        None,
+        "staged header must not be written on stage-1 failure"
+    );
 }
 
 #[tokio::test]
@@ -391,5 +435,34 @@ async fn staged_tx_hash_visibility_is_hidden_until_confirmation() {
     assert!(
         backend.view_on_latest_confirmed().find_transaction_by_hash(&tx_hash).unwrap().is_some(),
         "tx should become visible after confirmation"
+    );
+}
+
+#[tokio::test]
+async fn compute_parallel_merkle_root_from_snapshot_base_rejects_incompatible_snapshot_base() {
+    let backend = MadaraBackend::open_for_testing(ChainConfig::madara_test().into());
+    for block_n in 0..=2_u64 {
+        let block = make_staged_block(block_n, Felt::from(0x800_u64 + block_n));
+        backend
+            .write_access()
+            .add_full_block_with_classes(&block, &[], /* pre_v0_13_2_hash_override */ true)
+            .expect("confirmed write should succeed");
+    }
+
+    let err = backend
+        .write_access()
+        .compute_parallel_merkle_root_from_snapshot_base(
+            0,
+            3,
+            &StateDiff::default(),
+            false,
+            crate::ParallelMerkleInMemoryTrieLogMode::Off,
+        )
+        .expect_err("older-than-head snapshot base without historical snapshots must fail");
+
+    let err_text = format!("{err:#}");
+    assert!(
+        err_text.contains("No compatible snapshot at-or-before requested snapshot_base_block_n=0"),
+        "unexpected error: {err_text}"
     );
 }

--- a/madara/crates/client/devnet/src/lib.rs
+++ b/madara/crates/client/devnet/src/lib.rs
@@ -414,7 +414,8 @@ mod tests {
             Arc::new(mc_settlement_client::L1SyncDisabledClient) as _,
             true,
             parallel_merkle,
-        );
+        )
+        .expect("creating block production task");
 
         let tx_validator = Arc::new(TransactionValidator::new(
             Arc::clone(&mempool) as _,

--- a/madara/node/src/service/block_production.rs
+++ b/madara/node/src/service/block_production.rs
@@ -49,7 +49,7 @@ impl BlockProductionService {
                 l1_client,
                 no_charge_fee,
                 Self::parallel_merkle_config(config),
-            )),
+            )?),
             n_devnet_contracts: config.devnet_contracts,
             disabled: config.block_production_disabled,
         })


### PR DESCRIPTION
## What changed
- Added `finalizer` orchestration in block production for parallel-merkle mode.
- Routed `close_block` through finalizer when parallel mode is enabled, while keeping legacy close behavior unchanged when disabled.
- Implemented dual-path finalization per block:
  - Path A: staged persistence (`write_parallel_merkle_staged_block_data`)
  - Path B: snapshot-based root computation
- Added strict in-order confirmation gate so a block confirms only when persistence + root are both ready for the next contiguous height.
- Added boundary flush hook to persist bonsai overlay/checkpoint and advance snapshot head at flush boundaries.
- Exposed DB writer APIs needed by finalizer (`compute_parallel_merkle_root_from_snapshot_base`, `flush_parallel_merkle_overlay_and_checkpoint`).

## Scope notes
- This PR focuses on block-production orchestration only.
- Startup recovery and admin revert handling are intentionally deferred to PR-04.
