### PR TITLE
feat: add --unsafe-no-l1-handler-tx-creation-from-message flag

### DIFF
--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -73,6 +73,7 @@
       "nanos": 0
     },
     "unsafe_skip_l1_message_consumed_check": false,
+    "unsafe_no_l1_handler_tx_creation_from_message": false,
     "settlement_layer": "Eth"
   },
   "analytics_params": {

--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -73,7 +73,7 @@
       "nanos": 0
     },
     "unsafe_skip_l1_message_consumed_check": false,
-    "unsafe_no_l1_handler_tx_creation_from_message": false,
+    "unsafe_l1_handler_metadata_only": false,
     "settlement_layer": "Eth"
   },
   "analytics_params": {

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -6,24 +6,11 @@ use mp_convert::Felt;
 use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::v0_9_0::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
-    ClassAndTxnHash, ContractAndTxnHash, L1TxnHash,
+    ClassAndTxnHash, ContractAndTxnHash,
 };
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use mp_utils::service::{MadaraServiceId, MadaraServiceStatus};
 use serde::{Deserialize, Serialize};
-
-/// An L1 handler message together with the L1 origin metadata needed by
-/// `starknet_getMessagesStatus`.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct L1HandlerMessageWithOrigin {
-    /// The L1 handler transaction and its paid fee on L1.
-    #[serde(flatten)]
-    pub message: L1HandlerTransactionWithFee,
-    /// Hash of the L1 transaction that emitted the `LogMessageToL2` event.
-    pub l1_transaction_hash: L1TxnHash,
-    /// L1 block number in which the message was emitted.
-    pub l1_block_number: u64,
-}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct ServiceStatusInfo {
@@ -90,15 +77,11 @@ pub trait MadaraWriteRpcApi {
     #[method(name = "revertToAndShutdown")]
     async fn revert_to_and_shutdown(&self, block_hash: Felt) -> RpcResult<()>;
 
-    /// Submit a L1 message into the bypass input stream.
-    ///
-    /// Also persists L1 origin metadata (nonce→L1 tx hash, nonce→L1 block,
-    /// and a `(l1_tx_hash, nonce)` seen marker) so that
-    /// `starknet_getMessagesStatus` can track admin-submitted messages.
+    /// Submit a L1 message into the bypass input stream
     #[method(name = "addL1HandlerMessage")]
     async fn add_l1_handler_message(
         &self,
-        l1_handler_message: L1HandlerMessageWithOrigin,
+        l1_handler_message: L1HandlerTransactionWithFee,
     ) -> RpcResult<L1HandlerTransactionResult>;
 
     /// Sets custom headers to be used for the upcoming block

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -6,11 +6,24 @@ use mp_convert::Felt;
 use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::v0_9_0::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
-    ClassAndTxnHash, ContractAndTxnHash,
+    ClassAndTxnHash, ContractAndTxnHash, L1TxnHash,
 };
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use mp_utils::service::{MadaraServiceId, MadaraServiceStatus};
 use serde::{Deserialize, Serialize};
+
+/// An L1 handler message together with the L1 origin metadata needed by
+/// `starknet_getMessagesStatus`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct L1HandlerMessageWithOrigin {
+    /// The L1 handler transaction and its paid fee on L1.
+    #[serde(flatten)]
+    pub message: L1HandlerTransactionWithFee,
+    /// Hash of the L1 transaction that emitted the `LogMessageToL2` event.
+    pub l1_transaction_hash: L1TxnHash,
+    /// L1 block number in which the message was emitted.
+    pub l1_block_number: u64,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct ServiceStatusInfo {
@@ -77,11 +90,15 @@ pub trait MadaraWriteRpcApi {
     #[method(name = "revertToAndShutdown")]
     async fn revert_to_and_shutdown(&self, block_hash: Felt) -> RpcResult<()>;
 
-    /// Submit a L1 message into the bypass input stream
+    /// Submit a L1 message into the bypass input stream.
+    ///
+    /// Also persists L1 origin metadata (nonce→L1 tx hash, nonce→L1 block,
+    /// and a `(l1_tx_hash, nonce)` seen marker) so that
+    /// `starknet_getMessagesStatus` can track admin-submitted messages.
     #[method(name = "addL1HandlerMessage")]
     async fn add_l1_handler_message(
         &self,
-        l1_handler_message: L1HandlerTransactionWithFee,
+        l1_handler_message: L1HandlerMessageWithOrigin,
     ) -> RpcResult<L1HandlerTransactionResult>;
 
     /// Sets custom headers to be used for the upcoming block

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -302,14 +302,19 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
 mod tests {
     use super::services_to_stop_for_revert;
     use crate::{
-        test_utils::TestTransactionProvider, versions::admin::v0_1_0::MadaraWriteRpcApiV0_1_0Server, Starknet,
+        test_utils::TestTransactionProvider,
+        versions::admin::v0_1_0::{api::L1HandlerMessageWithOrigin, MadaraWriteRpcApiV0_1_0Server},
+        Starknet,
     };
     use mc_db::{
+        storage::L1ToL2MessageIndexEntry,
         test_utils::{add_test_block, l1_handler_tx_with_receipt},
         MadaraBackend,
     };
     use mp_chain_config::ChainConfig;
-    use mp_convert::Felt;
+    use mp_convert::{Felt, L1TransactionHash};
+    use mp_rpc::v0_9_0::L1TxnHash;
+    use mp_transactions::{L1HandlerTransaction, L1HandlerTransactionWithFee};
     use mp_utils::service::{MadaraServiceMask, MadaraServiceStatus, ServiceContext};
     use std::sync::Arc;
     use std::time::Duration;
@@ -378,5 +383,47 @@ mod tests {
         assert_ne!(err.code(), 0);
         assert_eq!(backend.latest_confirmed_block_n(), Some(1));
         assert!(backend.get_l1_handler_txn_hash_by_nonce(reverted_nonce).expect("DB read should succeed").is_some());
+    }
+
+    #[tokio::test]
+    async fn add_l1_handler_message_persists_origin_metadata() {
+        let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
+        let rpc = make_starknet(backend.clone(), ServiceContext::default());
+
+        let nonce = 42u64;
+        let l1_tx_hash_bytes = [0xab_u8; 32];
+        let l1_block_number = 12345u64;
+
+        let msg = L1HandlerMessageWithOrigin {
+            message: L1HandlerTransactionWithFee::new(
+                L1HandlerTransaction {
+                    version: Felt::ZERO,
+                    nonce,
+                    contract_address: Felt::from(456u64),
+                    entry_point_selector: Felt::from(789u64),
+                    calldata: vec![Felt::from(123u64)].into(),
+                },
+                1000,
+            ),
+            l1_transaction_hash: L1TxnHash(l1_tx_hash_bytes),
+            l1_block_number,
+        };
+
+        // The call will fail (no block_prod_handle), but metadata must already be persisted.
+        let _err = rpc.add_l1_handler_message(msg).await.expect_err("should fail without block_prod_handle");
+
+        let expected_l1_hash = L1TransactionHash(l1_tx_hash_bytes);
+
+        // 1) nonce → L1 tx hash
+        assert_eq!(backend.get_l1_txn_hash_by_nonce(nonce).unwrap(), Some(expected_l1_hash));
+
+        // 2) nonce → L1 block number
+        assert_eq!(backend.get_l1_handler_l1_block_by_nonce(nonce).unwrap(), Some(l1_block_number));
+
+        // 3) (L1 tx hash, nonce) → seen marker (empty, not yet consumed)
+        assert_eq!(
+            backend.get_message_to_l2_index_entry(&expected_l1_hash, nonce).unwrap(),
+            Some(L1ToL2MessageIndexEntry::Seen),
+        );
     }
 }

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -4,13 +4,15 @@ use jsonrpsee::core::{async_trait, RpcResult};
 use mc_db::MadaraStorageRead;
 use mc_submit_tx::{SubmitL1HandlerTransaction, SubmitTransaction};
 use mp_block::header::CustomHeader;
-use mp_convert::Felt;
+use mp_convert::{Felt, L1TransactionHash};
 use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::v0_9_0::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
     ClassAndTxnHash, ContractAndTxnHash,
 };
-use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
+use mp_transactions::L1HandlerTransactionResult;
+
+use crate::versions::admin::v0_1_0::api::L1HandlerMessageWithOrigin;
 use mp_utils::service::{MadaraServiceId, MadaraServiceStatus, SERVICE_GRACE_PERIOD};
 use std::time::Duration;
 use tokio::time::Instant;
@@ -252,13 +254,32 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
 
     async fn add_l1_handler_message(
         &self,
-        l1_handler_message: L1HandlerTransactionWithFee,
+        l1_handler_message: L1HandlerMessageWithOrigin,
     ) -> RpcResult<L1HandlerTransactionResult> {
+        let nonce = l1_handler_message.message.tx.nonce;
+        let l1_tx_hash = L1TransactionHash(l1_handler_message.l1_transaction_hash.0);
+        let l1_block_number = l1_handler_message.l1_block_number;
+
+        // Persist L1 origin metadata so `starknet_getMessagesStatus` can track
+        // this message, matching what the settlement messaging worker writes.
+        self.backend
+            .write_l1_txn_hash_by_nonce(nonce, &l1_tx_hash)
+            .context("Storing nonce → L1 tx hash")
+            .map_err(StarknetRpcApiError::from)?;
+        self.backend
+            .insert_message_to_l2_seen_marker(&l1_tx_hash, nonce)
+            .context("Storing (L1 tx hash, nonce) seen marker")
+            .map_err(StarknetRpcApiError::from)?;
+        self.backend
+            .write_l1_handler_l1_block_by_nonce(nonce, l1_block_number)
+            .context("Storing nonce → L1 block number")
+            .map_err(StarknetRpcApiError::from)?;
+
         Ok(self
             .block_prod_handle
             .as_ref()
-            .unwrap()
-            .submit_l1_handler_transaction(l1_handler_message)
+            .ok_or(StarknetRpcApiError::UnimplementedMethod)?
+            .submit_l1_handler_transaction(l1_handler_message.message)
             .await
             .map_err(StarknetRpcApiError::from)?)
     }

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -4,15 +4,13 @@ use jsonrpsee::core::{async_trait, RpcResult};
 use mc_db::MadaraStorageRead;
 use mc_submit_tx::{SubmitL1HandlerTransaction, SubmitTransaction};
 use mp_block::header::CustomHeader;
-use mp_convert::{Felt, L1TransactionHash};
+use mp_convert::Felt;
 use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::v0_9_0::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
     ClassAndTxnHash, ContractAndTxnHash,
 };
-use mp_transactions::L1HandlerTransactionResult;
-
-use crate::versions::admin::v0_1_0::api::L1HandlerMessageWithOrigin;
+use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use mp_utils::service::{MadaraServiceId, MadaraServiceStatus, SERVICE_GRACE_PERIOD};
 use std::time::Duration;
 use tokio::time::Instant;
@@ -254,32 +252,13 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
 
     async fn add_l1_handler_message(
         &self,
-        l1_handler_message: L1HandlerMessageWithOrigin,
+        l1_handler_message: L1HandlerTransactionWithFee,
     ) -> RpcResult<L1HandlerTransactionResult> {
-        let nonce = l1_handler_message.message.tx.nonce;
-        let l1_tx_hash = L1TransactionHash(l1_handler_message.l1_transaction_hash.0);
-        let l1_block_number = l1_handler_message.l1_block_number;
-
-        // Persist L1 origin metadata so `starknet_getMessagesStatus` can track
-        // this message, matching what the settlement messaging worker writes.
-        self.backend
-            .write_l1_txn_hash_by_nonce(nonce, &l1_tx_hash)
-            .context("Storing nonce → L1 tx hash")
-            .map_err(StarknetRpcApiError::from)?;
-        self.backend
-            .insert_message_to_l2_seen_marker(&l1_tx_hash, nonce)
-            .context("Storing (L1 tx hash, nonce) seen marker")
-            .map_err(StarknetRpcApiError::from)?;
-        self.backend
-            .write_l1_handler_l1_block_by_nonce(nonce, l1_block_number)
-            .context("Storing nonce → L1 block number")
-            .map_err(StarknetRpcApiError::from)?;
-
         Ok(self
             .block_prod_handle
             .as_ref()
             .ok_or(StarknetRpcApiError::UnimplementedMethod)?
-            .submit_l1_handler_transaction(l1_handler_message.message)
+            .submit_l1_handler_transaction(l1_handler_message)
             .await
             .map_err(StarknetRpcApiError::from)?)
     }
@@ -302,19 +281,14 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
 mod tests {
     use super::services_to_stop_for_revert;
     use crate::{
-        test_utils::TestTransactionProvider,
-        versions::admin::v0_1_0::{api::L1HandlerMessageWithOrigin, MadaraWriteRpcApiV0_1_0Server},
-        Starknet,
+        test_utils::TestTransactionProvider, versions::admin::v0_1_0::MadaraWriteRpcApiV0_1_0Server, Starknet,
     };
     use mc_db::{
-        storage::L1ToL2MessageIndexEntry,
         test_utils::{add_test_block, l1_handler_tx_with_receipt},
         MadaraBackend,
     };
     use mp_chain_config::ChainConfig;
-    use mp_convert::{Felt, L1TransactionHash};
-    use mp_rpc::v0_9_0::L1TxnHash;
-    use mp_transactions::{L1HandlerTransaction, L1HandlerTransactionWithFee};
+    use mp_convert::Felt;
     use mp_utils::service::{MadaraServiceMask, MadaraServiceStatus, ServiceContext};
     use std::sync::Arc;
     use std::time::Duration;
@@ -383,47 +357,5 @@ mod tests {
         assert_ne!(err.code(), 0);
         assert_eq!(backend.latest_confirmed_block_n(), Some(1));
         assert!(backend.get_l1_handler_txn_hash_by_nonce(reverted_nonce).expect("DB read should succeed").is_some());
-    }
-
-    #[tokio::test]
-    async fn add_l1_handler_message_persists_origin_metadata() {
-        let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
-        let rpc = make_starknet(backend.clone(), ServiceContext::default());
-
-        let nonce = 42u64;
-        let l1_tx_hash_bytes = [0xab_u8; 32];
-        let l1_block_number = 12345u64;
-
-        let msg = L1HandlerMessageWithOrigin {
-            message: L1HandlerTransactionWithFee::new(
-                L1HandlerTransaction {
-                    version: Felt::ZERO,
-                    nonce,
-                    contract_address: Felt::from(456u64),
-                    entry_point_selector: Felt::from(789u64),
-                    calldata: vec![Felt::from(123u64)].into(),
-                },
-                1000,
-            ),
-            l1_transaction_hash: L1TxnHash(l1_tx_hash_bytes),
-            l1_block_number,
-        };
-
-        // The call will fail (no block_prod_handle), but metadata must already be persisted.
-        let _err = rpc.add_l1_handler_message(msg).await.expect_err("should fail without block_prod_handle");
-
-        let expected_l1_hash = L1TransactionHash(l1_tx_hash_bytes);
-
-        // 1) nonce → L1 tx hash
-        assert_eq!(backend.get_l1_txn_hash_by_nonce(nonce).unwrap(), Some(expected_l1_hash));
-
-        // 2) nonce → L1 block number
-        assert_eq!(backend.get_l1_handler_l1_block_by_nonce(nonce).unwrap(), Some(l1_block_number));
-
-        // 3) (L1 tx hash, nonce) → seen marker (empty, not yet consumed)
-        assert_eq!(
-            backend.get_message_to_l2_index_entry(&expected_l1_hash, nonce).unwrap(),
-            Some(L1ToL2MessageIndexEntry::Seen),
-        );
     }
 }

--- a/madara/crates/client/settlement_client/src/eth/mod.rs
+++ b/madara/crates/client/settlement_client/src/eth/mod.rs
@@ -362,10 +362,7 @@ impl SettlementLayerProvider for EthereumClient {
     async fn get_block_n_timestamp(&self, l1_block_n: u64) -> Result<u64, SettlementClientError> {
         let block = self
             .provider
-            .get_block(
-                BlockId::Number(BlockNumberOrTag::Number(l1_block_n)),
-                alloy::rpc::types::BlockTransactionsKind::Hashes,
-            )
+            .get_block(BlockId::Number(BlockNumberOrTag::Number(l1_block_n)), BlockTransactionsKind::Hashes)
             .await
             .map_err(|e| -> SettlementClientError {
                 EthereumClientError::ArchiveRequired(format!("Could not get block timestamp: {}", e)).into()
@@ -687,13 +684,13 @@ mod l1_messaging_tests {
     /// Common setup for tests
     ///
     /// This test performs the following steps:
-    /// 1. Sets up test environemment
+    /// 1. Sets up test environment
     /// 2. Starts worker
     /// 3. Fires a Message event from the dummy contract
     /// 4. Waits for event to be processed
     /// 5. Assert that the worker handle the event with correct data
     /// 6. Assert that the hash computed by the worker is correct
-    /// 7. Assert that the tx is succesfully submited
+    /// 7. Assert that the tx is successfully submitted
     /// 8. Assert that the event is successfully pushed to the db
     /// 9. TODO : Assert that the tx was correctly executed
     ///
@@ -754,6 +751,7 @@ mod l1_messaging_tests {
                     Arc::clone(&db),
                     Default::default(),
                     ServiceContext::new_for_testing(),
+                    false,
                     false,
                 )
                 .await
@@ -890,6 +888,7 @@ mod l1_messaging_tests {
                     Arc::clone(&db),
                     Default::default(),
                     ServiceContext::new_for_testing(),
+                    false,
                     false,
                 )
                 .await

--- a/madara/crates/client/settlement_client/src/messaging.rs
+++ b/madara/crates/client/settlement_client/src/messaging.rs
@@ -94,6 +94,7 @@ pub async fn sync(
     notify_consumer: Arc<Notify>,
     mut ctx: ServiceContext,
     unsafe_skip_l1_message_consumed_check: bool,
+    metadata_only: bool,
 ) -> Result<(), SettlementClientError> {
     // sync inner is cancellation safe.
     ctx.run_until_cancelled(sync_inner(
@@ -101,6 +102,7 @@ pub async fn sync(
         backend,
         notify_consumer,
         unsafe_skip_l1_message_consumed_check,
+        metadata_only,
     ))
     .await
     .transpose()?;
@@ -112,6 +114,7 @@ async fn sync_inner(
     backend: Arc<MadaraBackend>,
     notify_consumer: Arc<Notify>,
     unsafe_skip_l1_message_consumed_check: bool,
+    metadata_only: bool,
 ) -> Result<(), SettlementClientError> {
     // Note: It's fine to reprocess events - duplicates are filtered during block production.
 
@@ -129,6 +132,7 @@ async fn sync_inner(
             replay_max_duration,
             finality_blocks,
             unsafe_skip_l1_message_consumed_check,
+            metadata_only,
         )
         .await
         {
@@ -153,6 +157,7 @@ async fn run_message_sync(
     replay_max_duration: Duration,
     finality_blocks: u64,
     unsafe_skip_l1_message_consumed_check: bool,
+    metadata_only: bool,
 ) -> Result<(), SettlementClientError> {
     let from_l1_block_n = get_start_block(settlement_client, backend, replay_max_duration).await?;
 
@@ -200,6 +205,7 @@ async fn run_message_sync(
             &mut pending_events,
             finality_blocks,
             unsafe_skip_l1_message_consumed_check,
+            metadata_only,
         )
         .await
         {
@@ -241,6 +247,7 @@ async fn process_finalized_events(
     pending_events: &mut VecDeque<MessageToL2WithMetadata>,
     finality_blocks: u64,
     unsafe_skip_l1_message_consumed_check: bool,
+    metadata_only: bool,
 ) -> Result<(), SettlementClientError> {
     if pending_events.is_empty() {
         return Ok(());
@@ -286,20 +293,24 @@ async fn process_finalized_events(
 
         // Backfill the consumed L2 tx hash in case the L1 handler transaction was already written to the DB
         // before we observed the L1 event for this nonce.
+        // Checking nonce -> L2 transaction hash
         if let Some(l2_tx_hash) = backend.get_l1_handler_txn_hash_by_nonce(nonce).map_err(|e| {
             SettlementClientError::DatabaseError(format!("Failed to read l1 handler tx hash by nonce: {}", e))
         })? {
+            // Write l1_tx_hash|nonce -> l2_tx_hash
             backend.write_message_to_l2_consumed_txn_hash(&l1_tx_hash, nonce, &l2_tx_hash).map_err(|e| {
                 SettlementClientError::DatabaseError(format!(
                     "Failed to backfill l1->l2 consumed tx hash for (l1_tx_hash, nonce): {}",
                     e
                 ))
             })?;
+            // Write nonce -> l1_block
             backend.write_l1_handler_l1_block_by_nonce(nonce, event.l1_block_number).map_err(|e| {
                 SettlementClientError::DatabaseError(format!("Failed to store message source block: {}", e))
             })?;
         }
 
+        // Check if the message is still valid
         let is_valid = check_message_to_l2_validity(
             settlement_client,
             backend,
@@ -315,17 +326,28 @@ async fn process_finalized_events(
         })?;
 
         if is_valid {
+            // Write nonce -> l1_block
             backend.write_l1_handler_l1_block_by_nonce(event.message.tx.nonce, event.l1_block_number).map_err(|e| {
                 SettlementClientError::DatabaseError(format!("Failed to store message source block: {}", e))
             })?;
-            backend
-                .write_pending_message_to_l2(&event.message)
-                .map_err(|e| SettlementClientError::DatabaseError(format!("Failed to store message: {}", e)))?;
-            tracing::debug!("Message stored: nonce={}", event.message.tx.nonce);
+            if metadata_only {
+                tracing::debug!(
+                    "Message metadata stored but NOT queued for block production (unsafe flag): nonce={}",
+                    event.message.tx.nonce
+                );
+            } else {
+                // Write nonce -> pending_message (to be picked by block production service)
+                backend
+                    .write_pending_message_to_l2(&event.message)
+                    .map_err(|e| SettlementClientError::DatabaseError(format!("Failed to store message: {}", e)))?;
+                tracing::debug!("Message stored: nonce={}", event.message.tx.nonce);
+            }
         } else {
             tracing::debug!("Message skipped (invalid/cancelled): nonce={}", event.message.tx.nonce);
         }
 
+        // Write the l1 message sync tip
+        // This is a marker for l1 sync service to start from later on
         backend
             .write_l1_messaging_sync_tip(Some(event.l1_block_number))
             .map_err(|e| SettlementClientError::DatabaseError(format!("Failed to update sync tip: {}", e)))?;
@@ -452,14 +474,14 @@ mod messaging_module_tests {
         let db_backend_clone = db.clone();
 
         // Spawn the sync task in a separate thread
-        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false, false).await });
 
         // Wait for event to be processed (short wait since stream returns immediately)
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Verify the message was processed
         assert_eq!(db.get_pending_message_to_l2(mock_event1.message.tx.nonce).unwrap().unwrap(), mock_event1.message);
-        let l1_tx_hash = mp_convert::L1TransactionHash(mock_event1.l1_transaction_hash.to_be_bytes::<32>());
+        let l1_tx_hash = L1TransactionHash(mock_event1.l1_transaction_hash.to_be_bytes::<32>());
         assert_eq!(db.get_l1_txn_hash_by_nonce(mock_event1.message.tx.nonce).unwrap(), Some(l1_tx_hash));
         assert_eq!(
             db.get_messages_to_l2_by_l1_tx_hash(&l1_tx_hash).unwrap().unwrap(),
@@ -515,7 +537,7 @@ mod messaging_module_tests {
         let db_backend_clone = db.clone();
 
         // Spawn the sync task in a separate thread
-        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false, false).await });
 
         // Wait for event to be processed (short wait since stream returns immediately)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -585,7 +607,7 @@ mod messaging_module_tests {
         let db_backend_clone = db.clone();
 
         // Spawn the sync task in a separate thread
-        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false, false).await });
 
         // Wait for event to be processed (short wait since stream returns immediately)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -644,7 +666,7 @@ mod messaging_module_tests {
         let notify = Arc::new(Notify::new());
         let db_clone = db.clone();
 
-        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false, false).await });
 
         // Wait for processing attempt (short wait)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -700,7 +722,7 @@ mod messaging_module_tests {
         let notify = Arc::new(Notify::new());
         let db_clone = db.clone();
 
-        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false).await });
+        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false, false).await });
 
         // Wait for processing (short wait)
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -744,7 +766,8 @@ mod messaging_module_tests {
         let client = Arc::new(mock_client);
         let ctx = ServiceContext::new_for_testing();
 
-        let sync_handle = tokio::spawn(async move { sync(client, db, Arc::new(Notify::new()), ctx, false).await });
+        let sync_handle =
+            tokio::spawn(async move { sync(client, db, Arc::new(Notify::new()), ctx, false, false).await });
 
         // Verify exponential backoff: 1s -> 2s -> 4s
         tokio::time::advance(Duration::from_millis(50)).await;
@@ -762,6 +785,57 @@ mod messaging_module_tests {
         // Task should still be running (no panic)
         assert!(!sync_handle.is_finished());
 
+        sync_handle.abort();
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_metadata_only_flag_stores_metadata_but_not_pending(
+        #[future] setup_messaging_tests: MessagingTestRunner,
+    ) -> anyhow::Result<()> {
+        let MessagingTestRunner { mut client, db, ctx } = setup_messaging_tests.await;
+
+        let mock_event1 = create_mock_event(100, 1);
+        let notify = Arc::new(Notify::new());
+
+        db.write_l1_messaging_sync_tip(Some(99))?;
+
+        let events = vec![mock_event1.clone()];
+        client.expect_messages_to_l2_stream().returning(move |_| Ok(stream::iter(events.clone()).map(Ok).boxed()));
+        client.expect_get_latest_block_number().returning(|| Ok(200));
+
+        mock_l1_handler_tx(&mut client, 1, true, false);
+        client.expect_get_client_type().returning(|| ClientType::Eth);
+
+        let client = Arc::new(client) as Arc<dyn SettlementLayerProvider>;
+        let ctx_clone = ctx.clone();
+        let db_backend_clone = db.clone();
+
+        // Pass metadata_only = true (last argument)
+        let sync_handle = tokio::spawn(async move { sync(client, db_backend_clone, notify, ctx, false, true).await });
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Metadata SHOULD be written
+        let l1_tx_hash = mp_convert::L1TransactionHash(mock_event1.l1_transaction_hash.to_be_bytes::<32>());
+        assert_eq!(db.get_l1_txn_hash_by_nonce(mock_event1.message.tx.nonce).unwrap(), Some(l1_tx_hash));
+        assert_eq!(
+            db.get_messages_to_l2_by_l1_tx_hash(&l1_tx_hash).unwrap().unwrap(),
+            vec![(mock_event1.message.tx.nonce, None)]
+        );
+        assert_eq!(
+            db.get_l1_handler_l1_block_by_nonce(mock_event1.message.tx.nonce).unwrap(),
+            Some(mock_event1.l1_block_number)
+        );
+
+        // Pending message should NOT be written
+        assert!(
+            db.get_pending_message_to_l2(mock_event1.message.tx.nonce).unwrap().is_none(),
+            "Pending message should NOT be written when metadata_only is true"
+        );
+
+        ctx_clone.cancel_global();
         sync_handle.abort();
         Ok(())
     }

--- a/madara/crates/client/settlement_client/src/messaging.rs
+++ b/madara/crates/client/settlement_client/src/messaging.rs
@@ -362,7 +362,9 @@ async fn process_finalized_events(
 mod messaging_module_tests {
     use super::*;
     use crate::client::MockSettlementLayerProvider;
+    use crate::messages_to_l2_consumer::MessagesToL2Consumer;
     use futures::stream;
+    use futures::FutureExt;
     use mockall::predicate;
     use mp_chain_config::ChainConfig;
     use mp_transactions::L1HandlerTransaction;
@@ -833,6 +835,16 @@ mod messaging_module_tests {
         assert!(
             db.get_pending_message_to_l2(mock_event1.message.tx.nonce).unwrap().is_none(),
             "Pending message should NOT be written when metadata_only is true"
+        );
+
+        // A consumer subscribed to the same notify should find nothing to consume
+        let mut mock_for_consumer = MockSettlementLayerProvider::new();
+        mock_for_consumer.expect_get_client_type().returning(|| ClientType::Eth);
+        let consumer_notify = Arc::new(Notify::new());
+        let mut consumer = MessagesToL2Consumer::new(db.clone(), Arc::new(mock_for_consumer), consumer_notify, false);
+        assert!(
+            consumer.consume_next_or_wait().now_or_never().is_none(),
+            "Consumer should have nothing to consume when metadata_only is true"
         );
 
         ctx_clone.cancel_global();

--- a/madara/crates/client/settlement_client/src/starknet/mod.rs
+++ b/madara/crates/client/settlement_client/src/starknet/mod.rs
@@ -489,7 +489,7 @@ pub mod starknet_client_tests {
 
     /// This struct holds all commonly used test resources
     pub struct StarknetClientTextFixture {
-        pub context: crate::starknet::test_utils::TestContext,
+        pub context: test_utils::TestContext,
         pub client: StarknetClient,
     }
 
@@ -517,7 +517,7 @@ pub mod starknet_client_tests {
         let fixture = test_fixture.await;
 
         let starknet_client = StarknetClient::new(StarknetClientConfig {
-            rpc_url: fixture.context.cmd.rpc_url().parse().unwrap(),
+            rpc_url: fixture.context.cmd.rpc_url().parse()?,
             core_contract_address: "0xdeadbeef".to_string(),
         })
         .await;
@@ -710,7 +710,7 @@ mod starknet_client_messaging_test {
 
     /// This struct holds all commonly used test resources
     pub struct StarknetClientTextFixture {
-        pub context: crate::starknet::test_utils::TestContext,
+        pub context: test_utils::TestContext,
         pub db_service: Arc<MadaraBackend>,
         pub starknet_client: StarknetClient,
     }
@@ -761,6 +761,7 @@ mod starknet_client_messaging_test {
                     Default::default(),
                     ServiceContext::new_for_testing(),
                     false,
+                    false,
                 )
                 .await
                 .unwrap();
@@ -771,7 +772,7 @@ mod starknet_client_messaging_test {
         // Firing the event
         let l1_tx_hash_felt =
             fire_messaging_event(&fixture.context.account, fixture.context.deployed_messaging_contract_address).await;
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        sleep(Duration::from_secs(10)).await;
 
         // Assert that the event is well stored in db:
         // - pending message is persisted
@@ -850,6 +851,7 @@ mod starknet_client_messaging_test {
                     Default::default(),
                     ServiceContext::new_for_testing(),
                     false,
+                    false,
                 )
                 .await
             })
@@ -860,7 +862,7 @@ mod starknet_client_messaging_test {
                 .await;
 
         cancel_messaging_event(&fixture.context.account, fixture.context.deployed_messaging_contract_address).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        sleep(Duration::from_secs(5)).await;
         assert!(fixture.starknet_client.message_to_l2_has_cancel_request(&message_hash.to_bytes_be()).await.unwrap());
 
         Ok(())

--- a/madara/crates/client/settlement_client/src/sync.rs
+++ b/madara/crates/client/settlement_client/src/sync.rs
@@ -12,6 +12,7 @@ pub struct SyncWorkerConfig {
     pub l1_block_metrics: Arc<L1BlockMetrics>,
     pub l1_head_sender: L1HeadSender,
     pub unsafe_skip_l1_message_consumed_check: bool,
+    pub unsafe_no_l1_handler_tx_creation_from_message: bool,
 }
 
 impl L1ClientImpl {
@@ -36,6 +37,7 @@ impl L1ClientImpl {
             self.notify_new_message_to_l2.clone(),
             ctx.clone(),
             config.unsafe_skip_l1_message_consumed_check,
+            config.unsafe_no_l1_handler_tx_creation_from_message,
         ));
 
         if !config.gas_provider_config.all_is_fixed() {

--- a/madara/crates/client/settlement_client/src/sync.rs
+++ b/madara/crates/client/settlement_client/src/sync.rs
@@ -12,7 +12,7 @@ pub struct SyncWorkerConfig {
     pub l1_block_metrics: Arc<L1BlockMetrics>,
     pub l1_head_sender: L1HeadSender,
     pub unsafe_skip_l1_message_consumed_check: bool,
-    pub unsafe_no_l1_handler_tx_creation_from_message: bool,
+    pub unsafe_l1_handler_metadata_only: bool,
 }
 
 impl L1ClientImpl {
@@ -37,7 +37,7 @@ impl L1ClientImpl {
             self.notify_new_message_to_l2.clone(),
             ctx.clone(),
             config.unsafe_skip_l1_message_consumed_check,
-            config.unsafe_no_l1_handler_tx_creation_from_message,
+            config.unsafe_l1_handler_metadata_only,
         ));
 
         if !config.gas_provider_config.all_is_fixed() {

--- a/madara/node/src/cli/l1.rs
+++ b/madara/node/src/cli/l1.rs
@@ -123,6 +123,23 @@ pub struct L1SyncParams {
     #[clap(env = "MADARA_UNSAFE_SKIP_L1_MESSAGE_CONSUMED_CHECK", long)]
     pub unsafe_skip_l1_message_consumed_check: bool,
 
+    /// DANGEROUS: Prevents L1→L2 messages from being queued for automatic inclusion in blocks.
+    ///
+    /// When enabled, the L1 sync messaging worker will still run and persist all metadata
+    /// (nonce → L1 tx hash, seen marker, nonce → L1 block number) needed by
+    /// `starknet_getMessagesStatus`, but it will NOT write messages to the pending table.
+    /// Block production will also not consume L1 messages from the pending table.
+    ///
+    /// This is useful when an external orchestrator submits L1 handler transactions exclusively
+    /// via the admin RPC (`addL1HandlerMessage`).
+    ///
+    /// WARNING: If this flag is enabled and no external service submits L1 handler transactions,
+    /// L1→L2 messages will be silently ignored and never executed on L2.
+    ///
+    /// Cannot be combined with `--no-l1-sync`.
+    #[clap(env = "MADARA_UNSAFE_NO_L1_HANDLER_TX_CREATION_FROM_MESSAGE", long, conflicts_with = "l1_sync_disabled")]
+    pub unsafe_no_l1_handler_tx_creation_from_message: bool,
+
     /// The settlement layer type. This specifies the type of API `--l1-endpoint <RPC url>` uses: Ethereum RPC, or Starknet RPC.
     /// The usual cases for this is:
     /// - When settling on Ethereum, which is the case for Starknet Mainnet, we are usually running an L2 - because Ethrereum is an L1 and doesn't settle on any other chain.

--- a/madara/node/src/cli/l1.rs
+++ b/madara/node/src/cli/l1.rs
@@ -123,12 +123,12 @@ pub struct L1SyncParams {
     #[clap(env = "MADARA_UNSAFE_SKIP_L1_MESSAGE_CONSUMED_CHECK", long)]
     pub unsafe_skip_l1_message_consumed_check: bool,
 
-    /// DANGEROUS: Prevents L1→L2 messages from being queued for automatic inclusion in blocks.
+    /// DANGEROUS: Runs L1 sync in metadata-only mode for L1→L2 messages.
     ///
     /// When enabled, the L1 sync messaging worker will still run and persist all metadata
     /// (nonce → L1 tx hash, seen marker, nonce → L1 block number) needed by
     /// `starknet_getMessagesStatus`, but it will NOT write messages to the pending table.
-    /// Block production will also not consume L1 messages from the pending table.
+    /// This means L1→L2 messages will never be automatically included in blocks.
     ///
     /// This is useful when an external orchestrator submits L1 handler transactions exclusively
     /// via the admin RPC (`addL1HandlerMessage`).
@@ -137,8 +137,8 @@ pub struct L1SyncParams {
     /// L1→L2 messages will be silently ignored and never executed on L2.
     ///
     /// Cannot be combined with `--no-l1-sync`.
-    #[clap(env = "MADARA_UNSAFE_NO_L1_HANDLER_TX_CREATION_FROM_MESSAGE", long, conflicts_with = "l1_sync_disabled")]
-    pub unsafe_no_l1_handler_tx_creation_from_message: bool,
+    #[clap(env = "MADARA_UNSAFE_L1_HANDLER_METADATA_ONLY", long, conflicts_with = "l1_sync_disabled")]
+    pub unsafe_l1_handler_metadata_only: bool,
 
     /// The settlement layer type. This specifies the type of API `--l1-endpoint <RPC url>` uses: Ethereum RPC, or Starknet RPC.
     /// The usual cases for this is:

--- a/madara/node/src/service/l1.rs
+++ b/madara/node/src/service/l1.rs
@@ -69,9 +69,9 @@ impl L1SyncService {
             return Ok(Self { sync_worker_config: None, client: None });
         }
 
-        if config.unsafe_no_l1_handler_tx_creation_from_message {
+        if config.unsafe_l1_handler_metadata_only {
             tracing::warn!(
-                "⚠⚠⚠ UNSAFE: --unsafe-no-l1-handler-tx-creation-from-message is enabled. \
+                "⚠⚠⚠ UNSAFE: --unsafe-l1-handler-metadata-only is enabled. \
                  L1 sync will persist metadata but will NOT queue L1→L2 messages for block production. \
                  L1 handler transactions must be submitted via the admin RPC. ⚠⚠⚠"
             );
@@ -116,7 +116,7 @@ impl L1SyncService {
                 l1_head_sender: sync_config.l1_head_snd,
                 l1_block_metrics: sync_config.l1_block_metrics,
                 unsafe_skip_l1_message_consumed_check: config.unsafe_skip_l1_message_consumed_check,
-                unsafe_no_l1_handler_tx_creation_from_message: config.unsafe_no_l1_handler_tx_creation_from_message,
+                unsafe_l1_handler_metadata_only: config.unsafe_l1_handler_metadata_only,
             }),
         })
     }

--- a/madara/node/src/service/l1.rs
+++ b/madara/node/src/service/l1.rs
@@ -21,6 +21,7 @@ pub struct L1SyncConfig {
 pub struct L1SyncService {
     sync_worker_config: Option<SyncWorkerConfig>,
     client: Option<Arc<L1ClientImpl>>,
+    no_l1_handler_tx_creation: bool,
 }
 
 impl L1SyncService {
@@ -66,7 +67,15 @@ impl L1SyncService {
         }
 
         if config.l1_sync_disabled {
-            return Ok(Self { sync_worker_config: None, client: None });
+            return Ok(Self { sync_worker_config: None, client: None, no_l1_handler_tx_creation: false });
+        }
+
+        if config.unsafe_no_l1_handler_tx_creation_from_message {
+            tracing::warn!(
+                "⚠⚠⚠ UNSAFE: --unsafe-no-l1-handler-tx-creation-from-message is enabled. \
+                 L1 sync will persist metadata but will NOT queue L1→L2 messages for block production. \
+                 L1 handler transactions must be submitted via the admin RPC. ⚠⚠⚠"
+            );
         }
         let Some(endpoint) = config.l1_endpoint.clone() else {
             tracing::error!("Missing l1_endpoint CLI argument. Either disable L1 sync using `--no-l1-sync` or give an L1 RPC endpoint URL using `--l1-endpoint <url>`.");
@@ -108,12 +117,18 @@ impl L1SyncService {
                 l1_head_sender: sync_config.l1_head_snd,
                 l1_block_metrics: sync_config.l1_block_metrics,
                 unsafe_skip_l1_message_consumed_check: config.unsafe_skip_l1_message_consumed_check,
+                unsafe_no_l1_handler_tx_creation_from_message: config.unsafe_no_l1_handler_tx_creation_from_message,
             }),
+            no_l1_handler_tx_creation: config.unsafe_no_l1_handler_tx_creation_from_message,
         })
     }
 
     pub fn client(&self) -> Arc<dyn SettlementClient> {
-        if let Some(client) = self.client.clone() {
+        if self.no_l1_handler_tx_creation {
+            // Flag set: block production gets an empty L1 message stream.
+            // L1 sync itself still runs with the real client for metadata.
+            Arc::new(L1SyncDisabledClient)
+        } else if let Some(client) = self.client.clone() {
             client
         } else {
             Arc::new(L1SyncDisabledClient)

--- a/madara/node/src/service/l1.rs
+++ b/madara/node/src/service/l1.rs
@@ -21,7 +21,6 @@ pub struct L1SyncConfig {
 pub struct L1SyncService {
     sync_worker_config: Option<SyncWorkerConfig>,
     client: Option<Arc<L1ClientImpl>>,
-    no_l1_handler_tx_creation: bool,
 }
 
 impl L1SyncService {
@@ -67,7 +66,7 @@ impl L1SyncService {
         }
 
         if config.l1_sync_disabled {
-            return Ok(Self { sync_worker_config: None, client: None, no_l1_handler_tx_creation: false });
+            return Ok(Self { sync_worker_config: None, client: None });
         }
 
         if config.unsafe_no_l1_handler_tx_creation_from_message {
@@ -119,16 +118,11 @@ impl L1SyncService {
                 unsafe_skip_l1_message_consumed_check: config.unsafe_skip_l1_message_consumed_check,
                 unsafe_no_l1_handler_tx_creation_from_message: config.unsafe_no_l1_handler_tx_creation_from_message,
             }),
-            no_l1_handler_tx_creation: config.unsafe_no_l1_handler_tx_creation_from_message,
         })
     }
 
     pub fn client(&self) -> Arc<dyn SettlementClient> {
-        if self.no_l1_handler_tx_creation {
-            // Flag set: block production gets an empty L1 message stream.
-            // L1 sync itself still runs with the real client for metadata.
-            Arc::new(L1SyncDisabledClient)
-        } else if let Some(client) = self.client.clone() {
+        if let Some(client) = self.client.clone() {
             client
         } else {
             Arc::new(L1SyncDisabledClient)


### PR DESCRIPTION
## Pull Request type

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Testing
- [ ] Other (please describe):

## What is the current behavior?

When L1 sync is enabled, the messaging worker writes L1→L2 messages to both the metadata tables (for `starknet_getMessagesStatus`) and the pending table (for block production to consume). There is no way to have L1 sync populate metadata without also having messages automatically queued for block production.

This is problematic when an external orchestrator (e.g. a transaction replay service) submits L1 handler transactions exclusively via the admin RPC `addL1HandlerMessage` — the L1 sync messaging worker creates duplicate entries in the pending table that compete with the admin-submitted transactions.

Resolves: #NA

## What is the new behavior?

- Adds `--unsafe-no-l1-handler-tx-creation-from-message` CLI flag (env: `MADARA_UNSAFE_NO_L1_HANDLER_TX_CREATION_FROM_MESSAGE`)
- When enabled:
  - L1 sync messaging worker runs normally and persists all metadata (nonce → L1 tx hash, seen marker, nonce → L1 block number) but does NOT write messages to the pending table
  - L1 handler transactions can only enter blocks via the admin RPC (since we don't populate the pending column in rocks DB from where the block production creates L1 handler transactions)
  - State update and gas price workers continue running normally
- The flag cannot be combined with `--no-l1-sync` (enforced via clap `conflicts_with`)
- A prominent warning is logged when the flag is enabled
- The admin RPC `addL1HandlerMessage` is reverted to its original `L1HandlerTransactionWithFee` parameter — L1 origin metadata is now populated exclusively by the L1 sync messaging worker, with backfill support for messages executed before the corresponding L1 event is discovered

## Does this introduce a breaking change?

No. The new flag is opt-in and defaults to `false`. Existing behavior is unchanged.

The admin RPC `addL1HandlerMessage` parameter type is reverted to `L1HandlerTransactionWithFee` (from the short-lived `L1HandlerMessageWithOrigin`), but since that change was never released, this is not a breaking change.

## Other information

When `--unsafe-no-l1-handler-tx-creation-from-message` is enabled and an L1 handler transaction is submitted via admin RPC before L1 sync discovers the corresponding L1 event, the nonce → L2 tx hash mapping is written at block commit time. When L1 sync later catches up, `process_finalized_events` detects the existing mapping and backfills the L1 origin metadata (L1 tx hash, seen marker, L1 block number) without writing to the pending table. This ensures `starknet_getMessagesStatus` eventually returns complete data.