### PR TITLE
[codex] isolate Blacksmith Docker caches

### DIFF
--- a/.github/workflows/task-build-and-publish-release.yml
+++ b/.github/workflows/task-build-and-publish-release.yml
@@ -36,6 +36,8 @@ permissions:
 jobs:
   build-and-publish-release:
     runs-on: blacksmith-8vcpu-ubuntu-2204
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-${{ inputs.image-name }}
 
     steps:
       - name: Checkout repository
@@ -105,10 +107,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
 
       - name: Build Docker Image and Publish
         id: push
         uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
         with:
           context: .
           push: true

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -37,6 +37,8 @@ jobs:
   build-artifacts:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     if: inputs.should_run == 'true'
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-artifacts
     outputs:
       artifacts: ${{ steps.tag.outputs.artifacts }}
       artifacts-pr: ${{ steps.tag.outputs.artifacts-pr }}
@@ -77,10 +79,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
 
       - name: Build Docker image
         id: push
         uses: useblacksmith/build-push-action@v1.2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
         with:
           context: .
           push: false

--- a/.github/workflows/task-build-manual-and-publish.yml
+++ b/.github/workflows/task-build-manual-and-publish.yml
@@ -35,6 +35,8 @@ permissions:
 jobs:
   build-manual-and-publish:
     runs-on: blacksmith-8vcpu-ubuntu-2204
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-${{ inputs.image-name }}
     outputs:
       manual-sha: ${{ steps.tag.outputs.manual-sha }}
       manual-latest: ${{ steps.tag.outputs.manual-latest }}
@@ -97,10 +99,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
 
       - name: Build Docker Image and Publish
         id: push
         uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
         with:
           context: .
           push: true

--- a/.github/workflows/task-build-nightly-and-publish.yml
+++ b/.github/workflows/task-build-nightly-and-publish.yml
@@ -35,6 +35,8 @@ permissions:
 jobs:
   build-nightly-and-publish:
     runs-on: blacksmith-8vcpu-ubuntu-2204
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-${{ inputs.image-name }}
     outputs:
       nightly: ${{ steps.tag.outputs.nightly }}
       nightly-sha: ${{ steps.tag.outputs.nightly-sha }}
@@ -86,10 +88,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
 
       - name: Build Docker Image and Publish
         id: push
         uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
Isolate Blacksmith Docker sticky-disk caches per image/workflow instead of sharing one repo-wide BuildKit cache volume.

## Root Cause
The failed manual Docker image build on `fix/sla` was not failing in the Dockerfile or registry push path. Blacksmith's BuildKit failed while preparing a local snapshot from the sticky disk with a `rename ... file exists` error under `/var/lib/buildkit/runc-overlayfs/snapshots`.

Blacksmith keys its sticky disk by `GITHUB_REPO_NAME`. In the existing workflows, every Docker build in the repository reused the same repo-wide sticky disk, so a corrupted or inconsistent snapshot state could affect unrelated manual, nightly, release, and artifacts builds.

## What Changed
- Added a job-level `BLACKSMITH_DOCKER_CACHE_KEY` for each Docker workflow.
- Overrode `GITHUB_REPO_NAME` only for the Blacksmith `setup-docker-builder` and `build-push-action` steps.
- Used per-image cache keys for manual, nightly, and release image builds.
- Used a dedicated artifacts cache key for the artifacts image workflow.

## Impact
This keeps the Blacksmith-based build flow intact while isolating BuildKit sticky-disk state across image families, reducing the chance that one stale or corrupted cache volume breaks another Docker workflow.

## Validation
- Parsed the edited workflow YAML files successfully with Ruby's YAML parser.
- Ran `git diff --check` successfully.