### PR TITLE
fix: populate trace state diff fields per Starknet spec

### DIFF
--- a/madara/Cargo.toml
+++ b/madara/Cargo.toml
@@ -143,6 +143,7 @@ starknet-types-core = { version = "0.2.4", default-features = false, features = 
 blockifier = { git = "https://github.com/karnotxyz/sequencer", tag = "v0.14.1-alpha.0", features = [
   "node_api",
   "cairo_native",
+  "reexecution",
 ] }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", tag = "v0.14.1-alpha.0" }
 cairo-lang-starknet-classes = "2.12.3"

--- a/madara/crates/client/exec/src/execution.rs
+++ b/madara/crates/client/exec/src/execution.rs
@@ -88,7 +88,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                     .state_maps
                     .class_hashes
                     .keys()
-                    .filter(|addr| initial_reads.class_hashes.get(addr).map_or(true, |ch| *ch == ClassHash::default()))
+                    .filter(|addr| initial_reads.class_hashes.get(addr).is_none_or(|ch| *ch == ClassHash::default()))
                     .map(|addr| addr.to_felt())
                     .collect();
 

--- a/madara/crates/client/exec/src/execution.rs
+++ b/madara/crates/client/exec/src/execution.rs
@@ -8,11 +8,12 @@ use blockifier::transaction::objects::{HasRelatedFeeType, TransactionInfoCreator
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use mc_db::MadaraStorageRead;
-use mp_convert::ToFelt;
+use mp_convert::{Felt, ToFelt};
 use mp_receipt::RevertErrorExt;
 use starknet_api::block::FeeType;
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use std::collections::HashSet;
 use starknet_api::executable_transaction::{AccountTransaction as ApiAccountTransaction, TransactionType};
 use starknet_api::transaction::fields::{GasVectorComputationMode, Tip};
 use starknet_api::transaction::{TransactionHash, TransactionVersion};
@@ -75,7 +76,39 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                     .to_state_diff()
                     .map_err(TransactionExecutionError::StateError)
                     .map_err(make_reexec_error)?;
+
+                // Determine which addresses are new deployments vs class replacements.
+                // If the initial class hash was ClassHash::default() (zero), the contract
+                // didn't exist before this tx, so it's a deployment. Otherwise it's a replacement.
+                let initial_reads = transactional_state
+                    .get_initial_reads()
+                    .map_err(TransactionExecutionError::StateError)
+                    .map_err(make_reexec_error)?;
+                let deployed_contracts: HashSet<Felt> = state_diff
+                    .state_maps
+                    .class_hashes
+                    .keys()
+                    .filter(|addr| {
+                        initial_reads
+                            .class_hashes
+                            .get(addr)
+                            .map_or(true, |ch| *ch == ClassHash::default())
+                    })
+                    .map(|addr| addr.to_felt())
+                    .collect();
+
                 transactional_state.commit();
+
+                // Check if this is a deprecated (Cairo 0) class declaration (DeclareV0/V1).
+                let deprecated_declared_class = match &tx {
+                    Transaction::Account(AccountTransaction {
+                        tx: ApiAccountTransaction::Declare(declare_tx),
+                        ..
+                    }) if declare_tx.version() < TransactionVersion::TWO => {
+                        Some(declare_tx.class_hash().to_felt())
+                    }
+                    _ => None,
+                };
 
                 let gas_vector_computation_mode = match tx {
                     Transaction::Account(tx) => tx.tx.create_tx_info(tx.execution_flags.only_query).gas_mode(),
@@ -90,6 +123,8 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                     execution_info,
                     gas_vector_computation_mode,
                     state_diff: state_diff.state_maps.into(),
+                    deployed_contracts,
+                    deprecated_declared_class,
                 })
             })
             .collect::<Result<Vec<_>, _>>()

--- a/madara/crates/client/exec/src/execution.rs
+++ b/madara/crates/client/exec/src/execution.rs
@@ -13,10 +13,10 @@ use mp_receipt::RevertErrorExt;
 use starknet_api::block::FeeType;
 use starknet_api::contract_class::ContractClass;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
-use std::collections::HashSet;
 use starknet_api::executable_transaction::{AccountTransaction as ApiAccountTransaction, TransactionType};
 use starknet_api::transaction::fields::{GasVectorComputationMode, Tip};
 use starknet_api::transaction::{TransactionHash, TransactionVersion};
