### PR TITLE
fix(mempool): gate intake admin control via rpc-unsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ are exposed on a separate port **9943** unless specified otherwise with
 | `madara_bypassAddDeployAccountTransaction` | Bypasses mempool/validation for DeployAccount transactions  |
 | `madara_bypassAddInvokeTransaction`        | Bypasses mempool/validation for Invoke transactions         |
 | `madara_closeBlock`                        | Forces block closure in block production mode               |
-| `madara_setMempoolIntake`                  | Enables/disables mempool intake (feature-gated)             |
+| `madara_setMempoolIntake`                  | Enables/disables mempool intake (requires `--rpc-unsafe`)   |
 | `madara_revertToAndShutdown`               | Reverts chain state to a block hash and shuts down the node |
 | `madara_addL1HandlerMessage`               | Pushes an L1 handler message into bypass input              |
 | `madara_setCustomBlockHeader`              | Sets custom block header fields for upcoming block          |
@@ -494,21 +494,20 @@ are exposed on a separate port **9943** unless specified otherwise with
 
 </details>
 
-#### Mempool Intake Control (Feature-gated)
+#### Mempool Intake Control (Unsafe Admin RPC)
 
-`madara_setMempoolIntake` is intentionally compiled out of default builds.
-To enable it, build Madara with:
-
-```bash
-cargo build --manifest-path madara/Cargo.toml --bin madara --features mempool-intake-admin
-```
+`madara_setMempoolIntake` is only exposed when unsafe admin RPC methods are
+enabled (`--rpc-admin --rpc-unsafe`).
+When `--rpc-unsafe` is disabled, the method is not registered and returns
+`Method not found` if called.
 
 When enabled:
 
 - `madara_setMempoolIntake(true)` resumes intake from the mempool.
 - `madara_setMempoolIntake(false)` pauses intake from the mempool.
 - Bypass/L1 message paths remain active while intake is paused.
-- You can start with intake paused via `--mempool-paused` (available only when built with `mempool-intake-admin`).
+- You can start with intake paused via `--mempool-paused`, which requires
+  `--rpc-admin --rpc-unsafe`.
 
 > [!CAUTION]
 > These methods are exposed on `localhost` by default for obvious security

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ are exposed on a separate port **9943** unless specified otherwise with
 | `madara_bypassAddDeployAccountTransaction` | Bypasses mempool/validation for DeployAccount transactions  |
 | `madara_bypassAddInvokeTransaction`        | Bypasses mempool/validation for Invoke transactions         |
 | `madara_closeBlock`                        | Forces block closure in block production mode               |
+| `madara_setMempoolIntake`                  | Enables/disables mempool intake (feature-gated)             |
 | `madara_revertToAndShutdown`               | Reverts chain state to a block hash and shuts down the node |
 | `madara_addL1HandlerMessage`               | Pushes an L1 handler message into bypass input              |
 | `madara_setCustomBlockHeader`              | Sets custom block header fields for upcoming block          |
@@ -492,6 +493,22 @@ are exposed on a separate port **9943** unless specified otherwise with
 | `madara_pulse` | Periodically sends a signal that the node is alive |
 
 </details>
+
+#### Mempool Intake Control (Feature-gated)
+
+`madara_setMempoolIntake` is intentionally compiled out of default builds.
+To enable it, build Madara with:
+
+```bash
+cargo build --manifest-path madara/Cargo.toml --bin madara --features mempool-intake-admin
+```
+
+When enabled:
+
+- `madara_setMempoolIntake(true)` resumes intake from the mempool.
+- `madara_setMempoolIntake(false)` pauses intake from the mempool.
+- Bypass/L1 message paths remain active while intake is paused.
+- You can start with intake paused via `--mempool-paused` (available only when built with `mempool-intake-admin`).
 
 > [!CAUTION]
 > These methods are exposed on `localhost` by default for obvious security

--- a/madara/crates/client/block_production/Cargo.toml
+++ b/madara/crates/client/block_production/Cargo.toml
@@ -38,6 +38,7 @@ m-cairo-test-contracts.workspace = true
 
 [features]
 testing = ["mc-db/testing", "mockall", "mc-settlement-client/testing"]
+mempool-intake-admin = []
 
 [dependencies]
 

--- a/madara/crates/client/block_production/Cargo.toml
+++ b/madara/crates/client/block_production/Cargo.toml
@@ -38,7 +38,6 @@ m-cairo-test-contracts.workspace = true
 
 [features]
 testing = ["mc-db/testing", "mockall", "mc-settlement-client/testing"]
-mempool-intake-admin = []
 
 [dependencies]
 

--- a/madara/crates/client/block_production/src/batcher.rs
+++ b/madara/crates/client/block_production/src/batcher.rs
@@ -1,5 +1,4 @@
 use crate::util::{AdditionalTxInfo, BatchToExecute};
