### PR TITLE
Stop S3 directory listing in storage cleanup; tag known paths directly and treat 404 as NotFound

### DIFF
--- a/orchestrator/src/core/client/storage/mod.rs
+++ b/orchestrator/src/core/client/storage/mod.rs
@@ -17,9 +17,6 @@ pub trait StorageClient: Send + Sync {
     /// Delete a bucket
     async fn delete_data(&self, key: &str) -> Result<(), StorageError>;
 
-    /// List files in a directory
-    async fn list_files_in_dir(&self, dir_path: &str) -> Result<Vec<String>, StorageError>;
-
     /// Perform a health check on the storage service
     ///
     /// This method verifies that the storage service (e.g., AWS S3) is accessible

--- a/orchestrator/src/core/client/storage/s3.rs
+++ b/orchestrator/src/core/client/storage/s3.rs
@@ -4,12 +4,10 @@ use crate::core::client::storage::StorageError;
 use crate::types::params::AWSResourceIdentifier;
 use async_trait::async_trait;
 use aws_config::SdkConfig;
+use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_s3::operation::put_object_tagging::PutObjectTaggingError;
 use aws_sdk_s3::types::{Tag, Tagging};
 use aws_sdk_s3::Client;
-use aws_smithy_runtime_api::client::result::SdkError;
-use aws_smithy_runtime_api::http::Response as SmithyResponse;
-use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use bytes::Bytes;
 
 /// AWSS3 is a struct that represents an AWS S3 client.
@@ -69,7 +67,7 @@ impl AWSS3 {
     }
 }
 
