### PR TITLE
fix: add integration-sepolia to pre-v0.13.2 block hash skip list

### DIFF
--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -189,10 +189,14 @@ impl BlockImporterCtx {
         const SEPOLIA_FIRST_V0_13_2: u64 = 86311;
         // First v0.13.2 mainnet block: https://voyager.online/block/671813.
         const MAINNET_FIRST_V0_13_2: u64 = 671813;
+        // First v0.13.2 integration-sepolia block.
+        const INTEGRATION_SEPOLIA_FIRST_V0_13_2: u64 = 35748;
 
         if signed_header.header.protocol_version < StarknetVersion::V0_13_2
             && ((self.backend.chain_config().chain_id == ChainId::Sepolia && block_n < SEPOLIA_FIRST_V0_13_2)
-                || (self.backend.chain_config().chain_id == ChainId::Mainnet && block_n < MAINNET_FIRST_V0_13_2))
+                || (self.backend.chain_config().chain_id == ChainId::Mainnet && block_n < MAINNET_FIRST_V0_13_2)
+                || (self.backend.chain_config().chain_id == ChainId::IntegrationSepolia
+                    && block_n < INTEGRATION_SEPOLIA_FIRST_V0_13_2))
         {
             // Skip integrity check.
             return Ok(());


### PR DESCRIPTION
## Summary
- Add `ChainId::IntegrationSepolia` (first v0.13.2 block: 35748) to the pre-v0.13.2 block hash verification skip list in `verify_header()`
- Previously, only mainnet and sepolia were in this list, causing integration-sepolia to fail at block 0 with a block hash mismatch

## Problem
When syncing the integration-sepolia network, Madara fails at block 0 with:
```
Block hash mismatch: expected 0x1fedbf8..., got 0x19f675d...
```

The root cause: `verify_header()` skips block hash verification for pre-v0.13.2 blocks on mainnet/sepolia (since the old hash algorithm doesn't cover all fields). But integration-sepolia (`SN_INTEGRATION_SEPOLIA`) was missing from this skip list, so Madara applied the v0.13.2 Poseidon hash algorithm to block 0 (version 0.12.3), which should use the older algorithm.

Both the feeder gateway and Pathfinder confirm the correct block 0 hash is `0x19f675d...` — Madara's "expected" value was wrong because it used the wrong hash algorithm.

## Test plan
- [x] Fresh sync of integration-sepolia from block 0 with all verification enabled (`MADARA_NO_BLOCK_HASH_CHECK=false`) — passes block 0 and continues syncing
- [x] Resumed sync from S3 backup (block ~9.1M) with all verification enabled — 299+ state root checks passed, 0 mismatches
- [x] Verified first v0.13.2 block on integration is 35748 via feeder gateway binary search

🤖 Generated with [Claude Code](https://claude.com/claude-code)