### PR TITLE
rpc: reject pre_confirmed for traceBlockTransactions

### DIFF
--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
@@ -1,7 +1,9 @@
 use crate::{versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_9_0::{
-    BlockId, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
+    BlockId, BlockTag, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
     TraceTransactionResult,
 };
 use simulate_transactions::simulate_transactions;
@@ -25,10 +27,35 @@ impl StarknetTraceRpcApiV0_9_0Server for Starknet {
     }
 
     async fn trace_block_transactions(&self, block_id: BlockId) -> RpcResult<Vec<TraceBlockTransactionsResult>> {
+        if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
+            return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
+        }
         Ok(trace_block_transactions(self, block_id).await?)
     }
 
     async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceTransactionResult> {
         Ok(trace_transaction(self, transaction_hash).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{sample_chain_for_block_getters, SampleChainForBlockGetters};
+    use rstest::rstest;
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_trace_block_transactions_rejects_pre_confirmed_block_tag(
+        sample_chain_for_block_getters: (SampleChainForBlockGetters, Starknet),
+    ) {
+        let (_sample_chain, rpc) = sample_chain_for_block_getters;
+
+        let err = StarknetTraceRpcApiV0_9_0Server::trace_block_transactions(&rpc, BlockId::Tag(BlockTag::PreConfirmed))
+            .await
+            .expect_err("pre_confirmed must be rejected by the RPC layer");
+
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        assert_eq!(err.message(), "Invalid params");
     }
 }


### PR DESCRIPTION
## Summary
- reject `pre_confirmed` in `starknet_traceBlockTransactions` at the RPC boundary
- return JSON-RPC `Invalid params` (code `-32602`) for this disallowed tag
- add a unit regression test for the rejection behavior

## Context
Tracks MDR-1020 Starknet trace API spec divergence.

## Validation
- Remote endpoint checks:
  - `starknet_getMessagesStatus` currently returns `-32601 Method not found` on https://madara-starkpay.d.karnot.xyz
  - `starknet_traceBlockTransactions` currently accepts `pre_confirmed` (returns `[]`) on https://madara-starkpay.d.karnot.xyz
  - `starknet_traceTransaction` `function_invocation` includes only `revert_reason` (spec-allowed)
- Local tests:
  - `cargo test -p mc-rpc test_trace_block_transactions_rejects_pre_confirmed_block_tag -- --nocapture`
- Quality gates:
  - `cargo fmt --all`
  - `cargo clippy --workspace --all-targets -- -D warnings`
