### PR TITLE
feat: add unsafe flag to not check if a message is consumed on L1

### DIFF
--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -72,6 +72,7 @@
       "secs": 10,
       "nanos": 0
     },
+    "unsafe_skip_l1_message_consumed_check": false,
     "settlement_layer": "Eth"
   },
   "analytics_params": {

--- a/madara/crates/client/settlement_client/src/eth/mod.rs
+++ b/madara/crates/client/settlement_client/src/eth/mod.rs
@@ -661,7 +661,14 @@ mod l1_messaging_tests {
         let worker_handle = {
             let db = Arc::clone(&db);
             tokio::spawn(async move {
-                sync(Arc::new(eth_client), Arc::clone(&db), Default::default(), ServiceContext::new_for_testing()).await
+                sync(
+                    Arc::new(eth_client),
+                    Arc::clone(&db),
+                    Default::default(),
+                    ServiceContext::new_for_testing(),
+                    false,
+                )
+                .await
             })
         };
 

--- a/madara/crates/client/settlement_client/src/lib.rs
+++ b/madara/crates/client/settlement_client/src/lib.rs
@@ -193,11 +193,23 @@ pub struct L1ClientImpl {
     provider: Arc<dyn SettlementLayerProvider>,
     backend: Arc<MadaraBackend>,
     notify_new_message_to_l2: Arc<Notify>,
+    unsafe_skip_l1_message_consumed_check: bool,
 }
 
 impl L1ClientImpl {
-    fn new(backend: Arc<MadaraBackend>, provider: Arc<dyn SettlementLayerProvider>) -> Self {
-        Self { provider, backend, notify_new_message_to_l2: Default::default() }
+    fn new(
+        backend: Arc<MadaraBackend>,
+        provider: Arc<dyn SettlementLayerProvider>,
+        unsafe_skip_l1_message_consumed_check: bool,
+    ) -> Self {
+        if unsafe_skip_l1_message_consumed_check {
+            tracing::warn!(
+                "⚠⚠⚠ UNSAFE: L1 message consumed check is DISABLED. \
+                 L1→L2 messages will NOT be verified against the core contract before consumption. \
+                 This removes a safety guard against double-processing. ⚠⚠⚠"
+            );
+        }
+        Self { provider, backend, notify_new_message_to_l2: Default::default(), unsafe_skip_l1_message_consumed_check }
     }
 
     pub fn provider(&self) -> Arc<dyn SettlementLayerProvider> {
@@ -208,22 +220,24 @@ impl L1ClientImpl {
         backend: Arc<MadaraBackend>,
         rpc_url: Url,
         core_contract_address: String,
+        unsafe_skip_l1_message_consumed_check: bool,
     ) -> anyhow::Result<Self> {
         let provider = EthereumClient::new(EthereumClientConfig { rpc_url, core_contract_address })
             .await
             .context("Creating ethereum client")?;
-        Ok(Self::new(backend, Arc::new(provider)))
+        Ok(Self::new(backend, Arc::new(provider), unsafe_skip_l1_message_consumed_check))
     }
 
     pub async fn new_starknet(
         backend: Arc<MadaraBackend>,
         rpc_url: Url,
         core_contract_address: String,
+        unsafe_skip_l1_message_consumed_check: bool,
     ) -> anyhow::Result<Self> {
         let provider = StarknetClient::new(StarknetClientConfig { rpc_url, core_contract_address })
             .await
             .context("Creating starknet client")?;
-        Ok(Self::new(backend, Arc::new(provider)))
+        Ok(Self::new(backend, Arc::new(provider), unsafe_skip_l1_message_consumed_check))
     }
 }
 
@@ -233,6 +247,7 @@ impl SettlementClient for L1ClientImpl {
             self.backend.clone(),
             self.provider.clone(),
             self.notify_new_message_to_l2.clone(),
+            self.unsafe_skip_l1_message_consumed_check,
         );
         stream::unfold(consumer, |mut consumer| async move { Some((consumer.consume_next_or_wait().await, consumer)) })
             .boxed()

--- a/madara/crates/client/settlement_client/src/messages_to_l2_consumer.rs
+++ b/madara/crates/client/settlement_client/src/messages_to_l2_consumer.rs
@@ -10,11 +10,17 @@ pub struct MessagesToL2Consumer {
     backend: Arc<MadaraBackend>,
     l1_read: Arc<dyn SettlementLayerProvider>,
     notify: Arc<Notify>,
+    unsafe_skip_l1_message_consumed_check: bool,
 }
 
 impl MessagesToL2Consumer {
-    pub fn new(backend: Arc<MadaraBackend>, l1_read: Arc<dyn SettlementLayerProvider>, notify: Arc<Notify>) -> Self {
-        Self { next_nonce: 0, backend, l1_read, notify }
+    pub fn new(
+        backend: Arc<MadaraBackend>,
+        l1_read: Arc<dyn SettlementLayerProvider>,
+        notify: Arc<Notify>,
+        unsafe_skip_l1_message_consumed_check: bool,
+    ) -> Self {
+        Self { next_nonce: 0, backend, l1_read, notify, unsafe_skip_l1_message_consumed_check }
     }
 
     pub async fn consume_next_or_wait(&mut self) -> anyhow::Result<L1HandlerTransactionWithFee> {
@@ -40,9 +46,14 @@ impl MessagesToL2Consumer {
                 .context("Getting next pending message to l2")?
             {
                 self.next_nonce = msg.tx.nonce + 1;
-                match check_message_to_l2_validity(&self.l1_read, &self.backend, &msg)
-                    .await
-                    .context("Checking message to l2 validity")?
+                match check_message_to_l2_validity(
+                    &self.l1_read,
+                    &self.backend,
+                    &msg,
+                    self.unsafe_skip_l1_message_consumed_check,
+                )
+                .await
+                .context("Checking message to l2 validity")?
                 {
                     // can be consumed (not cancelled, still exists, not already in chain)
                     true => return Ok(msg),
@@ -134,7 +145,7 @@ mod tests {
         backend.write_pending_message_to_l2(&l1_handler_tx(103)).unwrap();
         mock_l1_handler_tx(&mut mock, 103, true, false);
 
-        let mut consumer = MessagesToL2Consumer::new(backend.clone(), Arc::new(mock), notify);
+        let mut consumer = MessagesToL2Consumer::new(backend.clone(), Arc::new(mock), notify, false);
 
         assert_eq!(consumer.consume_next_or_wait().now_or_never().unwrap().unwrap(), l1_handler_tx(4));
         assert_eq!(consumer.consume_next_or_wait().now_or_never().unwrap().unwrap(), l1_handler_tx(5));
@@ -153,7 +164,7 @@ mod tests {
         mock_l1_handler_tx(&mut mock, 4, true, false);
         mock_l1_handler_tx(&mut mock, 5, true, false);
 
-        let mut consumer = MessagesToL2Consumer::new(backend.clone(), Arc::new(mock), notify.clone());
+        let mut consumer = MessagesToL2Consumer::new(backend.clone(), Arc::new(mock), notify.clone(), false);
 
         // first: test empty, then write.
         {

--- a/madara/crates/client/settlement_client/src/messaging.rs
+++ b/madara/crates/client/settlement_client/src/messaging.rs
@@ -26,10 +26,16 @@ pub struct MessageToL2WithMetadata {
 }
 
 /// Returns true if the message is valid, can be consumed.
+///
+/// When `unsafe_skip_l1_message_consumed_check` is true, the check against the core contract's
+/// `l1ToL2Messages(hash)` mapping is skipped. This means messages that have already been consumed
+/// on L1 (refcount == 0 after a state update) will still be considered valid. The local nonce
+/// check and cancellation check remain active.
 pub async fn check_message_to_l2_validity(
     settlement_client: &Arc<dyn SettlementLayerProvider>,
     backend: &MadaraBackend,
     tx: &L1HandlerTransactionWithFee,
+    unsafe_skip_l1_message_consumed_check: bool,
 ) -> Result<bool, SettlementClientError> {
     // Skip if already processed.
     if backend
@@ -53,7 +59,13 @@ pub async fn check_message_to_l2_validity(
     };
     tracing::debug!("Checking for cancellation, event hash: {:?}", converted_event_hash);
 
-    if !settlement_client
+    if unsafe_skip_l1_message_consumed_check {
+        tracing::warn!(
+            "UNSAFE: Skipping L1 consumed check for message nonce={}, hash={}",
+            tx.tx.nonce,
+            converted_event_hash
+        );
+    } else if !settlement_client
         .message_to_l2_is_pending(&event_hash)
         .await
         .map_err(|e| SettlementClientError::InvalidResponse(format!("Failed to check message still exists: {}", e)))?
@@ -81,9 +93,17 @@ pub async fn sync(
     backend: Arc<MadaraBackend>,
     notify_consumer: Arc<Notify>,
     mut ctx: ServiceContext,
+    unsafe_skip_l1_message_consumed_check: bool,
 ) -> Result<(), SettlementClientError> {
     // sync inner is cancellation safe.
-    ctx.run_until_cancelled(sync_inner(settlement_client, backend, notify_consumer)).await.transpose()?;
+    ctx.run_until_cancelled(sync_inner(
+        settlement_client,
+        backend,
+        notify_consumer,
+        unsafe_skip_l1_message_consumed_check,
+    ))
+    .await
+    .transpose()?;
     Ok(())
 }
 
@@ -91,6 +111,7 @@ async fn sync_inner(
     settlement_client: Arc<dyn SettlementLayerProvider>,
     backend: Arc<MadaraBackend>,
     notify_consumer: Arc<Notify>,
+    unsafe_skip_l1_message_consumed_check: bool,
 ) -> Result<(), SettlementClientError> {
     // Note: It's fine to reprocess events - duplicates are filtered during block production.
 
@@ -101,8 +122,15 @@ async fn sync_inner(
     let mut reconnect_delay = RECONNECT_BASE_DELAY;
 
     loop {
-        match run_message_sync(&settlement_client, &backend, &notify_consumer, replay_max_duration, finality_blocks)
-            .await
+        match run_message_sync(
+            &settlement_client,
+            &backend,
+            &notify_consumer,
+            replay_max_duration,
+            finality_blocks,
+            unsafe_skip_l1_message_consumed_check,
+        )
+        .await
         {
             Ok(()) => {
                 reconnect_delay = RECONNECT_BASE_DELAY;
@@ -124,6 +152,7 @@ async fn run_message_sync(
     notify_consumer: &Notify,
     replay_max_duration: Duration,
     finality_blocks: u64,
+    unsafe_skip_l1_message_consumed_check: bool,
 ) -> Result<(), SettlementClientError> {
     let from_l1_block_n = get_start_block(settlement_client, backend, replay_max_duration).await?;
 
@@ -164,9 +193,15 @@ async fn run_message_sync(
         }
 
         // Process finalized events - continue on transient errors
-        if let Err(e) =
-            process_finalized_events(settlement_client, backend, notify_consumer, &mut pending_events, finality_blocks)
-                .await
+        if let Err(e) = process_finalized_events(
+            settlement_client,
+            backend,
+            notify_consumer,
+            &mut pending_events,
+            finality_blocks,
+            unsafe_skip_l1_message_consumed_check,
+        )
+        .await
         {
             tracing::warn!("Error processing finalized events: {e:#}");
         }
@@ -205,6 +240,7 @@ async fn process_finalized_events(
     notify_consumer: &Notify,
     pending_events: &mut VecDeque<MessageToL2WithMetadata>,
     finality_blocks: u64,
+    unsafe_skip_l1_message_consumed_check: bool,
 ) -> Result<(), SettlementClientError> {
     if pending_events.is_empty() {
         return Ok(());
@@ -264,7 +300,14 @@ async fn process_finalized_events(
             })?;
         }
 
-        let is_valid = check_message_to_l2_validity(settlement_client, backend, &event.message).await.map_err(|e| {
+        let is_valid = check_message_to_l2_validity(
+            settlement_client,
+            backend,
+            &event.message,
+            unsafe_skip_l1_message_consumed_check,
+        )
+        .await
+        .map_err(|e| {
             SettlementClientError::InvalidResponse(format!(
                 "Validity check failed for tx {}: {}",
                 event.l1_transaction_hash, e
@@ -409,7 +452,7 @@ mod messaging_module_tests {
         let db_backend_clone = db.clone();
 
         // Spawn the sync task in a separate thread
-        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false).await });
 
         // Wait for event to be processed (short wait since stream returns immediately)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -472,7 +515,7 @@ mod messaging_module_tests {
         let db_backend_clone = db.clone();
 
         // Spawn the sync task in a separate thread
-        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false).await });
 
         // Wait for event to be processed (short wait since stream returns immediately)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -542,7 +585,7 @@ mod messaging_module_tests {
         let db_backend_clone = db.clone();
 
         // Spawn the sync task in a separate thread
-        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false).await });
 
         // Wait for event to be processed (short wait since stream returns immediately)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -601,7 +644,7 @@ mod messaging_module_tests {
         let notify = Arc::new(Notify::new());
         let db_clone = db.clone();
 
-        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false).await });
 
         // Wait for processing attempt (short wait)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -657,7 +700,7 @@ mod messaging_module_tests {
         let notify = Arc::new(Notify::new());
         let db_clone = db.clone();
 
-        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false).await });
 
         // Wait for processing (short wait)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -701,7 +744,7 @@ mod messaging_module_tests {
         let client = Arc::new(mock_client);
         let ctx = ServiceContext::new_for_testing();
 
-        let sync_handle = tokio::spawn(async move { sync(client, db, Arc::new(Notify::new()), ctx).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db, Arc::new(Notify::new()), ctx, false).await });
 
         // Verify exponential backoff: 1s -> 2s -> 4s
         tokio::time::advance(Duration::from_millis(50)).await;

--- a/madara/crates/client/settlement_client/src/starknet/mod.rs
+++ b/madara/crates/client/settlement_client/src/starknet/mod.rs
@@ -755,9 +755,15 @@ mod starknet_client_messaging_test {
             let starknet_client = fixture.starknet_client.clone();
 
             tokio::spawn(async move {
-                sync(Arc::new(starknet_client), Arc::clone(&db), Default::default(), ServiceContext::new_for_testing())
-                    .await
-                    .unwrap();
+                sync(
+                    Arc::new(starknet_client),
+                    Arc::clone(&db),
+                    Default::default(),
+                    ServiceContext::new_for_testing(),
+                    false,
+                )
+                .await
+                .unwrap();
                 tracing::debug!("messaging worker stopped");
             })
         };
@@ -838,8 +844,14 @@ mod starknet_client_messaging_test {
             let starknet_client = fixture.starknet_client.clone();
 
             tokio::spawn(async move {
-                sync(Arc::new(starknet_client), Arc::clone(&db), Default::default(), ServiceContext::new_for_testing())
-                    .await
+                sync(
+                    Arc::new(starknet_client),
+                    Arc::clone(&db),
+                    Default::default(),
+                    ServiceContext::new_for_testing(),
+                    false,
+                )
+                .await
             })
         };
 

--- a/madara/crates/client/settlement_client/src/sync.rs
+++ b/madara/crates/client/settlement_client/src/sync.rs
@@ -11,6 +11,7 @@ pub struct SyncWorkerConfig {
     pub gas_provider_config: GasPriceProviderConfig,
     pub l1_block_metrics: Arc<L1BlockMetrics>,
     pub l1_head_sender: L1HeadSender,
+    pub unsafe_skip_l1_message_consumed_check: bool,
 }
 
 impl L1ClientImpl {
@@ -34,6 +35,7 @@ impl L1ClientImpl {
             Arc::clone(&self.backend),
             self.notify_new_message_to_l2.clone(),
             ctx.clone(),
+            config.unsafe_skip_l1_message_consumed_check,
         ));
 
         if !config.gas_provider_config.all_is_fixed() {

--- a/madara/node/src/cli/l1.rs
+++ b/madara/node/src/cli/l1.rs
@@ -107,6 +107,22 @@ pub struct L1SyncParams {
     )]
     pub gas_price_poll: Duration,
 
+    /// DANGEROUS: Disables the check that verifies an L1→L2 message has not already been consumed
+    /// on the settlement layer (L1) before including it in block production.
+    ///
+    /// Normally, before consuming an L1→L2 message, Madara queries the core contract's `l1ToL2Messages(hash)`
+    /// mapping to confirm the message still exists (refcount > 0). After a state update is posted to L1, this
+    /// refcount is decremented to 0, causing the check to reject the message even if it hasn't been processed
+    /// locally. Enabling this flag skips that specific L1 query.
+    ///
+    /// **You almost certainly do not need this flag.** It is intended only for rare recovery scenarios where
+    /// messages must be re-processed locally despite already being marked as consumed on L1.
+    ///
+    /// WARNING: Enabling this removes a safety guard against double-processing of L1→L2 messages.
+    /// The local nonce check and cancellation check remain active.
+    #[clap(env = "MADARA_UNSAFE_SKIP_L1_MESSAGE_CONSUMED_CHECK", long)]
+    pub unsafe_skip_l1_message_consumed_check: bool,
+
     /// The settlement layer type. This specifies the type of API `--l1-endpoint <RPC url>` uses: Ethereum RPC, or Starknet RPC.
     /// The usual cases for this is:
     /// - When settling on Ethereum, which is the case for Starknet Mainnet, we are usually running an L2 - because Ethrereum is an L1 and doesn't settle on any other chain.

--- a/madara/node/src/service/l1.rs
+++ b/madara/node/src/service/l1.rs
@@ -73,16 +73,22 @@ impl L1SyncService {
             std::process::exit(1);
         };
         let client = match config.settlement_layer {
-            MadaraSettlementLayer::Eth => {
-                L1ClientImpl::new_ethereum(backend.clone(), endpoint, sync_config.l1_core_address)
-                    .await
-                    .context("Starting ethereum core contract client")?
-            }
-            MadaraSettlementLayer::Starknet => {
-                L1ClientImpl::new_starknet(backend.clone(), endpoint, sync_config.l1_core_address)
-                    .await
-                    .context("Starting starknet core contract client")?
-            }
+            MadaraSettlementLayer::Eth => L1ClientImpl::new_ethereum(
+                backend.clone(),
+                endpoint,
+                sync_config.l1_core_address,
+                config.unsafe_skip_l1_message_consumed_check,
+            )
+            .await
+            .context("Starting ethereum core contract client")?,
+            MadaraSettlementLayer::Starknet => L1ClientImpl::new_starknet(
+                backend.clone(),
+                endpoint,
+                sync_config.l1_core_address,
+                config.unsafe_skip_l1_message_consumed_check,
+            )
+            .await
+            .context("Starting starknet core contract client")?,
         };
 
         if !gas_provider_config.all_is_fixed() {
@@ -101,6 +107,7 @@ impl L1SyncService {
                 gas_provider_config,
                 l1_head_sender: sync_config.l1_head_snd,
                 l1_block_metrics: sync_config.l1_block_metrics,
+                unsafe_skip_l1_message_consumed_check: config.unsafe_skip_l1_message_consumed_check,
             }),
         })
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

The code correctly checks if a message is already consumed on L1 before keeping it for processing and before actually processing it.

Resolves: #NA

Added a dangerous flag to skip this check. This will be used mostly for shadow networks to make sure that they are able to consume L1 messages even if the original sequencer has consumed it and done the state update!

## Does this introduce a breaking change?

NO

## Other information

Use this flag with caution!!