### PR TITLE
fix(orchestrator): cache SQS consumer to prevent DispatchFailure on ack

### DIFF
--- a/orchestrator/src/core/client/queue/sqs.rs
+++ b/orchestrator/src/core/client/queue/sqs.rs
@@ -144,11 +144,16 @@ impl InnerSQS {
     }
 }
 
-/// SQS client with queue URL caching.
+/// SQS client with queue URL and consumer caching.
 ///
 /// Queue URLs are cached per QueueType to avoid redundant GetQueueUrl API calls.
 /// - For ARN-based identifiers: URLs are computed directly without any API call
 /// - For Name-based identifiers: URLs are fetched once and cached
+///
+/// Consumers are cached per QueueType to reuse the underlying AWS SDK client and
+/// its HTTP connection pool across message consumptions. This avoids per-message
+/// STS credential fetches and cold TCP+TLS connection setup that can intermittently
+/// fail with `SdkError::DispatchFailure`.
 #[derive(Clone)]
 pub struct SQS {
     pub inner: InnerSQS,
@@ -156,6 +161,10 @@ pub struct SQS {
     /// Cache for queue URLs, keyed by QueueType.
     /// Each entry is lazily initialized on first use.
     queue_url_cache: Arc<RwLock<HashMap<QueueType, Arc<OnceCell<String>>>>>,
+    /// Cache for SQS consumers, keyed by QueueType.
+    /// Reusing consumers avoids creating a new AWS SDK client (and fresh STS
+    /// credential fetch) on every message consumption.
+    consumer_cache: Arc<RwLock<HashMap<QueueType, Arc<OnceCell<SqsConsumer>>>>>,
 }
 
 impl SQS {
@@ -187,6 +196,7 @@ impl SQS {
             inner: InnerSQS::new(&latest_aws_config),
             queue_template_identifier: args.queue_template_identifier.clone(),
             queue_url_cache: Arc::new(RwLock::new(HashMap::new())),
+            consumer_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -229,6 +239,45 @@ impl SQS {
             .await?;
 
         Ok(url.clone())
+    }
+
+    /// Get a cached consumer `Arc` for the given queue type.
+    ///
+    /// Consumers are lazily created on first use and then reused. This ensures the
+    /// underlying AWS SDK client (and its HTTP connection pool / STS credentials)
+    /// are shared across all message consumptions for the same queue type, avoiding
+    /// the per-message overhead of `aws_config::load_from_env()` + `Client::new()`.
+    ///
+    /// Returns the `Arc<OnceCell<SqsConsumer>>` so the caller can hold a reference
+    /// to the consumer without lifetime issues (SqsConsumer does not implement Clone).
+    async fn get_cached_consumer_cell(&self, queue_type: &QueueType) -> Result<Arc<OnceCell<SqsConsumer>>, QueueError> {
+        // Fast path: check if cell already exists and is initialized
+        {
+            let cache = self.consumer_cache.read().await;
+            if let Some(cell) = cache.get(queue_type) {
+                if cell.get().is_some() {
+                    return Ok(cell.clone());
+                }
+            }
+        }
+
+        // Slow path: get or create the OnceCell for this queue type
+        let cell = {
+            let mut cache = self.consumer_cache.write().await;
+            cache.entry(queue_type.clone()).or_insert_with(|| Arc::new(OnceCell::new())).clone()
+        };
+
+        // Initialize the cell if not already done
+        cell.get_or_try_init(|| async {
+            let queue_url = self.get_or_resolve_queue_url(queue_type).await?;
+            let consumer = SqsBackend::builder(SqsConfig { queue_dsn: queue_url, override_endpoint: false })
+                .build_consumer()
+                .await?;
+            Ok::<_, QueueError>(consumer)
+        })
+        .await?;
+
+        Ok(cell)
     }
 
     pub fn client(&self) -> &Client {
@@ -501,7 +550,8 @@ impl QueueClient for SQS {
 
             return Err(omniqueue::QueueError::NoData.into());
         }
-        let consumer = self.get_consumer(queue.clone()).await?;
+        let consumer_cell = self.get_cached_consumer_cell(&queue).await?;
+        let consumer = consumer_cell.get().expect("consumer cell was just initialized");
         let delivery = consumer.wrap_message(messages_vec.first().unwrap());
 
         Ok(delivery)

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -309,8 +309,21 @@ impl EventWorker {
             return Err(consumption_error.into());
         }
 
-        message.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
-        Ok(())
+        // Retry ack once on failure. A transient DispatchFailure (e.g. stale HTTP
+        // connection) should not discard a successfully processed job — the message
+        // would become visible again and get re-processed, wasting work.
+        match message.ack().await {
+            Ok(()) => Ok(()),
+            Err((first_err, delivery)) => {
+                tracing::warn!("First ack attempt failed, retrying: {}", first_err);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                delivery
+                    .ack()
+                    .await
+                    .map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
+                Ok(())
+            }
+        }
     }
 
     /// process_message - Process the message received from the queue

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -317,10 +317,7 @@ impl EventWorker {
             Err((first_err, delivery)) => {
                 tracing::warn!("First ack attempt failed, retrying: {}", first_err);
                 tokio::time::sleep(Duration::from_millis(500)).await;
-                delivery
-                    .ack()
-                    .await
-                    .map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
+                delivery.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
                 Ok(())
             }
         }


### PR DESCRIPTION
## Summary

Fixes intermittent `FailedToAcknowledgeMessage("dispatch failure")` errors observed ~8 times over 48 hours across all orchestrator pods in the `mocknet-dev` deployment.

- **Cache `SqsConsumer` per queue type** instead of creating a throwaway consumer (and a brand new AWS SDK client) on every message consumption
- **Add one-retry on ack failure** using the `Delivery` returned by `ack()`, preventing transient dispatch errors from discarding successfully processed work

## Root Cause

In `consume_message_from_queue`, messages were **received** using the persistent `self.inner.client()`, but **acknowledged** using a throwaway client created by `self.get_consumer()` → `SqsBackend::builder().build_consumer()`. Under the hood, omniqueue's `consuming_half()` calls `aws_config::load_from_env().await` + `Client::new()` on every invocation — meaning every single message ack triggered:

1. A fresh STS `AssumeRoleWithWebIdentity` call (IRSA credential fetch)
2. A cold HTTP connection pool (no established connections to SQS)

When either the STS call or the TCP+TLS setup encountered any transient hiccup, the `delete_message` call failed with `SdkError::DispatchFailure` — an error meaning the HTTP request could never be dispatched.

The 5-second gap observed in Loki logs between job completion and the error was the new client's connection timeout expiring.

### Evidence from production investigation

| Signal | Finding |
|---|---|
| NAT Gateway metrics | Clean — 0 `ErrorPortAllocation`, 0 `PacketsDropCount` |
| DNS (CoreDNS) | No resolution failures for SQS/Atlantic domains |
| STS/credentials | No credential errors in logs |
| SQS visibility timeouts | 300-660s; jobs complete in <30s |
| DLQ | 0 messages — retries eventually succeed |
| Pod distribution | All 4 pods affected across AZ-c and AZ-d |

## Changes

### `orchestrator/src/core/client/queue/sqs.rs`
- Add `consumer_cache: Arc<RwLock<HashMap<QueueType, Arc<OnceCell<SqsConsumer>>>>>` to `SQS` struct
- Add `get_cached_consumer_cell()` method (same lazy-init pattern as existing `queue_url_cache`)
- Replace `self.get_consumer(queue).await?` with `self.get_cached_consumer_cell(&queue).await?` in `consume_message_from_queue`

### `orchestrator/src/worker/controller/event_worker.rs`
- Replace single `message.ack().await?` with a match that retries once on failure using the `Delivery` returned by the failed `ack()` call (the omniqueue API is designed for this — `ack(self)` returns `Err((QueueError, Self))`)

## Test plan

- [ ] CI passes (`cargo check`, orchestrator tests)
- [ ] Deploy to `mocknet-dev` and monitor Loki for `dispatch failure` errors over 48h
- [ ] Verify `FailedToAcknowledgeMessage` count drops to 0
- [ ] Verify no regression in job processing throughput

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)