### PR TITLE
feat: add --no-block-hash-check CLI arg and fix integration feeder URL

### DIFF
--- a/configs/presets/integration.yaml
+++ b/configs/presets/integration.yaml
@@ -1,7 +1,7 @@
 config_version: 1
 chain_name: "Starknet Sepolia"
 chain_id: "SN_INTEGRATION_SEPOLIA"
-feeder_gateway_url: "https://feeder.integration-sepolia.starknet.io/feeder_gateway/"
+feeder_gateway_url: "https://integration-sepolia.starknet.io/feeder_gateway/"
 gateway_url: "https://integration-sepolia.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 parent_fee_token_address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"

--- a/configs/presets/integration.yaml
+++ b/configs/presets/integration.yaml
@@ -1,7 +1,7 @@
 config_version: 1
 chain_name: "Starknet Sepolia"
 chain_id: "SN_INTEGRATION_SEPOLIA"
-feeder_gateway_url: "https://integration-sepolia.starknet.io/feeder_gateway/"
+feeder_gateway_url: "https://feeder.integration-sepolia.starknet.io/feeder_gateway/"
 gateway_url: "https://integration-sepolia.starknet.io/gateway/"
 native_fee_token_address: "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 parent_fee_token_address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"

--- a/madara/node/src/cli/l2.rs
+++ b/madara/node/src/cli/l2.rs
@@ -88,6 +88,12 @@ pub struct L2SyncParams {
     /// operators who want to manually handle chain divergences.
     #[clap(env = "MADARA_DISABLE_REORG", long, default_value_t = false)]
     pub disable_reorg: bool,
+
+    /// Disable all block hash verification checks during sync. This allows syncing blocks
+    /// without verifying block hashes, which can be useful for development or when syncing
+    /// against networks where hash computation may differ.
+    #[clap(env = "MADARA_NO_BLOCK_HASH_CHECK", long, default_value_t = false)]
+    pub no_block_hash_check: bool,
 }
 
 impl L2SyncParams {

--- a/madara/node/src/service/l2.rs
+++ b/madara/node/src/service/l2.rs
@@ -72,10 +72,10 @@ impl Service for SyncService {
         let this = self.start_args.take().expect("Service already started");
         let importer = Arc::new(BlockImporter::new(
             this.db_backend.clone(),
-            // TODO(heemankv, 2025-10-26): all_verifications_disabled should be configured from the env
             BlockValidationConfig::default()
                 .trust_parent_hash(this.unsafe_starting_block_enabled)
-                .trust_state_root(this.unsafe_starting_block_enabled),
+                .trust_state_root(this.unsafe_starting_block_enabled)
+                .all_verifications_disabled(this.params.no_block_hash_check),
         ));
 
         let config = SyncControllerConfig::default()


### PR DESCRIPTION
## Summary
- Add `--no-block-hash-check` / `MADARA_NO_BLOCK_HASH_CHECK` as a proper clap CLI argument following the existing config plumbing pattern through `L2SyncParams`, instead of reading env var directly at runtime
- Fix integration-sepolia feeder gateway URL to `feeder.integration-sepolia.starknet.io`

## Test plan
- [ ] Node starts without `--no-block-hash-check` — block hash verification is enabled (default behavior)
- [ ] Node starts with `--no-block-hash-check` — all block hash checks are skipped
- [ ] Node starts with `MADARA_NO_BLOCK_HASH_CHECK=true` env var — same as CLI flag
- [ ] Integration preset loads correctly with the updated feeder gateway URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)