+use std::collections::HashSet;
 
 impl<D: MadaraStorageRead> ExecutionContext<D> {
     /// Execute transactions. The returned `ExecutionResult`s are the results of the `transactions_to_trace`. The results of `transactions_before` are discarded.
@@ -88,12 +88,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                     .state_maps
                     .class_hashes
                     .keys()
-                    .filter(|addr| {
-                        initial_reads
-                            .class_hashes
-                            .get(addr)
-                            .map_or(true, |ch| *ch == ClassHash::default())
-                    })
+                    .filter(|addr| initial_reads.class_hashes.get(addr).map_or(true, |ch| *ch == ClassHash::default()))
                     .map(|addr| addr.to_felt())
                     .collect();
 
@@ -102,11 +97,8 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                 // Check if this is a deprecated (Cairo 0) class declaration (DeclareV0/V1).
                 let deprecated_declared_class = match &tx {
                     Transaction::Account(AccountTransaction {
-                        tx: ApiAccountTransaction::Declare(declare_tx),
-                        ..
-                    }) if declare_tx.version() < TransactionVersion::TWO => {
-                        Some(declare_tx.class_hash().to_felt())
-                    }
+                        tx: ApiAccountTransaction::Declare(declare_tx), ..
+                    }) if declare_tx.version() < TransactionVersion::TWO => Some(declare_tx.class_hash().to_felt()),
                     _ => None,
                 };
 

--- a/madara/crates/client/exec/src/lib.rs
+++ b/madara/crates/client/exec/src/lib.rs
@@ -157,6 +157,7 @@ use mp_chain_config::StarknetVersion;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{block::FeeType, executable_transaction::TransactionType};
 use starknet_api::{execution_resources::GasVector, transaction::fields::GasVectorComputationMode};
+use std::collections::HashSet;
 use starknet_types_core::felt::Felt;
 
 mod block_context;
@@ -239,4 +240,8 @@ pub struct ExecutionResult {
     pub execution_info: TransactionExecutionInfo,
     pub state_diff: CommitmentStateDiff,
     pub gas_vector_computation_mode: GasVectorComputationMode,
+    /// Addresses that were newly deployed by this transaction (vs class replacements).
+    pub deployed_contracts: HashSet<Felt>,
+    /// Class hash declared as deprecated (Cairo 0) by this transaction, if any.
+    pub deprecated_declared_class: Option<Felt>,
 }

--- a/madara/crates/client/exec/src/lib.rs
+++ b/madara/crates/client/exec/src/lib.rs
@@ -157,8 +157,8 @@ use mp_chain_config::StarknetVersion;
 use starknet_api::transaction::TransactionHash;
 use starknet_api::{block::FeeType, executable_transaction::TransactionType};
 use starknet_api::{execution_resources::GasVector, transaction::fields::GasVectorComputationMode};
-use std::collections::HashSet;
 use starknet_types_core::felt::Felt;
+use std::collections::HashSet;
 
 mod block_context;
 mod blockifier_state_adapter;

--- a/madara/crates/client/exec/src/trace.rs
+++ b/madara/crates/client/exec/src/trace.rs
@@ -566,15 +566,11 @@ fn to_state_diff(
         let address_felt = address.to_felt();
         let class_hash_felt = class_hash.to_felt();
         if deployed_contracts_set.contains(&address_felt) {
-            deployed_contracts.push(mp_rpc::v0_7_1::DeployedContractItem {
-                address: address_felt,
-                class_hash: class_hash_felt,
-            });
+            deployed_contracts
+                .push(mp_rpc::v0_7_1::DeployedContractItem { address: address_felt, class_hash: class_hash_felt });
         } else {
-            replaced_classes.push(mp_rpc::v0_7_1::ReplacedClass {
-                contract_address: address_felt,
-                class_hash: class_hash_felt,
-            });
+            replaced_classes
+                .push(mp_rpc::v0_7_1::ReplacedClass { contract_address: address_felt, class_hash: class_hash_felt });
         }
     }
 

