### PR TITLE
feat: add blob size buffer for aggregator batching

### DIFF
--- a/orchestrator/src/cli/batching.rs
+++ b/orchestrator/src/cli/batching.rs
@@ -16,6 +16,12 @@ pub struct BatchingCliArgs {
     #[arg(env = "MADARA_ORCHESTRATOR_MAX_NUM_BLOBS", long, default_value = "6")]
     pub max_num_blobs: usize,
 
+    /// Buffer (in number of felts) to subtract from the maximum blob capacity.
+    /// The effective max blob size becomes (max_num_blobs * 4096) - blob_size_buffer.
+    /// This accounts for overhead added by the prover (e.g. encryption headers).
+    #[arg(env = "MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER", long, default_value = "15")]
+    pub blob_size_buffer: usize,
+
     /// Batching worker lock duration in seconds.
     /// This lock ensures that only one Batching Worker is running at a time.
     #[arg(env = "MADARA_ORCHESTRATOR_BATCHING_LOCK_DURATION_SECONDS", long, default_value = "3600")]

--- a/orchestrator/src/compression/stateful.rs
+++ b/orchestrator/src/compression/stateful.rs
@@ -6,7 +6,7 @@ use starknet::core::types::{
 };
 use starknet_core::types::BlockId;
 use std::collections::{HashMap, HashSet};
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 // https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257
 const STATEFUL_SPECIAL_ADDRESS: Felt = Felt::from_hex_unchecked("0x2");
@@ -141,7 +141,10 @@ impl CompressedKeyValues {
 
             // Add fetched values to mappings
             for key in keys_needing_provider {
-                let value = provider_values.get(&(STATEFUL_SPECIAL_ADDRESS, key)).copied().unwrap_or(Felt::ZERO);
+                let value = provider_values.get(&(STATEFUL_SPECIAL_ADDRESS, key)).copied().unwrap_or_else(|| {
+                    error!("Failed to get 0x2 mapping for {}", key);
+                    Felt::ZERO
+                });
                 mappings.insert(key, value);
             }
         }

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -781,7 +781,11 @@ pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
         .parse::<u64>()
         .unwrap(),
         max_num_blobs,
-        max_blob_size: max_num_blobs * BLOB_LEN,
+        blob_size_buffer: get_env_var_or_default("MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER", "15")
+            .parse::<usize>()
+            .unwrap(),
+        max_blob_size: max_num_blobs * BLOB_LEN
+            - get_env_var_or_default("MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER", "15").parse::<usize>().unwrap(),
         default_empty_block_proving_gas: get_env_var_or_default(
             "MADARA_ORCHESTRATOR_DEFAULT_EMPTY_BLOCK_PROVING_GAS",
             "1500000",

--- a/orchestrator/src/types/params/batching.rs
+++ b/orchestrator/src/types/params/batching.rs
@@ -10,11 +10,13 @@ pub struct BatchingParams {
     pub fixed_blocks_per_snos_batch: Option<u64>,
     pub max_snos_batches_per_aggregator_batch: u64,
     pub max_num_blobs: usize,
+    /// Buffer (in number of felts) subtracted from the maximum blob capacity to account for
+    /// overhead added by the prover (e.g. encryption headers).
+    pub blob_size_buffer: usize,
     /// Max number of felts (each encoded using 256 bits) that can be attached in a single state
     /// update transaction.
     ///
-    /// It's calculated by multiplying [BLOB_LEN] with max number of blobs to attach in a txn
-    /// (taken through ENV/CLI, default is 6, max that ethereum allows is 9)
+    /// It's calculated as (max_num_blobs * [BLOB_LEN]) - blob_size_buffer
     pub max_blob_size: usize,
     /// Default proving gas to use for empty blocks.
     /// Empty blocks return zero proving_gas from the bouncer weights API, but every block
@@ -34,9 +36,51 @@ impl From<BatchingCliArgs> for BatchingParams {
             fixed_blocks_per_snos_batch: args.fixed_blocks_per_snos_batch,
             max_snos_batches_per_aggregator_batch: args.max_snos_batches_per_aggregator_batch,
             max_num_blobs: args.max_num_blobs,
-            max_blob_size: args.max_num_blobs * BLOB_LEN,
+            blob_size_buffer: args.blob_size_buffer,
+            max_blob_size: args.max_num_blobs * BLOB_LEN - args.blob_size_buffer,
             default_empty_block_proving_gas: args.default_empty_block_proving_gas,
             max_batch_processing_size: args.max_batch_processing_size,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cli_args(max_num_blobs: usize, blob_size_buffer: usize) -> BatchingCliArgs {
+        BatchingCliArgs {
+            max_batch_time_seconds: 3600,
+            max_batch_size: 100,
+            max_num_blobs,
+            blob_size_buffer,
+            batching_worker_lock_duration: 3600,
+            max_blocks_per_snos_batch: 10,
+            fixed_blocks_per_snos_batch: None,
+            max_snos_batches_per_aggregator_batch: 50,
+            default_empty_block_proving_gas: 1500000,
+            max_batch_processing_size: 10,
+        }
+    }
+
+    #[test]
+    fn test_max_blob_size_with_default_buffer() {
+        let params = BatchingParams::from(make_cli_args(6, 15));
+        assert_eq!(params.max_blob_size, 6 * BLOB_LEN - 15);
+        assert_eq!(params.max_blob_size, 24561);
+    }
+
+    #[test]
+    fn test_max_blob_size_with_zero_buffer() {
+        let params = BatchingParams::from(make_cli_args(6, 0));
+        assert_eq!(params.max_blob_size, 6 * BLOB_LEN);
+        assert_eq!(params.max_blob_size, 24576);
+    }
+
+    #[test]
+    fn test_max_blob_size_with_custom_blobs_and_buffer() {
+        let params = BatchingParams::from(make_cli_args(9, 100));
+        assert_eq!(params.max_blob_size, 9 * BLOB_LEN - 100);
+        assert_eq!(params.max_blob_size, 36764);
     }
 }


### PR DESCRIPTION
## Pull Request type

- [x] Feature

## What is the current behavior?

The maximum blob size for aggregator batching is calculated as `max_num_blobs * 4096` with no margin. The prover (Atlantic) adds encryption overhead (e.g. 7 felts for `n_keys + sn_public_keys + encrypted_symmetric_keys`) to the compressed state diff, which can push the final blob count beyond the Ethereum limit of 6 blobs per transaction.

Resolves: #NA

## What is the new behavior?

- Added `--blob-size-buffer` CLI argument / `MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER` env var (default: 15) that specifies a buffer (in number of felts) subtracted from the maximum blob capacity.
- The effective max blob size is now `(max_num_blobs * 4096) - blob_size_buffer`.
- With defaults (6 blobs, 15 buffer): `24576 - 15 = 24561` felts.
- Added unit tests to verify the buffer calculation with default, zero, and custom values.

## Does this introduce a breaking change?

No. The default buffer of 15 is applied automatically, which is a stricter (safer) limit than before. Existing deployments will batch slightly more conservatively, avoiding the "too many blobs" error.

## Other information

The 15-felt default buffer accounts for the 7-felt encryption overhead added by the aggregator's Cairo program (`n_keys + n sn_public_keys + n encrypted_symmetric_keys` where n=3 DA committee members), with additional margin for safety.