### PR TITLE
feat: stop sync on unsupported Starknet protocol version

### DIFF
--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -94,6 +94,10 @@ pub enum BlockImportError {
 
     #[error("Global state root mismatch: expected {expected:#x}, got {got:#x}")]
     GlobalStateRoot { got: Felt, expected: Felt },
+
+    #[error("Unsupported Starknet version {version} at block {block_n}. Latest supported version is {latest_supported}. Please upgrade Madara.")]
+    UnsupportedStarknetVersion { block_n: u64, version: StarknetVersion, latest_supported: StarknetVersion },
+
     /// Internal error, see [`BlockImportError::is_internal`].
     #[error("Internal database error while {context}: {error:#}")]
     InternalDb { context: Cow<'static, str>, error: anyhow::Error },
@@ -163,6 +167,20 @@ impl BlockImporterCtx {
         // verify block_number
         if !self.config.no_check && block_n != signed_header.header.block_number {
             return Err(BlockImportError::BlockNumber { expected: block_n, got: signed_header.header.block_number });
+        }
+
+        // Reject blocks with unsupported Starknet versions.
+        // This is NOT gated by no_check — we always want to stop on unsupported versions
+        // to prevent syncing data that the node cannot correctly process or verify.
+        // Uses the compile-time constant rather than chain config to prevent config overrides
+        // from accidentally allowing unsupported versions.
+        let latest_supported = StarknetVersion::LATEST;
+        if signed_header.header.protocol_version > latest_supported {
+            return Err(BlockImportError::UnsupportedStarknetVersion {
+                block_n: signed_header.header.block_number,
+                version: signed_header.header.protocol_version,
+                latest_supported,
+            });
         }
 
         // TODO(cchudant): for pre-v0.13.2 blocks, we currently do not check their integrity. Checking them is cumbersome, as it requires us

--- a/madara/crates/client/sync/src/tests/gateway_mock.rs
+++ b/madara/crates/client/sync/src/tests/gateway_mock.rs
@@ -71,16 +71,6 @@ impl GatewayMock {
         self.mock_block_with_declared_class_and_version(block_number, hash, parent_hash, None, starknet_version);
     }
 
-    pub fn mock_block_with_declared_class(
-        &self,
-        block_number: u64,
-        hash: Felt,
-        parent_hash: Felt,
-        declared_class: Option<DeclaredClassItem>,
-    ) {
-        self.mock_block_with_declared_class_and_version(block_number, hash, parent_hash, declared_class, "0.13.2.1");
-    }
-
     fn mock_block_with_declared_class_and_version(
         &self,
         block_number: u64,

--- a/madara/crates/client/sync/src/tests/gateway_mock.rs
+++ b/madara/crates/client/sync/src/tests/gateway_mock.rs
@@ -58,7 +58,17 @@ impl GatewayMock {
     }
 
     pub fn mock_block(&self, block_number: u64, hash: Felt, parent_hash: Felt) {
-        self.mock_block_with_declared_class(block_number, hash, parent_hash, None);
+        self.mock_block_with_declared_class_and_version(block_number, hash, parent_hash, None, "0.13.2.1");
+    }
+
+    pub fn mock_block_with_starknet_version(
+        &self,
+        block_number: u64,
+        hash: Felt,
+        parent_hash: Felt,
+        starknet_version: impl Into<String>,
+    ) {
+        self.mock_block_with_declared_class_and_version(block_number, hash, parent_hash, None, starknet_version);
     }
 
     pub fn mock_block_with_declared_class(
@@ -68,6 +78,18 @@ impl GatewayMock {
         parent_hash: Felt,
         declared_class: Option<DeclaredClassItem>,
     ) {
+        self.mock_block_with_declared_class_and_version(block_number, hash, parent_hash, declared_class, "0.13.2.1");
+    }
+
+    fn mock_block_with_declared_class_and_version(
+        &self,
+        block_number: u64,
+        hash: Felt,
+        parent_hash: Felt,
+        declared_class: Option<DeclaredClassItem>,
+        starknet_version: impl Into<String>,
+    ) {
+        let starknet_version = starknet_version.into();
         let declared_classes = declared_class
             .map(|item| {
                 json!({
@@ -109,7 +131,7 @@ impl GatewayMock {
                     "timestamp": 1725974819,
                     "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
                     "transaction_receipts": [],
-                    "starknet_version": "0.13.2.1"
+                    "starknet_version": starknet_version
                 },
                 "state_update": {
                     "block_hash": "0x541112d5d5937a66ff09425a0256e53ac5c4f554be7e24917fc21a71aa3cf32",

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use mc_db::MadaraBackend;
 use mc_settlement_client::state_update::StateUpdate;
-use mp_chain_config::ChainConfig;
+use mp_chain_config::{ChainConfig, StarknetVersion};
 use mp_utils::{service::ServiceContext, AbortOnDrop};
 use rstest::{fixture, rstest};
 use starknet_api::felt;
@@ -38,6 +38,27 @@ fn ctx(gateway_mock: GatewayMock) -> TestContext {
     let (service_state_sender, service_state_recv) = crate::util::service_state_channel();
 
     TestContext { backend, importer, service_state_sender, service_state_recv, gateway_mock }
+}
+
+fn next_unsupported_starknet_version() -> String {
+    let mut components =
+        StarknetVersion::LATEST.to_string().split('.').map(|part| part.parse::<u8>().unwrap()).collect::<Vec<_>>();
+
+    while components.len() < 4 {
+        components.push(0);
+    }
+
+    for idx in (0..components.len()).rev() {
+        if components[idx] < u8::MAX {
+            components[idx] += 1;
+            for component in components.iter_mut().skip(idx + 1) {
+                *component = 0;
+            }
+            return format!("{}.{}.{}.{}", components[0], components[1], components[2], components[3]);
+        }
+    }
+
+    panic!("failed to derive unsupported Starknet version after {}", StarknetVersion::LATEST);
 }
 
 #[rstest]
@@ -86,6 +107,43 @@ async fn test_probed(mut ctx: TestContext) {
 
     assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::SyncingTo { target: 6 });
     assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Idle);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_stop_sync_on_unsupported_starknet_version(mut ctx: TestContext) {
+    let unsupported_version = next_unsupported_starknet_version();
+
+    ctx.gateway_mock.mock_block(0, felt!("0x10"), felt!("0x0"));
+    ctx.gateway_mock.mock_block(1, felt!("0x11"), felt!("0x10"));
+    ctx.gateway_mock.mock_block_with_starknet_version(2, felt!("0x12"), felt!("0x11"), unsupported_version.clone());
+    ctx.gateway_mock.mock_header_latest(2, felt!("0x12"));
+    ctx.gateway_mock.mock_block_pending_not_found();
+
+    let mut sync = crate::gateway::forward_sync(
+        ctx.backend.clone(),
+        ctx.importer,
+        ctx.gateway_mock.client(),
+        SyncControllerConfig::default().service_state_sender(ctx.service_state_sender),
+        ForwardSyncConfig::default(),
+    );
+
+    let task = AbortOnDrop::spawn(async move { sync.run(ServiceContext::default()).await });
+
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Starting);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Idle);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::SyncingTo { target: 2 });
+
+    let err = task.await.expect_err("sync should stop on the first unsupported Starknet version");
+    let err = format!("{err:#}");
+    assert!(err.contains("Unsupported Starknet version {unsupported_version}"), "{err}");
+    assert!(err.contains("Latest supported version is"), "{err}");
+    assert!(err.contains("block 2"), "{err}");
+
+    assert_eq!(ctx.backend.block_view_on_confirmed(0).unwrap().get_block_info().unwrap().block_hash, felt!("0x10"));
+    assert_eq!(ctx.backend.block_view_on_confirmed(1).unwrap().get_block_info().unwrap().block_hash, felt!("0x11"));
+    assert_eq!(ctx.backend.block_view_on_confirmed(2), None);
+    assert!(!ctx.backend.has_preconfirmed_block());
 }
 
 #[rstest]

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -140,8 +140,10 @@ async fn test_stop_sync_on_unsupported_starknet_version(mut ctx: TestContext) {
     assert!(err.contains("Latest supported version is"), "{err}");
     assert!(err.contains("block 2"), "{err}");
 
-    assert_eq!(ctx.backend.block_view_on_confirmed(0).unwrap().get_block_info().unwrap().block_hash, felt!("0x10"));
-    assert_eq!(ctx.backend.block_view_on_confirmed(1).unwrap().get_block_info().unwrap().block_hash, felt!("0x11"));
+    // The sync aborts as soon as the unsupported block is encountered. Because the block, class,
+    // and state pipelines run independently, earlier blocks may still be in flight and not yet
+    // sealed as confirmed when the error is returned.
+    assert!(ctx.backend.latest_confirmed_block_n().map(|n| n < 2).unwrap_or(true));
     assert_eq!(ctx.backend.block_view_on_confirmed(2), None);
     assert!(!ctx.backend.has_preconfirmed_block());
 }

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -136,7 +136,7 @@ async fn test_stop_sync_on_unsupported_starknet_version(mut ctx: TestContext) {
 
     let err = task.await.expect_err("sync should stop on the first unsupported Starknet version");
     let err = format!("{err:#}");
-    assert!(err.contains("Unsupported Starknet version {unsupported_version}"), "{err}");
+    assert!(err.contains(&format!("Unsupported Starknet version {unsupported_version}")), "{err}");
     assert!(err.contains("Latest supported version is"), "{err}");
     assert!(err.contains("block 2"), "{err}");
 

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use mc_db::MadaraBackend;
 use mc_settlement_client::state_update::StateUpdate;
-use mp_chain_config::{ChainConfig, StarknetVersion};
+use mp_chain_config::ChainConfig;
 use mp_utils::{service::ServiceContext, AbortOnDrop};
 use rstest::{fixture, rstest};
 use starknet_api::felt;
@@ -39,28 +39,6 @@ fn ctx(gateway_mock: GatewayMock) -> TestContext {
 
     TestContext { backend, importer, service_state_sender, service_state_recv, gateway_mock }
 }
-
-fn next_unsupported_starknet_version() -> String {
-    let mut components =
-        StarknetVersion::LATEST.to_string().split('.').map(|part| part.parse::<u8>().unwrap()).collect::<Vec<_>>();
-
-    while components.len() < 4 {
-        components.push(0);
-    }
-
-    for idx in (0..components.len()).rev() {
-        if components[idx] < u8::MAX {
-            components[idx] += 1;
-            for component in components.iter_mut().skip(idx + 1) {
-                *component = 0;
-            }
-            return format!("{}.{}.{}.{}", components[0], components[1], components[2], components[3]);
-        }
-    }
-
-    panic!("failed to derive unsupported Starknet version after {}", StarknetVersion::LATEST);
-}
-
 #[rstest]
 #[tokio::test]
 /// The pipeline should follow the mock_header_latest.
@@ -112,7 +90,8 @@ async fn test_probed(mut ctx: TestContext) {
 #[rstest]
 #[tokio::test]
 async fn test_stop_sync_on_unsupported_starknet_version(mut ctx: TestContext) {
-    let unsupported_version = next_unsupported_starknet_version();
+    // TODO: Update this value whenever the latest supported Starknet version is bumped.
+    let unsupported_version = "0.14.2".to_string();
 
     ctx.gateway_mock.mock_block(0, felt!("0x10"), felt!("0x0"));
     ctx.gateway_mock.mock_block(1, felt!("0x11"), felt!("0x10"));


### PR DESCRIPTION
## Summary
- Adds a version guard in `verify_header` that stops block sync when a block's `protocol_version` exceeds `StarknetVersion::LATEST` (compile-time constant, currently `0.14.1`)
- Returns a clear error: `Unsupported Starknet version X.Y.Z at block N. Latest supported version is A.B.C. Please upgrade Madara.`
- Covers both snap sync and normal sync paths (both go through `verify_header`)

## Motivation
Without this check, a node encountering blocks from a newer Starknet version would attempt to sync data it cannot correctly verify, execute, or produce valid state roots for. This could lead to:
- Silent state corruption
- Incorrect trie computations  
- Misleading sync progress that eventually fails in hard-to-debug ways

## Design decisions
- **Not gated by `no_check`**: This is intentional. Even with all verification disabled, we should never sync blocks from a version the node doesn't understand. The data structures, hash computations, and execution semantics may have changed.
- **Uses `StarknetVersion::LATEST` (compile-time constant)** instead of `chain_config.latest_protocol_version`: Prevents config file overrides from accidentally allowing unsupported versions. The only way to bump the supported version is to update the source code and rebuild — forcing a conscious upgrade.

## Test plan
- [ ] Verify existing tests pass (`cargo test -p mc-sync`)
- [ ] Manual test: set `latest_protocol_version` in chain config to a version higher than `LATEST` and confirm the compile-time constant takes precedence
- [ ] Verify error message is clear and actionable when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)