### PR TITLE
rpc: align traceBlockTransactions block_id with Starknet spec

### DIFF
--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
@@ -1,7 +1,9 @@
 use crate::{versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_9_0::{
-    BlockId, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
+    BlockId, BlockTag, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
     TraceTransactionResult,
 };
 use simulate_transactions::simulate_transactions;
@@ -12,6 +14,13 @@ use trace_transaction::trace_transaction;
 pub(crate) mod simulate_transactions;
 pub mod trace_block_transactions;
 pub(crate) mod trace_transaction;
+
+fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
+    if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
+        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
+    }
+    Ok(())
+}
 
 #[async_trait]
 impl StarknetTraceRpcApiV0_9_0Server for Starknet {
@@ -25,10 +34,29 @@ impl StarknetTraceRpcApiV0_9_0Server for Starknet {
     }
 
     async fn trace_block_transactions(&self, block_id: BlockId) -> RpcResult<Vec<TraceBlockTransactionsResult>> {
+        validate_trace_block_transactions_block_id(&block_id)?;
         Ok(trace_block_transactions(self, block_id).await?)
     }
 
     async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceTransactionResult> {
         Ok(trace_transaction(self, transaction_hash).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_block_transactions_rejects_pre_confirmed_tag() {
+        let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
+            .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        assert_eq!(err.message(), "Invalid params");
+    }
+
+    #[test]
+    fn trace_block_transactions_accepts_latest_tag() {
+        assert!(validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::Latest)).is_ok());
     }
 }


### PR DESCRIPTION
## MDR-1020 Status Diagrams

### 1) `starknet_getMessagesStatus`
```mermaid
flowchart LR
  A["Earlier endpoint state"] --> B["starknet_getMessagesStatus -> -32601 Method not found"]
  C["Current codebase"] --> D["Method implemented and exposed"]
  B --> E["Status: deployment skew"]
  D --> F["Flow now (once deployed): call -> message status result"]
```

### 2) `starknet_traceBlockTransactions` + `pre_confirmed`
```mermaid
flowchart LR
  A["Before: input pre_confirmed"] --> B["traceBlockTransactions accepted request"]
  B --> C["Trace execution continued"]

  D["Now: input pre_confirmed"] --> E["RPC boundary validation"]
  E --> F["Reject with Invalid params (-32602)"]

  G["Now: input latest/hash/number"] --> H["RPC boundary validation"]
  H --> I["Trace execution continues"]
```

### 3) `function_invocation.is_reverted` claim
```mermaid
flowchart LR
  A["Observed payload: function_invocation={revert_reason}"] --> B["Spec: REVERTIBLE_FUNCTION_INVOCATION is oneOf"]
  B --> C["Option 1: full FUNCTION_INVOCATION"]
  B --> D["Option 2: {revert_reason}"]
  D --> E["Status: spec-compliant, no code change needed"]
```