-fn is_not_found_tagging_error(err: &SdkError<PutObjectTaggingError, SmithyResponse>) -> bool {
+fn is_not_found_tagging_error(err: &SdkError<PutObjectTaggingError>) -> bool {
     if let Some(service_err) = err.as_service_error() {
         if matches!(service_err.code(), Some("NoSuchKey" | "NotFound")) {
             return true;

--- a/orchestrator/src/core/client/storage/s3.rs
+++ b/orchestrator/src/core/client/storage/s3.rs
@@ -4,8 +4,12 @@ use crate::core::client::storage::StorageError;
 use crate::types::params::AWSResourceIdentifier;
 use async_trait::async_trait;
 use aws_config::SdkConfig;
+use aws_sdk_s3::operation::put_object_tagging::PutObjectTaggingError;
 use aws_sdk_s3::types::{Tag, Tagging};
 use aws_sdk_s3::Client;
+use aws_smithy_runtime_api::client::result::SdkError;
+use aws_smithy_runtime_api::http::Response as SmithyResponse;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use bytes::Bytes;
 
 /// AWSS3 is a struct that represents an AWS S3 client.
@@ -65,6 +69,23 @@ impl AWSS3 {
     }
 }
 
+fn is_not_found_tagging_error(err: &SdkError<PutObjectTaggingError, SmithyResponse>) -> bool {
+    if let Some(service_err) = err.as_service_error() {
+        if matches!(service_err.code(), Some("NoSuchKey" | "NotFound")) {
+            return true;
+        }
+    }
+
+    if let Some(raw) = err.raw_response() {
+        let status: u16 = raw.status().into();
+        if status == 404 {
+            return true;
+        }
+    }
+
+    false
+}
+
 #[async_trait]
 impl StorageClient for AWSS3 {
     /// Get the data from the bucket with the specified key.
@@ -105,37 +126,6 @@ impl StorageClient for AWSS3 {
         Ok(self.client().delete_object().bucket(self.bucket_name()?).key(key).send().await.map(|_| ())?)
     }
 
-    async fn list_files_in_dir(&self, dir_path: &str) -> Result<Vec<String>, StorageError> {
-        let mut file_paths = Vec::new();
-
-        // Ensure the directory path ends with '/' for proper prefix matching
-        let prefix = if dir_path.ends_with('/') { dir_path.to_string() } else { format!("{}/", dir_path) };
-
-        let mut paginator =
-            self.client().list_objects_v2().bucket(self.bucket_name()?).prefix(&prefix).into_paginator().send();
-
-        // Iterate through all pages of results
-        while let Some(page) = paginator.next().await {
-            if let Some(objects) = page
-                .map_err(|e| {
-                    StorageError::ObjectStreamError(format!("Failed to list files in path {}: {}", dir_path, e))
-                })?
-                .contents
-            {
-                for object in objects {
-                    if let Some(key) = object.key {
-                        // Skip directories (keys ending with '/')
-                        if !key.ends_with('/') {
-                            file_paths.push(key);
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(file_paths)
-    }
-
     async fn health_check(&self) -> Result<(), StorageError> {
         // Verify S3 bucket accessibility by checking if it exists
         // This operation requires ListBucket permission
@@ -169,11 +159,7 @@ impl StorageClient for AWSS3 {
 
         self.client().put_object_tagging().bucket(self.bucket_name()?).key(key).tagging(tagging).send().await.map_err(
             |e| {
-                let error_str = e.to_string();
-                if error_str.contains("NoSuchKey")
-                    || error_str.contains("not found")
-                    || error_str.contains("does not exist")
-                {
+                if is_not_found_tagging_error(&e) {
                     StorageError::NotFound(format!("Object '{}' not found", key))
                 } else {
                     StorageError::ObjectStreamError(format!("Failed to tag object '{}': {}", key, e))

--- a/orchestrator/src/core/client/storage/s3.rs
+++ b/orchestrator/src/core/client/storage/s3.rs
@@ -68,20 +68,15 @@ impl AWSS3 {
 }
 
 fn is_not_found_tagging_error(err: &SdkError<PutObjectTaggingError>) -> bool {
-    if let Some(service_err) = err.as_service_error() {
-        if matches!(service_err.code(), Some("NoSuchKey" | "NotFound")) {
-            return true;
-        }
-    }
+    let service_error = err
+        .as_service_error()
+        .and_then(|e| e.code())
+        .map(|code| matches!(code, "NoSuchKey" | "NotFound"))
+        .unwrap_or(false);
 
-    if let Some(raw) = err.raw_response() {
-        let status: u16 = raw.status().into();
-        if status == 404 {
-            return true;
-        }
-    }
+    let status_404 = err.raw_response().map(|raw| raw.status().as_u16() == 404).unwrap_or(false);
 
-    false
+    service_error || status_404
 }
 
 #[async_trait]

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -259,19 +259,13 @@ async fn test_storage_cleanup_l2_direct_snos_paths_without_listing() -> Result<(
         .collect::<Vec<_>>();
 
     database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![job.clone()]));
-    database
-        .expect_get_snos_batches_by_aggregator_index()
-        .returning(move |_| Ok(snos_batches.clone()));
+    database.expect_get_snos_batches_by_aggregator_index().returning(move |_| Ok(snos_batches.clone()));
     database.expect_update_job().returning(|_, _| Ok(()));
 
     let mut expected = BTreeSet::new();
-    for file in [
-        CAIRO_PIE_FILE_NAME,
-        DA_SEGMENT_FILE_NAME,
-        PROGRAM_OUTPUT_FILE_NAME,
-        SNOS_OUTPUT_FILE_NAME,
-        PROOF_FILE_NAME,
-    ] {
+    for file in
+        [CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME, SNOS_OUTPUT_FILE_NAME, PROOF_FILE_NAME]
+    {
         expected.insert(get_batch_artifact_file(job_id, file));
     }
     for blob_index in 0..=MAX_BLOBS {
@@ -356,13 +350,9 @@ async fn test_storage_cleanup_l3_direct_snos_paths_without_listing() -> Result<(
     database.expect_update_job().returning(|_, _| Ok(()));
 
     let mut expected = BTreeSet::new();
-    for file in [
-        CAIRO_PIE_FILE_NAME,
-        DA_SEGMENT_FILE_NAME,
-        PROGRAM_OUTPUT_FILE_NAME,
-        SNOS_OUTPUT_FILE_NAME,
-        PROOF_FILE_NAME,
-    ] {
+    for file in
+        [CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME, SNOS_OUTPUT_FILE_NAME, PROOF_FILE_NAME]
+    {
         expected.insert(get_batch_artifact_file(job_id, file));
     }
     for blob_index in 0..=MAX_BLOBS {

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -3,8 +3,9 @@
 
 use bytes::Bytes;
 use rstest::rstest;
+use std::collections::BTreeSet;
 use std::error::Error;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::core::client::database::{DatabaseError, MockDatabaseClient};
 use crate::core::client::lock::error::LockError;
@@ -15,8 +16,9 @@ use crate::tests::utils::build_snos_batch;
 use crate::tests::workers::utils::get_job_by_mock_id_vector;
 use crate::types::constant::{
     get_batch_artifact_file, get_batch_blob_dir, get_batch_blob_file, get_batch_state_update_file, get_snos_batch_dir,
-    BLOB_DATA_FILE_NAME, CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME, PROOF_FILE_NAME,
-    PROOF_PART2_FILE_NAME, SNOS_OUTPUT_FILE_NAME, STORAGE_EXPIRATION_TAG_KEY, STORAGE_EXPIRATION_TAG_VALUE,
+    BLOB_DATA_FILE_NAME, CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, MAX_BLOBS, PROGRAM_OUTPUT_FILE_NAME,
+    PROOF_FILE_NAME, PROOF_PART2_FILE_NAME, SNOS_OUTPUT_FILE_NAME, STORAGE_EXPIRATION_TAG_KEY,
+    STORAGE_EXPIRATION_TAG_VALUE,
 };
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::metadata::{
@@ -141,7 +143,6 @@ async fn test_process_completed_jobs_skips_partial_tagging() -> Result<(), Box<d
 
     database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![valid_job.clone()]));
     database.expect_get_snos_batches_by_aggregator_index().times(0);
-    storage.expect_list_files_in_dir().returning(|_| Ok(vec!["file1.json".to_string()]));
     storage.expect_tag_object().returning(|_, _| {
         Err(crate::core::client::storage::StorageError::ObjectStreamError("Connection timeout".to_string()))
     });
@@ -199,8 +200,6 @@ async fn test_process_completed_jobs_skips_on_snos_batch_lookup_failure() -> Res
         .expect_get_snos_batches_by_aggregator_index()
         .returning(|_| Err(DatabaseError::KeyNotFound("db error".to_string())));
 
-    // Storage listing can still be called before DB error
-    storage.expect_list_files_in_dir().returning(|_| Ok(vec![]));
     storage.expect_tag_object().never();
     database.expect_update_job().never();
 
@@ -213,6 +212,203 @@ async fn test_process_completed_jobs_skips_on_snos_batch_lookup_failure() -> Res
 
     let result = StorageCleanupTrigger.run_worker(services.config).await;
     assert!(result.is_ok(), "Worker should continue even when SNOS batch lookup fails");
+    Ok(())
+}
+
+/// Test: L2 uses direct SNOS file paths (3 files) and never lists directories
+#[rstest]
+#[tokio::test]
+async fn test_storage_cleanup_l2_direct_snos_paths_without_listing() -> Result<(), Box<dyn Error>> {
+    let mut database = MockDatabaseClient::new();
+    let mut storage = MockStorageClient::new();
+    let mut lock = MockLockClient::new();
+
+    lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
+    lock.expect_release_lock().returning(|_, _| Ok(LockResult::Released));
+
+    let job_id: u64 = 4242;
+    let snos_batch_ids = vec![10001_u64, 10002_u64];
+
+    let job = JobItem {
+        id: uuid::Uuid::new_v4(),
+        internal_id: job_id,
+        job_type: JobType::StateTransition,
+        status: JobStatus::Completed,
+        external_id: crate::types::jobs::external_id::ExternalId::Number(job_id as usize),
+        metadata: JobMetadata {
+            common: CommonMetadata::default(),
+            specific: JobSpecificMetadata::StateUpdate(StateUpdateMetadata {
+                snos_output_path: None,
+                program_output_path: None,
+                blob_data_path: None,
+                da_segment_path: None,
+                tx_hash: Some("0xabc".to_string()),
+                context: SettlementContext::Batch(SettlementContextData { to_settle: job_id, last_failed: None }),
+                storage_artifacts_tagged_at: None,
+            }),
+        },
+        version: 0,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+
+    let snos_batches = snos_batch_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, snos_batch_id)| build_snos_batch(*snos_batch_id, Some(job_id), 1000 + idx as u64))
+        .collect::<Vec<_>>();
+
+    database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![job.clone()]));
+    database
+        .expect_get_snos_batches_by_aggregator_index()
+        .returning(move |_| Ok(snos_batches.clone()));
+    database.expect_update_job().returning(|_, _| Ok(()));
+
+    let mut expected = BTreeSet::new();
+    for file in [
+        CAIRO_PIE_FILE_NAME,
+        DA_SEGMENT_FILE_NAME,
+        PROGRAM_OUTPUT_FILE_NAME,
+        SNOS_OUTPUT_FILE_NAME,
+        PROOF_FILE_NAME,
+    ] {
+        expected.insert(get_batch_artifact_file(job_id, file));
+    }
+    for blob_index in 0..=MAX_BLOBS {
+        expected.insert(get_batch_blob_file(job_id, blob_index as u64));
+    }
+    expected.insert(get_batch_state_update_file(job_id));
+    for snos_batch_id in &snos_batch_ids {
+        let snos_dir = get_snos_batch_dir(*snos_batch_id);
+        for file in [CAIRO_PIE_FILE_NAME, SNOS_OUTPUT_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME] {
+            expected.insert(format!("{}/{}", snos_dir, file));
+        }
+    }
+
+    let expected = Arc::new(expected);
+    let seen = Arc::new(Mutex::new(BTreeSet::new()));
+    let expected_len = expected.len();
+
+    storage.expect_tag_object().times(expected_len).returning({
+        let expected = Arc::clone(&expected);
+        let seen = Arc::clone(&seen);
+        move |key, _| {
+            assert!(expected.contains(key), "Unexpected key tagged: {}", key);
+            seen.lock().unwrap().insert(key.to_string());
+            Ok(())
+        }
+    });
+
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(storage.into())
+        .configure_database(database.into())
+        .configure_lock_client(lock.into())
+        .build()
+        .await;
+
+    let result = StorageCleanupTrigger.run_worker(services.config).await;
+    assert!(result.is_ok(), "Worker should complete");
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(*seen, *expected, "Tagged keys should match expected set");
+
+    Ok(())
+}
+
+/// Test: L3 uses direct SNOS file paths (6 files) and never lists directories
+#[rstest]
+#[tokio::test]
+async fn test_storage_cleanup_l3_direct_snos_paths_without_listing() -> Result<(), Box<dyn Error>> {
+    let mut database = MockDatabaseClient::new();
+    let mut storage = MockStorageClient::new();
+    let mut lock = MockLockClient::new();
+
+    lock.expect_acquire_lock().returning(|_, _, _, _| Ok(LockResult::Acquired));
+    lock.expect_release_lock().returning(|_, _| Ok(LockResult::Released));
+
+    let job_id: u64 = 7777;
+
+    let job = JobItem {
+        id: uuid::Uuid::new_v4(),
+        internal_id: job_id,
+        job_type: JobType::StateTransition,
+        status: JobStatus::Completed,
+        external_id: crate::types::jobs::external_id::ExternalId::Number(job_id as usize),
+        metadata: JobMetadata {
+            common: CommonMetadata::default(),
+            specific: JobSpecificMetadata::StateUpdate(StateUpdateMetadata {
+                snos_output_path: None,
+                program_output_path: None,
+                blob_data_path: None,
+                da_segment_path: None,
+                tx_hash: Some("0xdef".to_string()),
+                context: SettlementContext::Block(SettlementContextData { to_settle: job_id, last_failed: None }),
+                storage_artifacts_tagged_at: None,
+            }),
+        },
+        version: 0,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+
+    database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![job.clone()]));
+    database.expect_get_snos_batches_by_aggregator_index().times(0);
+    database.expect_update_job().returning(|_, _| Ok(()));
+
+    let mut expected = BTreeSet::new();
+    for file in [
+        CAIRO_PIE_FILE_NAME,
+        DA_SEGMENT_FILE_NAME,
+        PROGRAM_OUTPUT_FILE_NAME,
+        SNOS_OUTPUT_FILE_NAME,
+        PROOF_FILE_NAME,
+    ] {
+        expected.insert(get_batch_artifact_file(job_id, file));
+    }
+    for blob_index in 0..=MAX_BLOBS {
+        expected.insert(get_batch_blob_file(job_id, blob_index as u64));
+    }
+    expected.insert(get_batch_state_update_file(job_id));
+
+    let snos_dir = get_snos_batch_dir(job_id);
+    for file in [
+        CAIRO_PIE_FILE_NAME,
+        SNOS_OUTPUT_FILE_NAME,
+        PROGRAM_OUTPUT_FILE_NAME,
+        BLOB_DATA_FILE_NAME,
+        PROOF_FILE_NAME,
+        PROOF_PART2_FILE_NAME,
+    ] {
+        expected.insert(format!("{}/{}", snos_dir, file));
+    }
+
+    let expected = Arc::new(expected);
+    let seen = Arc::new(Mutex::new(BTreeSet::new()));
+    let expected_len = expected.len();
+
+    storage.expect_tag_object().times(expected_len).returning({
+        let expected = Arc::clone(&expected);
+        let seen = Arc::clone(&seen);
+        move |key, _| {
+            assert!(expected.contains(key), "Unexpected key tagged: {}", key);
+            seen.lock().unwrap().insert(key.to_string());
+            Ok(())
+        }
+    });
+
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(storage.into())
+        .configure_database(database.into())
+        .configure_lock_client(lock.into())
+        .build()
+        .await;
+
+    let result = StorageCleanupTrigger.run_worker(services.config).await;
+    assert!(result.is_ok(), "Worker should complete");
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(*seen, *expected, "Tagged keys should match expected set");
+
     Ok(())
 }
 
@@ -413,39 +609,13 @@ async fn test_tag_object_success_and_error_cases() -> Result<(), Box<dyn Error>>
         applied_tags
     );
 
-    // Test 2: tag_nonexistent_object returns error
+    // Test 2: tag_nonexistent_object returns NotFound
     let result = storage.tag_object("nonexistent/path/file.json", &tags).await;
-    assert!(result.is_err(), "Tagging nonexistent object should return error");
-
-    Ok(())
-}
-
-/// Tests: list_files_in_dir returns all files in directory
-#[rstest]
-#[tokio::test]
-async fn test_list_files_in_dir_returns_all_files() -> Result<(), Box<dyn Error>> {
-    let services = TestConfigBuilder::new().configure_storage_client(ConfigType::Actual).build().await;
-    let storage = services.config.storage();
-
-    // Setup: create multiple files in a directory
-    let test_dir = "test_list_dir_12345";
-    let files = ["file1.json", "file2.json", "nested/file3.json"];
-    for file in &files {
-        let key = format!("{}/{}", test_dir, file);
-        storage.put_data(Bytes::from(r#"{"test": "list"}"#), &key).await?;
-    }
-
-    // Test: list_files_in_dir returns all files
-    let listed_files = storage.list_files_in_dir(test_dir).await?;
-    assert_eq!(listed_files.len(), 3, "Should list all 3 files");
-    for file in &files {
-        let expected_key = format!("{}/{}", test_dir, file);
-        assert!(listed_files.contains(&expected_key), "Should contain {}", expected_key);
-    }
-
-    // Test: empty directory returns empty list
-    let empty_result = storage.list_files_in_dir("nonexistent_dir_xyz").await?;
-    assert!(empty_result.is_empty(), "Nonexistent dir should return empty list");
+    assert!(
+        matches!(result, Err(crate::core::client::storage::StorageError::NotFound(_))),
+        "Expected NotFound for nonexistent object, got: {:?}",
+        result
+    );
 
     Ok(())
 }

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -663,8 +663,8 @@ async fn test_collect_and_tag_artifacts_integration() -> Result<(), Box<dyn Erro
     let job_id: u64 = 88888;
     let test_data = Bytes::from(r#"{"test": "collect_and_tag"}"#);
 
-    // Create artifacts in multiple directories
-    let artifact_file = get_batch_artifact_file(job_id, "test_proof.json");
+    // Create artifacts in multiple directories (use known filenames)
+    let artifact_file = get_batch_artifact_file(job_id, PROOF_FILE_NAME);
     let blob_file = get_batch_blob_file(job_id, 0);
     let state_update_file = get_batch_state_update_file(job_id);
 

--- a/orchestrator/src/tests/workers/storage_cleanup/mod.rs
+++ b/orchestrator/src/tests/workers/storage_cleanup/mod.rs
@@ -260,7 +260,7 @@ async fn test_storage_cleanup_l2_direct_snos_paths_without_listing() -> Result<(
 
     database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![job.clone()]));
     database.expect_get_snos_batches_by_aggregator_index().returning(move |_| Ok(snos_batches.clone()));
-    database.expect_update_job().returning(|_, _| Ok(()));
+    database.expect_update_job().returning(|job, _| Ok(job.clone()));
 
     let mut expected = BTreeSet::new();
     for file in
@@ -347,7 +347,7 @@ async fn test_storage_cleanup_l3_direct_snos_paths_without_listing() -> Result<(
 
     database.expect_get_jobs_without_storage_artifacts_tagged().returning(move |_| Ok(vec![job.clone()]));
     database.expect_get_snos_batches_by_aggregator_index().times(0);
-    database.expect_update_job().returning(|_, _| Ok(()));
+    database.expect_update_job().returning(|job, _| Ok(job.clone()));
 
     let mut expected = BTreeSet::new();
     for file in

--- a/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
+++ b/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
@@ -4,9 +4,8 @@ use crate::core::config::Config;
 use crate::types::constant::{
     get_batch_artifact_file, get_batch_blob_file, get_batch_state_update_file, get_snos_batch_dir, BLOB_DATA_FILE_NAME,
     CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, MAX_BLOBS, PROGRAM_OUTPUT_FILE_NAME, PROOF_FILE_NAME,
-    PROOF_PART2_FILE_NAME, SNOS_OUTPUT_FILE_NAME, STORAGE_CLEANUP_LOCK_DURATION,
-    STORAGE_CLEANUP_MAX_JOBS_PER_RUN, STORAGE_CLEANUP_WORKER_KEY, STORAGE_EXPIRATION_TAG_KEY,
-    STORAGE_EXPIRATION_TAG_VALUE,
+    PROOF_PART2_FILE_NAME, SNOS_OUTPUT_FILE_NAME, STORAGE_CLEANUP_LOCK_DURATION, STORAGE_CLEANUP_MAX_JOBS_PER_RUN,
+    STORAGE_CLEANUP_WORKER_KEY, STORAGE_EXPIRATION_TAG_KEY, STORAGE_EXPIRATION_TAG_VALUE,
 };
 use crate::types::jobs::job_updates::JobItemUpdates;
 use crate::types::jobs::metadata::{JobMetadata, JobSpecificMetadata, SettlementContext, StateUpdateMetadata};

--- a/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
+++ b/orchestrator/src/worker/event_handler/triggers/storage_cleanup.rs
@@ -2,9 +2,11 @@ use crate::core::client::lock::LockValue;
 use crate::core::client::storage::StorageError;
 use crate::core::config::Config;
 use crate::types::constant::{
-    get_batch_artifacts_dir, get_batch_blob_dir, get_batch_state_update_file, get_snos_batch_dir,
-    STORAGE_CLEANUP_LOCK_DURATION, STORAGE_CLEANUP_MAX_JOBS_PER_RUN, STORAGE_CLEANUP_WORKER_KEY,
-    STORAGE_EXPIRATION_TAG_KEY, STORAGE_EXPIRATION_TAG_VALUE,
+    get_batch_artifact_file, get_batch_blob_file, get_batch_state_update_file, get_snos_batch_dir, BLOB_DATA_FILE_NAME,
+    CAIRO_PIE_FILE_NAME, DA_SEGMENT_FILE_NAME, MAX_BLOBS, PROGRAM_OUTPUT_FILE_NAME, PROOF_FILE_NAME,
+    PROOF_PART2_FILE_NAME, SNOS_OUTPUT_FILE_NAME, STORAGE_CLEANUP_LOCK_DURATION,
+    STORAGE_CLEANUP_MAX_JOBS_PER_RUN, STORAGE_CLEANUP_WORKER_KEY, STORAGE_EXPIRATION_TAG_KEY,
+    STORAGE_EXPIRATION_TAG_VALUE,
 };
 use crate::types::jobs::job_updates::JobItemUpdates;
 use crate::types::jobs::metadata::{JobMetadata, JobSpecificMetadata, SettlementContext, StateUpdateMetadata};
@@ -21,8 +23,6 @@ pub struct StorageCleanupTrigger;
 #[async_trait]
 impl JobTrigger for StorageCleanupTrigger {
     async fn run_worker(&self, config: Arc<Config>) -> color_eyre::Result<()> {
-        info!("StorageCleanupTrigger started");
-
         // Try to acquire distributed lock
         match config
             .lock()
@@ -31,6 +31,7 @@ impl JobTrigger for StorageCleanupTrigger {
         {
             Ok(_) => {
                 debug!("StorageCleanupTrigger acquired distributed lock");
+                info!("StorageCleanupTrigger started");
             }
             Err(err) => {
                 debug!("StorageCleanupTrigger could not acquire lock (another instance may be running): {}", err);
@@ -157,10 +158,9 @@ impl StorageCleanupTrigger {
     }
 
     /// Collect artifact paths from:
-    /// - batch artifacts dir
-    /// - batch blob dir
-    /// - SNOS batch dir (L3 only)
-    /// - SNOS batch dirs for all SNOS batches inside the aggregator batch (L2 only)
+    /// - known batch-scoped artifacts (no directory listing)
+    /// - known blob files (0..=MAX_BLOBS)
+    /// - SNOS batch root artifacts (L2: from DB, L3: job_id)
     /// - state update file
     async fn collect_artifact_paths(
         &self,
@@ -170,25 +170,21 @@ impl StorageCleanupTrigger {
     ) -> color_eyre::Result<Vec<String>> {
         let mut paths = BTreeSet::new();
 
-        // List files from each artifact directory
-        let mut dirs = vec![get_batch_artifacts_dir(job_id), get_batch_blob_dir(job_id)];
-
-        let is_l3 = matches!(state_metadata.context, SettlementContext::Block(_));
-        if is_l3 {
-            dirs.push(get_snos_batch_dir(job_id));
+        // Batch-scoped artifacts (known filenames)
+        let batch_artifact_files = [
+            CAIRO_PIE_FILE_NAME,
+            DA_SEGMENT_FILE_NAME,
+            PROGRAM_OUTPUT_FILE_NAME,
+            SNOS_OUTPUT_FILE_NAME,
+            PROOF_FILE_NAME,
+        ];
+        for file in batch_artifact_files {
+            paths.insert(get_batch_artifact_file(job_id, file));
         }
 
-        for dir in &dirs {
-            match config.storage().list_files_in_dir(dir).await {
-                Ok(files) => {
-                    debug!(job_id = %job_id, dir = %dir, count = files.len(), "Found files");
-                    paths.extend(files);
-                }
-                Err(e) => {
-                    MetricsRecorder::record_cleanup_failure("list_dir");
-                    debug!(job_id = %job_id, dir = %dir, error = %e, "Dir not found or error");
-                }
-            }
+        // Blob files (0..=MAX_BLOBS). Missing files are treated as NotFound during tagging.
+        for blob_index in 0..=MAX_BLOBS {
+            paths.insert(get_batch_blob_file(job_id, blob_index as u64));
         }
 
         if matches!(state_metadata.context, SettlementContext::Batch(_)) {
@@ -202,28 +198,22 @@ impl StorageCleanupTrigger {
             };
             for snos_batch in snos_batches {
                 let snos_dir = get_snos_batch_dir(snos_batch.index);
-                match config.storage().list_files_in_dir(&snos_dir).await {
-                    Ok(files) => {
-                        debug!(
-                            job_id = %job_id,
-                            snos_batch_index = %snos_batch.index,
-                            dir = %snos_dir,
-                            count = files.len(),
-                            "Found SNOS batch files"
-                        );
-                        paths.extend(files);
-                    }
-                    Err(e) => {
-                        MetricsRecorder::record_cleanup_failure("list_dir");
-                        debug!(
-                            job_id = %job_id,
-                            snos_batch_index = %snos_batch.index,
-                            dir = %snos_dir,
-                            error = %e,
-                            "SNOS batch dir not found or error"
-                        );
-                    }
+                for file in [CAIRO_PIE_FILE_NAME, SNOS_OUTPUT_FILE_NAME, PROGRAM_OUTPUT_FILE_NAME] {
+                    paths.insert(format!("{}/{}", snos_dir, file));
                 }
+            }
+        } else {
+            // L3: use job_id as SNOS batch id (assumes block_number == snos_batch_id)
+            let snos_dir = get_snos_batch_dir(job_id);
+            for file in [
+                CAIRO_PIE_FILE_NAME,
+                SNOS_OUTPUT_FILE_NAME,
+                PROGRAM_OUTPUT_FILE_NAME,
+                BLOB_DATA_FILE_NAME,
+                PROOF_FILE_NAME,
+                PROOF_PART2_FILE_NAME,
+            ] {
+                paths.insert(format!("{}/{}", snos_dir, file));
             }
         }
 


### PR DESCRIPTION
## Pull Request type
- [x] Bugfix
- [x] Refactoring (no functional changes, no API changes)
- [x] Testing
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
- Storage cleanup lists S3 directories to discover artifacts, which is costly and error‑prone.
- Missing objects during tagging can surface as generic errors due to string matching.
- Cleanup behavior for SNOS root artifacts is implicit via listing.

Resolves: #NA

## What is the new behavior?
- Storage cleanup **never lists S3 directories**. It tags only **known, explicit paths** for batch artifacts, blob files, state updates, and SNOS root artifacts.
- L2 SNOS root tagging now directly targets **three files**: `cairo_pie.zip`, `snos_output.json`, `program_output.txt`.
- L3 SNOS root tagging now directly targets **six files**: `cairo_pie.zip`, `snos_output.json`, `program_output.txt`, `blob_data.txt`, `proof.json`, `proof_part2.json`.
- Missing objects are treated as `NotFound` via SDK metadata/HTTP status (`404`, `NoSuchKey`) and are **not considered failures** for cleanup.

## Does this introduce a breaking change?
No.

## Other information
**Tests added/updated**
- Unit tests assert direct tagging for L2/L3 without directory listing.
- Tagging test now expects `StorageError::NotFound` for missing objects.

**Notes**
- `list_files_in_dir` was removed from the storage trait and S3 implementation since it is no longer used.