### PR TITLE
perf: rewrite MongoDB $lookup pipelines to use indexes

### DIFF
--- a/orchestrator/src/core/client/database/mongodb.rs
+++ b/orchestrator/src/core/client/database/mongodb.rs
@@ -589,27 +589,29 @@ impl DatabaseClient for MongoDbClient {
             doc! {
                 "$match": match_filter
             },
-            // Stage 2: Lookup to find corresponding job_b_type jobs
+            // Stage 2: Lookup to find jobs with matching internal_id
+            // Uses localField/foreignField form for proper index utilization
             doc! {
                 "$lookup": {
                     "from": JOBS_COLLECTION,
-                    "let": { "internal_id": "$internal_id" },
-                    "pipeline": [
-                        {
-                            "$match": {
-                                "$expr": {
-                                    "$and": [
-                                        { "$eq": ["$job_type", job_b_type_bson] },
-                                        { "$eq": ["$internal_id", "$$internal_id"] }
-                                    ]
-                                }
-                            }
-                        }
-                    ],
+                    "localField": "internal_id",
+                    "foreignField": "internal_id",
                     "as": "successor_jobs"
                 }
             },
-            // Stage 3: Filter out job_a_type jobs that have corresponding job_b_type jobs
+            // Stage 3: Filter successor_jobs to only include job_b_type
+            doc! {
+                "$addFields": {
+                    "successor_jobs": {
+                        "$filter": {
+                            "input": "$successor_jobs",
+                            "as": "job",
+                            "cond": { "$eq": ["$$job.job_type", job_b_type_bson] }
+                        }
+                    }
+                }
+            },
+            // Stage 4: Keep only documents with no successors
             doc! {
                 "$match": {
                     "successor_jobs": { "$eq": [] }
@@ -1199,28 +1201,29 @@ impl DatabaseClient for MongoDbClient {
             doc! {
                 "$match": match_filter
             },
-            // Stage 2: Lookup to find corresponding SNOS jobs
-            // We look for jobs where internal_id matches the index
+            // Stage 2: Lookup to find jobs with matching internal_id
+            // Uses localField/foreignField form for proper index utilization
             doc! {
                 "$lookup": {
                     "from": JOBS_COLLECTION,
-                    "let": { "index": "$index" },
-                    "pipeline": [
-                        {
-                            "$match": {
-                                "$expr": {
-                                    "$and": [
-                                        { "$eq": ["$job_type", snos_job_type_bson] },
-                                        { "$eq": ["$internal_id", "$$index"] }
-                                    ]
-                                }
-                            }
-                        }
-                    ],
+                    "localField": "index",
+                    "foreignField": "internal_id",
                     "as": "corresponding_jobs"
                 }
             },
-            // Stage 3: Filter to get only SNOS batches that DON'T have corresponding jobs
+            // Stage 3: Filter corresponding_jobs to only include SnosRun jobs
+            doc! {
+                "$addFields": {
+                    "corresponding_jobs": {
+                        "$filter": {
+                            "input": "$corresponding_jobs",
+                            "as": "job",
+                            "cond": { "$eq": ["$$job.job_type", snos_job_type_bson] }
+                        }
+                    }
+                }
+            },
+            // Stage 4: Keep only batches without corresponding jobs
             doc! {
                 "$match": {
                     "corresponding_jobs": { "$eq": [] }


### PR DESCRIPTION
## Problem

Two MongoDB aggregation queries in the orchestrator take **~20-22 seconds per call**:

- `get_jobs_without_successor` — finds completed jobs of type A that don't have a corresponding job of type B
- `get_snos_batches_without_jobs` — finds SNOS batches that don't have corresponding SnosRun jobs

Both use the `$lookup` stage with `let/pipeline/$expr` form:

```js
"$lookup": {
    "from": "jobs",
    "let": { "internal_id": "$internal_id" },
    "pipeline": [
        { "$match": { "$expr": { "$and": [
            { "$eq": ["$job_type", "ProofCreation"] },
            { "$eq": ["$internal_id", "$$internal_id"] }
        ]}}}
    ],
    "as": "successor_jobs"
}
```

MongoDB's query planner **does not use indexes** for `$expr`-based matches inside `$lookup` pipelines — even on MongoDB 7.0.5. We confirmed this by creating compound indexes (`{job_type: 1, internal_id: 1}` on jobs, `{status: 1, orchestrator_version: 1, index: 1}` on snos_batches) and observing **zero index usage** after 10+ minutes while query times remained at ~22 seconds.

This directly impacts the orchestrator's job processing pipeline — these queries run on every trigger cycle and the latency delays job creation.

## Solution

Rewrite both `$lookup` stages to use the `localField/foreignField` form, which **is** optimized by MongoDB's query planner and will use existing indexes on `internal_id`.

Since `localField/foreignField` joins on all matching documents (not just those of a specific `job_type`), we add a `$filter` stage after the join to narrow the results before checking for empty arrays.

**Before** (index-unfriendly `let/pipeline/$expr`):
```
$match → $lookup(let/pipeline/$expr) → $match(empty)
```

**After** (index-friendly `localField/foreignField` + post-filter):
```
$match → $lookup(localField/foreignField) → $addFields($filter by job_type) → $match(empty)
```

The existing compound indexes on the `jobs` collection (`{job_type: 1, internal_id: -1}`) will now be utilized for the join.

### Changes

- **`get_jobs_without_successor`**: Replaced `$lookup` with `localField: "internal_id"` / `foreignField: "internal_id"`, added `$addFields` with `$filter` to keep only `job_b_type` entries
- **`get_snos_batches_without_jobs`**: Replaced `$lookup` with `localField: "index"` / `foreignField: "internal_id"`, added `$addFields` with `$filter` to keep only `SnosRun` jobs

No changes to `execute_pipeline`, function signatures, return types, metrics, or logging.

## Test plan

- [x] `cargo check -p orchestrator --release` passes
- [x] `make fmt` passes
- [ ] Monitor `db_calls_response_time_seconds` after deployment — `get_jobs_without_successor` and `get_snos_batches_without_jobs` should drop from ~22s to <1s


🤖 Generated with [Claude Code](https://claude.com/claude-code)