### PR TITLE
feat: file-based secret loading & settlement CLI fix

### DIFF
--- a/orchestrator/crates/utils/src/env_utils.rs
+++ b/orchestrator/crates/utils/src/env_utils.rs
@@ -1,4 +1,5 @@
 use std::env::VarError;
+use std::path::Path;
 
 pub fn get_env_var(key: &str) -> Result<String, VarError> {
     std::env::var(key)
@@ -24,4 +25,96 @@ pub fn get_env_var_optional(key: &str) -> Result<Option<String>, VarError> {
 
 pub fn get_env_var_optional_or_panic(key: &str) -> Option<String> {
     get_env_var_optional(key).unwrap_or_else(|e| panic!("Failed to get env var {}: {}", key, e))
+}
+
+/// Reads a secret from a file path specified by the `{env_var_name}_FILE` environment variable.
+///
+/// This supports the file-based secret injection pattern used by Kubernetes CSI Secrets Store
+/// Driver, where secrets are mounted as files on a tmpfs volume rather than passed as environment
+/// variables. This avoids secrets leaking through `/proc/pid/environ`, crash dumps, logs, or
+/// `kubectl describe pod`.
+///
+/// Returns:
+/// - `Ok(Some(content))` if the `_FILE` env var is set and the file is readable
+/// - `Ok(None)` if the `_FILE` env var is not set
+/// - `Err` if the `_FILE` env var is set but the file can't be read or is empty
+pub fn resolve_secret_from_file(env_var_name: &str) -> Result<Option<String>, String> {
+    let file_env_var = format!("{}_FILE", env_var_name);
+    match std::env::var(&file_env_var) {
+        Ok(file_path) if !file_path.is_empty() => {
+            let path = Path::new(&file_path);
+            let content = std::fs::read_to_string(path).map_err(|e| {
+                format!("Failed to read secret from file '{}' (set via {}): {}", file_path, file_env_var, e)
+            })?;
+            let trimmed = content.trim().to_string();
+            if trimmed.is_empty() {
+                Err(format!("Secret file '{}' (set via {}) is empty", file_path, file_env_var))
+            } else {
+                tracing::info!(
+                    env_var = env_var_name,
+                    file_env_var = file_env_var,
+                    file_path = file_path,
+                    "Loaded secret from file"
+                );
+                Ok(Some(trimmed))
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_resolve_secret_from_file_reads_file() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp, "  my-secret-value\n  ").unwrap();
+
+        let env_var = "TEST_RESOLVE_SECRET_READS";
+        let file_env_var = format!("{}_FILE", env_var);
+        std::env::set_var(&file_env_var, tmp.path().to_str().unwrap());
+
+        let result = resolve_secret_from_file(env_var).unwrap();
+        assert_eq!(result, Some("my-secret-value".to_string()));
+
+        std::env::remove_var(&file_env_var);
+    }
+
+    #[test]
+    fn test_resolve_secret_from_file_returns_none_when_unset() {
+        let result = resolve_secret_from_file("TEST_RESOLVE_SECRET_UNSET").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_resolve_secret_from_file_errors_on_empty_file() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(tmp, "   \n  ").unwrap();
+
+        let env_var = "TEST_RESOLVE_SECRET_EMPTY";
+        let file_env_var = format!("{}_FILE", env_var);
+        std::env::set_var(&file_env_var, tmp.path().to_str().unwrap());
+
+        let result = resolve_secret_from_file(env_var);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("is empty"));
+
+        std::env::remove_var(&file_env_var);
+    }
+
+    #[test]
+    fn test_resolve_secret_from_file_errors_on_missing_file() {
+        let env_var = "TEST_RESOLVE_SECRET_MISSING";
+        let file_env_var = format!("{}_FILE", env_var);
+        std::env::set_var(&file_env_var, "/nonexistent/path/secret.txt");
+
+        let result = resolve_secret_from_file(env_var);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to read secret"));
+
+        std::env::remove_var(&file_env_var);
+    }
 }

--- a/orchestrator/src/cli/prover/atlantic.rs
+++ b/orchestrator/src/cli/prover/atlantic.rs
@@ -10,8 +10,10 @@ pub struct AtlanticCliArgs {
     pub atlantic: bool,
 
     /// The API key for the Atlantic.
+    /// Note: not marked required_if_eq because the value can be loaded from a file
+    /// via MADARA_ORCHESTRATOR_ATLANTIC_API_KEY_FILE. Validation is done in
+    /// TryFrom<RunCmd> for ProverConfig (see src/types/params/prover.rs).
     #[arg(env = "MADARA_ORCHESTRATOR_ATLANTIC_API_KEY", long)]
-    #[arg(required_if_eq("atlantic", "true"))]
     pub atlantic_api_key: Option<String>,
 
     /// The URL of the Atlantic server.

--- a/orchestrator/src/cli/settlement/ethereum.rs
+++ b/orchestrator/src/cli/settlement/ethereum.rs
@@ -2,7 +2,10 @@ use clap::Args;
 use url::Url;
 
 #[derive(Debug, Clone, Args)]
-#[group(requires_all = ["ethereum_rpc_url", "ethereum_private_key", "l1_core_contract_address", "starknet_operator_address"])]
+// Note: we intentionally do not use requires_all here because env vars can populate
+// fields even when --settle-on-ethereum is not passed, causing clap to incorrectly
+// demand all fields. Validation is done in TryFrom<RunCmd> for SettlementConfig
+// (see src/types/params/settlement.rs).
 pub struct EthereumSettlementCliArgs {
     /// Use the Ethereum settlement layer.
     #[arg(long)]

--- a/orchestrator/src/cli/settlement/starknet.rs
+++ b/orchestrator/src/cli/settlement/starknet.rs
@@ -2,7 +2,10 @@ use clap::Args;
 use url::Url;
 
 #[derive(Debug, Clone, Args)]
-#[group(requires_all = ["starknet_rpc_url", "starknet_private_key", "starknet_account_address", "starknet_cairo_core_contract_address", "starknet_finality_retry_wait_in_secs"])]
+// Note: we intentionally do not use requires_all here because env vars can populate
+// fields even when --settle-on-starknet is not passed, causing clap to incorrectly
+// demand all fields. Validation is done in TryFrom<RunCmd> for SettlementConfig
+// (see src/types/params/settlement.rs).
 pub struct StarknetSettlementCliArgs {
     /// Use the Starknet settlement layer.
     #[arg(long)]

--- a/orchestrator/src/types/params/da.rs
+++ b/orchestrator/src/types/params/da.rs
@@ -2,6 +2,8 @@ use crate::cli::RunCmd;
 use crate::OrchestratorError;
 use orchestrator_ethereum_da_client::EthereumDaValidatedArgs;
 use orchestrator_starknet_da_client::StarknetDaValidatedArgs;
+use orchestrator_utils::env_utils::resolve_secret_from_file;
+use url::Url;
 
 #[derive(Debug, Clone)]
 pub enum DAConfig {
@@ -19,18 +21,44 @@ impl TryFrom<RunCmd> for DAConfig {
             (false, false) => {
                 Err(OrchestratorError::SetupCommandError("At least one DA layer must be enabled".to_string()))
             }
-            (true, false) => Ok(DAConfig::Ethereum(EthereumDaValidatedArgs {
-                ethereum_da_rpc_url: run_cmd
-                    .ethereum_da_args
-                    .ethereum_da_rpc_url
-                    .ok_or_else(|| OrchestratorError::SetupCommandError("Ethereum RPC URL is missing".to_string()))?,
-            })),
-            (false, true) => Ok(DAConfig::Starknet(StarknetDaValidatedArgs {
-                starknet_da_rpc_url: run_cmd
-                    .starknet_da_args
-                    .starknet_da_rpc_url
-                    .ok_or_else(|| OrchestratorError::SetupCommandError("Starknet RPC url is missing".to_string()))?,
-            })),
+            (true, false) => {
+                // Resolve secret: _FILE env var takes precedence over direct value
+                let ethereum_da_rpc_url =
+                    match resolve_secret_from_file("MADARA_ORCHESTRATOR_ETHEREUM_DA_RPC_URL")
+                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                    {
+                        Some(url_str) => Url::parse(&url_str).map_err(|e| {
+                            OrchestratorError::SetupCommandError(format!(
+                                "Invalid Ethereum DA RPC URL from secret file: {}",
+                                e
+                            ))
+                        })?,
+                        None => run_cmd.ethereum_da_args.ethereum_da_rpc_url.ok_or_else(|| {
+                            OrchestratorError::SetupCommandError("Ethereum RPC URL is missing".to_string())
+                        })?,
+                    };
+
+                Ok(DAConfig::Ethereum(EthereumDaValidatedArgs { ethereum_da_rpc_url }))
+            }
+            (false, true) => {
+                // Resolve secret: _FILE env var takes precedence over direct value
+                let starknet_da_rpc_url =
+                    match resolve_secret_from_file("MADARA_ORCHESTRATOR_STARKNET_DA_RPC_URL")
+                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                    {
+                        Some(url_str) => Url::parse(&url_str).map_err(|e| {
+                            OrchestratorError::SetupCommandError(format!(
+                                "Invalid Starknet DA RPC URL from secret file: {}",
+                                e
+                            ))
+                        })?,
+                        None => run_cmd.starknet_da_args.starknet_da_rpc_url.ok_or_else(|| {
+                            OrchestratorError::SetupCommandError("Starknet RPC url is missing".to_string())
+                        })?,
+                    };
+
+                Ok(DAConfig::Starknet(StarknetDaValidatedArgs { starknet_da_rpc_url }))
+            }
         }
     }
 }

--- a/orchestrator/src/types/params/da.rs
+++ b/orchestrator/src/types/params/da.rs
@@ -23,39 +23,37 @@ impl TryFrom<RunCmd> for DAConfig {
             }
             (true, false) => {
                 // Resolve secret: _FILE env var takes precedence over direct value
-                let ethereum_da_rpc_url =
-                    match resolve_secret_from_file("MADARA_ORCHESTRATOR_ETHEREUM_DA_RPC_URL")
-                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
-                    {
-                        Some(url_str) => Url::parse(&url_str).map_err(|e| {
-                            OrchestratorError::SetupCommandError(format!(
-                                "Invalid Ethereum DA RPC URL from secret file: {}",
-                                e
-                            ))
-                        })?,
-                        None => run_cmd.ethereum_da_args.ethereum_da_rpc_url.ok_or_else(|| {
-                            OrchestratorError::SetupCommandError("Ethereum RPC URL is missing".to_string())
-                        })?,
-                    };
+                let ethereum_da_rpc_url = match resolve_secret_from_file("MADARA_ORCHESTRATOR_ETHEREUM_DA_RPC_URL")
+                    .map_err(OrchestratorError::SetupCommandError)?
+                {
+                    Some(url_str) => Url::parse(&url_str).map_err(|e| {
+                        OrchestratorError::SetupCommandError(format!(
+                            "Invalid Ethereum DA RPC URL from secret file: {}",
+                            e
+                        ))
+                    })?,
+                    None => run_cmd.ethereum_da_args.ethereum_da_rpc_url.ok_or_else(|| {
+                        OrchestratorError::SetupCommandError("Ethereum RPC URL is missing".to_string())
+                    })?,
+                };
 
                 Ok(DAConfig::Ethereum(EthereumDaValidatedArgs { ethereum_da_rpc_url }))
             }
             (false, true) => {
                 // Resolve secret: _FILE env var takes precedence over direct value
-                let starknet_da_rpc_url =
-                    match resolve_secret_from_file("MADARA_ORCHESTRATOR_STARKNET_DA_RPC_URL")
-                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
-                    {
-                        Some(url_str) => Url::parse(&url_str).map_err(|e| {
-                            OrchestratorError::SetupCommandError(format!(
-                                "Invalid Starknet DA RPC URL from secret file: {}",
-                                e
-                            ))
-                        })?,
-                        None => run_cmd.starknet_da_args.starknet_da_rpc_url.ok_or_else(|| {
-                            OrchestratorError::SetupCommandError("Starknet RPC url is missing".to_string())
-                        })?,
-                    };
+                let starknet_da_rpc_url = match resolve_secret_from_file("MADARA_ORCHESTRATOR_STARKNET_DA_RPC_URL")
+                    .map_err(OrchestratorError::SetupCommandError)?
+                {
+                    Some(url_str) => Url::parse(&url_str).map_err(|e| {
+                        OrchestratorError::SetupCommandError(format!(
+                            "Invalid Starknet DA RPC URL from secret file: {}",
+                            e
+                        ))
+                    })?,
+                    None => run_cmd.starknet_da_args.starknet_da_rpc_url.ok_or_else(|| {
+                        OrchestratorError::SetupCommandError("Starknet RPC url is missing".to_string())
+                    })?,
+                };
 
                 Ok(DAConfig::Starknet(StarknetDaValidatedArgs { starknet_da_rpc_url }))
             }

--- a/orchestrator/src/types/params/database.rs
+++ b/orchestrator/src/types/params/database.rs
@@ -1,5 +1,6 @@
 use crate::cli::RunCmd;
 use crate::OrchestratorError;
+use orchestrator_utils::env_utils::resolve_secret_from_file;
 
 /// Validated MongoDB parameters
 #[derive(Debug, Clone)]
@@ -12,11 +13,14 @@ impl TryFrom<RunCmd> for DatabaseArgs {
     type Error = OrchestratorError;
 
     fn try_from(run_cmd: RunCmd) -> Result<Self, Self::Error> {
+        // Resolve secret: _FILE env var takes precedence over direct value
+        let connection_uri = resolve_secret_from_file("MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL")
+            .map_err(|e| OrchestratorError::SetupCommandError(e))?
+            .or(run_cmd.mongodb_args.mongodb_connection_url)
+            .ok_or(OrchestratorError::SetupCommandError("Database Connection URL is required".to_string()))?;
+
         Ok(Self {
-            connection_uri: run_cmd
-                .mongodb_args
-                .mongodb_connection_url
-                .ok_or(OrchestratorError::SetupCommandError("Database Connection URL is required".to_string()))?,
+            connection_uri,
             database_name: run_cmd
                 .mongodb_args
                 .mongodb_database_name

--- a/orchestrator/src/types/params/database.rs
+++ b/orchestrator/src/types/params/database.rs
@@ -15,7 +15,7 @@ impl TryFrom<RunCmd> for DatabaseArgs {
     fn try_from(run_cmd: RunCmd) -> Result<Self, Self::Error> {
         // Resolve secret: _FILE env var takes precedence over direct value
         let connection_uri = resolve_secret_from_file("MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL")
-            .map_err(|e| OrchestratorError::SetupCommandError(e))?
+            .map_err(OrchestratorError::SetupCommandError)?
             .or(run_cmd.mongodb_args.mongodb_connection_url)
             .ok_or(OrchestratorError::SetupCommandError("Database Connection URL is required".to_string()))?;
 

--- a/orchestrator/src/types/params/prover.rs
+++ b/orchestrator/src/types/params/prover.rs
@@ -62,13 +62,10 @@ impl TryFrom<RunCmd> for ProverConfig {
                     ));
                 }
                 // Resolve secret: _FILE env var takes precedence over direct value
-                let atlantic_api_key =
-                    resolve_secret_from_file("MADARA_ORCHESTRATOR_ATLANTIC_API_KEY")
-                        .map_err(|e| OrchestratorError::RunCommandError(e))?
-                        .or(atlantic_args.atlantic_api_key)
-                        .ok_or_else(|| {
-                            OrchestratorError::RunCommandError("Atlantic API key is required".to_string())
-                        })?;
+                let atlantic_api_key = resolve_secret_from_file("MADARA_ORCHESTRATOR_ATLANTIC_API_KEY")
+                    .map_err(OrchestratorError::RunCommandError)?
+                    .or(atlantic_args.atlantic_api_key)
+                    .ok_or_else(|| OrchestratorError::RunCommandError("Atlantic API key is required".to_string()))?;
 
                 Ok(Self::Atlantic(AtlanticValidatedArgs {
                     atlantic_api_key,

--- a/orchestrator/src/types/params/prover.rs
+++ b/orchestrator/src/types/params/prover.rs
@@ -2,6 +2,7 @@ use crate::cli::RunCmd;
 use crate::OrchestratorError;
 use orchestrator_atlantic_service::AtlanticValidatedArgs;
 use orchestrator_sharp_service::SharpValidatedArgs;
+use orchestrator_utils::env_utils::resolve_secret_from_file;
 use orchestrator_utils::layer::Layer;
 
 #[derive(Debug, Clone)]
@@ -60,10 +61,17 @@ impl TryFrom<RunCmd> for ProverConfig {
                         "Cairo verifier program hash is required for L3".to_string(),
                     ));
                 }
+                // Resolve secret: _FILE env var takes precedence over direct value
+                let atlantic_api_key =
+                    resolve_secret_from_file("MADARA_ORCHESTRATOR_ATLANTIC_API_KEY")
+                        .map_err(|e| OrchestratorError::RunCommandError(e))?
+                        .or(atlantic_args.atlantic_api_key)
+                        .ok_or_else(|| {
+                            OrchestratorError::RunCommandError("Atlantic API key is required".to_string())
+                        })?;
+
                 Ok(Self::Atlantic(AtlanticValidatedArgs {
-                    atlantic_api_key: atlantic_args.atlantic_api_key.ok_or_else(|| {
-                        OrchestratorError::RunCommandError("Atlantic API key is required".to_string())
-                    })?,
+                    atlantic_api_key,
                     atlantic_service_url: atlantic_args
                         .atlantic_service_url
                         .ok_or_else(|| OrchestratorError::RunCommandError("Atlantic URL is required".to_string()))?,

--- a/orchestrator/src/types/params/settlement.rs
+++ b/orchestrator/src/types/params/settlement.rs
@@ -49,10 +49,8 @@ impl TryFrom<RunCmd> for SettlementConfig {
                 );
 
                 // Resolve secrets: _FILE env vars take precedence over direct values
-                let ethereum_rpc_url = match resolve_secret_from_file(
-                    "MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL",
-                )
-                .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                let ethereum_rpc_url = match resolve_secret_from_file("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL")
+                    .map_err(OrchestratorError::SetupCommandError)?
                 {
                     Some(url_str) => Url::parse(&url_str).map_err(|e| {
                         OrchestratorError::SetupCommandError(format!(
@@ -65,13 +63,12 @@ impl TryFrom<RunCmd> for SettlementConfig {
                     })?,
                 };
 
-                let ethereum_private_key =
-                    resolve_secret_from_file("MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY")
-                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
-                        .or(run_cmd.ethereum_settlement_args.ethereum_private_key.clone())
-                        .ok_or_else(|| {
-                            OrchestratorError::SetupCommandError("Ethereum private key is required".to_string())
-                        })?;
+                let ethereum_private_key = resolve_secret_from_file("MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY")
+                    .map_err(OrchestratorError::SetupCommandError)?
+                    .or(run_cmd.ethereum_settlement_args.ethereum_private_key.clone())
+                    .ok_or_else(|| {
+                        OrchestratorError::SetupCommandError("Ethereum private key is required".to_string())
+                    })?;
 
                 let ethereum_params = EthereumSettlementValidatedArgs {
                     ethereum_rpc_url,
@@ -91,10 +88,8 @@ impl TryFrom<RunCmd> for SettlementConfig {
             }
             (false, true) => {
                 // Resolve secrets: _FILE env vars take precedence over direct values
-                let starknet_rpc_url = match resolve_secret_from_file(
-                    "MADARA_ORCHESTRATOR_STARKNET_SETTLEMENT_RPC_URL",
-                )
-                .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                let starknet_rpc_url = match resolve_secret_from_file("MADARA_ORCHESTRATOR_STARKNET_SETTLEMENT_RPC_URL")
+                    .map_err(OrchestratorError::SetupCommandError)?
                 {
                     Some(url_str) => Url::parse(&url_str).map_err(|e| {
                         OrchestratorError::SetupCommandError(format!(
@@ -107,13 +102,12 @@ impl TryFrom<RunCmd> for SettlementConfig {
                     })?,
                 };
 
-                let starknet_private_key =
-                    resolve_secret_from_file("MADARA_ORCHESTRATOR_STARKNET_PRIVATE_KEY")
-                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
-                        .or(run_cmd.starknet_settlement_args.starknet_private_key.clone())
-                        .ok_or_else(|| {
-                            OrchestratorError::SetupCommandError("Starknet private key is required".to_string())
-                        })?;
+                let starknet_private_key = resolve_secret_from_file("MADARA_ORCHESTRATOR_STARKNET_PRIVATE_KEY")
+                    .map_err(OrchestratorError::SetupCommandError)?
+                    .or(run_cmd.starknet_settlement_args.starknet_private_key.clone())
+                    .ok_or_else(|| {
+                        OrchestratorError::SetupCommandError("Starknet private key is required".to_string())
+                    })?;
 
                 let starknet_params = StarknetSettlementValidatedArgs {
                     starknet_rpc_url,

--- a/orchestrator/src/types/params/settlement.rs
+++ b/orchestrator/src/types/params/settlement.rs
@@ -3,7 +3,9 @@ use crate::OrchestratorError;
 use alloy::primitives::Address;
 use orchestrator_ethereum_settlement_client::EthereumSettlementValidatedArgs;
 use orchestrator_starknet_settlement_client::StarknetSettlementValidatedArgs;
+use orchestrator_utils::env_utils::resolve_secret_from_file;
 use std::str::FromStr as _;
+use url::Url;
 
 #[derive(Clone, Debug)]
 pub enum SettlementConfig {
@@ -46,13 +48,34 @@ impl TryFrom<RunCmd> for SettlementConfig {
                     .unwrap_or_else(|_| panic!("Invalid Starknet operator address")),
                 );
 
-                let ethereum_params = EthereumSettlementValidatedArgs {
-                    ethereum_rpc_url: run_cmd.ethereum_settlement_args.ethereum_rpc_url.clone().ok_or_else(|| {
+                // Resolve secrets: _FILE env vars take precedence over direct values
+                let ethereum_rpc_url = match resolve_secret_from_file(
+                    "MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL",
+                )
+                .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                {
+                    Some(url_str) => Url::parse(&url_str).map_err(|e| {
+                        OrchestratorError::SetupCommandError(format!(
+                            "Invalid Ethereum settlement RPC URL from secret file: {}",
+                            e
+                        ))
+                    })?,
+                    None => run_cmd.ethereum_settlement_args.ethereum_rpc_url.clone().ok_or_else(|| {
                         OrchestratorError::SetupCommandError("Ethereum RPC URL is required".to_string())
                     })?,
-                    ethereum_private_key: run_cmd.ethereum_settlement_args.ethereum_private_key.clone().ok_or_else(
-                        || OrchestratorError::SetupCommandError("Ethereum private key is required".to_string()),
-                    )?,
+                };
+
+                let ethereum_private_key =
+                    resolve_secret_from_file("MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY")
+                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                        .or(run_cmd.ethereum_settlement_args.ethereum_private_key.clone())
+                        .ok_or_else(|| {
+                            OrchestratorError::SetupCommandError("Ethereum private key is required".to_string())
+                        })?;
+
+                let ethereum_params = EthereumSettlementValidatedArgs {
+                    ethereum_rpc_url,
+                    ethereum_private_key,
                     l1_core_contract_address,
                     starknet_operator_address: ethereum_operator_address,
                     ethereum_finality_retry_wait_in_secs: run_cmd
@@ -67,13 +90,34 @@ impl TryFrom<RunCmd> for SettlementConfig {
                 Ok(Self::Ethereum(ethereum_params))
             }
             (false, true) => {
-                let starknet_params = StarknetSettlementValidatedArgs {
-                    starknet_rpc_url: run_cmd.starknet_settlement_args.starknet_rpc_url.clone().ok_or_else(|| {
+                // Resolve secrets: _FILE env vars take precedence over direct values
+                let starknet_rpc_url = match resolve_secret_from_file(
+                    "MADARA_ORCHESTRATOR_STARKNET_SETTLEMENT_RPC_URL",
+                )
+                .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                {
+                    Some(url_str) => Url::parse(&url_str).map_err(|e| {
+                        OrchestratorError::SetupCommandError(format!(
+                            "Invalid Starknet settlement RPC URL from secret file: {}",
+                            e
+                        ))
+                    })?,
+                    None => run_cmd.starknet_settlement_args.starknet_rpc_url.clone().ok_or_else(|| {
                         OrchestratorError::SetupCommandError("Starknet RPC URL is required".to_string())
                     })?,
-                    starknet_private_key: run_cmd.starknet_settlement_args.starknet_private_key.clone().ok_or_else(
-                        || OrchestratorError::SetupCommandError("Starknet private key is required".to_string()),
-                    )?,
+                };
+
+                let starknet_private_key =
+                    resolve_secret_from_file("MADARA_ORCHESTRATOR_STARKNET_PRIVATE_KEY")
+                        .map_err(|e| OrchestratorError::SetupCommandError(e))?
+                        .or(run_cmd.starknet_settlement_args.starknet_private_key.clone())
+                        .ok_or_else(|| {
+                            OrchestratorError::SetupCommandError("Starknet private key is required".to_string())
+                        })?;
+
+                let starknet_params = StarknetSettlementValidatedArgs {
+                    starknet_rpc_url,
+                    starknet_private_key,
                     starknet_account_address: run_cmd
                         .starknet_settlement_args
                         .starknet_account_address


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [x] Feature

## What is the current behavior?

1. **Secrets are only configurable via environment variables**, which leak through `/proc/pid/environ`, crash dumps, `kubectl describe pod`, and logging frameworks. No support for file-based secret injection (K8s CSI Secrets Store Driver).

2. **Settlement CLI `requires_all` group is broken**: if any Ethereum settlement env var is set in the pod environment, clap demands all Ethereum settlement fields — even when running with `--settle-on-starknet`. This causes startup failures when both sets of env vars coexist.

Resolves: #NA

## What is the new behavior?

- **File-based secret loading**: For 8 sensitive env vars, the orchestrator now checks for a corresponding `_FILE` suffix variant (e.g. `MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY_FILE=/mnt/secrets/eth-key`). If set, the secret is read from the file at that path. `_FILE` takes precedence over the direct env var. Fully backward compatible.

  Supported `_FILE` variants:
  - `MADARA_ORCHESTRATOR_ETHEREUM_PRIVATE_KEY_FILE`
  - `MADARA_ORCHESTRATOR_STARKNET_PRIVATE_KEY_FILE`
  - `MADARA_ORCHESTRATOR_ATLANTIC_API_KEY_FILE`
  - `MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL_FILE`
  - `MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL_FILE`
  - `MADARA_ORCHESTRATOR_STARKNET_SETTLEMENT_RPC_URL_FILE`
  - `MADARA_ORCHESTRATOR_ETHEREUM_DA_RPC_URL_FILE`
  - `MADARA_ORCHESTRATOR_STARKNET_DA_RPC_URL_FILE`

- **Settlement CLI fix**: Removed `requires_all` from `EthereumSettlementCliArgs` and `StarknetSettlementCliArgs`. Validation is already handled in `TryFrom<RunCmd>` for `SettlementConfig` (`src/types/params/settlement.rs`), so the clap-level constraint was redundant and caused false errors.

## Does this introduce a breaking change?

No. All existing env var configurations continue to work unchanged. The `_FILE` variants are additive. The `requires_all` removal is purely a bug fix — the actual validation logic is unchanged.

## Other information

- `resolve_secret_from_file()` utility added in `crates/utils/src/env_utils.rs` with 4 unit tests
- Follows the `_FILE` suffix convention used by official Docker images (MySQL, PostgreSQL, Redis)
- Designed for K8s CSI Secrets Store Driver: secrets mounted as tmpfs files never enter etcd, env vars, or process environment