### PR TITLE
perf(gateway): rehost #962 for org CI

### DIFF
--- a/madara/crates/primitives/gateway/src/block.rs
+++ b/madara/crates/primitives/gateway/src/block.rs
@@ -92,7 +92,7 @@ impl ProviderBlock {
             .map(|(index, tx)| {
                 let l1_to_l2_consumed_message = match &tx.transaction {
                     mp_block::Transaction::L1Handler(l1_handler) => {
-                        mp_receipt::MsgToL2::try_from(&l1_handler.clone()).ok()
+                        mp_receipt::MsgToL2::try_from(l1_handler).ok()
                     }
                     _ => None,
                 };
@@ -217,7 +217,7 @@ impl ProviderBlockPreConfirmed {
             .map(|(index, (tx, state_diff))| {
                 let l1_to_l2_consumed_message = match &tx.transaction {
                     mp_block::Transaction::L1Handler(l1_handler) => {
-                        mp_receipt::MsgToL2::try_from(&l1_handler.clone()).ok()
+                        mp_receipt::MsgToL2::try_from(l1_handler).ok()
                     }
                     _ => None,
                 };

--- a/madara/crates/primitives/gateway/src/block.rs
+++ b/madara/crates/primitives/gateway/src/block.rs
@@ -91,9 +91,7 @@ impl ProviderBlock {
             .enumerate()
             .map(|(index, tx)| {
                 let l1_to_l2_consumed_message = match &tx.transaction {
-                    mp_block::Transaction::L1Handler(l1_handler) => {
-                        mp_receipt::MsgToL2::try_from(l1_handler).ok()
-                    }
+                    mp_block::Transaction::L1Handler(l1_handler) => mp_receipt::MsgToL2::try_from(l1_handler).ok(),
                     _ => None,
                 };
                 (
@@ -216,9 +214,7 @@ impl ProviderBlockPreConfirmed {
             .enumerate()
             .map(|(index, (tx, state_diff))| {
                 let l1_to_l2_consumed_message = match &tx.transaction {
-                    mp_block::Transaction::L1Handler(l1_handler) => {
-                        mp_receipt::MsgToL2::try_from(l1_handler).ok()
-                    }
+                    mp_block::Transaction::L1Handler(l1_handler) => mp_receipt::MsgToL2::try_from(l1_handler).ok(),
                     _ => None,
                 };
 


### PR DESCRIPTION
## Summary
- Rehosts external contribution from #962 so organization CI (including secret-scoped jobs) can run.
- Applies the same performance improvement by removing redundant `L1Handler` cloning in gateway block mapping logic.
- Preserves contributor attribution through commit co-author metadata.

Supersedes #962.