--- a/madara/crates/client/exec/src/trace.rs
+++ b/madara/crates/client/exec/src/trace.rs
@@ -647,3 +647,79 @@ fn agregate_execution_ressources_v0_7(
         segment_arena_builtin: sum(abc.clone(), |x| x.segment_arena_builtin),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blockifier::state::cached_state::CommitmentStateDiff;
+    use starknet_api::core::{ClassHash, ContractAddress};
+
+    /// Build a minimal `CommitmentStateDiff` with the given address→class_hash entries.
+    fn make_commitment_diff(entries: Vec<(ContractAddress, ClassHash)>) -> CommitmentStateDiff {
+        CommitmentStateDiff {
+            address_to_class_hash: entries.into_iter().collect(),
+            address_to_nonce: Default::default(),
+            storage_updates: Default::default(),
+            class_hash_to_compiled_class_hash: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_deployed_vs_replaced_classification() {
+        let deployed_addr = ContractAddress::try_from(Felt::from(1u64)).unwrap();
+        let replaced_addr = ContractAddress::try_from(Felt::from(2u64)).unwrap();
+        let class_hash = ClassHash(Felt::from(42u64));
+
+        let diff = make_commitment_diff(vec![(deployed_addr, class_hash), (replaced_addr, class_hash)]);
+
+        // Only deployed_addr is in the deployed set
+        let deployed_set: HashSet<Felt> = [deployed_addr.to_felt()].into_iter().collect();
+        let result = to_state_diff(&diff, &deployed_set, &None);
+
+        assert_eq!(result.deployed_contracts.len(), 1);
+        assert_eq!(result.deployed_contracts[0].address, deployed_addr.to_felt());
+        assert_eq!(result.deployed_contracts[0].class_hash, class_hash.to_felt());
+
+        assert_eq!(result.replaced_classes.len(), 1);
+        assert_eq!(result.replaced_classes[0].contract_address, replaced_addr.to_felt());
+        assert_eq!(result.replaced_classes[0].class_hash, class_hash.to_felt());
+    }
+
+    #[test]
+    fn test_deprecated_declared_class_populated() {
+        let diff = make_commitment_diff(vec![]);
+        let deprecated_class = Felt::from(0xCAFE);
+
+        let result = to_state_diff(&diff, &HashSet::new(), &Some(deprecated_class));
+
+        assert_eq!(result.deprecated_declared_classes, vec![deprecated_class]);
+    }
+
+    #[test]
+    fn test_deprecated_declared_class_empty_when_none() {
+        let diff = make_commitment_diff(vec![]);
+
+        let result = to_state_diff(&diff, &HashSet::new(), &None);
+
+        assert!(result.deprecated_declared_classes.is_empty());
+    }
+
+    #[test]
+    fn test_declared_classes_from_compiled_class_hash() {
+        let class_hash = ClassHash(Felt::from(10u64));
+        let compiled_hash = starknet_api::core::CompiledClassHash(Felt::from(20u64));
+
+        let diff = CommitmentStateDiff {
+            address_to_class_hash: Default::default(),
+            address_to_nonce: Default::default(),
+            storage_updates: Default::default(),
+            class_hash_to_compiled_class_hash: [(class_hash, compiled_hash)].into_iter().collect(),
+        };
+
+        let result = to_state_diff(&diff, &HashSet::new(), &None);
+
+        assert_eq!(result.declared_classes.len(), 1);
+        assert_eq!(result.declared_classes[0].class_hash, class_hash.to_felt());
+        assert_eq!(result.declared_classes[0].compiled_class_hash, compiled_hash.to_felt());
+    }
+}

--- a/madara/crates/client/exec/src/trace.rs
+++ b/madara/crates/client/exec/src/trace.rs
@@ -10,7 +10,7 @@ use mp_rpc::{
 };
 use starknet_api::executable_transaction::TransactionType;
 use starknet_api::transaction::fields::GasVectorComputationMode;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -34,13 +34,13 @@ pub struct FunctionInvocation {
 #[derive(thiserror::Error, Debug)]
 pub enum ConvertCallInfoToExecuteInvocationError {
     #[error(transparent)]
-    GetFunctionInvocation(#[from] TryFuntionInvocationFromCallInfoError),
+    GetFunctionInvocation(#[from] TryFunctionInvocationFromCallInfoError),
     #[error("Missing FunctionInvocation")]
     MissingFunctionInvocation,
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum TryFuntionInvocationFromCallInfoError {
+pub enum TryFunctionInvocationFromCallInfoError {
     #[error(transparent)]
     TransactionExecution(#[from] TransactionExecutionError),
 }
@@ -135,11 +135,12 @@ pub fn execution_result_to_tx_trace_v0_7(
     executions_result: &ExecutionResult,
     versioned_constants: &VersionedConstants,
 ) -> Result<mp_rpc::v0_7_1::TransactionTrace, ConvertCallInfoToExecuteInvocationError> {
-    let ExecutionResult { tx_type, execution_info, state_diff, .. } = executions_result;
+    let ExecutionResult { tx_type, execution_info, state_diff, deployed_contracts, deprecated_declared_class, .. } =
+        executions_result;
 
     let state_diff = match state_diff_is_empty(state_diff) {
         true => None,
-        false => Some(to_state_diff(state_diff)),
+        false => Some(to_state_diff(state_diff, deployed_contracts, deprecated_declared_class)),
     };
 
     let validate_invocation = execution_info.validate_call_info.as_ref().map(|call_info| {
@@ -267,11 +268,12 @@ pub fn execution_result_to_tx_trace_v0_8(
     executions_result: &ExecutionResult,
     versioned_constants: &VersionedConstants,
 ) -> Result<mp_rpc::v0_8_1::TransactionTrace, ConvertCallInfoToExecuteInvocationError> {
-    let ExecutionResult { tx_type, execution_info, state_diff, .. } = executions_result;
+    let ExecutionResult { tx_type, execution_info, state_diff, deployed_contracts, deprecated_declared_class, .. } =
+        executions_result;
 
     let state_diff = match state_diff_is_empty(state_diff) {
         true => None,
-        false => Some(to_state_diff(state_diff)),
+        false => Some(to_state_diff(state_diff, deployed_contracts, deprecated_declared_class)),
     };
 
     let validate_invocation = execution_info.validate_call_info.as_ref().map(|call_info| {
@@ -383,11 +385,12 @@ pub fn execution_result_to_tx_trace_v0_9(
     executions_result: &ExecutionResult,
     versioned_constants: &VersionedConstants,
 ) -> Result<mp_rpc::v0_9_0::TransactionTrace, ConvertCallInfoToExecuteInvocationError> {
-    let ExecutionResult { tx_type, execution_info, state_diff, .. } = executions_result;
+    let ExecutionResult { tx_type, execution_info, state_diff, deployed_contracts, deprecated_declared_class, .. } =
+        executions_result;
 
     let state_diff = match state_diff_is_empty(state_diff) {
         true => None,
-        false => Some(to_state_diff(state_diff)),
+        false => Some(to_state_diff(state_diff, deployed_contracts, deprecated_declared_class)),
     };
 
     let validate_invocation = execution_info.validate_call_info.as_ref().map(|call_info| {
@@ -552,7 +555,38 @@ fn resources_mapping(
     }
 }
 
-fn to_state_diff(commitment_state_diff: &CommitmentStateDiff) -> mp_rpc::v0_7_1::StateDiff {
+fn to_state_diff(
+    commitment_state_diff: &CommitmentStateDiff,
+    deployed_contracts_set: &HashSet<Felt>,
+    deprecated_declared_class: &Option<Felt>,
+) -> mp_rpc::v0_7_1::StateDiff {
+    let mut deployed_contracts = vec![];
+    let mut replaced_classes = vec![];
+    for (address, class_hash) in &commitment_state_diff.address_to_class_hash {
+        let address_felt = address.to_felt();
+        let class_hash_felt = class_hash.to_felt();
+        if deployed_contracts_set.contains(&address_felt) {
+            deployed_contracts.push(mp_rpc::v0_7_1::DeployedContractItem {
+                address: address_felt,
+                class_hash: class_hash_felt,
+            });
+        } else {
+            replaced_classes.push(mp_rpc::v0_7_1::ReplacedClass {
+                contract_address: address_felt,
+                class_hash: class_hash_felt,
+            });
+        }
+    }
+
+    let declared_classes = commitment_state_diff
+        .class_hash_to_compiled_class_hash
+        .iter()
+        .map(|(class_hash, compiled_class_hash)| mp_rpc::v0_7_1::NewClasses {
+            class_hash: class_hash.to_felt(),
+            compiled_class_hash: compiled_class_hash.to_felt(),
+        })
+        .collect();
+
     mp_rpc::v0_7_1::StateDiff {
         storage_diffs: commitment_state_diff
             .storage_updates
@@ -565,10 +599,10 @@ fn to_state_diff(commitment_state_diff: &CommitmentStateDiff) -> mp_rpc::v0_7_1:
                 mp_rpc::v0_7_1::ContractStorageDiffItem { address: address.to_felt(), storage_entries }
             })
             .collect(),
-        deprecated_declared_classes: vec![],
-        declared_classes: vec![],
-        deployed_contracts: vec![],
-        replaced_classes: vec![],
+        deprecated_declared_classes: deprecated_declared_class.iter().copied().collect(),
+        declared_classes,
+        deployed_contracts,
+        replaced_classes,
         nonces: commitment_state_diff
             .address_to_nonce
             .iter()

--- a/madara/crates/client/exec/src/trace.rs
+++ b/madara/crates/client/exec/src/trace.rs
@@ -482,6 +482,14 @@ pub fn execution_result_to_tx_trace_v0_9(
     Ok(tx_trace)
 }
 
+pub fn execution_result_to_tx_trace_v0_10(
+    executions_result: &ExecutionResult,
+    versioned_constants: &VersionedConstants,
+) -> Result<mp_rpc::v0_10_0::TransactionTrace, ConvertCallInfoToExecuteInvocationError> {
+    let v0_9_trace = execution_result_to_tx_trace_v0_9(executions_result, versioned_constants)?;
+    Ok(v0_9_trace.into())
+}
+
 fn collect_call_info_ordered_messages(call_info: &CallInfo) -> Vec<mp_rpc::v0_7_1::OrderedMessage> {
     call_info
         .execution

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/trace/mod.rs
@@ -1,13 +1,24 @@
-use crate::versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server as V0_9_0Impl;
+use crate::versions::user::v0_9_0::methods::trace::{
+    simulate_transactions::simulate_transactions as simulate_transactions_v0_9,
+    trace_block_transactions::trace_block_transactions as trace_block_transactions_v0_9,
+    trace_transaction::trace_transaction as trace_transaction_v0_9,
+};
 use crate::{versions::user::v0_10_0::StarknetTraceRpcApiV0_10_0Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_10_0::{
-    BlockId, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
+    BlockId, BlockTag, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
     TraceTransactionResult,
 };
 use starknet_types_core::felt::Felt;
 
-// Trace types unchanged in v0.10.0, delegating to v0.9.0
+fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
+    if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
+        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
+    }
+    Ok(())
+}
 
 #[async_trait]
 impl StarknetTraceRpcApiV0_10_0Server for Starknet {
@@ -17,14 +28,18 @@ impl StarknetTraceRpcApiV0_10_0Server for Starknet {
         transactions: Vec<BroadcastedTxn>,
         simulation_flags: Vec<SimulationFlag>,
     ) -> RpcResult<Vec<SimulateTransactionsResult>> {
-        V0_9_0Impl::simulate_transactions(self, block_id, transactions, simulation_flags).await
+        let v0_9_results = simulate_transactions_v0_9(self, block_id, transactions, simulation_flags).await?;
+        Ok(v0_9_results.into_iter().map(Into::into).collect())
     }
 
     async fn trace_block_transactions(&self, block_id: BlockId) -> RpcResult<Vec<TraceBlockTransactionsResult>> {
-        V0_9_0Impl::trace_block_transactions(self, block_id).await
+        validate_trace_block_transactions_block_id(&block_id)?;
+        let v0_9_results = trace_block_transactions_v0_9(self, block_id).await?;
+        Ok(v0_9_results.into_iter().map(Into::into).collect())
     }
 
     async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceTransactionResult> {
-        V0_9_0Impl::trace_transaction(self, transaction_hash).await
+        let v0_9_result = trace_transaction_v0_9(self, transaction_hash).await?;
+        Ok(v0_9_result.into())
     }
 }

--- a/madara/crates/primitives/rpc/src/v0_10_0/starknet_trace_api_openrpc.rs
+++ b/madara/crates/primitives/rpc/src/v0_10_0/starknet_trace_api_openrpc.rs
@@ -1,5 +1,197 @@
-pub use crate::v0_9_0::{
-    CallType, DeclareTransactionTrace, DeployAccountTransactionTrace, EntryPointType, InvokeTransactionTrace,
-    L1HandlerTransactionTrace, OrderedEvent, OrderedMessage, RevertedInvocation, RevertibleFunctionInvocation,
-    SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult, TraceTransactionResult, TransactionTrace,
+use super::starknet_api_openrpc::{ExecutionResources, FeeEstimate, StateDiff};
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+// Re-export unchanged trace types from v0.8.1/v0.9
+pub use crate::v0_8_1::{
+    CallType, EntryPointType, FunctionInvocation, InnerCallExecutionResources, OrderedEvent, OrderedMessage,
+    RevertedInvocation, RevertibleFunctionInvocation, SimulationFlag,
 };
+
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "type")]
+pub enum TransactionTrace {
+    /// the execution trace of an invoke transaction
+    #[serde(rename = "INVOKE")]
+    Invoke(InvokeTransactionTrace),
+    /// the execution trace of a declare transaction
+    #[serde(rename = "DECLARE")]
+    Declare(DeclareTransactionTrace),
+    /// the execution trace of a deploy account transaction
+    #[serde(rename = "DEPLOY_ACCOUNT")]
+    DeployAccount(DeployAccountTransactionTrace),
+    /// the execution trace of an L1 handler transaction
+    #[serde(rename = "L1_HANDLER")]
+    L1Handler(L1HandlerTransactionTrace),
+}
+
+/// the execution trace of an invoke transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct InvokeTransactionTrace {
+    /// the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)
+    pub execute_invocation: RevertibleFunctionInvocation,
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    #[serde(default)]
+    pub fee_transfer_invocation: Option<FunctionInvocation>,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+    #[serde(default)]
+    pub validate_invocation: Option<FunctionInvocation>,
+}
+
+/// the execution trace of a declare transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeclareTransactionTrace {
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    #[serde(default)]
+    pub fee_transfer_invocation: Option<FunctionInvocation>,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+    #[serde(default)]
+    pub validate_invocation: Option<FunctionInvocation>,
+}
+
+/// the execution trace of a deploy account transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DeployAccountTransactionTrace {
+    /// the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)
+    pub constructor_invocation: FunctionInvocation,
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    #[serde(default)]
+    pub fee_transfer_invocation: Option<FunctionInvocation>,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+    #[serde(default)]
+    pub validate_invocation: Option<FunctionInvocation>,
+}
+
+/// the execution trace of an L1 handler transaction
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct L1HandlerTransactionTrace {
+    /// the resources consumed by the transaction, includes both computation and data
+    pub execution_resources: ExecutionResources,
+    /// the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)
+    pub function_invocation: RevertibleFunctionInvocation,
+    /// the state diffs induced by the transaction
+    #[serde(default)]
+    pub state_diff: Option<StateDiff>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SimulateTransactionsResult {
+    pub fee_estimation: FeeEstimate,
+    pub transaction_trace: TransactionTrace,
+}
+
+/// A single pair of transaction hash and corresponding trace
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TraceBlockTransactionsResult {
+    pub trace_root: TransactionTrace,
+    pub transaction_hash: Felt,
+}
+
+/// Trace of a single transaction returned by `starknet_traceTransaction`
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct TraceTransactionResult {
+    #[serde(flatten)]
+    pub trace: TransactionTrace,
+}
+
+// Conversions from v0.9 trace types to v0.10
+
+impl From<crate::v0_7_1::StateDiff> for StateDiff {
+    fn from(sd: crate::v0_7_1::StateDiff) -> Self {
+        StateDiff {
+            declared_classes: sd.declared_classes,
+            deployed_contracts: sd.deployed_contracts,
+            deprecated_declared_classes: sd.deprecated_declared_classes,
+            nonces: sd.nonces,
+            replaced_classes: sd.replaced_classes,
+            storage_diffs: sd.storage_diffs,
+            // Migrated compiled classes are computed only during block finalization
+            // (BlockExecutionSummary), not during per-transaction execution. The trace
+            // code path uses per-tx TransactionalState which doesn't expose migration info.
+            migrated_compiled_classes: vec![],
+        }
+    }
+}
+
+impl From<crate::v0_9_0::TransactionTrace> for TransactionTrace {
+    fn from(trace: crate::v0_9_0::TransactionTrace) -> Self {
+        match trace {
+            crate::v0_9_0::TransactionTrace::Invoke(t) => TransactionTrace::Invoke(t.into()),
+            crate::v0_9_0::TransactionTrace::Declare(t) => TransactionTrace::Declare(t.into()),
+            crate::v0_9_0::TransactionTrace::DeployAccount(t) => TransactionTrace::DeployAccount(t.into()),
+            crate::v0_9_0::TransactionTrace::L1Handler(t) => TransactionTrace::L1Handler(t.into()),
+        }
+    }
+}
+
+impl From<crate::v0_8_1::InvokeTransactionTrace> for InvokeTransactionTrace {
+    fn from(t: crate::v0_8_1::InvokeTransactionTrace) -> Self {
+        InvokeTransactionTrace {
+            execute_invocation: t.execute_invocation,
+            execution_resources: t.execution_resources,
+            fee_transfer_invocation: t.fee_transfer_invocation,
+            state_diff: t.state_diff.map(Into::into),
+            validate_invocation: t.validate_invocation,
+        }
+    }
+}
+
+impl From<crate::v0_8_1::DeclareTransactionTrace> for DeclareTransactionTrace {
+    fn from(t: crate::v0_8_1::DeclareTransactionTrace) -> Self {
+        DeclareTransactionTrace {
+            execution_resources: t.execution_resources,
+            fee_transfer_invocation: t.fee_transfer_invocation,
+            state_diff: t.state_diff.map(Into::into),
+            validate_invocation: t.validate_invocation,
+        }
+    }
+}
+
+impl From<crate::v0_8_1::DeployAccountTransactionTrace> for DeployAccountTransactionTrace {
+    fn from(t: crate::v0_8_1::DeployAccountTransactionTrace) -> Self {
+        DeployAccountTransactionTrace {
+            constructor_invocation: t.constructor_invocation,
+            execution_resources: t.execution_resources,
+            fee_transfer_invocation: t.fee_transfer_invocation,
+            state_diff: t.state_diff.map(Into::into),
+            validate_invocation: t.validate_invocation,
+        }
+    }
+}
+
+impl From<crate::v0_9_0::L1HandlerTransactionTrace> for L1HandlerTransactionTrace {
+    fn from(t: crate::v0_9_0::L1HandlerTransactionTrace) -> Self {
+        L1HandlerTransactionTrace {
+            execution_resources: t.execution_resources,
+            function_invocation: t.function_invocation,
+            state_diff: t.state_diff.map(Into::into),
+        }
+    }
+}
+
+impl From<crate::v0_9_0::TraceTransactionResult> for TraceTransactionResult {
+    fn from(t: crate::v0_9_0::TraceTransactionResult) -> Self {
+        TraceTransactionResult { trace: t.trace.into() }
+    }
+}
+
+impl From<crate::v0_9_0::TraceBlockTransactionsResult> for TraceBlockTransactionsResult {
+    fn from(t: crate::v0_9_0::TraceBlockTransactionsResult) -> Self {
+        TraceBlockTransactionsResult { trace_root: t.trace_root.into(), transaction_hash: t.transaction_hash }
+    }
+}
+
+impl From<crate::v0_9_0::SimulateTransactionsResult> for SimulateTransactionsResult {
+    fn from(t: crate::v0_9_0::SimulateTransactionsResult) -> Self {
+        SimulateTransactionsResult { fee_estimation: t.fee_estimation, transaction_trace: t.transaction_trace.into() }
+    }
+}

--- a/orchestrator/src/cli/batching.rs
+++ b/orchestrator/src/cli/batching.rs
@@ -18,7 +18,11 @@ pub struct BatchingCliArgs {
 
     /// Buffer (in number of felts) to subtract from the maximum blob capacity.
     /// The effective max blob size becomes (max_num_blobs * 4096) - blob_size_buffer.
-    /// This accounts for overhead added by the prover (e.g. encryption headers).
+    ///
+    /// This is needed because the prover appends additional data to the blob before submission.
+    /// For example, encryption keys add 2n+1 felts of overhead (where n = number of encryption
+    /// keys). The buffer reserves space for this overhead so the final blob does not exceed the
+    /// EIP-4844 limit. A conservative default is recommended to accommodate future additions.
     #[arg(env = "MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER", long, default_value = "15")]
     pub blob_size_buffer: usize,
 

--- a/orchestrator/src/tests/config.rs
+++ b/orchestrator/src/tests/config.rs
@@ -759,6 +759,8 @@ pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
     };
 
     let max_num_blobs = get_env_var_or_default("MADARA_ORCHESTRATOR_MAX_NUM_BLOBS", "6").parse::<usize>().unwrap();
+    let blob_size_buffer =
+        get_env_var_or_default("MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER", "15").parse::<usize>().unwrap();
 
     let batching_config = BatchingParams {
         max_batch_time_seconds: get_env_var_or_panic("MADARA_ORCHESTRATOR_MAX_BATCH_TIME_SECONDS")
@@ -781,11 +783,8 @@ pub(crate) fn get_env_params(test_id: Option<&str>) -> EnvParams {
         .parse::<u64>()
         .unwrap(),
         max_num_blobs,
-        blob_size_buffer: get_env_var_or_default("MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER", "15")
-            .parse::<usize>()
-            .unwrap(),
-        max_blob_size: max_num_blobs * BLOB_LEN
-            - get_env_var_or_default("MADARA_ORCHESTRATOR_BLOB_SIZE_BUFFER", "15").parse::<usize>().unwrap(),
+        blob_size_buffer,
+        max_blob_size: max_num_blobs * BLOB_LEN - blob_size_buffer,
         default_empty_block_proving_gas: get_env_var_or_default(
             "MADARA_ORCHESTRATOR_DEFAULT_EMPTY_BLOCK_PROVING_GAS",
             "1500000",

--- a/orchestrator/src/types/params/batching.rs
+++ b/orchestrator/src/types/params/batching.rs
@@ -10,8 +10,12 @@ pub struct BatchingParams {
     pub fixed_blocks_per_snos_batch: Option<u64>,
     pub max_snos_batches_per_aggregator_batch: u64,
     pub max_num_blobs: usize,
-    /// Buffer (in number of felts) subtracted from the maximum blob capacity to account for
-    /// overhead added by the prover (e.g. encryption headers).
+    /// Buffer (in number of felts) subtracted from the maximum blob capacity.
+    ///
+    /// The prover appends additional data to the blob before submission (e.g. encryption keys
+    /// add 2n+1 felts of overhead, where n = number of encryption keys). This buffer reserves
+    /// space for that overhead so the final blob stays within the EIP-4844 limit. A conservative
+    /// value is recommended to accommodate future additions to the blob format.
     pub blob_size_buffer: usize,
     /// Max number of felts (each encoded using 256 bits) that can be attached in a single state
     /// update transaction.
@@ -47,6 +51,7 @@ impl From<BatchingCliArgs> for BatchingParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     fn make_cli_args(max_num_blobs: usize, blob_size_buffer: usize) -> BatchingCliArgs {
         BatchingCliArgs {
@@ -63,24 +68,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_max_blob_size_with_default_buffer() {
-        let params = BatchingParams::from(make_cli_args(6, 15));
-        assert_eq!(params.max_blob_size, 6 * BLOB_LEN - 15);
-        assert_eq!(params.max_blob_size, 24561);
-    }
-
-    #[test]
-    fn test_max_blob_size_with_zero_buffer() {
-        let params = BatchingParams::from(make_cli_args(6, 0));
-        assert_eq!(params.max_blob_size, 6 * BLOB_LEN);
-        assert_eq!(params.max_blob_size, 24576);
-    }
-
-    #[test]
-    fn test_max_blob_size_with_custom_blobs_and_buffer() {
-        let params = BatchingParams::from(make_cli_args(9, 100));
-        assert_eq!(params.max_blob_size, 9 * BLOB_LEN - 100);
-        assert_eq!(params.max_blob_size, 36764);
+    #[rstest]
+    #[case(6, 15, 6 * BLOB_LEN - 15)]
+    #[case(6, 0, 6 * BLOB_LEN)]
+    #[case(9, 100, 9 * BLOB_LEN - 100)]
+    fn test_max_blob_size(#[case] max_num_blobs: usize, #[case] blob_size_buffer: usize, #[case] expected: usize) {
+        let params = BatchingParams::from(make_cli_args(max_num_blobs, blob_size_buffer));
+        assert_eq!(params.max_blob_size, expected);
     }
 }


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

`starknet_traceTransaction` and `starknet_traceBlockTransactions` return state diffs with `deployed_contracts`, `replaced_classes`, `declared_classes`, and `deprecated_declared_classes` always hardcoded to empty arrays. This does not match the Starknet RPC spec.

Resolves: #NA

## What is the new behavior?

- Properly distinguish deployed contracts vs replaced classes by checking initial state reads (if prior class hash was zero, it's a deployment; otherwise it's a replacement)
- Populate `declared_classes` from `class_hash_to_compiled_class_hash` in the state diff
- Populate `deprecated_declared_classes` for Cairo 0 class declarations (DeclareV0/V1)
- Enable blockifier's `reexecution` feature to access `get_initial_reads()` on transactional state
- Fix applies to all RPC versions (v0.7.1, v0.8.1, v0.9.0) and all trace methods (`traceTransaction`, `traceBlockTransactions`, `simulateTransactions`)
- Address PR #993 review comments: use rstest for parametrized tests, extract duplicate env var parsing, add documentation for blob size buffer

## Does this introduce a breaking change?

No. The trace responses now include data that was previously omitted. No existing fields are removed or modified.

## Other information

- The approach matches pathfinder's implementation (checking initial class hash == zero for deployment detection)
- Changes only affect the RPC re-execution path, zero impact on sequencer block production performance
- `get_initial_reads()` returns data already tracked by blockifier's `StateCache` internally, so no additional state tracking overhead