-#[cfg(feature = "mempool-intake-admin")]
 use crate::MempoolIntakeMode;
 use anyhow::Context;
 use futures::{
@@ -17,7 +16,6 @@ use mp_transactions::{
 use mp_utils::service::ServiceContext;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-#[cfg(feature = "mempool-intake-admin")]
 use tokio::sync::watch;
 
 pub struct Batcher {
@@ -27,7 +25,6 @@ pub struct Batcher {
     ctx: ServiceContext,
     out: mpsc::Sender<BatchToExecute>,
     bypass_in: mpsc::Receiver<ValidatedTransaction>,
-    #[cfg(feature = "mempool-intake-admin")]
     mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     batch_size: usize,
 }
@@ -40,7 +37,7 @@ impl Batcher {
         ctx: ServiceContext,
         out: mpsc::Sender<BatchToExecute>,
         bypass_in: mpsc::Receiver<ValidatedTransaction>,
-        #[cfg(feature = "mempool-intake-admin")] mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
+        mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     ) -> Self {
         Self {
             mempool,
@@ -48,7 +45,6 @@ impl Batcher {
             ctx,
             out,
             bypass_in,
-            #[cfg(feature = "mempool-intake-admin")]
             mempool_intake_rx,
             batch_size: backend.chain_config().block_production_concurrency.batch_size,
             backend,
@@ -93,30 +89,9 @@ impl Batcher {
 
             // Note: this is not hoisted out of the loop, because we don't want to keep the lock around when waiting on the output channel reserve().
             let mempool_txs_stream: BoxStream<'static, anyhow::Result<_>> = {
-                #[cfg(feature = "mempool-intake-admin")]
-                {
-                    match *self.mempool_intake_rx.borrow() {
-                        MempoolIntakeMode::Paused => stream::pending().boxed(),
-                        MempoolIntakeMode::Running => stream::unfold(self.mempool.clone(), |mempool| async move {
-                            let consumer = mempool.get_consumer().await;
-                            Some((consumer, mempool))
-                        })
-                        .map(|c| {
-                            stream::iter(c.map(|tx| {
-                                tx.into_blockifier_for_sequencing()
-                                    .map(|(btx, ts, declared_class)| {
-                                        (btx, AdditionalTxInfo { declared_class, arrived_at: ts })
-                                    })
-                                    .map_err(anyhow::Error::from)
-                            }))
-                        })
-                        .flatten()
-                        .boxed(),
-                    }
-                }
-                #[cfg(not(feature = "mempool-intake-admin"))]
-                {
-                    stream::unfold(self.mempool.clone(), |mempool| async move {
+                match *self.mempool_intake_rx.borrow() {
+                    MempoolIntakeMode::Paused => stream::pending().boxed(),
+                    MempoolIntakeMode::Running => stream::unfold(self.mempool.clone(), |mempool| async move {
                         let consumer = mempool.get_consumer().await;
                         Some((consumer, mempool))
                     })
@@ -130,7 +105,7 @@ impl Batcher {
                         }))
                     })
                     .flatten()
-                    .boxed()
+                    .boxed(),
                 }
             };
 
@@ -156,7 +131,6 @@ impl Batcher {
 
             tokio::pin!(tx_stream);
 
-            #[cfg(feature = "mempool-intake-admin")]
             let batch = tokio::select! {
                 _ = self.ctx.cancelled() => {
                     // Stop condition: cancelled.
@@ -167,21 +141,6 @@ impl Batcher {
                         return anyhow::Ok(());
                     }
                     continue;
-                }
-                Some(got) = tx_stream.next() => {
-                    // got a batch :)
-                    let got = got.context("Creating batch for block building")?;
-                    tracing::debug!("Batcher got a batch of {}.", got.len());
-                    got.into_iter().collect::<BatchToExecute>()
-                }
-                // Stop condition: tx_stream is empty.
-                else => return anyhow::Ok(())
-            };
-            #[cfg(not(feature = "mempool-intake-admin"))]
-            let batch = tokio::select! {
-                _ = self.ctx.cancelled() => {
-                    // Stop condition: cancelled.
-                    return anyhow::Ok(());
                 }
                 Some(got) = tx_stream.next() => {
                     // got a batch :)

--- a/madara/crates/client/block_production/src/batcher.rs
+++ b/madara/crates/client/block_production/src/batcher.rs
@@ -1,4 +1,5 @@
 use crate::util::{AdditionalTxInfo, BatchToExecute};
+use crate::MempoolIntakeMode;
 use anyhow::Context;
 use futures::{
     stream::{self, BoxStream, PollNext},
@@ -14,7 +15,7 @@ use mp_transactions::{
 };
 use mp_utils::service::ServiceContext;
 use std::sync::Arc;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 pub struct Batcher {
     backend: Arc<MadaraBackend>,
@@ -23,6 +24,7 @@ pub struct Batcher {
     ctx: ServiceContext,
     out: mpsc::Sender<BatchToExecute>,
     bypass_in: mpsc::Receiver<ValidatedTransaction>,
+    mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     batch_size: usize,
 }
 
@@ -34,6 +36,7 @@ impl Batcher {
         ctx: ServiceContext,
         out: mpsc::Sender<BatchToExecute>,
         bypass_in: mpsc::Receiver<ValidatedTransaction>,
+        mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     ) -> Self {
         Self {
             mempool,
@@ -41,6 +44,7 @@ impl Batcher {
             ctx,
             out,
             bypass_in,
+            mempool_intake_rx,
             batch_size: backend.chain_config().block_production_concurrency.batch_size,
             backend,
         }
@@ -83,18 +87,22 @@ impl Batcher {
             });
 
             // Note: this is not hoisted out of the loop, because we don't want to keep the lock around when waiting on the output channel reserve().
-            let mempool_txs_stream = stream::unfold(self.mempool.clone(), |mempool| async move {
-                let consumer = mempool.get_consumer().await;
-                Some((consumer, mempool))
-            })
-            .map(|c| {
-                stream::iter(c.map(|tx| {
-                    tx.into_blockifier_for_sequencing()
-                        .map(|(btx, ts, declared_class)| (btx, AdditionalTxInfo { declared_class, arrived_at: ts }))
-                        .map_err(anyhow::Error::from)
-                }))
-            })
-            .flatten();
+            let mempool_txs_stream: BoxStream<'static, anyhow::Result<_>> = match *self.mempool_intake_rx.borrow() {
+                MempoolIntakeMode::Paused => stream::pending().boxed(),
+                MempoolIntakeMode::Running => stream::unfold(self.mempool.clone(), |mempool| async move {
+                    let consumer = mempool.get_consumer().await;
+                    Some((consumer, mempool))
+                })
+                .map(|c| {
+                    stream::iter(c.map(|tx| {
+                        tx.into_blockifier_for_sequencing()
+                            .map(|(btx, ts, declared_class)| (btx, AdditionalTxInfo { declared_class, arrived_at: ts }))
+                            .map_err(anyhow::Error::from)
+                    }))
+                })
+                .flatten()
+                .boxed(),
+            };
 
             // merge all three streams :)
             // * all three streams are merged into one stream, allowing us to poll them all at once.
@@ -122,6 +130,12 @@ impl Batcher {
                 _ = self.ctx.cancelled() => {
                     // Stop condition: cancelled.
                     return anyhow::Ok(());
+                }
+                res = self.mempool_intake_rx.changed() => {
+                    if res.is_err() {
+                        return anyhow::Ok(());
+                    }
+                    continue;
                 }
                 Some(got) = tx_stream.next() => {
                     // got a batch :)

--- a/madara/crates/client/block_production/src/batcher.rs
+++ b/madara/crates/client/block_production/src/batcher.rs
@@ -1,4 +1,5 @@
 use crate::util::{AdditionalTxInfo, BatchToExecute};
+#[cfg(feature = "mempool-intake-admin")]
 use crate::MempoolIntakeMode;
 use anyhow::Context;
 use futures::{
@@ -15,7 +16,9 @@ use mp_transactions::{
 };
 use mp_utils::service::ServiceContext;
 use std::sync::Arc;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
+#[cfg(feature = "mempool-intake-admin")]
+use tokio::sync::watch;
 
 pub struct Batcher {
     backend: Arc<MadaraBackend>,
@@ -24,6 +27,7 @@ pub struct Batcher {
     ctx: ServiceContext,
     out: mpsc::Sender<BatchToExecute>,
     bypass_in: mpsc::Receiver<ValidatedTransaction>,
+    #[cfg(feature = "mempool-intake-admin")]
     mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     batch_size: usize,
 }
@@ -36,7 +40,7 @@ impl Batcher {
         ctx: ServiceContext,
         out: mpsc::Sender<BatchToExecute>,
         bypass_in: mpsc::Receiver<ValidatedTransaction>,
-        mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
+        #[cfg(feature = "mempool-intake-admin")] mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     ) -> Self {
         Self {
             mempool,
@@ -44,6 +48,7 @@ impl Batcher {
             ctx,
             out,
             bypass_in,
+            #[cfg(feature = "mempool-intake-admin")]
             mempool_intake_rx,
             batch_size: backend.chain_config().block_production_concurrency.batch_size,
             backend,
@@ -87,21 +92,46 @@ impl Batcher {
             });
 
             // Note: this is not hoisted out of the loop, because we don't want to keep the lock around when waiting on the output channel reserve().
-            let mempool_txs_stream: BoxStream<'static, anyhow::Result<_>> = match *self.mempool_intake_rx.borrow() {
-                MempoolIntakeMode::Paused => stream::pending().boxed(),
-                MempoolIntakeMode::Running => stream::unfold(self.mempool.clone(), |mempool| async move {
-                    let consumer = mempool.get_consumer().await;
-                    Some((consumer, mempool))
-                })
-                .map(|c| {
-                    stream::iter(c.map(|tx| {
-                        tx.into_blockifier_for_sequencing()
-                            .map(|(btx, ts, declared_class)| (btx, AdditionalTxInfo { declared_class, arrived_at: ts }))
-                            .map_err(anyhow::Error::from)
-                    }))
-                })
-                .flatten()
-                .boxed(),
+            let mempool_txs_stream: BoxStream<'static, anyhow::Result<_>> = {
+                #[cfg(feature = "mempool-intake-admin")]
+                {
+                    match *self.mempool_intake_rx.borrow() {
+                        MempoolIntakeMode::Paused => stream::pending().boxed(),
+                        MempoolIntakeMode::Running => stream::unfold(self.mempool.clone(), |mempool| async move {
+                            let consumer = mempool.get_consumer().await;
+                            Some((consumer, mempool))
+                        })
+                        .map(|c| {
+                            stream::iter(c.map(|tx| {
+                                tx.into_blockifier_for_sequencing()
+                                    .map(|(btx, ts, declared_class)| {
+                                        (btx, AdditionalTxInfo { declared_class, arrived_at: ts })
+                                    })
+                                    .map_err(anyhow::Error::from)
+                            }))
+                        })
+                        .flatten()
+                        .boxed(),
+                    }
+                }
+                #[cfg(not(feature = "mempool-intake-admin"))]
+                {
+                    stream::unfold(self.mempool.clone(), |mempool| async move {
+                        let consumer = mempool.get_consumer().await;
+                        Some((consumer, mempool))
+                    })
+                    .map(|c| {
+                        stream::iter(c.map(|tx| {
+                            tx.into_blockifier_for_sequencing()
+                                .map(|(btx, ts, declared_class)| {
+                                    (btx, AdditionalTxInfo { declared_class, arrived_at: ts })
+                                })
+                                .map_err(anyhow::Error::from)
+                        }))
+                    })
+                    .flatten()
+                    .boxed()
+                }
             };
 
             // merge all three streams :)
@@ -126,6 +156,7 @@ impl Batcher {
 
             tokio::pin!(tx_stream);
 
+            #[cfg(feature = "mempool-intake-admin")]
             let batch = tokio::select! {
                 _ = self.ctx.cancelled() => {
                     // Stop condition: cancelled.
@@ -136,6 +167,21 @@ impl Batcher {
                         return anyhow::Ok(());
                     }
                     continue;
+                }
+                Some(got) = tx_stream.next() => {
+                    // got a batch :)
+                    let got = got.context("Creating batch for block building")?;
+                    tracing::debug!("Batcher got a batch of {}.", got.len());
+                    got.into_iter().collect::<BatchToExecute>()
+                }
+                // Stop condition: tx_stream is empty.
+                else => return anyhow::Ok(())
+            };
+            #[cfg(not(feature = "mempool-intake-admin"))]
+            let batch = tokio::select! {
+                _ = self.ctx.cancelled() => {
+                    // Stop condition: cancelled.
+                    return anyhow::Ok(());
                 }
                 Some(got) = tx_stream.next() => {
                     // got a batch :)

--- a/madara/crates/client/block_production/src/handle.rs
+++ b/madara/crates/client/block_production/src/handle.rs
@@ -1,4 +1,5 @@
 use crate::executor::{self, ExecutorCommand, ExecutorCommandError};
+#[cfg(feature = "mempool-intake-admin")]
 use crate::MempoolIntakeMode;
 use async_trait::async_trait;
 use mc_db::MadaraBackend;
@@ -14,7 +15,9 @@ use mp_rpc::v0_9_0::{
 use mp_transactions::validated::ValidatedTransaction;
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot, watch};
+#[cfg(feature = "mempool-intake-admin")]
+use tokio::sync::watch;
+use tokio::sync::{mpsc, oneshot};
 
 struct BypassInput(mpsc::Sender<ValidatedTransaction>);
 
@@ -39,6 +42,7 @@ pub struct BlockProductionHandle {
     /// Commands to executor task.
     executor_commands: mpsc::UnboundedSender<executor::ExecutorCommand>,
     bypass_input: mpsc::Sender<ValidatedTransaction>,
+    #[cfg(feature = "mempool-intake-admin")]
     mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
     /// We use TransactionValidator to handle conversion to blockifier, class compilation etc. Mostly for convenience.
     tx_converter: Arc<TransactionValidator>,
@@ -49,12 +53,13 @@ impl BlockProductionHandle {
         backend: Arc<MadaraBackend>,
         executor_commands: mpsc::UnboundedSender<executor::ExecutorCommand>,
         bypass_input: mpsc::Sender<ValidatedTransaction>,
-        mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
+        #[cfg(feature = "mempool-intake-admin")] mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
         no_charge_fee: bool,
     ) -> Self {
         Self {
             executor_commands,
             bypass_input: bypass_input.clone(),
+            #[cfg(feature = "mempool-intake-admin")]
             mempool_intake_tx,
             tx_converter: TransactionValidator::new(
                 Arc::new(BypassInput(bypass_input)),
@@ -74,6 +79,7 @@ impl BlockProductionHandle {
         recv.await.map_err(|_| ExecutorCommandError::ChannelClosed)?
     }
 
+    #[cfg(feature = "mempool-intake-admin")]
     pub fn set_mempool_intake(&self, enabled: bool) -> anyhow::Result<()> {
         let mode = if enabled { MempoolIntakeMode::Running } else { MempoolIntakeMode::Paused };
         self.mempool_intake_tx.send(mode).map_err(|e| anyhow::anyhow!("Mempool intake channel closed: {e}"))?;

--- a/madara/crates/client/block_production/src/handle.rs
+++ b/madara/crates/client/block_production/src/handle.rs
@@ -1,5 +1,4 @@
 use crate::executor::{self, ExecutorCommand, ExecutorCommandError};
-#[cfg(feature = "mempool-intake-admin")]
 use crate::MempoolIntakeMode;
 use async_trait::async_trait;
 use mc_db::MadaraBackend;
@@ -15,7 +14,6 @@ use mp_rpc::v0_9_0::{
 use mp_transactions::validated::ValidatedTransaction;
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use std::sync::Arc;
-#[cfg(feature = "mempool-intake-admin")]
 use tokio::sync::watch;
 use tokio::sync::{mpsc, oneshot};
 
@@ -42,7 +40,6 @@ pub struct BlockProductionHandle {
     /// Commands to executor task.
     executor_commands: mpsc::UnboundedSender<executor::ExecutorCommand>,
     bypass_input: mpsc::Sender<ValidatedTransaction>,
-    #[cfg(feature = "mempool-intake-admin")]
     mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
     /// We use TransactionValidator to handle conversion to blockifier, class compilation etc. Mostly for convenience.
     tx_converter: Arc<TransactionValidator>,
@@ -53,13 +50,12 @@ impl BlockProductionHandle {
         backend: Arc<MadaraBackend>,
         executor_commands: mpsc::UnboundedSender<executor::ExecutorCommand>,
         bypass_input: mpsc::Sender<ValidatedTransaction>,
-        #[cfg(feature = "mempool-intake-admin")] mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
+        mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
         no_charge_fee: bool,
     ) -> Self {
         Self {
             executor_commands,
             bypass_input: bypass_input.clone(),
-            #[cfg(feature = "mempool-intake-admin")]
             mempool_intake_tx,
             tx_converter: TransactionValidator::new(
                 Arc::new(BypassInput(bypass_input)),
@@ -79,7 +75,6 @@ impl BlockProductionHandle {
         recv.await.map_err(|_| ExecutorCommandError::ChannelClosed)?
     }
 
-    #[cfg(feature = "mempool-intake-admin")]
     pub fn set_mempool_intake(&self, enabled: bool) -> anyhow::Result<()> {
         let mode = if enabled { MempoolIntakeMode::Running } else { MempoolIntakeMode::Paused };
         self.mempool_intake_tx.send(mode).map_err(|e| anyhow::anyhow!("Mempool intake channel closed: {e}"))?;

--- a/madara/crates/client/block_production/src/handle.rs
+++ b/madara/crates/client/block_production/src/handle.rs
@@ -1,4 +1,5 @@
 use crate::executor::{self, ExecutorCommand, ExecutorCommandError};
+use crate::MempoolIntakeMode;
 use async_trait::async_trait;
 use mc_db::MadaraBackend;
 use mc_submit_tx::{
@@ -13,7 +14,7 @@ use mp_rpc::v0_9_0::{
 use mp_transactions::validated::ValidatedTransaction;
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 
 struct BypassInput(mpsc::Sender<ValidatedTransaction>);
 
@@ -38,6 +39,7 @@ pub struct BlockProductionHandle {
     /// Commands to executor task.
     executor_commands: mpsc::UnboundedSender<executor::ExecutorCommand>,
     bypass_input: mpsc::Sender<ValidatedTransaction>,
+    mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
     /// We use TransactionValidator to handle conversion to blockifier, class compilation etc. Mostly for convenience.
     tx_converter: Arc<TransactionValidator>,
 }
@@ -47,11 +49,13 @@ impl BlockProductionHandle {
         backend: Arc<MadaraBackend>,
         executor_commands: mpsc::UnboundedSender<executor::ExecutorCommand>,
         bypass_input: mpsc::Sender<ValidatedTransaction>,
+        mempool_intake_tx: watch::Sender<MempoolIntakeMode>,
         no_charge_fee: bool,
     ) -> Self {
         Self {
             executor_commands,
             bypass_input: bypass_input.clone(),
+            mempool_intake_tx,
             tx_converter: TransactionValidator::new(
                 Arc::new(BypassInput(bypass_input)),
                 backend,
@@ -68,6 +72,12 @@ impl BlockProductionHandle {
             .send(ExecutorCommand::CloseBlock(sender))
             .map_err(|_| ExecutorCommandError::ChannelClosed)?;
         recv.await.map_err(|_| ExecutorCommandError::ChannelClosed)?
+    }
+
+    pub fn set_mempool_intake(&self, enabled: bool) -> anyhow::Result<()> {
+        let mode = if enabled { MempoolIntakeMode::Running } else { MempoolIntakeMode::Paused };
+        self.mempool_intake_tx.send(mode).map_err(|e| anyhow::anyhow!("Mempool intake channel closed: {e}"))?;
+        Ok(())
     }
 
     /// Send a transaction through the bypass channel to bypass mempool and validation.

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -151,7 +151,6 @@ use std::mem;
 use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
 use tokio::sync::mpsc;
-#[cfg(feature = "mempool-intake-admin")]
 use tokio::sync::watch;
 
 mod batcher;
@@ -169,7 +168,6 @@ pub enum BlockProductionStateNotification {
     BatchExecuted,
 }
 
-#[cfg(feature = "mempool-intake-admin")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MempoolIntakeMode {
     Running,
@@ -330,7 +328,6 @@ pub struct BlockProductionTask {
     executor_commands_recv: Option<mpsc::UnboundedReceiver<executor::ExecutorCommand>>,
     l1_client: Arc<dyn SettlementClient>,
     bypass_tx_input: Option<mpsc::Receiver<ValidatedTransaction>>,
-    #[cfg(feature = "mempool-intake-admin")]
     mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     no_charge_fee: bool,
 }
@@ -354,12 +351,8 @@ impl BlockProductionTask {
     ) -> Self {
         let (sender, recv) = mpsc::unbounded_channel();
         let (bypass_input_sender, bypass_tx_input) = mpsc::channel(16);
-        #[cfg(feature = "mempool-intake-admin")]
         let initial_intake = if mempool_paused { MempoolIntakeMode::Paused } else { MempoolIntakeMode::Running };
-        #[cfg(feature = "mempool-intake-admin")]
         let (mempool_intake_tx, mempool_intake_rx) = watch::channel(initial_intake);
-        #[cfg(not(feature = "mempool-intake-admin"))]
-        let _ = mempool_paused;
         Self {
             backend: backend.clone(),
             mempool,
@@ -369,7 +362,6 @@ impl BlockProductionTask {
                 backend,
                 sender,
                 bypass_input_sender,
-                #[cfg(feature = "mempool-intake-admin")]
                 mempool_intake_tx.clone(),
                 no_charge_fee,
             ),
@@ -377,7 +369,6 @@ impl BlockProductionTask {
             executor_commands_recv: Some(recv),
             l1_client,
             bypass_tx_input: Some(bypass_tx_input),
-            #[cfg(feature = "mempool-intake-admin")]
             mempool_intake_rx,
             no_charge_fee,
         }
@@ -1035,7 +1026,6 @@ impl BlockProductionTask {
                 ctx,
                 batch_sender,
                 bypass_tx_input,
-                #[cfg(feature = "mempool-intake-admin")]
                 self.mempool_intake_rx.clone(),
             )
             .run(),

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -150,7 +150,9 @@ use std::collections::HashSet;
 use std::mem;
 use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
+#[cfg(feature = "mempool-intake-admin")]
+use tokio::sync::watch;
 
 mod batcher;
 mod executor;
@@ -167,6 +169,7 @@ pub enum BlockProductionStateNotification {
     BatchExecuted,
 }
 
+#[cfg(feature = "mempool-intake-admin")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MempoolIntakeMode {
     Running,
@@ -327,6 +330,7 @@ pub struct BlockProductionTask {
     executor_commands_recv: Option<mpsc::UnboundedReceiver<executor::ExecutorCommand>>,
     l1_client: Arc<dyn SettlementClient>,
     bypass_tx_input: Option<mpsc::Receiver<ValidatedTransaction>>,
+    #[cfg(feature = "mempool-intake-admin")]
     mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     no_charge_fee: bool,
 }
@@ -350,8 +354,12 @@ impl BlockProductionTask {
     ) -> Self {
         let (sender, recv) = mpsc::unbounded_channel();
         let (bypass_input_sender, bypass_tx_input) = mpsc::channel(16);
+        #[cfg(feature = "mempool-intake-admin")]
         let initial_intake = if mempool_paused { MempoolIntakeMode::Paused } else { MempoolIntakeMode::Running };
+        #[cfg(feature = "mempool-intake-admin")]
         let (mempool_intake_tx, mempool_intake_rx) = watch::channel(initial_intake);
+        #[cfg(not(feature = "mempool-intake-admin"))]
+        let _ = mempool_paused;
         Self {
             backend: backend.clone(),
             mempool,
@@ -361,6 +369,7 @@ impl BlockProductionTask {
                 backend,
                 sender,
                 bypass_input_sender,
+                #[cfg(feature = "mempool-intake-admin")]
                 mempool_intake_tx.clone(),
                 no_charge_fee,
             ),
@@ -368,6 +377,7 @@ impl BlockProductionTask {
             executor_commands_recv: Some(recv),
             l1_client,
             bypass_tx_input: Some(bypass_tx_input),
+            #[cfg(feature = "mempool-intake-admin")]
             mempool_intake_rx,
             no_charge_fee,
         }
@@ -1016,7 +1026,6 @@ impl BlockProductionTask {
         // Batcher task is handled in a separate tokio task.
         let batch_sender = executor.send_batch.take().context("Channel sender already taken")?;
         let bypass_tx_input = self.bypass_tx_input.take().context("Bypass tx channel already taken")?;
-        let mempool_intake_rx = self.mempool_intake_rx.clone();
         // Clone ctx to check for cancellation in the main loop
         let mut batcher_task = AbortOnDrop::spawn(
             Batcher::new(
@@ -1026,7 +1035,8 @@ impl BlockProductionTask {
                 ctx,
                 batch_sender,
                 bypass_tx_input,
-                mempool_intake_rx,
+                #[cfg(feature = "mempool-intake-admin")]
+                self.mempool_intake_rx.clone(),
             )
             .run(),
         );

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -150,7 +150,7 @@ use std::collections::HashSet;
 use std::mem;
 use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 mod batcher;
 mod executor;
@@ -165,6 +165,12 @@ pub use handle::BlockProductionHandle;
 pub enum BlockProductionStateNotification {
     ClosedBlock,
     BatchExecuted,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MempoolIntakeMode {
+    Running,
+    Paused,
 }
 
 #[derive(Debug)]
@@ -321,6 +327,7 @@ pub struct BlockProductionTask {
     executor_commands_recv: Option<mpsc::UnboundedReceiver<executor::ExecutorCommand>>,
     l1_client: Arc<dyn SettlementClient>,
     bypass_tx_input: Option<mpsc::Receiver<ValidatedTransaction>>,
+    mempool_intake_rx: watch::Receiver<MempoolIntakeMode>,
     no_charge_fee: bool,
 }
 
@@ -329,6 +336,7 @@ impl BlockProductionTask {
     ///
     /// # Parameters
     ///
+    /// * `mempool_paused`: If true, block production starts with mempool intake paused.
     /// * `no_charge_fee`: Determines whether fees are charged during transaction execution.
     ///
     /// # TODO(mohit 18/11/2025): Update the code to use config same as pre-close
@@ -337,20 +345,30 @@ impl BlockProductionTask {
         mempool: Arc<Mempool>,
         metrics: Arc<BlockProductionMetrics>,
         l1_client: Arc<dyn SettlementClient>,
+        mempool_paused: bool,
         no_charge_fee: bool,
     ) -> Self {
         let (sender, recv) = mpsc::unbounded_channel();
         let (bypass_input_sender, bypass_tx_input) = mpsc::channel(16);
+        let initial_intake = if mempool_paused { MempoolIntakeMode::Paused } else { MempoolIntakeMode::Running };
+        let (mempool_intake_tx, mempool_intake_rx) = watch::channel(initial_intake);
         Self {
             backend: backend.clone(),
             mempool,
             current_state: None,
             metrics,
-            handle: BlockProductionHandle::new(backend, sender, bypass_input_sender, no_charge_fee),
+            handle: BlockProductionHandle::new(
+                backend,
+                sender,
+                bypass_input_sender,
+                mempool_intake_tx.clone(),
+                no_charge_fee,
+            ),
             state_notifications: None,
             executor_commands_recv: Some(recv),
             l1_client,
             bypass_tx_input: Some(bypass_tx_input),
+            mempool_intake_rx,
             no_charge_fee,
         }
     }
@@ -998,6 +1016,7 @@ impl BlockProductionTask {
         // Batcher task is handled in a separate tokio task.
         let batch_sender = executor.send_batch.take().context("Channel sender already taken")?;
         let bypass_tx_input = self.bypass_tx_input.take().context("Bypass tx channel already taken")?;
+        let mempool_intake_rx = self.mempool_intake_rx.clone();
         // Clone ctx to check for cancellation in the main loop
         let mut batcher_task = AbortOnDrop::spawn(
             Batcher::new(
@@ -1007,6 +1026,7 @@ impl BlockProductionTask {
                 ctx,
                 batch_sender,
                 bypass_tx_input,
+                mempool_intake_rx,
             )
             .run(),
         );
@@ -1133,6 +1153,7 @@ pub(crate) mod tests {
                 self.mempool.clone(),
                 self.metrics.clone(),
                 Arc::new(self.l1_client.clone()),
+                false, /* mempool_paused = false */
                 false, /* no_charge_fee = false */
             )
         }
@@ -1973,6 +1994,7 @@ pub(crate) mod tests {
             original_devnet_setup.mempool.clone(),
             original_devnet_setup.metrics.clone(),
             Arc::new(original_devnet_setup.l1_client.clone()),
+            false, // mempool_paused
             initial_no_charge_fee,
         );
 
@@ -2003,6 +2025,7 @@ pub(crate) mod tests {
             original_devnet_setup.mempool.clone(),
             original_devnet_setup.metrics.clone(),
             Arc::new(original_devnet_setup.l1_client.clone()),
+            false,                 // mempool_paused
             restart_no_charge_fee, // Current config: no_charge_fee = false
         );
 

--- a/madara/crates/client/devnet/src/lib.rs
+++ b/madara/crates/client/devnet/src/lib.rs
@@ -408,6 +408,7 @@ mod tests {
             Arc::clone(&mempool),
             Arc::new(metrics),
             Arc::new(mc_settlement_client::L1SyncDisabledClient) as _,
+            false,
             true,
         );
 

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 default = []
-mempool-intake-admin = []
+mempool-intake-admin = ["mc-block-production/mempool-intake-admin"]
 
 [dev-dependencies]
 

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -14,6 +14,10 @@ workspace = true
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+default = []
+mempool-intake-admin = []
+
 [dev-dependencies]
 
 rstest = { workspace = true }

--- a/madara/crates/client/rpc/Cargo.toml
+++ b/madara/crates/client/rpc/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 default = []
-mempool-intake-admin = ["mc-block-production/mempool-intake-admin"]
 
 [dev-dependencies]
 

--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -895,6 +895,8 @@ pub fn rpc_api_admin(starknet: &Starknet) -> anyhow::Result<RpcModule<()>> {
     let mut rpc_api = RpcModule::new(());
 
     rpc_api.merge(versions::admin::v0_1_0::MadaraWriteRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
+    #[cfg(feature = "mempool-intake-admin")]
+    rpc_api.merge(versions::admin::v0_1_0::MadaraMempoolRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
     rpc_api.merge(versions::admin::v0_1_0::MadaraStatusRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
     rpc_api.merge(versions::admin::v0_1_0::MadaraServicesRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
     rpc_api.merge(versions::admin::v0_1_0::MadaraReadRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;

--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -895,8 +895,9 @@ pub fn rpc_api_admin(starknet: &Starknet) -> anyhow::Result<RpcModule<()>> {
     let mut rpc_api = RpcModule::new(());
 
     rpc_api.merge(versions::admin::v0_1_0::MadaraWriteRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
-    #[cfg(feature = "mempool-intake-admin")]
-    rpc_api.merge(versions::admin::v0_1_0::MadaraMempoolRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
+    if starknet.rpc_unsafe_enabled {
+        rpc_api.merge(versions::admin::v0_1_0::MadaraMempoolRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
+    }
     rpc_api.merge(versions::admin::v0_1_0::MadaraStatusRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
     rpc_api.merge(versions::admin::v0_1_0::MadaraServicesRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;
     rpc_api.merge(versions::admin::v0_1_0::MadaraReadRpcApiV0_1_0Server::into_rpc(starknet.clone()))?;

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -89,6 +89,17 @@ pub trait MadaraWriteRpcApi {
     async fn set_block_header(&self, custom_block_headers: CustomHeader) -> RpcResult<()>;
 }
 
+#[cfg(feature = "mempool-intake-admin")]
+#[versioned_rpc("V0_1_0", "madara")]
+pub trait MadaraMempoolRpcApi {
+    /// Enable or disable intake of mempool transactions in block production mode.
+    ///
+    /// - `true`: consume transactions from mempool as usual.
+    /// - `false`: pause mempool intake while keeping bypass/L1 message paths active.
+    #[method(name = "setMempoolIntake")]
+    async fn set_mempool_intake(&self, enabled: bool) -> RpcResult<()>;
+}
+
 /// This is an admin method, so semver is different!
 #[versioned_rpc("V0_1_0", "madara")]
 pub trait MadaraReadRpcApi {

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -89,7 +89,6 @@ pub trait MadaraWriteRpcApi {
     async fn set_block_header(&self, custom_block_headers: CustomHeader) -> RpcResult<()>;
 }
 
-#[cfg(feature = "mempool-intake-admin")]
 #[versioned_rpc("V0_1_0", "madara")]
 pub trait MadaraMempoolRpcApi {
     /// Enable or disable intake of mempool transactions in block production mode.

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mempool.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mempool.rs
@@ -4,6 +4,13 @@ use jsonrpsee::core::{async_trait, RpcResult};
 #[async_trait]
 impl MadaraMempoolRpcApiV0_1_0Server for Starknet {
     async fn set_mempool_intake(&self, enabled: bool) -> RpcResult<()> {
+        if !self.rpc_unsafe_enabled {
+            return Err(StarknetRpcApiError::ErrUnexpectedError {
+                error: "This method requires the --rpc-unsafe flag to be enabled".to_string().into(),
+            }
+            .into());
+        }
+
         Ok(self
             .block_prod_handle
             .as_ref()

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mempool.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mempool.rs
@@ -1,0 +1,14 @@
+use crate::{versions::admin::v0_1_0::MadaraMempoolRpcApiV0_1_0Server, Starknet, StarknetRpcApiError};
+use jsonrpsee::core::{async_trait, RpcResult};
+
+#[async_trait]
+impl MadaraMempoolRpcApiV0_1_0Server for Starknet {
+    async fn set_mempool_intake(&self, enabled: bool) -> RpcResult<()> {
+        Ok(self
+            .block_prod_handle
+            .as_ref()
+            .ok_or(StarknetRpcApiError::UnimplementedMethod)?
+            .set_mempool_intake(enabled)
+            .map_err(StarknetRpcApiError::from)?)
+    }
+}

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mod.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "mempool-intake-admin")]
 pub mod mempool;
 pub mod read;
 pub mod services;

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mod.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "mempool-intake-admin")]
+pub mod mempool;
 pub mod read;
 pub mod services;
 pub mod status;

--- a/madara/node/Cargo.toml
+++ b/madara/node/Cargo.toml
@@ -18,6 +18,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 [[bin]]
 name = "madara"
 
+[features]
+default = []
+mempool-intake-admin = ["mc-rpc/mempool-intake-admin"]
+
 [dependencies]
 
 # Madara

--- a/madara/node/Cargo.toml
+++ b/madara/node/Cargo.toml
@@ -20,7 +20,6 @@ name = "madara"
 
 [features]
 default = []
-mempool-intake-admin = ["mc-rpc/mempool-intake-admin", "mc-block-production/mempool-intake-admin"]
 
 [dependencies]
 

--- a/madara/node/Cargo.toml
+++ b/madara/node/Cargo.toml
@@ -20,7 +20,7 @@ name = "madara"
 
 [features]
 default = []
-mempool-intake-admin = ["mc-rpc/mempool-intake-admin"]
+mempool-intake-admin = ["mc-rpc/mempool-intake-admin", "mc-block-production/mempool-intake-admin"]
 
 [dependencies]
 

--- a/madara/node/src/cli/block_production.rs
+++ b/madara/node/src/cli/block_production.rs
@@ -8,9 +8,9 @@ pub struct BlockProductionParams {
     #[arg(env = "MADARA_BLOCK_PRODUCTION_DISABLED", long, alias = "no-block-production")]
     pub block_production_disabled: bool,
 
-    /// Start with mempool intake paused. This option is only available when
-    /// built with `--features mempool-intake-admin`.
-    #[cfg(feature = "mempool-intake-admin")]
+    /// Start with mempool intake paused.
+    ///
+    /// Requires `--rpc-admin --rpc-unsafe`.
     #[arg(env = "MADARA_MEMPOOL_PAUSED", long)]
     pub mempool_paused: bool,
 

--- a/madara/node/src/cli/block_production.rs
+++ b/madara/node/src/cli/block_production.rs
@@ -8,6 +8,12 @@ pub struct BlockProductionParams {
     #[arg(env = "MADARA_BLOCK_PRODUCTION_DISABLED", long, alias = "no-block-production")]
     pub block_production_disabled: bool,
 
+    /// Start with mempool intake paused. This option is only available when
+    /// built with `--features mempool-intake-admin`.
+    #[cfg(feature = "mempool-intake-admin")]
+    #[arg(env = "MADARA_MEMPOOL_PAUSED", long)]
+    pub mempool_paused: bool,
+
     /// Create this number of contracts in the genesis block for the devnet configuration.
     #[arg(env = "MADARA_DEVNET_CONTRACTS", long, default_value_t = 10)]
     pub devnet_contracts: u64,

--- a/madara/node/src/cli/rpc.rs
+++ b/madara/node/src/cli/rpc.rs
@@ -92,7 +92,8 @@ pub struct RpcParams {
     pub rpc_admin_external: bool,
 
     /// Enables unsafe admin RPC methods. This includes dangerous methods like
-    /// `revertToAndShutdown` and `setCustomBlockHeader` that can modify the blockchain state.
+    /// `setMempoolIntake`, `revertToAndShutdown`, and `setCustomBlockHeader` that can modify
+    /// runtime or blockchain state.
     /// Use with extreme caution. Requires `--rpc-admin` to be enabled.
     #[arg(env = "MADARA_RPC_UNSAFE", long, default_value_t = false, requires = "rpc_admin")]
     pub rpc_unsafe: bool,

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -174,6 +174,11 @@ async fn main() -> anyhow::Result<()> {
     // Extracts the arguments into the struct
     let mut run_cmd: RunCmd = config.extract()?;
     run_cmd.check_mode()?;
+    if run_cmd.block_production_params.mempool_paused
+        && !(run_cmd.rpc_params.rpc_admin && run_cmd.rpc_params.rpc_unsafe)
+    {
+        bail!("`--mempool-paused` requires both `--rpc-admin` and `--rpc-unsafe`.");
+    }
 
     // Setting up analytics
     let mut service_analytics = AnalyticsService::new(run_cmd.analytics_params.as_analytics_config())

--- a/madara/node/src/service/block_production.rs
+++ b/madara/node/src/service/block_production.rs
@@ -24,10 +24,7 @@ impl BlockProductionService {
         no_charge_fee: bool,
     ) -> anyhow::Result<Self> {
         let metrics = Arc::new(BlockProductionMetrics::register());
-        #[cfg(feature = "mempool-intake-admin")]
         let mempool_paused = config.mempool_paused;
-        #[cfg(not(feature = "mempool-intake-admin"))]
-        let mempool_paused = false;
 
         Ok(Self {
             backend: backend.clone(),

--- a/madara/node/src/service/block_production.rs
+++ b/madara/node/src/service/block_production.rs
@@ -24,10 +24,21 @@ impl BlockProductionService {
         no_charge_fee: bool,
     ) -> anyhow::Result<Self> {
         let metrics = Arc::new(BlockProductionMetrics::register());
+        #[cfg(feature = "mempool-intake-admin")]
+        let mempool_paused = config.mempool_paused;
+        #[cfg(not(feature = "mempool-intake-admin"))]
+        let mempool_paused = false;
 
         Ok(Self {
             backend: backend.clone(),
-            task: Some(BlockProductionTask::new(backend.clone(), mempool, metrics, l1_client, no_charge_fee)),
+            task: Some(BlockProductionTask::new(
+                backend.clone(),
+                mempool,
+                metrics,
+                l1_client,
+                mempool_paused,
+                no_charge_fee,
+            )),
             n_devnet_contracts: config.devnet_contracts,
             disabled: config.block_production_disabled,
         })


### PR DESCRIPTION
## Summary
- Move mempool intake control from compile-time gating to runtime CLI gating.
- Expose `madara_setMempoolIntake(bool)` only when `--rpc-admin --rpc-unsafe` are enabled.
- Enforce the same unsafe requirement inside the endpoint handler as defense in depth.
- Keep pause semantics unchanged: pausing stops mempool intake while bypass and L1 message paths continue.
- Require `--rpc-admin --rpc-unsafe` when starting with `--mempool-paused`.

## Runtime Flow
```mermaid
flowchart TD
    A[Node startup] --> B{rpc-admin AND rpc-unsafe enabled?}
    B -- No --> C[Do not register setMempoolIntake]
    C --> D[RPC call returns method not found]
    B -- Yes --> E[Register setMempoolIntake]
    E --> F[Admin client calls setMempoolIntake true/false]
    F --> G[Unsafe check in handler]
    G --> H[Publish Running or Paused mode]
    H --> I{Mode}
    I -- Running --> J[Consume mempool transactions]
    I -- Paused --> K[Stop mempool intake]
    K --> L[Bypass and L1 message ingestion remains active]
```

## Sequence
```mermaid
sequenceDiagram
    participant N as Node Startup
    participant R as Admin RPC
    participant C as Admin Client
    participant H as Block Production Handle
    participant B as Batcher

    N->>R: Initialize admin methods
    alt rpc-unsafe disabled
        R-->>C: setMempoolIntake not registered
        C->>R: setMempoolIntake(false)
        R-->>C: method not found
    else rpc-unsafe enabled
        R-->>C: setMempoolIntake registered
        C->>R: setMempoolIntake(false)
        R->>H: set intake mode Paused
        H->>B: notify mode change
        B-->>B: stop mempool intake
        C->>R: setMempoolIntake(true)
        R->>H: set intake mode Running
        H->>B: notify mode change
        B-->>B: resume mempool intake
    end
```
