### PR TITLE
feat: remote CASM fetch fallback for Sierra compilation failures

### DIFF
--- a/madara/Cargo.lock
+++ b/madara/Cargo.lock
@@ -7955,6 +7955,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
@@ -11781,6 +11782,22 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -114,11 +114,15 @@ pub struct BlockImporter {
     db: Arc<MadaraBackend>,
     config: BlockValidationConfig,
     rayon_pool: Arc<RayonPool>,
+    casm_rpc_urls: Vec<String>,
 }
 
 impl BlockImporter {
-    pub fn new(db: Arc<MadaraBackend>, config: BlockValidationConfig) -> BlockImporter {
-        Self { db, config, rayon_pool: Arc::new(RayonPool::new()) }
+    pub fn new(db: Arc<MadaraBackend>, config: BlockValidationConfig, casm_rpc_urls: Vec<String>) -> BlockImporter {
+        if !casm_rpc_urls.is_empty() {
+            tracing::info!("Remote CASM fetch configured with {} endpoint(s)", casm_rpc_urls.len());
+        }
+        Self { db, config, rayon_pool: Arc::new(RayonPool::new()), casm_rpc_urls }
     }
 
     pub async fn run_in_rayon_pool<F, R>(&self, func: F) -> R
@@ -142,14 +146,32 @@ impl BlockImporter {
     }
 
     fn ctx(&self) -> BlockImporterCtx {
-        BlockImporterCtx { backend: self.db.clone(), config: self.config.clone() }
+        BlockImporterCtx { backend: self.db.clone(), config: self.config.clone(), casm_rpc_urls: self.casm_rpc_urls.clone() }
     }
 }
 
 pub struct BlockImporterCtx {
     backend: Arc<MadaraBackend>,
     config: BlockValidationConfig,
+    casm_rpc_urls: Vec<String>,
 }
+
+/// Internal result type for the two-phase compilation approach.
+/// This allows us to defer remote CASM fetching to a sequential phase,
+/// avoiding blocking rayon threads with HTTP requests.
+enum CompileResult {
+    /// Class needs remote CASM fetch - compilation failed locally
+    NeedsRemoteFetch {
+        class_hash: Felt,
+        sierra: SierraClassInfo,
+        uses_blake: bool,
+        gateway_hash: Felt,
+        compile_error: ClassCompilationError,
+    },
+    /// Fatal error that should stop processing
+    Error(BlockImportError),
+}
+
 impl BlockImporterCtx {
     // HEADERS
 
@@ -300,6 +322,10 @@ impl BlockImporterCtx {
     // CLASSES
 
     /// Called in a rayon-pool context.
+    ///
+    /// This function uses a two-phase approach to avoid blocking rayon threads with HTTP requests:
+    /// 1. Phase 1 (parallel): Try to compile all classes, collect those that need remote CASM fetch
+    /// 2. Phase 2 (sequential): Fetch CASM for failed classes one at a time to avoid starving rayon pool
     pub fn verify_compile_classes(
         &self,
         block_n: Option<u64>,
@@ -312,49 +338,132 @@ impl BlockImporterCtx {
                 expected: check_against.len() as _,
             });
         }
-        let classes = declared_classes
+
+        // Phase 1: Try to compile all classes in parallel, collect results
+        let results: Vec<_> = declared_classes
             .into_par_iter()
-            .map(|class| self.verify_compile_class(block_n, class, check_against))
-            .collect::<Result<_, _>>()?;
+            .map(|class| self.try_compile_class(block_n, class, check_against))
+            .collect();
+
+        let needs_fetch_count =
+            results.iter().filter(|r| matches!(r, Err(CompileResult::NeedsRemoteFetch { .. }))).count();
+
+        // Phase 2: Process results - for classes that need remote fetch, do it sequentially
+        // to avoid blocking multiple rayon threads with HTTP requests
+        let mut classes = Vec::with_capacity(results.len());
+        let mut fetch_index = 0;
+
+        if needs_fetch_count > 0 {
+            tracing::info!(
+                "Local compilation failed for {} classes, fetching CASM from remote RPC sequentially",
+                needs_fetch_count
+            );
+        }
+
+        for result in results {
+            match result {
+                Ok(converted) => classes.push(converted),
+                Err(CompileResult::NeedsRemoteFetch {
+                    class_hash,
+                    sierra,
+                    uses_blake,
+                    gateway_hash,
+                    compile_error,
+                }) => {
+                    fetch_index += 1;
+                    tracing::warn!(
+                        "[{}/{}] Local compilation failed for class {:#x}: {}. Fetching from remote RPC...",
+                        fetch_index,
+                        needs_fetch_count,
+                        class_hash,
+                        compile_error
+                    );
+
+                    let endpoint_strs: Vec<&str> = self.casm_rpc_urls.iter().map(|s| s.as_str()).collect();
+                    match mp_class::casm_fetch::fetch_compiled_casm(&class_hash, &endpoint_strs) {
+                        Ok(fetched_casm) => {
+                            tracing::info!(
+                                "[{}/{}] Successfully fetched CASM for class {:#x}",
+                                fetch_index,
+                                needs_fetch_count,
+                                class_hash,
+                            );
+
+                            let (stored_poseidon, stored_blake) =
+                                if uses_blake { (None, Some(gateway_hash)) } else { (Some(gateway_hash), None) };
+
+                            classes.push(ConvertedClass::Sierra(SierraConvertedClass {
+                                class_hash,
+                                info: SierraClassInfo {
+                                    contract_class: sierra.contract_class,
+                                    compiled_class_hash: stored_poseidon,
+                                    compiled_class_hash_v2: stored_blake,
+                                },
+                                compiled: Arc::new((&fetched_casm).try_into().map_err(|e| {
+                                    BlockImportError::CompilationClassError {
+                                        class_hash,
+                                        error: ClassCompilationError::ParsingProgramJsonFailed(e),
+                                    }
+                                })?),
+                            }));
+                        }
+                        Err(fetch_error) => {
+                            tracing::error!(
+                                "[{}/{}] Failed to fetch CASM for class {:#x}: {}",
+                                fetch_index,
+                                needs_fetch_count,
+                                class_hash,
+                                fetch_error
+                            );
+                            return Err(BlockImportError::CompilationClassError { class_hash, error: compile_error });
+                        }
+                    }
+                }
+                Err(CompileResult::Error(e)) => return Err(e),
+            }
+        }
+
         Ok(classes)
     }
 
     /// Called in a rayon-pool context.
-    fn verify_compile_class(
+    fn try_compile_class(
         &self,
         block_n: Option<u64>,
         class: ClassInfoWithHash,
         check_against: &HashMap<Felt, DeclaredClassCompiledClass>,
-    ) -> Result<ConvertedClass, BlockImportError> {
+    ) -> Result<ConvertedClass, CompileResult> {
         let class_hash = class.class_hash;
 
-        let check_against = *check_against.get(&class_hash).ok_or(BlockImportError::UnexpectedClass { class_hash })?;
+        let check_against = *check_against
+            .get(&class_hash)
+            .ok_or(CompileResult::Error(BlockImportError::UnexpectedClass { class_hash }))?;
 
         match class.class_info {
             ClassInfo::Sierra(sierra) => {
                 tracing::trace!("Converting class with hash {:#x}", class_hash);
 
                 let DeclaredClassCompiledClass::Sierra(expected_compiled_hash) = check_against else {
-                    return Err(BlockImportError::ClassType {
+                    return Err(CompileResult::Error(BlockImportError::ClassType {
                         class_hash,
                         got: ClassType::Legacy,
                         expected: ClassType::Sierra,
-                    });
+                    }));
                 };
 
                 // Get the gateway-provided hash (canonical for this temp ClassInfo)
                 let gateway_hash = sierra.compiled_class_hash.ok_or_else(|| {
-                    BlockImportError::Internal(anyhow::anyhow!(
+                    CompileResult::Error(BlockImportError::Internal(anyhow::anyhow!(
                         "Sierra class from gateway should have compiled_class_hash"
-                    ))
+                    )))
                 })?;
 
                 if !self.config.no_check && gateway_hash != expected_compiled_hash {
-                    return Err(BlockImportError::CompiledClassHash {
+                    return Err(CompileResult::Error(BlockImportError::CompiledClassHash {
                         class_hash,
                         got: gateway_hash,
                         expected: expected_compiled_hash,
-                    });
+                    }));
                 }
 
                 // Verify class hash
@@ -362,9 +471,9 @@ impl BlockImporterCtx {
                     let expected = sierra
                         .contract_class
                         .compute_class_hash()
-                        .map_err(|error| BlockImportError::ComputeClassHash { class_hash, error })?;
+                        .map_err(|error| CompileResult::Error(BlockImportError::ComputeClassHash { class_hash, error }))?;
                     if !self.config.no_check && class_hash != expected {
-                        return Err(BlockImportError::ClassHash { got: class_hash, expected });
+                        return Err(CompileResult::Error(BlockImportError::ClassHash { got: class_hash, expected }));
                     }
                 }
 
@@ -375,53 +484,70 @@ impl BlockImporterCtx {
                     .unwrap_or(false);
 
                 // Compile and get both Poseidon and BLAKE hashes
-                let hashes = sierra
-                    .contract_class
-                    .compile_to_casm_with_hashes()
-                    .map_err(|e| BlockImportError::CompilationClassError { class_hash, error: e })?;
+                let compile_result = sierra.contract_class.compile_to_casm_with_hashes();
 
-                // Verify compiled class hash based on protocol version
-                // For v0.14.1+: gateway provides BLAKE hash
-                // For pre-v0.14.1: gateway provides Poseidon hash
-                let expected_hash = if uses_blake { hashes.blake_hash } else { hashes.poseidon_hash };
-                if !self.config.no_check && expected_hash != gateway_hash {
-                    return Err(BlockImportError::CompiledClassHash {
-                        class_hash,
-                        got: gateway_hash,
-                        expected: expected_hash,
-                    });
-                }
-
-                // Store:
-                // - For v0.14.1+: compiled_class_hash = None, compiled_class_hash_v2 = BLAKE
-                // - For pre-v0.14.1: compiled_class_hash = Poseidon, compiled_class_hash_v2 = None
-                let (stored_poseidon, stored_blake) =
-                    if uses_blake { (None, Some(hashes.blake_hash)) } else { (Some(hashes.poseidon_hash), None) };
-
-                Ok(ConvertedClass::Sierra(SierraConvertedClass {
-                    class_hash,
-                    info: SierraClassInfo {
-                        contract_class: sierra.contract_class,
-                        compiled_class_hash: stored_poseidon,
-                        compiled_class_hash_v2: stored_blake,
-                    },
-                    compiled: Arc::new((&hashes.casm_class).try_into().map_err(|e| {
-                        BlockImportError::CompilationClassError {
-                            class_hash,
-                            error: ClassCompilationError::ParsingProgramJsonFailed(e),
+                match compile_result {
+                    Ok(hashes) => {
+                        // Verify compiled class hash based on protocol version
+                        let expected_hash = if uses_blake { hashes.blake_hash } else { hashes.poseidon_hash };
+                        if !self.config.no_check && expected_hash != gateway_hash {
+                            return Err(CompileResult::Error(BlockImportError::CompiledClassHash {
+                                class_hash,
+                                got: gateway_hash,
+                                expected: expected_hash,
+                            }));
                         }
-                    })?),
-                }))
+
+                        let (stored_poseidon, stored_blake) = if uses_blake {
+                            (None, Some(hashes.blake_hash))
+                        } else {
+                            (Some(hashes.poseidon_hash), None)
+                        };
+
+                        Ok(ConvertedClass::Sierra(SierraConvertedClass {
+                            class_hash,
+                            info: SierraClassInfo {
+                                contract_class: sierra.contract_class,
+                                compiled_class_hash: stored_poseidon,
+                                compiled_class_hash_v2: stored_blake,
+                            },
+                            compiled: Arc::new((&hashes.casm_class).try_into().map_err(|e| {
+                                CompileResult::Error(BlockImportError::CompilationClassError {
+                                    class_hash,
+                                    error: ClassCompilationError::ParsingProgramJsonFailed(e),
+                                })
+                            })?),
+                        }))
+                    }
+                    Err(compile_error) => {
+                        if self.casm_rpc_urls.is_empty() {
+                            Err(CompileResult::Error(BlockImportError::CompilationClassError {
+                                class_hash,
+                                error: compile_error,
+                            }))
+                        } else {
+                            // Compilation failed - signal that we need remote fetch
+                            // Don't do HTTP here to avoid blocking rayon threads
+                            Err(CompileResult::NeedsRemoteFetch {
+                                class_hash,
+                                sierra,
+                                uses_blake,
+                                gateway_hash,
+                                compile_error,
+                            })
+                        }
+                    }
+                }
             }
             ClassInfo::Legacy(legacy) => {
                 tracing::trace!("Converting legacy class with hash {:#x}", class_hash);
 
                 if !self.config.no_check && check_against != DeclaredClassCompiledClass::Legacy {
-                    return Err(BlockImportError::ClassType {
+                    return Err(CompileResult::Error(BlockImportError::ClassType {
                         class_hash,
                         got: ClassType::Sierra,
                         expected: ClassType::Legacy,
-                    });
+                    }));
                 }
 
                 // Verify class hash
@@ -429,7 +555,7 @@ impl BlockImporterCtx {
                     let mut expected = legacy
                         .contract_class
                         .compute_class_hash()
-                        .map_err(|e| BlockImportError::ComputeClassHash { class_hash, error: e })?;
+                        .map_err(|e| CompileResult::Error(BlockImportError::ComputeClassHash { class_hash, error: e }))?;
 
                     if let Some(block_n) = block_n {
                         if self.backend.chain_config().chain_id == ChainId::Mainnet {
@@ -441,7 +567,7 @@ impl BlockImporterCtx {
                     }
 
                     if !self.config.no_check && class_hash != expected {
-                        return Err(BlockImportError::ClassHash { got: class_hash, expected });
+                        return Err(CompileResult::Error(BlockImportError::ClassHash { got: class_hash, expected }));
                     }
                 }
 
@@ -682,7 +808,7 @@ mod tests {
 
         // AND: We have a validation context with specified trust_global_tries
         let validation = BlockValidationConfig::default();
-        let importer = BlockImporter::new(backend, validation);
+        let importer = BlockImporter::new(backend, validation, vec![]);
 
         // WHEN: We call update_tries with these parameters
         let result = importer.ctx().apply_to_global_trie(0..1, vec![state_diff]).map(|_| ());
@@ -707,7 +833,7 @@ mod tests {
 
         let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::starknet_sepolia()));
         let validation = BlockValidationConfig::default();
-        let importer = BlockImporter::new(backend.clone(), validation).ctx();
+        let importer = BlockImporter::new(backend.clone(), validation, vec![]).ctx();
 
         let block: FullBlock = block.into_full_block().unwrap();
 

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -146,7 +146,11 @@ impl BlockImporter {
     }
 
     fn ctx(&self) -> BlockImporterCtx {
-        BlockImporterCtx { backend: self.db.clone(), config: self.config.clone(), casm_rpc_urls: self.casm_rpc_urls.clone() }
+        BlockImporterCtx {
+            backend: self.db.clone(),
+            config: self.config.clone(),
+            casm_rpc_urls: self.casm_rpc_urls.clone(),
+        }
     }
 }
 
@@ -160,16 +164,19 @@ pub struct BlockImporterCtx {
 /// This allows us to defer remote CASM fetching to a sequential phase,
 /// avoiding blocking rayon threads with HTTP requests.
 enum CompileResult {
-    /// Class needs remote CASM fetch - compilation failed locally
-    NeedsRemoteFetch {
-        class_hash: Felt,
-        sierra: SierraClassInfo,
-        uses_blake: bool,
-        gateway_hash: Felt,
-        compile_error: ClassCompilationError,
-    },
+    /// Class needs remote CASM fetch - compilation failed locally.
+    /// Boxed to reduce enum size (SierraClassInfo is large).
+    NeedsRemoteFetch(Box<NeedsRemoteFetch>),
     /// Fatal error that should stop processing
     Error(BlockImportError),
+}
+
+struct NeedsRemoteFetch {
+    class_hash: Felt,
+    sierra: SierraClassInfo,
+    uses_blake: bool,
+    gateway_hash: Felt,
+    compile_error: ClassCompilationError,
 }
 
 impl BlockImporterCtx {
@@ -345,8 +352,7 @@ impl BlockImporterCtx {
             .map(|class| self.try_compile_class(block_n, class, check_against))
             .collect();
 
-        let needs_fetch_count =
-            results.iter().filter(|r| matches!(r, Err(CompileResult::NeedsRemoteFetch { .. }))).count();
+        let needs_fetch_count = results.iter().filter(|r| matches!(r, Err(CompileResult::NeedsRemoteFetch(_)))).count();
 
         // Phase 2: Process results - for classes that need remote fetch, do it sequentially
         // to avoid blocking multiple rayon threads with HTTP requests
@@ -363,13 +369,8 @@ impl BlockImporterCtx {
         for result in results {
             match result {
                 Ok(converted) => classes.push(converted),
-                Err(CompileResult::NeedsRemoteFetch {
-                    class_hash,
-                    sierra,
-                    uses_blake,
-                    gateway_hash,
-                    compile_error,
-                }) => {
+                Err(CompileResult::NeedsRemoteFetch(fetch)) => {
+                    let NeedsRemoteFetch { class_hash, sierra, uses_blake, gateway_hash, compile_error } = *fetch;
                     fetch_index += 1;
                     tracing::warn!(
                         "[{}/{}] Local compilation failed for class {:#x}: {}. Fetching from remote RPC...",
@@ -468,10 +469,9 @@ impl BlockImporterCtx {
 
                 // Verify class hash
                 if !self.config.no_check && !self.config.trust_class_hashes {
-                    let expected = sierra
-                        .contract_class
-                        .compute_class_hash()
-                        .map_err(|error| CompileResult::Error(BlockImportError::ComputeClassHash { class_hash, error }))?;
+                    let expected = sierra.contract_class.compute_class_hash().map_err(|error| {
+                        CompileResult::Error(BlockImportError::ComputeClassHash { class_hash, error })
+                    })?;
                     if !self.config.no_check && class_hash != expected {
                         return Err(CompileResult::Error(BlockImportError::ClassHash { got: class_hash, expected }));
                     }
@@ -528,13 +528,13 @@ impl BlockImporterCtx {
                         } else {
                             // Compilation failed - signal that we need remote fetch
                             // Don't do HTTP here to avoid blocking rayon threads
-                            Err(CompileResult::NeedsRemoteFetch {
+                            Err(CompileResult::NeedsRemoteFetch(Box::new(NeedsRemoteFetch {
                                 class_hash,
                                 sierra,
                                 uses_blake,
                                 gateway_hash,
                                 compile_error,
-                            })
+                            })))
                         }
                     }
                 }
@@ -552,10 +552,9 @@ impl BlockImporterCtx {
 
                 // Verify class hash
                 if !self.config.trust_class_hashes {
-                    let mut expected = legacy
-                        .contract_class
-                        .compute_class_hash()
-                        .map_err(|e| CompileResult::Error(BlockImportError::ComputeClassHash { class_hash, error: e }))?;
+                    let mut expected = legacy.contract_class.compute_class_hash().map_err(|e| {
+                        CompileResult::Error(BlockImportError::ComputeClassHash { class_hash, error: e })
+                    })?;
 
                     if let Some(block_n) = block_n {
                         if self.backend.chain_config().chain_id == ChainId::Mainnet {

--- a/madara/crates/client/sync/src/lib.rs
+++ b/madara/crates/client/sync/src/lib.rs
@@ -70,7 +70,7 @@
 //!     .all_verifications_disabled(true)
 //!     .trust_class_hashes(true);
 //!
-//! let importer = BlockImporter::new(backend, strict_config);
+//! let importer = BlockImporter::new(backend, strict_config, vec![]);
 //! ```
 //!
 //! # Sync Controller Configuration

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -33,6 +33,7 @@ fn ctx(gateway_mock: GatewayMock) -> TestContext {
     let importer = Arc::new(BlockImporter::new(
         backend.clone(),
         BlockValidationConfig::default().all_verifications_disabled(true),
+        vec![],
     ));
 
     let (service_state_sender, service_state_recv) = crate::util::service_state_channel();

--- a/madara/crates/client/sync/src/tests/realistic.rs
+++ b/madara/crates/client/sync/src/tests/realistic.rs
@@ -36,7 +36,7 @@ impl TestContext {
 #[fixture]
 fn ctx(gateway_mock: GatewayMock) -> TestContext {
     let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::starknet_sepolia()));
-    let importer = Arc::new(BlockImporter::new(backend.clone(), BlockValidationConfig::default()));
+    let importer = Arc::new(BlockImporter::new(backend.clone(), BlockValidationConfig::default(), vec![]));
 
     gateway_mock.mock_block_from_json(0, include_str!("../../../../resources/sepolia.block_0.json"));
     gateway_mock.mock_class_from_json(
@@ -200,7 +200,7 @@ async fn test_should_import(ctx: TestContext) {
 #[fixture]
 fn ctx_mainnet(gateway_mock: GatewayMock) -> TestContext {
     let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::starknet_mainnet()));
-    let importer = Arc::new(BlockImporter::new(backend.clone(), BlockValidationConfig::default()));
+    let importer = Arc::new(BlockImporter::new(backend.clone(), BlockValidationConfig::default(), vec![]));
 
     gateway_mock.mock_block_from_json(0, include_str!("../../../../resources/mainnet.block_0.json"));
     gateway_mock.mock_class_from_json(

--- a/madara/crates/client/sync/src/tests/reorg.rs
+++ b/madara/crates/client/sync/src/tests/reorg.rs
@@ -63,7 +63,7 @@ struct ReorgTestArgs {
 #[fixture]
 fn reorg_ctx(gateway_mock: GatewayMock) -> ReorgTestContext {
     let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::starknet_sepolia()));
-    let importer = Arc::new(BlockImporter::new(backend.clone(), BlockValidationConfig::default()));
+    let importer = Arc::new(BlockImporter::new(backend.clone(), BlockValidationConfig::default(), vec![]));
 
     // Set up genesis and base chain (blocks 0-2)
     gateway_mock.mock_block_from_json(0, include_str!("../../../../resources/sepolia.block_0.json"));

--- a/madara/crates/primitives/class/Cargo.toml
+++ b/madara/crates/primitives/class/Cargo.toml
@@ -45,6 +45,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+ureq = "2.9"
 
 [dev-dependencies]
 starknet-providers = { workspace = true }

--- a/madara/crates/primitives/class/src/casm_fetch.rs
+++ b/madara/crates/primitives/class/src/casm_fetch.rs
@@ -1,0 +1,151 @@
+//! Dynamic CASM fetching for Sierra classes that fail to compile locally.
+//!
+//! When a Sierra class fails to compile with the local compiler (e.g., due to
+//! version mismatches), this module provides functionality to fetch the pre-compiled
+//! CASM from a remote Starknet RPC endpoint.
+//!
+//! This is a fallback mechanism that allows sync to continue even when local
+//! compilation fails for certain classes.
+
+use casm_classes_v2::casm_contract_class::CasmContractClass;
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+use std::time::Duration;
+
+/// Timeout for RPC requests
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Error type for CASM fetching operations
+#[derive(Debug, thiserror::Error)]
+pub enum CasmFetchError {
+    #[error("HTTP request failed: {0}")]
+    HttpError(String),
+
+    #[error("Failed to parse JSON response: {0}")]
+    JsonParseError(String),
+
+    #[error("RPC error: code={code}, message={message}")]
+    RpcError { code: i64, message: String },
+
+    #[error("All RPC endpoints failed")]
+    AllEndpointsFailed,
+
+    #[error("No compiled CASM found for class")]
+    NotFound,
+
+    #[error("No RPC endpoints configured")]
+    NoEndpoints,
+}
+
+#[derive(Serialize)]
+struct JsonRpcRequest<'a> {
+    jsonrpc: &'static str,
+    method: &'static str,
+    params: JsonRpcParams<'a>,
+    id: u32,
+}
+
+#[derive(Serialize)]
+struct JsonRpcParams<'a> {
+    class_hash: &'a str,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcResponse {
+    result: Option<CasmContractClass>,
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+}
+
+/// Fetches compiled CASM for a Sierra class from remote RPC endpoints.
+///
+/// Tries each endpoint in order until one succeeds. Uses the `starknet_getCompiledCasm`
+/// RPC method.
+///
+/// # Arguments
+/// * `class_hash` - The class hash to fetch compiled CASM for
+/// * `endpoints` - List of RPC endpoint URLs to try
+///
+/// # Returns
+/// * `Ok(CasmContractClass)` - The compiled CASM if found
+/// * `Err(CasmFetchError)` - If all endpoints fail or class not found
+pub fn fetch_compiled_casm(class_hash: &Felt, endpoints: &[&str]) -> Result<CasmContractClass, CasmFetchError> {
+    if endpoints.is_empty() {
+        return Err(CasmFetchError::NoEndpoints);
+    }
+
+    let class_hash_hex = format!("{:#x}", class_hash);
+
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0",
+        method: "starknet_getCompiledCasm",
+        params: JsonRpcParams { class_hash: &class_hash_hex },
+        id: 1,
+    };
+
+    let request_body = serde_json::to_string(&request).map_err(|e| CasmFetchError::JsonParseError(e.to_string()))?;
+
+    let mut last_error = CasmFetchError::AllEndpointsFailed;
+
+    for endpoint in endpoints {
+        tracing::debug!("Trying to fetch compiled CASM from {}", endpoint);
+
+        match fetch_from_endpoint(endpoint, &request_body) {
+            Ok(casm) => {
+                tracing::info!("Successfully fetched compiled CASM for class {:#x} from {}", class_hash, endpoint);
+                return Ok(casm);
+            }
+            Err(e) => {
+                tracing::debug!("Failed to fetch from {}: {}", endpoint, e);
+                last_error = e;
+            }
+        }
+    }
+
+    Err(last_error)
+}
+
+/// Performs synchronous HTTP request to fetch CASM from a single endpoint.
+fn fetch_from_endpoint(endpoint: &str, request_body: &str) -> Result<CasmContractClass, CasmFetchError> {
+    let response = ureq::post(endpoint)
+        .set("Content-Type", "application/json")
+        .timeout(REQUEST_TIMEOUT)
+        .send_string(request_body)
+        .map_err(|e| CasmFetchError::HttpError(e.to_string()))?;
+
+    let response_text = response.into_string().map_err(|e| CasmFetchError::HttpError(e.to_string()))?;
+
+    let rpc_response: JsonRpcResponse = serde_json::from_str(&response_text).map_err(|e| {
+        CasmFetchError::JsonParseError(format!("{}: {}", e, &response_text[..200.min(response_text.len())]))
+    })?;
+
+    if let Some(error) = rpc_response.error {
+        return Err(CasmFetchError::RpcError { code: error.code, message: error.message });
+    }
+
+    rpc_response.result.ok_or(CasmFetchError::NotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "Requires network access"]
+    fn test_fetch_compiled_casm() {
+        let class_hash =
+            Felt::from_hex_unchecked("0x78d552edf8d22e566b050c9158d7f770b55021c36a9f5a98170ff8fcabc9e10");
+        let endpoints = ["https://free-rpc.nethermind.io/mainnet-juno/"];
+
+        let result = fetch_compiled_casm(&class_hash, &endpoints);
+        assert!(result.is_ok(), "Should fetch compiled CASM: {:?}", result);
+
+        let casm = result.unwrap();
+        assert!(!casm.bytecode.is_empty(), "CASM should have bytecode");
+    }
+}

--- a/madara/crates/primitives/class/src/casm_fetch.rs
+++ b/madara/crates/primitives/class/src/casm_fetch.rs
@@ -138,8 +138,7 @@ mod tests {
     #[test]
     #[ignore = "Requires network access"]
     fn test_fetch_compiled_casm() {
-        let class_hash =
-            Felt::from_hex_unchecked("0x78d552edf8d22e566b050c9158d7f770b55021c36a9f5a98170ff8fcabc9e10");
+        let class_hash = Felt::from_hex_unchecked("0x78d552edf8d22e566b050c9158d7f770b55021c36a9f5a98170ff8fcabc9e10");
         let endpoints = ["https://free-rpc.nethermind.io/mainnet-juno/"];
 
         let result = fetch_compiled_casm(&class_hash, &endpoints);

--- a/madara/crates/primitives/class/src/lib.rs
+++ b/madara/crates/primitives/class/src/lib.rs
@@ -18,6 +18,7 @@ use compile::ClassCompilationError;
 use starknet_types_core::felt::Felt;
 use std::{collections::HashMap, fmt, sync::Arc};
 
+pub mod casm_fetch;
 pub mod class_hash;
 pub mod class_update;
 pub mod compile;

--- a/madara/node/src/cli/l2.rs
+++ b/madara/node/src/cli/l2.rs
@@ -40,6 +40,12 @@ pub struct L2SyncParams {
     #[clap(env = "MADARA_GATEWAY_URL", long, value_parser = parse_url, value_name = "URL")]
     pub gateway_url: Option<Url>,
 
+    /// Comma-separated list of RPC endpoint URLs used to fetch compiled CASM when local
+    /// Sierra compilation fails. This is a fallback mechanism that allows sync to continue
+    /// even when the local compiler cannot handle certain classes.
+    #[clap(env = "MADARA_CASM_RPC_URL", long, value_name = "URL")]
+    pub casm_rpc_url: Option<String>,
+
     /// The port used for nodes to make rpc calls during a warp update.
     #[arg(env = "MADARA_WARP_UPDATE_PORT_RPC", long, value_name = "WARP UPDATE PORT RPC", default_value_t = RPC_DEFAULT_PORT_ADMIN)]
     pub warp_update_port_rpc: u16,

--- a/madara/node/src/service/l2.rs
+++ b/madara/node/src/service/l2.rs
@@ -70,12 +70,19 @@ impl Service for SyncService {
             return Ok(());
         }
         let this = self.start_args.take().expect("Service already started");
+        let casm_rpc_urls: Vec<String> = this
+            .params
+            .casm_rpc_url
+            .as_deref()
+            .map(|val| val.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect())
+            .unwrap_or_default();
+
         let importer = Arc::new(BlockImporter::new(
             this.db_backend.clone(),
-            // TODO(heemankv, 2025-10-26): all_verifications_disabled should be configured from the env
             BlockValidationConfig::default()
                 .trust_parent_hash(this.unsafe_starting_block_enabled)
                 .trust_state_root(this.unsafe_starting_block_enabled),
+            casm_rpc_urls,
         ));
 
         let config = SyncControllerConfig::default()


### PR DESCRIPTION
## Summary
This branch allows Madara to keep syncing even when local Sierra-to-CASM compilation fails for certain historical classes.

Before this change, if Madara hit an old class that it could not compile locally, sync could fail even though the class had already been compiled elsewhere on the network.

With this branch, Madara can:
- try local Sierra-to-CASM compilation first, as before
- detect classes whose local compilation failed
- fetch the compiled CASM remotely from a Starknet RPC node via `starknet_getCompiledCasm`
- continue syncing using the remotely fetched compiled class instead of failing immediately

## Why This Was Created
This was created to handle mainnet sync failures caused by very old historical classes that do not reliably compile in the local environment, typically because of compiler-version or historical compatibility mismatches.

In practice, the classes already exist on the network and can be served by another node that has them, so failing hard on local compilation is unnecessarily strict. This branch makes sync more robust by using a remote compiled-class fallback when local compilation is not possible.

## How It Works
- Phase 1: compile classes locally in parallel
- Phase 2: for the subset that failed local compilation, fetch compiled CASM sequentially from configured remote RPC endpoints

The remote fallback is opt-in and configured through:
- `--casm-rpc-url`
- `MADARA_CASM_RPC_URL`

Multiple endpoints can be provided as a comma-separated list for failover.

## Operational Impact
This allows a syncing Madara node to recover from historical class compilation failures without requiring manual class repair or patching for each affected class.

It is especially useful when syncing from mainnet or from an RPC source that can already serve the compiled CASM for those problematic historical classes.

## Test Plan
- [ ] Sync with no CASM RPC URL configured and confirm behavior stays unchanged
- [ ] Sync with `MADARA_CASM_RPC_URL` set and confirm failed local compilations fall back to remote CASM fetch
- [ ] Verify logs show local compilation first and remote fallback only for failed classes
- [ ] Run existing sync tests (`cargo test -p mc-sync`)
