### PR TITLE
Optimize CI setup graph and LLVM provisioning

### DIFF
--- a/.github/actions/setup-cairo-native/action.yml
+++ b/.github/actions/setup-cairo-native/action.yml
@@ -1,0 +1,113 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-action.json
+name: Action - Setup Cairo Native
+description: Configures the LLVM toolchain required by Cairo Native. The preferred runner image already includes LLVM; this action only installs it as a fallback.
+
+inputs:
+  llvm-version:
+    description: LLVM version required by Cairo Native
+    required: false
+    default: "19"
+  install-if-missing:
+    description: Whether to install LLVM from the repo Makefile when the runner image does not already provide it
+    required: false
+    default: "true"
+  codename:
+    description: Ubuntu/Debian codename used by the fallback installer
+    required: false
+    default: "jammy"
+
+runs:
+  using: composite
+  steps:
+    - name: Diagnose LLVM availability
+      shell: bash
+      run: |
+        LLVM_VERSION="${{ inputs.llvm-version }}"
+        LLVM_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+
+        echo "Diagnosing LLVM ${LLVM_VERSION} on runner"
+        echo "Runner kernel: $(uname -srmo)"
+
+        if [ -f /etc/os-release ]; then
+          echo "Runner OS:"
+          grep -E '^(NAME|VERSION|VERSION_CODENAME)=' /etc/os-release || true
+        fi
+
+        if command -v "clang-${LLVM_VERSION}" >/dev/null 2>&1; then
+          echo "clang-${LLVM_VERSION} path: $(command -v "clang-${LLVM_VERSION}")"
+          "clang-${LLVM_VERSION}" --version | head -n 1
+        elif [ -x "${LLVM_PREFIX}/bin/clang" ]; then
+          echo "clang path: ${LLVM_PREFIX}/bin/clang"
+          "${LLVM_PREFIX}/bin/clang" --version | head -n 1
+        else
+          echo "clang-${LLVM_VERSION} not found before setup"
+        fi
+
+        if command -v "lld-${LLVM_VERSION}" >/dev/null 2>&1; then
+          echo "lld-${LLVM_VERSION} path: $(command -v "lld-${LLVM_VERSION}")"
+          "lld-${LLVM_VERSION}" --version | head -n 1
+        elif [ -x "${LLVM_PREFIX}/bin/lld" ]; then
+          echo "lld path: ${LLVM_PREFIX}/bin/lld"
+          "${LLVM_PREFIX}/bin/lld" --version | head -n 1
+        elif [ -x "${LLVM_PREFIX}/bin/ld.lld" ]; then
+          echo "ld.lld path: ${LLVM_PREFIX}/bin/ld.lld"
+          "${LLVM_PREFIX}/bin/ld.lld" --version | head -n 1
+        else
+          echo "lld-${LLVM_VERSION} not found before setup"
+        fi
+
+        if [ -d "${LLVM_PREFIX}" ]; then
+          echo "LLVM prefix exists: ${LLVM_PREFIX}"
+        else
+          echo "LLVM prefix missing: ${LLVM_PREFIX}"
+        fi
+
+    - name: Ensure LLVM is available
+      shell: bash
+      run: |
+        LLVM_VERSION="${{ inputs.llvm-version }}"
+        LLVM_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+        HAS_CLANG=false
+        HAS_LINKER=false
+
+        if [ -d "${LLVM_PREFIX}" ] && { [ -x "${LLVM_PREFIX}/bin/clang-${LLVM_VERSION}" ] || [ -x "${LLVM_PREFIX}/bin/clang" ]; }; then
+          HAS_CLANG=true
+        fi
+
+        if [ -d "${LLVM_PREFIX}" ] && { [ -x "${LLVM_PREFIX}/bin/lld" ] || [ -x "${LLVM_PREFIX}/bin/lld-${LLVM_VERSION}" ] || [ -x "${LLVM_PREFIX}/bin/ld.lld" ] || [ -x "${LLVM_PREFIX}/bin/ld.lld-${LLVM_VERSION}" ]; }; then
+          HAS_LINKER=true
+        fi
+
+        if [ "${HAS_CLANG}" = "true" ] && [ "${HAS_LINKER}" = "true" ]; then
+          echo "LLVM ${LLVM_VERSION} already available on the runner image"
+          exit 0
+        fi
+
+        if [ "${{ inputs.install-if-missing }}" != "true" ]; then
+          echo "LLVM ${LLVM_VERSION} is required but missing from the runner image"
+          exit 1
+        fi
+
+        echo "LLVM ${LLVM_VERSION} not found on runner image, installing fallback toolchain"
+        make "install-llvm${LLVM_VERSION}" SUDO=sudo CODENAME="${{ inputs.codename }}"
+
+    - name: Export LLVM environment
+      shell: bash
+      run: |
+        LLVM_VERSION="${{ inputs.llvm-version }}"
+        LLVM_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+        LLVM_FAMILY_ENV_SUFFIX=$((LLVM_VERSION * 10))
+        LLVM_SYS_ENV_SUFFIX=$((LLVM_VERSION * 10 + 1))
+
+        echo "MLIR_SYS_${LLVM_FAMILY_ENV_SUFFIX}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
+        echo "LLVM_SYS_${LLVM_SYS_ENV_SUFFIX}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
+        echo "TABLEGEN_${LLVM_FAMILY_ENV_SUFFIX}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
+
+        echo "LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib" >> "$GITHUB_ENV"
+
+        echo "CC=clang-${LLVM_VERSION}" >> "$GITHUB_ENV"
+        echo "CXX=clang-${LLVM_VERSION}" >> "$GITHUB_ENV"
+        echo "LDFLAGS=-fuse-ld=lld-${LLVM_VERSION}" >> "$GITHUB_ENV"
+
+        echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-cairo-native/action.yml
+++ b/.github/actions/setup-cairo-native/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: LLVM version required by Cairo Native
     required: false
     default: "19"
+  llvm-sys-version:
+    description: llvm-sys crate version suffix used for LLVM_SYS_*_PREFIX
+    required: false
+    default: "191"
   install-if-missing:
     description: Whether to install LLVM from the repo Makefile when the runner image does not already provide it
     required: false
@@ -95,19 +99,19 @@ runs:
       shell: bash
       run: |
         LLVM_VERSION="${{ inputs.llvm-version }}"
+        LLVM_SYS_VERSION="${{ inputs.llvm-sys-version }}"
         LLVM_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
         LLVM_FAMILY_ENV_SUFFIX=$((LLVM_VERSION * 10))
-        LLVM_SYS_ENV_SUFFIX=$((LLVM_VERSION * 10 + 1))
 
         echo "MLIR_SYS_${LLVM_FAMILY_ENV_SUFFIX}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
-        echo "LLVM_SYS_${LLVM_SYS_ENV_SUFFIX}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
+        echo "LLVM_SYS_${LLVM_SYS_VERSION}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
         echo "TABLEGEN_${LLVM_FAMILY_ENV_SUFFIX}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
 
         echo "LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib" >> "$GITHUB_ENV"
         echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib" >> "$GITHUB_ENV"
 
         echo "CC=clang-${LLVM_VERSION}" >> "$GITHUB_ENV"
-        echo "CXX=clang-${LLVM_VERSION}" >> "$GITHUB_ENV"
+        echo "CXX=clang++-${LLVM_VERSION}" >> "$GITHUB_ENV"
         echo "LDFLAGS=-fuse-ld=lld-${LLVM_VERSION}" >> "$GITHUB_ENV"
 
         echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-cairo-native/action.yml
+++ b/.github/actions/setup-cairo-native/action.yml
@@ -27,14 +27,39 @@ runs:
       shell: bash
       run: |
         LLVM_VERSION="${{ inputs.llvm-version }}"
-        LLVM_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+        LLVM_DEFAULT_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+        LLVM_CONFIG=""
+
+        if command -v "llvm-config-${LLVM_VERSION}" >/dev/null 2>&1; then
+          LLVM_CONFIG="$(command -v "llvm-config-${LLVM_VERSION}")"
+        elif command -v llvm-config >/dev/null 2>&1 && [ "$(llvm-config --version | cut -d. -f1)" = "${LLVM_VERSION}" ]; then
+          LLVM_CONFIG="$(command -v llvm-config)"
+        elif [ -x "${LLVM_DEFAULT_PREFIX}/bin/llvm-config-${LLVM_VERSION}" ]; then
+          LLVM_CONFIG="${LLVM_DEFAULT_PREFIX}/bin/llvm-config-${LLVM_VERSION}"
+        elif [ -x "${LLVM_DEFAULT_PREFIX}/bin/llvm-config" ]; then
+          LLVM_CONFIG="${LLVM_DEFAULT_PREFIX}/bin/llvm-config"
+        fi
+
+        if [ -n "${LLVM_CONFIG}" ]; then
+          LLVM_PREFIX="$("${LLVM_CONFIG}" --prefix)"
+        else
+          LLVM_PREFIX="${LLVM_DEFAULT_PREFIX}"
+        fi
 
         echo "Diagnosing LLVM ${LLVM_VERSION} on runner"
         echo "Runner kernel: $(uname -srmo)"
+        echo "LLVM prefix candidate: ${LLVM_PREFIX}"
 
         if [ -f /etc/os-release ]; then
           echo "Runner OS:"
           grep -E '^(NAME|VERSION|VERSION_CODENAME)=' /etc/os-release || true
+        fi
+
+        if [ -n "${LLVM_CONFIG}" ]; then
+          echo "llvm-config path: ${LLVM_CONFIG}"
+          "${LLVM_CONFIG}" --version | head -n 1
+        else
+          echo "llvm-config-${LLVM_VERSION} not found before setup"
         fi
 
         if command -v "clang-${LLVM_VERSION}" >/dev/null 2>&1; then
@@ -70,9 +95,26 @@ runs:
       shell: bash
       run: |
         LLVM_VERSION="${{ inputs.llvm-version }}"
-        LLVM_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+        LLVM_DEFAULT_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+        LLVM_CONFIG=""
         HAS_CLANG=false
         HAS_LINKER=false
+
+        if command -v "llvm-config-${LLVM_VERSION}" >/dev/null 2>&1; then
+          LLVM_CONFIG="$(command -v "llvm-config-${LLVM_VERSION}")"
+        elif command -v llvm-config >/dev/null 2>&1 && [ "$(llvm-config --version | cut -d. -f1)" = "${LLVM_VERSION}" ]; then
+          LLVM_CONFIG="$(command -v llvm-config)"
+        elif [ -x "${LLVM_DEFAULT_PREFIX}/bin/llvm-config-${LLVM_VERSION}" ]; then
+          LLVM_CONFIG="${LLVM_DEFAULT_PREFIX}/bin/llvm-config-${LLVM_VERSION}"
+        elif [ -x "${LLVM_DEFAULT_PREFIX}/bin/llvm-config" ]; then
+          LLVM_CONFIG="${LLVM_DEFAULT_PREFIX}/bin/llvm-config"
+        fi
+
+        if [ -n "${LLVM_CONFIG}" ]; then
+          LLVM_PREFIX="$("${LLVM_CONFIG}" --prefix)"
+        else
+          LLVM_PREFIX="${LLVM_DEFAULT_PREFIX}"
+        fi
 
         if [ -d "${LLVM_PREFIX}" ] && { [ -x "${LLVM_PREFIX}/bin/clang-${LLVM_VERSION}" ] || [ -x "${LLVM_PREFIX}/bin/clang" ]; }; then
           HAS_CLANG=true
@@ -100,8 +142,25 @@ runs:
       run: |
         LLVM_VERSION="${{ inputs.llvm-version }}"
         LLVM_SYS_VERSION="${{ inputs.llvm-sys-version }}"
-        LLVM_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
+        LLVM_DEFAULT_PREFIX="/usr/lib/llvm-${LLVM_VERSION}"
         LLVM_FAMILY_ENV_SUFFIX=$((LLVM_VERSION * 10))
+        LLVM_CONFIG=""
+
+        if command -v "llvm-config-${LLVM_VERSION}" >/dev/null 2>&1; then
+          LLVM_CONFIG="$(command -v "llvm-config-${LLVM_VERSION}")"
+        elif command -v llvm-config >/dev/null 2>&1 && [ "$(llvm-config --version | cut -d. -f1)" = "${LLVM_VERSION}" ]; then
+          LLVM_CONFIG="$(command -v llvm-config)"
+        elif [ -x "${LLVM_DEFAULT_PREFIX}/bin/llvm-config-${LLVM_VERSION}" ]; then
+          LLVM_CONFIG="${LLVM_DEFAULT_PREFIX}/bin/llvm-config-${LLVM_VERSION}"
+        elif [ -x "${LLVM_DEFAULT_PREFIX}/bin/llvm-config" ]; then
+          LLVM_CONFIG="${LLVM_DEFAULT_PREFIX}/bin/llvm-config"
+        fi
+
+        if [ -n "${LLVM_CONFIG}" ]; then
+          LLVM_PREFIX="$("${LLVM_CONFIG}" --prefix)"
+        else
+          LLVM_PREFIX="${LLVM_DEFAULT_PREFIX}"
+        fi
 
         echo "MLIR_SYS_${LLVM_FAMILY_ENV_SUFFIX}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
         echo "LLVM_SYS_${LLVM_SYS_VERSION}_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"

--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -10,9 +10,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-
     - name: Setup Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:

--- a/.github/actions/setup-python-cairo/action.yml
+++ b/.github/actions/setup-python-cairo/action.yml
@@ -12,19 +12,11 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
-
-    #    - name: Cache Python dependencies
-    #      uses: actions/cache@v4
-    #      with:
-    #        path: |
-    #          sequencer_venv
-    #          ~/.cache/pip
-    #        key: python-cairo-${{ runner.os }}-${{ inputs.python-version }}-v3
-    #        restore-keys: |
-    #          python-cairo-${{ runner.os }}-${{ inputs.python-version }}-
+        cache: pip
+        cache-dependency-path: cairo_requirements.txt
 
     - name: Setup Python virtual environment with cairo-lang
       shell: bash

--- a/.github/actions/setup-python-cairo/action.yml
+++ b/.github/actions/setup-python-cairo/action.yml
@@ -11,11 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -6,6 +6,11 @@ inputs:
   rust-version:
     description: Rust version to set up
     required: true
+  cache-workspaces:
+    description: "Workspace to target-directory mappings cached by rust-cache"
+    required: false
+    default: |
+      . -> target
   extra-cache:
     description: "Whether or not to enable cached dependencies"
     required: false
@@ -22,11 +27,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
     - name: Setup Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
@@ -40,8 +40,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ inputs.cache-key }}
-        workspaces: |
-          . -> target
+        workspaces: ${{ inputs.cache-workspaces }}
         cache-workspace-crates: "true"
 
     - name: Setup mold

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-action.json
 name: Action - Setup Rust
-description: Sets up the Rust environment with a configurable toolchain
+description: Sets up the Rust toolchain and Rust build cache
 
 inputs:
   rust-version:
@@ -33,50 +33,16 @@ runs:
         toolchain: ${{ inputs.rust-version }}
         components: cargo, clippy, rustfmt
         rustflags: ""
-        cache: false # Disable built-in caching since we're using Blacksmith
+        cache: false # Disable built-in caching since this repo uses rust-cache explicitly
 
-    - name: Setup Blacksmith Rust Cache
+    - name: Setup Rust cache
       if: ${{ inputs.extra-cache == 'true' }}
-      uses: useblacksmith/rust-cache@v3
+      uses: Swatinem/rust-cache@v2
       with:
-        # Automatically handles:
-        # - ~/.cargo/bin
-        # - ~/.cargo/registry
-        # - ~/.cargo/git
-        # - target/ directories
-        # - Cargo.lock-based cache invalidation
         shared-key: ${{ inputs.cache-key }}
-
-    - name: Install dependencies
-      shell: bash
-      run: |
-        # Install LLVM 19 using Makefile target
-        make install-llvm19 SUDO=sudo CODENAME=jammy
-
-        # Set LLVM environment variables for Cairo Native
-        echo "MLIR_SYS_190_PREFIX=/usr/lib/llvm-19" >> $GITHUB_ENV
-        echo "LLVM_SYS_191_PREFIX=/usr/lib/llvm-19" >> $GITHUB_ENV
-        echo "TABLEGEN_190_PREFIX=/usr/lib/llvm-19" >> $GITHUB_ENV
-
-        # Configure linker search paths for Cairo Native runtime compilation
-        echo "LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib" >> $GITHUB_ENV
-
-        # Set up clang-19 as default clang for Cairo Native
-        sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-19/bin/clang-19 100
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-19/bin/clang++ 100
-
-        # Also set explicit compiler environment variables for Cairo Native runtime
-        # Note: clang-19 handles both C and C++ compilation
-        echo "CC=clang-19" >> $GITHUB_ENV
-        echo "CXX=clang-19" >> $GITHUB_ENV
-
-        # Configure linker for clang - use lld-19 for Cairo Native runtime compilation
-        # These flags are passed to clang when it invokes the linker
-        echo "LDFLAGS=-fuse-ld=lld-19" >> $GITHUB_ENV
-
-        # Add LLVM 19 binaries to PATH
-        echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
+        workspaces: |
+          . -> target
+        cache-workspace-crates: "true"
 
     - name: Setup mold
       uses: rui314/setup-mold@v1

--- a/.github/actions/setup-scarb/action.yml
+++ b/.github/actions/setup-scarb/action.yml
@@ -10,11 +10,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
     - name: Setup Scarb
       uses: software-mansion/setup-scarb@v1
       with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/nightly-run.yml
+++ b/.github/workflows/nightly-run.yml
@@ -19,7 +19,7 @@ jobs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check commits on main in previous UTC day

--- a/.github/workflows/pull-request-close.yml
+++ b/.github/workflows/pull-request-close.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/pull-request-main-ci.yml
+++ b/.github/workflows/pull-request-main-ci.yml
@@ -93,27 +93,38 @@ jobs:
   #                                   MADARA                                  #
   # ========================================================================= #
 
-  # Build Madara binary
+  # Build the runtime binary and reusable Cairo artifacts only.
+  # Madara test archives are split into separate producer jobs because
+  # `cargo nextest archive` still recompiles a large overlapping graph instead
+  # of cleanly reusing the release build one-for-one.
   build-madara:
     uses: ./.github/workflows/task-build-madara.yml
     secrets: inherit
 
+  build-madara-tests:
+    uses: ./.github/workflows/task-build-madara-tests.yml
+    secrets: inherit
+
+  build-migration-tests:
+    uses: ./.github/workflows/task-build-migration-tests.yml
+    secrets: inherit
+
   # Run integration tests
   test-madara:
-    needs: build-madara
+    needs: [build-madara, build-madara-tests]
     uses: ./.github/workflows/task-test-madara.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
-      madara-tests-hash: ${{ needs.build-madara.outputs.madara-tests-hash }}
+      madara-tests-hash: ${{ needs.build-madara-tests.outputs.madara-tests-hash }}
     secrets: inherit
 
   # Run migration tests
   test-migration:
-    needs: build-madara
+    needs: [build-madara, build-migration-tests]
     uses: ./.github/workflows/task-test-migration.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
-      migration-tests-hash: ${{ needs.build-madara.outputs.migration-tests-hash }}
+      migration-tests-hash: ${{ needs.build-migration-tests.outputs.migration-tests-hash }}
     secrets: inherit
 
   # Run JavaScript tests against the built binary

--- a/.github/workflows/pull-request-main-ci.yml
+++ b/.github/workflows/pull-request-main-ci.yml
@@ -80,13 +80,13 @@ jobs:
 
   # Run Rust-specific linters
   lint-rust:
-    needs: [update-version-db, publish-artifacts]
+    needs: update-version-db
     uses: ./.github/workflows/task-lint-cargo.yml
     secrets: inherit
 
   # Run linters for code style and quality
   lint-code-style:
-    needs: [update-version-db, publish-artifacts]
+    needs: update-version-db
     uses: ./.github/workflows/task-lint-code-style.yml
 
   # ========================================================================= #
@@ -95,16 +95,16 @@ jobs:
 
   # Build Madara binary
   build-madara:
-    needs: [lint-code-style]
     uses: ./.github/workflows/task-build-madara.yml
     secrets: inherit
 
-  # Run coverage tests
+  # Run integration tests
   test-madara:
     needs: build-madara
     uses: ./.github/workflows/task-test-madara.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
+      madara-tests-hash: ${{ needs.build-madara.outputs.madara-tests-hash }}
     secrets: inherit
 
   # Run migration tests
@@ -113,6 +113,7 @@ jobs:
     uses: ./.github/workflows/task-test-migration.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
+      migration-tests-hash: ${{ needs.build-madara.outputs.migration-tests-hash }}
     secrets: inherit
 
   # Run JavaScript tests against the built binary
@@ -127,32 +128,68 @@ jobs:
   test-cli:
     needs: build-madara
     uses: ./.github/workflows/task-test-cli.yml
+    with:
+      madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
     secrets: inherit
 
   # ========================================================================= #
   #                                ORCHESTRATOR                               #
   # ========================================================================= #
 
+  detect-orchestrator-runtime-changes:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    outputs:
+      should-run: ${{ steps.set-output.outputs.should-run }}
+    steps:
+      - name: Detect orchestrator runtime changes
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            orchestrator:
+              - 'orchestrator/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/actions/setup-rust/**'
+              - '.github/actions/setup-cairo-native/**'
+              - '.github/actions/setup-python-cairo/**'
+              - '.github/workflows/pull-request-main-ci.yml'
+              - '.github/workflows/task-build-binary.yml'
+              - '.github/workflows/task-build-orchestrator-tests.yml'
+              - '.github/workflows/task-check-orchestrator.yml'
+              - '.github/workflows/task-test-orchestrator.yml'
+
+      - name: Set check-orchestrator gate
+        id: set-output
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-run=${{ steps.filter.outputs.orchestrator }}" >> "$GITHUB_OUTPUT"
+          fi
+
   # Check Orchestrator binary
   # (We don't re-use the Orchestrator binary in other tests)
   check-orchestrator:
-    needs: lint-code-style
+    if: needs.detect-orchestrator-runtime-changes.outputs.should-run == 'true'
+    needs: [lint-code-style, detect-orchestrator-runtime-changes]
     uses: ./.github/workflows/task-check-orchestrator.yml
     secrets: inherit
 
-  # TODO: maybe we can remove the check, if we are building the binary ourselves ?
-  # Build Orchestrator binary
-  # build-orchestrator:
-  #   needs: lint-code-style
-  #   uses: ./.github/workflows/task-build-orchestrator.yml
-  #   secrets: inherit
+  # Build the archived orchestrator test binaries in parallel with Madara.
+  build-orchestrator-tests:
+    uses: ./.github/workflows/task-build-orchestrator-tests.yml
+    secrets: inherit
 
-  # Run coverage tests
+  # Run integration tests
   test-orchestrator:
-    needs: [build-madara, check-orchestrator]
+    needs: [build-madara, build-orchestrator-tests]
     uses: ./.github/workflows/task-test-orchestrator.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
+      cairo-artifacts-hash: ${{ needs.build-madara.outputs.cairo-artifacts-hash }}
+      orchestrator-tests-hash: ${{ needs.build-orchestrator-tests.outputs.orchestrator-tests-hash }}
     secrets: inherit
 
   # Run e2e tests

--- a/.github/workflows/pull-request-main-ci.yml
+++ b/.github/workflows/pull-request-main-ci.yml
@@ -93,12 +93,16 @@ jobs:
   #                                   MADARA                                  #
   # ========================================================================= #
 
-  # Build the runtime binary and reusable Cairo artifacts only.
-  # Madara test archives are split into separate producer jobs because
-  # `cargo nextest archive` still recompiles a large overlapping graph instead
-  # of cleanly reusing the release build one-for-one.
+  # Build the runtime binary and Cairo artifacts in separate producer jobs.
+  # Madara test archives are also split out because `cargo nextest archive`
+  # still recompiles a large overlapping graph instead of cleanly reusing the
+  # release build one-for-one.
   build-madara:
     uses: ./.github/workflows/task-build-madara.yml
+    secrets: inherit
+
+  build-cairo-artifacts:
+    uses: ./.github/workflows/task-build-cairo-artifacts.yml
     secrets: inherit
 
   build-madara-tests:
@@ -129,11 +133,11 @@ jobs:
 
   # Run JavaScript tests against the built binary
   test-js:
-    needs: build-madara
+    needs: [build-madara, build-cairo-artifacts]
     uses: ./.github/workflows/task-test-js.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
-      cairo-artifacts-hash: ${{ needs.build-madara.outputs.cairo-artifacts-hash }}
+      cairo-artifacts-hash: ${{ needs.build-cairo-artifacts.outputs.cairo-artifacts-hash }}
 
   # Run CLI tests against the built binary
   test-cli:
@@ -195,11 +199,11 @@ jobs:
 
   # Run integration tests
   test-orchestrator:
-    needs: [build-madara, build-orchestrator-tests]
+    needs: [build-madara, build-cairo-artifacts, build-orchestrator-tests]
     uses: ./.github/workflows/task-test-orchestrator.yml
     with:
       madara-binary-hash: ${{ needs.build-madara.outputs.madara-binary-hash }}
-      cairo-artifacts-hash: ${{ needs.build-madara.outputs.cairo-artifacts-hash }}
+      cairo-artifacts-hash: ${{ needs.build-cairo-artifacts.outputs.cairo-artifacts-hash }}
       orchestrator-tests-hash: ${{ needs.build-orchestrator-tests.outputs.orchestrator-tests-hash }}
     secrets: inherit
 

--- a/.github/workflows/schedule-daily-security-audit.yml
+++ b/.github/workflows/schedule-daily-security-audit.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository_owner == 'madara-alliance' || github.event_name != 'schedule' }}
     runs-on: blacksmith-8vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v5
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/task-build-and-publish-release.yml
+++ b/.github/workflows/task-build-and-publish-release.yml
@@ -54,8 +54,10 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: madara-${{ runner.os }}-rust-1.89
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Python Cairo setup (for apollo_starknet_os_program dependencies)
-        if: inputs.is-standalone == false
         uses: ./.github/actions/setup-python-cairo
         with:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}

--- a/.github/workflows/task-build-and-publish-release.yml
+++ b/.github/workflows/task-build-and-publish-release.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}-rust-1.89
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -100,7 +100,7 @@ jobs:
           outputs: type=docker,dest=${{ runner.temp }}/artifacts.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: artifacts
           path: ${{ runner.temp }}/artifacts.tar

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Load env
         uses: ./.github/actions/load-env
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Compile artifacts
         run: make artifacts
 

--- a/.github/workflows/task-build-artifacts.yml
+++ b/.github/workflows/task-build-artifacts.yml
@@ -104,3 +104,4 @@ jobs:
         with:
           name: artifacts
           path: ${{ runner.temp }}/artifacts.tar
+          retention-days: 3

--- a/.github/workflows/task-build-binary.yml
+++ b/.github/workflows/task-build-binary.yml
@@ -33,16 +33,25 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load env
         uses: ./.github/actions/load-env
 
-      - name: Rust setup
+      - name: Rust setup (workspace binary)
+        if: inputs.is-standalone == false
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: ${{ inputs.binary-name }}-${{ runner.os }}-rust-1.89${{ inputs.cache-key-suffix }}
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}${{ inputs.cache-key-suffix }}
+
+      - name: Rust setup (standalone binary)
+        if: inputs.is-standalone == true
+        uses: ./.github/actions/setup-rust
+        with:
+          rust-version: ${{ env.BUILD_RUST_VERSION }}
+          cache-key: ${{ inputs.binary-name }}-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}${{ inputs.cache-key-suffix }}
+          cache-workspaces: ${{ inputs.binary-name }} -> ${{ inputs.binary-name }}/target
 
       - name: Cairo Native setup
         if: inputs.is-standalone == false
@@ -89,7 +98,7 @@ jobs:
 
       # Upload binary as artifact
       - name: Upload ${{ inputs.binary-name }} binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.binary-name }}-binary-${{ steps.generate-binary-hash.outputs.binary-hash }}
           path: target/release/${{ inputs.binary-name }}

--- a/.github/workflows/task-build-binary.yml
+++ b/.github/workflows/task-build-binary.yml
@@ -44,6 +44,10 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: ${{ inputs.binary-name }}-${{ runner.os }}-rust-1.89${{ inputs.cache-key-suffix }}
 
+      - name: Cairo Native setup
+        if: inputs.is-standalone == false
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Python Cairo setup (for apollo_starknet_os_program dependencies)
         if: inputs.is-standalone == false
         uses: ./.github/actions/setup-python-cairo

--- a/.github/workflows/task-build-binary.yml
+++ b/.github/workflows/task-build-binary.yml
@@ -102,3 +102,4 @@ jobs:
         with:
           name: ${{ inputs.binary-name }}-binary-${{ steps.generate-binary-hash.outputs.binary-hash }}
           path: target/release/${{ inputs.binary-name }}
+          retention-days: 3

--- a/.github/workflows/task-build-cairo-artifacts.yml
+++ b/.github/workflows/task-build-cairo-artifacts.yml
@@ -28,6 +28,9 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Load env
+        uses: ./.github/actions/load-env
+
       - name: Build Cairo artifacts
         run: yes | make artifacts
 

--- a/.github/workflows/task-build-cairo-artifacts.yml
+++ b/.github/workflows/task-build-cairo-artifacts.yml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Build Runtime Cairo Artifacts
+
+# Build reusable Cairo artifacts in a dedicated producer job so the Docker-heavy
+# `make artifacts` step can run in parallel with the Madara release binary
+# build. The test-archive producer jobs intentionally keep their own local
+# artifact build because blocking them on shared artifacts regressed PR
+# wall-clock more than the duplicate compute helped.
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      cairo-artifacts-hash:
+        description: "Hash of the built cairo artifacts"
+        value: ${{ jobs.build-cairo-artifacts.outputs.cairo-artifacts-hash }}
+
+jobs:
+  build-cairo-artifacts:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    outputs:
+      cairo-artifacts-hash: ${{ steps.generate-artifact-hash.outputs.cairo-hash }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Cairo artifacts
+        run: yes | make artifacts
+
+      - name: Generate artifact hash
+        id: generate-artifact-hash
+        run: |
+          TIMESTAMP=$(date +%s)
+          CAIRO_HASH=$( { printf '%s\n' "$TIMESTAMP"; tar -cf - build-artifacts; } | sha256sum | awk '{ print $1 }')
+
+          echo "cairo-hash=$CAIRO_HASH" >> "$GITHUB_OUTPUT"
+          echo "Hash of cairo artifacts is: $CAIRO_HASH (with timestamp: $TIMESTAMP)"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-artifacts-${{ steps.generate-artifact-hash.outputs.cairo-hash }}
+          path: build-artifacts/**

--- a/.github/workflows/task-build-cairo-artifacts.yml
+++ b/.github/workflows/task-build-cairo-artifacts.yml
@@ -48,3 +48,4 @@ jobs:
         with:
           name: build-artifacts-${{ steps.generate-artifact-hash.outputs.cairo-hash }}
           path: build-artifacts/**
+          retention-days: 3

--- a/.github/workflows/task-build-madara-tests.yml
+++ b/.github/workflows/task-build-madara-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native
@@ -66,7 +66,7 @@ jobs:
           echo "Hash of Madara test archive is: $MADARA_TESTS_HASH (with timestamp: $TIMESTAMP)"
 
       - name: Upload Madara test archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: madara-tests-${{ steps.generate-hash.outputs.madara-tests-hash }}
           path: target/nextest/madara-tests.tar.zst

--- a/.github/workflows/task-build-madara-tests.yml
+++ b/.github/workflows/task-build-madara-tests.yml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Build Madara Test Archive
+
+# Build the Madara test archive in its own producer job.
+# CI logs showed `cargo nextest archive --features testing ...` recompiles a
+# large overlapping graph from the release build, so splitting it out shortens
+# PR wall-clock even if total compute goes up.
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      madara-tests-hash:
+        description: "Hash of the archived Madara test binaries"
+        value: ${{ jobs.build-madara-tests.outputs.madara-tests-hash }}
+
+jobs:
+  build-madara-tests:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    outputs:
+      madara-tests-hash: ${{ steps.generate-hash.outputs.madara-tests-hash }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load env
+        uses: ./.github/actions/load-env
+
+      - name: Rust setup
+        uses: ./.github/actions/setup-rust
+        with:
+          rust-version: ${{ env.BUILD_RUST_VERSION }}
+          cache-key: madara-${{ runner.os }}
+
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Build Cairo artifacts
+        run: yes | make artifacts
+
+      - name: Archive Madara tests
+        run: |
+          mkdir -p target/nextest
+          CARGO_TARGET_DIR=target cargo nextest archive \
+            --release \
+            --features testing \
+            --package "mc-*" \
+            --package "mp-*" \
+            --package "m-proc-*" \
+            --archive-file target/nextest/madara-tests.tar.zst
+
+      - name: Generate archive hash
+        id: generate-hash
+        run: |
+          TIMESTAMP=$(date +%s)
+          MADARA_TESTS_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/nextest/madara-tests.tar.zst; } | sha256sum | awk '{ print $1 }')
+
+          echo "madara-tests-hash=$MADARA_TESTS_HASH" >> $GITHUB_OUTPUT
+          echo "Hash of Madara test archive is: $MADARA_TESTS_HASH (with timestamp: $TIMESTAMP)"
+
+      - name: Upload Madara test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: madara-tests-${{ steps.generate-hash.outputs.madara-tests-hash }}
+          path: target/nextest/madara-tests.tar.zst

--- a/.github/workflows/task-build-madara-tests.yml
+++ b/.github/workflows/task-build-madara-tests.yml
@@ -70,3 +70,4 @@ jobs:
         with:
           name: madara-tests-${{ steps.generate-hash.outputs.madara-tests-hash }}
           path: target/nextest/madara-tests.tar.zst
+          retention-days: 3

--- a/.github/workflows/task-build-madara.yml
+++ b/.github/workflows/task-build-madara.yml
@@ -2,14 +2,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
 name: Task - Build Madara
 
-# This workflow builds the main Madara binary and related components
-# It also prepares the reusable Cairo artifacts consumed by downstream jobs.
+# This workflow builds only the main Madara runtime binary.
 #
-# Test archives are built in separate workflows on purpose. CI logs showed that
-# `cargo nextest archive --features testing ...` recompiles a large overlapping
-# Rust graph instead of behaving like a tiny delta on top of
-# `cargo build --bin madara --release`, so keeping those archive builds out of
-# this job improves PR wall-clock by parallelizing the producer lane.
+# The Docker-heavy `make artifacts` step now runs in its own producer workflow
+# so it no longer serializes the runtime binary lane on PRs. Test archives are
+# still built in separate workflows because `cargo nextest archive --features
+# testing ...` recompiles a large overlapping Rust graph instead of behaving
+# like a tiny delta on top of `cargo build --bin madara --release`.
 on:
   workflow_dispatch:
   workflow_call:
@@ -17,20 +16,16 @@ on:
       madara-binary-hash:
         description: "Hash of the built madara binary"
         value: ${{ jobs.build-binaries.outputs.madara-binary-hash }}
-      cairo-artifacts-hash:
-        description: "Hash of the cairo artifacts"
-        value: ${{ jobs.build-binaries.outputs.cairo-artifacts-hash }}
 
 jobs:
   build-binaries:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     outputs:
       madara-binary-hash: ${{ steps.generate-binary-hash.outputs.madara-hash }}
-      cairo-artifacts-hash: ${{ steps.generate-binary-hash.outputs.cairo-hash }}
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,47 +37,28 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
-
-      - name: Cairo Native setup
-        uses: ./.github/actions/setup-cairo-native
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       # Build Madara
       - name: Cargo build
         run: |
           CARGO_TARGET_DIR=target cargo build --bin madara --release
 
-      - name: Build Cairo artifacts
-        run: yes | make artifacts
-
-      # Generate hashes for all reusable build artifacts
+      # Generate hash for the reusable runtime binary.
       - name: Generate binary hashes
         id: generate-binary-hash
         run: |
           TIMESTAMP=$(date +%s)
 
           MADARA_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/release/madara; } | sha256sum | awk '{ print $1 }')
-          CAIRO_HASH=$( { printf '%s\n' "$TIMESTAMP"; tar -cf - build-artifacts; } | sha256sum | awk '{ print $1 }')
 
           echo "madara-hash=$MADARA_HASH" >> $GITHUB_OUTPUT
-          echo "cairo-hash=$CAIRO_HASH" >> $GITHUB_OUTPUT
 
           echo "Hash of the madara is: $MADARA_HASH (with timestamp: $TIMESTAMP)"
-          echo "Hash of cairo artifacts is: $CAIRO_HASH (with timestamp: $TIMESTAMP)"
 
       # Upload Madara binary as artifact
       - name: Upload Madara binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: madara-binary-${{ steps.generate-binary-hash.outputs.madara-hash }}
           path: target/release/madara
-
-      # Upload cairo artifacts
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts-${{ steps.generate-binary-hash.outputs.cairo-hash }}
-          path: build-artifacts/**

--- a/.github/workflows/task-build-madara.yml
+++ b/.github/workflows/task-build-madara.yml
@@ -39,6 +39,12 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
+      # The release binary still compiles crates that require LLVM tooling
+      # (for example `tblgen`), so this job needs the shared Cairo/LLVM setup
+      # even though `make artifacts` now runs in its own producer lane.
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       # Build Madara
       - name: Cargo build
         run: |

--- a/.github/workflows/task-build-madara.yml
+++ b/.github/workflows/task-build-madara.yml
@@ -14,6 +14,12 @@ on:
       cairo-artifacts-hash:
         description: "Hash of the cairo artifacts"
         value: ${{ jobs.build-binaries.outputs.cairo-artifacts-hash }}
+      madara-tests-hash:
+        description: "Hash of the archived madara test binaries"
+        value: ${{ jobs.build-binaries.outputs.madara-tests-hash }}
+      migration-tests-hash:
+        description: "Hash of the archived migration test binaries"
+        value: ${{ jobs.build-binaries.outputs.migration-tests-hash }}
 
 jobs:
   build-binaries:
@@ -21,6 +27,8 @@ jobs:
     outputs:
       madara-binary-hash: ${{ steps.generate-binary-hash.outputs.madara-hash }}
       cairo-artifacts-hash: ${{ steps.generate-binary-hash.outputs.cairo-hash }}
+      madara-tests-hash: ${{ steps.generate-binary-hash.outputs.madara-tests-hash }}
+      migration-tests-hash: ${{ steps.generate-binary-hash.outputs.migration-tests-hash }}
 
     steps:
       - name: Checkout Repository
@@ -38,29 +46,59 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: madara-${{ runner.os }}
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
       # Build Madara
       - name: Cargo build
         run: |
           CARGO_TARGET_DIR=target cargo build --bin madara --release
 
-      # Generate hash for the Madara binary
+      - name: Build Cairo artifacts
+        run: yes | make artifacts
+
+      - name: Archive Madara tests
+        run: |
+          mkdir -p target/nextest
+          CARGO_TARGET_DIR=target cargo nextest archive \
+            --release \
+            --features testing \
+            --package "mc-*" \
+            --package "mp-*" \
+            --package "m-proc-*" \
+            --archive-file target/nextest/madara-tests.tar.zst
+
+      - name: Archive migration tests
+        run: |
+          CARGO_TARGET_DIR=target cargo nextest archive \
+            --release \
+            --package mc-e2e-tests \
+            --features migration-tests \
+            --archive-file target/nextest/migration-tests.tar.zst
+
+      # Generate hashes for all reusable build artifacts
       - name: Generate binary hashes
         id: generate-binary-hash
         run: |
-          # Get current Unix timestamp for uniqueness
           TIMESTAMP=$(date +%s)
 
-          # Path to the compiled Madara binary
-          BINARY_PATH=./target/release/madara
-          HASH=$(echo "$TIMESTAMP" | cat - $BINARY_PATH | sha256sum | awk '{ print $1 }')
-          echo "madara-hash=$HASH" >> $GITHUB_OUTPUT
-          echo "Hash of the madara is: $HASH (with timestamp: $TIMESTAMP)"
+          MADARA_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/release/madara; } | sha256sum | awk '{ print $1 }')
+          CAIRO_HASH=$( { printf '%s\n' "$TIMESTAMP"; tar -cf - build-artifacts; } | sha256sum | awk '{ print $1 }')
+          MADARA_TESTS_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/nextest/madara-tests.tar.zst; } | sha256sum | awk '{ print $1 }')
+          MIGRATION_TESTS_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/nextest/migration-tests.tar.zst; } | sha256sum | awk '{ print $1 }')
 
-          # Path to the cairo artifacts
-          ARTIFACTS_PATH=./artifacts.tar.gz
-          HASH=$(echo "$TIMESTAMP" | cat - $ARTIFACTS_PATH | sha256sum | awk '{ print $1 }')
-          echo "cairo-hash=$HASH" >> $GITHUB_OUTPUT
-          echo "Hash of cairo artifacts is: $HASH (with timestamp: $TIMESTAMP)"
+          echo "madara-hash=$MADARA_HASH" >> $GITHUB_OUTPUT
+          echo "cairo-hash=$CAIRO_HASH" >> $GITHUB_OUTPUT
+          echo "madara-tests-hash=$MADARA_TESTS_HASH" >> $GITHUB_OUTPUT
+          echo "migration-tests-hash=$MIGRATION_TESTS_HASH" >> $GITHUB_OUTPUT
+
+          echo "Hash of the madara is: $MADARA_HASH (with timestamp: $TIMESTAMP)"
+          echo "Hash of cairo artifacts is: $CAIRO_HASH (with timestamp: $TIMESTAMP)"
+          echo "Hash of madara test archive is: $MADARA_TESTS_HASH (with timestamp: $TIMESTAMP)"
+          echo "Hash of migration test archive is: $MIGRATION_TESTS_HASH (with timestamp: $TIMESTAMP)"
 
       # Upload Madara binary as artifact
       - name: Upload Madara binary
@@ -75,3 +113,15 @@ jobs:
         with:
           name: build-artifacts-${{ steps.generate-binary-hash.outputs.cairo-hash }}
           path: build-artifacts/**
+
+      - name: Upload Madara test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: madara-tests-${{ steps.generate-binary-hash.outputs.madara-tests-hash }}
+          path: target/nextest/madara-tests.tar.zst
+
+      - name: Upload migration test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-tests-${{ steps.generate-binary-hash.outputs.migration-tests-hash }}
+          path: target/nextest/migration-tests.tar.zst

--- a/.github/workflows/task-build-madara.yml
+++ b/.github/workflows/task-build-madara.yml
@@ -3,7 +3,13 @@
 name: Task - Build Madara
 
 # This workflow builds the main Madara binary and related components
-# It also caches the build artifacts for other workflows to use
+# It also prepares the reusable Cairo artifacts consumed by downstream jobs.
+#
+# Test archives are built in separate workflows on purpose. CI logs showed that
+# `cargo nextest archive --features testing ...` recompiles a large overlapping
+# Rust graph instead of behaving like a tiny delta on top of
+# `cargo build --bin madara --release`, so keeping those archive builds out of
+# this job improves PR wall-clock by parallelizing the producer lane.
 on:
   workflow_dispatch:
   workflow_call:
@@ -14,12 +20,6 @@ on:
       cairo-artifacts-hash:
         description: "Hash of the cairo artifacts"
         value: ${{ jobs.build-binaries.outputs.cairo-artifacts-hash }}
-      madara-tests-hash:
-        description: "Hash of the archived madara test binaries"
-        value: ${{ jobs.build-binaries.outputs.madara-tests-hash }}
-      migration-tests-hash:
-        description: "Hash of the archived migration test binaries"
-        value: ${{ jobs.build-binaries.outputs.migration-tests-hash }}
 
 jobs:
   build-binaries:
@@ -27,8 +27,6 @@ jobs:
     outputs:
       madara-binary-hash: ${{ steps.generate-binary-hash.outputs.madara-hash }}
       cairo-artifacts-hash: ${{ steps.generate-binary-hash.outputs.cairo-hash }}
-      madara-tests-hash: ${{ steps.generate-binary-hash.outputs.madara-tests-hash }}
-      migration-tests-hash: ${{ steps.generate-binary-hash.outputs.migration-tests-hash }}
 
     steps:
       - name: Checkout Repository
@@ -60,25 +58,6 @@ jobs:
       - name: Build Cairo artifacts
         run: yes | make artifacts
 
-      - name: Archive Madara tests
-        run: |
-          mkdir -p target/nextest
-          CARGO_TARGET_DIR=target cargo nextest archive \
-            --release \
-            --features testing \
-            --package "mc-*" \
-            --package "mp-*" \
-            --package "m-proc-*" \
-            --archive-file target/nextest/madara-tests.tar.zst
-
-      - name: Archive migration tests
-        run: |
-          CARGO_TARGET_DIR=target cargo nextest archive \
-            --release \
-            --package mc-e2e-tests \
-            --features migration-tests \
-            --archive-file target/nextest/migration-tests.tar.zst
-
       # Generate hashes for all reusable build artifacts
       - name: Generate binary hashes
         id: generate-binary-hash
@@ -87,18 +66,12 @@ jobs:
 
           MADARA_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/release/madara; } | sha256sum | awk '{ print $1 }')
           CAIRO_HASH=$( { printf '%s\n' "$TIMESTAMP"; tar -cf - build-artifacts; } | sha256sum | awk '{ print $1 }')
-          MADARA_TESTS_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/nextest/madara-tests.tar.zst; } | sha256sum | awk '{ print $1 }')
-          MIGRATION_TESTS_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/nextest/migration-tests.tar.zst; } | sha256sum | awk '{ print $1 }')
 
           echo "madara-hash=$MADARA_HASH" >> $GITHUB_OUTPUT
           echo "cairo-hash=$CAIRO_HASH" >> $GITHUB_OUTPUT
-          echo "madara-tests-hash=$MADARA_TESTS_HASH" >> $GITHUB_OUTPUT
-          echo "migration-tests-hash=$MIGRATION_TESTS_HASH" >> $GITHUB_OUTPUT
 
           echo "Hash of the madara is: $MADARA_HASH (with timestamp: $TIMESTAMP)"
           echo "Hash of cairo artifacts is: $CAIRO_HASH (with timestamp: $TIMESTAMP)"
-          echo "Hash of madara test archive is: $MADARA_TESTS_HASH (with timestamp: $TIMESTAMP)"
-          echo "Hash of migration test archive is: $MIGRATION_TESTS_HASH (with timestamp: $TIMESTAMP)"
 
       # Upload Madara binary as artifact
       - name: Upload Madara binary
@@ -113,15 +86,3 @@ jobs:
         with:
           name: build-artifacts-${{ steps.generate-binary-hash.outputs.cairo-hash }}
           path: build-artifacts/**
-
-      - name: Upload Madara test archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: madara-tests-${{ steps.generate-binary-hash.outputs.madara-tests-hash }}
-          path: target/nextest/madara-tests.tar.zst
-
-      - name: Upload migration test archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: migration-tests-${{ steps.generate-binary-hash.outputs.migration-tests-hash }}
-          path: target/nextest/migration-tests.tar.zst

--- a/.github/workflows/task-build-madara.yml
+++ b/.github/workflows/task-build-madara.yml
@@ -68,3 +68,4 @@ jobs:
         with:
           name: madara-binary-${{ steps.generate-binary-hash.outputs.madara-hash }}
           path: target/release/madara
+          retention-days: 3

--- a/.github/workflows/task-build-manual-and-publish.yml
+++ b/.github/workflows/task-build-manual-and-publish.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}-rust-1.89
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native

--- a/.github/workflows/task-build-manual-and-publish.yml
+++ b/.github/workflows/task-build-manual-and-publish.yml
@@ -56,8 +56,10 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: madara-${{ runner.os }}-rust-1.89
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Python Cairo setup (for apollo_starknet_os_program dependencies)
-        if: inputs.is-standalone == false
         uses: ./.github/actions/setup-python-cairo
         with:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}

--- a/.github/workflows/task-build-migration-tests.yml
+++ b/.github/workflows/task-build-migration-tests.yml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Build Migration Test Archive
+
+# Build the migration test archive separately for the same reason as the main
+# Madara test archive: the nextest archive compilation still rebuilds a large
+# overlapping graph, so a dedicated producer job is better for PR wall-clock.
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      migration-tests-hash:
+        description: "Hash of the archived migration test binaries"
+        value: ${{ jobs.build-migration-tests.outputs.migration-tests-hash }}
+
+jobs:
+  build-migration-tests:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    outputs:
+      migration-tests-hash: ${{ steps.generate-hash.outputs.migration-tests-hash }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load env
+        uses: ./.github/actions/load-env
+
+      - name: Rust setup
+        uses: ./.github/actions/setup-rust
+        with:
+          rust-version: ${{ env.BUILD_RUST_VERSION }}
+          cache-key: madara-${{ runner.os }}
+
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Build Cairo artifacts
+        run: yes | make artifacts
+
+      - name: Archive migration tests
+        run: |
+          mkdir -p target/nextest
+          CARGO_TARGET_DIR=target cargo nextest archive \
+            --release \
+            --package mc-e2e-tests \
+            --features migration-tests \
+            --archive-file target/nextest/migration-tests.tar.zst
+
+      - name: Generate archive hash
+        id: generate-hash
+        run: |
+          TIMESTAMP=$(date +%s)
+          MIGRATION_TESTS_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/nextest/migration-tests.tar.zst; } | sha256sum | awk '{ print $1 }')
+
+          echo "migration-tests-hash=$MIGRATION_TESTS_HASH" >> $GITHUB_OUTPUT
+          echo "Hash of migration test archive is: $MIGRATION_TESTS_HASH (with timestamp: $TIMESTAMP)"
+
+      - name: Upload migration test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-tests-${{ steps.generate-hash.outputs.migration-tests-hash }}
+          path: target/nextest/migration-tests.tar.zst

--- a/.github/workflows/task-build-migration-tests.yml
+++ b/.github/workflows/task-build-migration-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native
@@ -63,7 +63,7 @@ jobs:
           echo "Hash of migration test archive is: $MIGRATION_TESTS_HASH (with timestamp: $TIMESTAMP)"
 
       - name: Upload migration test archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: migration-tests-${{ steps.generate-hash.outputs.migration-tests-hash }}
           path: target/nextest/migration-tests.tar.zst

--- a/.github/workflows/task-build-migration-tests.yml
+++ b/.github/workflows/task-build-migration-tests.yml
@@ -67,3 +67,4 @@ jobs:
         with:
           name: migration-tests-${{ steps.generate-hash.outputs.migration-tests-hash }}
           path: target/nextest/migration-tests.tar.zst
+          retention-days: 3

--- a/.github/workflows/task-build-nightly-and-publish.yml
+++ b/.github/workflows/task-build-nightly-and-publish.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}-rust-1.89
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native

--- a/.github/workflows/task-build-nightly-and-publish.yml
+++ b/.github/workflows/task-build-nightly-and-publish.yml
@@ -56,8 +56,10 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: madara-${{ runner.os }}-rust-1.89
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Python Cairo setup (for apollo_starknet_os_program dependencies)
-        if: inputs.is-standalone == false
         uses: ./.github/actions/setup-python-cairo
         with:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}

--- a/.github/workflows/task-build-orchestrator-tests.yml
+++ b/.github/workflows/task-build-orchestrator-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native
@@ -65,7 +65,7 @@ jobs:
           echo "Hash of orchestrator test archive is: $ORCHESTRATOR_TESTS_HASH (with timestamp: $TIMESTAMP)"
 
       - name: Upload orchestrator test archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: orchestrator-tests-${{ steps.generate-hash.outputs.orchestrator-tests-hash }}
           path: target/nextest/orchestrator-tests.tar.zst

--- a/.github/workflows/task-build-orchestrator-tests.yml
+++ b/.github/workflows/task-build-orchestrator-tests.yml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Build Orchestrator Test Archive
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      orchestrator-tests-hash:
+        description: "Hash of the archived orchestrator test binaries"
+        value: ${{ jobs.build-orchestrator-tests.outputs.orchestrator-tests-hash }}
+
+jobs:
+  build-orchestrator-tests:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    outputs:
+      orchestrator-tests-hash: ${{ steps.generate-hash.outputs.orchestrator-tests-hash }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load env
+        uses: ./.github/actions/load-env
+
+      - name: Rust setup
+        uses: ./.github/actions/setup-rust
+        with:
+          rust-version: ${{ env.BUILD_RUST_VERSION }}
+          cache-key: madara-${{ runner.os }}
+
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Build Cairo artifacts
+        run: yes | make artifacts
+
+      - name: Python Cairo setup (before orchestrator archive build)
+        uses: ./.github/actions/setup-python-cairo
+        with:
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
+
+      - name: Archive orchestrator tests
+        run: |
+          mkdir -p target/nextest
+          CARGO_TARGET_DIR=target cargo nextest archive \
+            --release \
+            --features testing \
+            --package "orchestrator*" \
+            --archive-file target/nextest/orchestrator-tests.tar.zst
+
+      - name: Generate archive hash
+        id: generate-hash
+        run: |
+          TIMESTAMP=$(date +%s)
+          ORCHESTRATOR_TESTS_HASH=$( { printf '%s\n' "$TIMESTAMP"; cat target/nextest/orchestrator-tests.tar.zst; } | sha256sum | awk '{ print $1 }')
+
+          echo "orchestrator-tests-hash=$ORCHESTRATOR_TESTS_HASH" >> $GITHUB_OUTPUT
+          echo "Hash of orchestrator test archive is: $ORCHESTRATOR_TESTS_HASH (with timestamp: $TIMESTAMP)"
+
+      - name: Upload orchestrator test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: orchestrator-tests-${{ steps.generate-hash.outputs.orchestrator-tests-hash }}
+          path: target/nextest/orchestrator-tests.tar.zst

--- a/.github/workflows/task-build-orchestrator-tests.yml
+++ b/.github/workflows/task-build-orchestrator-tests.yml
@@ -69,3 +69,4 @@ jobs:
         with:
           name: orchestrator-tests-${{ steps.generate-hash.outputs.orchestrator-tests-hash }}
           path: target/nextest/orchestrator-tests.tar.zst
+          retention-days: 3

--- a/.github/workflows/task-check-bootstrapper.yml
+++ b/.github/workflows/task-check-bootstrapper.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load env
         uses: ./.github/actions/load-env
@@ -23,7 +23,8 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          extra-cache: false
+          cache-key: bootstrapper-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
+          cache-workspaces: bootstrapper -> bootstrapper/target
 
       # Check Bootstrapper (standalone project)
       - name: Cargo check

--- a/.github/workflows/task-check-orchestrator.yml
+++ b/.github/workflows/task-check-orchestrator.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
-name: Task - Build Orchestrator
+name: Task - Check Orchestrator (Production)
 
 on:
   workflow_dispatch:
@@ -28,6 +28,9 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           extra-cache: false
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Compile artifacts
         run: make artifacts
 
@@ -36,7 +39,6 @@ jobs:
         with:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}
 
-      # Check Orchestrator
-      - name: Cargo check
+      - name: Cargo check production orchestrator
         run: |
           cargo check -p orchestrator --release

--- a/.github/workflows/task-check-orchestrator.yml
+++ b/.github/workflows/task-check-orchestrator.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          extra-cache: false
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native

--- a/.github/workflows/task-ci-version-file.yml
+++ b/.github/workflows/task-ci-version-file.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           submodules: recursive

--- a/.github/workflows/task-e2e-orchestrator.yml
+++ b/.github/workflows/task-e2e-orchestrator.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          extra-cache: false
+          cache-key: workspace-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native
@@ -69,7 +69,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download Madara binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/

--- a/.github/workflows/task-e2e-orchestrator.yml
+++ b/.github/workflows/task-e2e-orchestrator.yml
@@ -62,6 +62,9 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           extra-cache: false
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/task-lint-cargo.yml
+++ b/.github/workflows/task-lint-cargo.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          extra-cache: false
+          cache-key: workspace-clippy-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native

--- a/.github/workflows/task-lint-cargo.yml
+++ b/.github/workflows/task-lint-cargo.yml
@@ -24,6 +24,9 @@ jobs:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           extra-cache: false
 
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
+
       - name: Scarb setup
         uses: ./.github/actions/setup-scarb
         with:

--- a/.github/workflows/task-lint-code-style.yml
+++ b/.github/workflows/task-lint-code-style.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -46,7 +46,7 @@ jobs:
   toml-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/task-publish-image.yml
+++ b/.github/workflows/task-publish-image.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Download ${{ inputs.image-name }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.image-name }}
           path: ${{ runner.temp }}

--- a/.github/workflows/task-publish-stable.yml
+++ b/.github/workflows/task-publish-stable.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/task-test-bootstrapper.yml
+++ b/.github/workflows/task-test-bootstrapper.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
           cache-key: madara-${{ runner.os }}
+
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/.github/workflows/task-test-bootstrapper.yml
+++ b/.github/workflows/task-test-bootstrapper.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -41,7 +41,8 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
+          cache-key: bootstrapper-release-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
+          cache-workspaces: bootstrapper -> bootstrapper/target
 
       - name: Cairo Native setup
         uses: ./.github/actions/setup-cairo-native
@@ -52,7 +53,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download Madara binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/

--- a/.github/workflows/task-test-cli.yml
+++ b/.github/workflows/task-test-cli.yml
@@ -4,6 +4,11 @@ name: Task - Run CLI tests
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      madara-binary-hash:
+        description: "Hash used to retrieve the madara binary artifact"
+        required: true
+        type: string
 jobs:
   test-cli:
     runs-on: blacksmith-4vcpu-ubuntu-2204
@@ -14,22 +19,26 @@ jobs:
           submodules: recursive
       - name: Load env
         uses: ./.github/actions/load-env
-      - name: Rust setup
-        uses: ./.github/actions/setup-rust
+      - name: Download Madara binary
+        uses: actions/download-artifact@v4
         with:
-          rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
+          name: madara-binary-${{ inputs.madara-binary-hash }}
+          path: target/release/
+      - name: Make Madara binary executable
+        run: chmod +x target/release/madara
       - name: Run cli without arguments
         timeout-minutes: 20
         run: |
-          CARGO_TARGET_DIR=target cargo run --bin madara --release -- --no-l1-sync --devnet &
+          ./target/release/madara --no-l1-sync --devnet &
           MADARA_PID=$!
           while ! curl -s -X POST http://localhost:9944 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"starknet_chainId","params":[],"id":1}' | grep -q result; do sleep 1; done
           kill $MADARA_PID
+          wait $MADARA_PID || true
       - name: Run cli pointing to a file
         timeout-minutes: 20
         run: |
-          CARGO_TARGET_DIR=target cargo run --bin madara --release -- --no-l1-sync --devnet --config-file ./configs/args/config.json &
+          ./target/release/madara --no-l1-sync --devnet --config-file ./configs/args/config.json &
           MADARA_PID=$!
           while ! curl -s -X POST http://localhost:9944 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"starknet_chainId","params":[],"id":1}' | grep -q result; do sleep 1; done
           kill $MADARA_PID
+          wait $MADARA_PID || true

--- a/.github/workflows/task-test-cli.yml
+++ b/.github/workflows/task-test-cli.yml
@@ -3,6 +3,11 @@
 name: Task - Run CLI tests
 on:
   workflow_dispatch:
+    inputs:
+      madara-binary-hash:
+        description: "Hash used to retrieve the madara binary artifact"
+        required: true
+        type: string
   workflow_call:
     inputs:
       madara-binary-hash:

--- a/.github/workflows/task-test-cli.yml
+++ b/.github/workflows/task-test-cli.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Load env
         uses: ./.github/actions/load-env
       - name: Download Madara binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/

--- a/.github/workflows/task-test-end-to-end.yml
+++ b/.github/workflows/task-test-end-to-end.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load env
         uses: ./.github/actions/load-env
@@ -33,7 +33,10 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          extra-cache: false
+          cache-key: workspace-dev-${{ runner.os }}-rust-${{ env.BUILD_RUST_VERSION }}
+
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
 
       - name: Setup Python Cairo (needed for orchestrator build)
         uses: ./.github/actions/setup-python-cairo

--- a/.github/workflows/task-test-hive.yml
+++ b/.github/workflows/task-test-hive.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Download madara
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara
           path: ${{ runner.temp }}

--- a/.github/workflows/task-test-js.yml
+++ b/.github/workflows/task-test-js.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Download Madara binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/
@@ -36,7 +36,7 @@ jobs:
         run: chmod +x target/release/madara
 
       - name: Download Cairo artiracts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-artifacts-${{ inputs.cairo-artifacts-hash }}
           path: build-artifacts/

--- a/.github/workflows/task-test-madara.yml
+++ b/.github/workflows/task-test-madara.yml
@@ -97,6 +97,7 @@ jobs:
           PROPTEST_CASES: ${{ inputs.proptest-cases }}
           ANVIL_URL: ${{ env.ANVIL_DEFAULT_URL }}
         run: |
+          export COVERAGE_BIN="$(realpath target/release/madara)"
           cargo nextest run \
             --archive-file target/nextest/madara-tests.tar.zst \
             --workspace-remap "$GITHUB_WORKSPACE" \

--- a/.github/workflows/task-test-madara.yml
+++ b/.github/workflows/task-test-madara.yml
@@ -1,9 +1,8 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
-name: Task - Integration Tests and Coverage (Madara)
+name: Task - Integration Tests (Madara)
 
-# This workflow runs integration tests and generates code coverage
-# reports for the Madara codebase
+# This workflow runs Madara integration tests from a prebuilt nextest archive
 on:
   workflow_dispatch:
   workflow_call:
@@ -15,6 +14,10 @@ on:
         default: "10"
       madara-binary-hash:
         description: "Hash used to retrieve the artifact"
+        required: true
+        type: string
+      madara-tests-hash:
+        description: "Hash used to retrieve the archived test binaries"
         required: true
         type: string
     secrets:
@@ -46,10 +49,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+          extra-cache: false
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -60,6 +60,12 @@ jobs:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/
       - run: chmod +x target/release/madara
+
+      - name: Download Madara test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: madara-tests-${{ inputs.madara-tests-hash }}
+          path: target/nextest/
 
       - name: Start Anvil with fork
         run: |
@@ -84,32 +90,18 @@ jobs:
             exit 1
           fi
 
-      - name: Run make artifacts
-        run: yes | make artifacts
-
-      - name: Run tests with coverage
+      - name: Run tests
         env:
           ETH_FORK_URL: ${{ secrets.ETH_FORK_URL }}
           GATEWAY_KEY: ${{ secrets.GITHUB_GATEWAY_KEY || '' }}
           PROPTEST_CASES: ${{ inputs.proptest-cases }}
-          LLVM_PROFILE_FILE: "madara-%p-%m.profraw"
           ANVIL_URL: ${{ env.ANVIL_DEFAULT_URL }}
-          # Cairo Native runtime compilation: use lld instead of mold
-          LDFLAGS: "-fuse-ld=lld-19"
         run: |
           export COVERAGE_BIN=$(realpath target/release/madara)
-          rm -f target/madara-* lcov.info
-
-          # run tests for madara client / primitive crates
-          cargo llvm-cov nextest \
-              --release \
-              --features testing \
-              --lcov \
-              --output-path lcov.info \
-              --package "mc-*" \
-              --package "mp-*" \
-              --package "m-proc-*" \
-              --no-fail-fast
+          cargo nextest run \
+            --archive-file target/nextest/madara-tests.tar.zst \
+            --workspace-remap "$GITHUB_WORKSPACE" \
+            --no-fail-fast
 
       - name: Kill Anvil
         if: always()
@@ -121,11 +113,3 @@ jobs:
           else
             echo "No Anvil PID found"
           fi
-
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
-        continue-on-error: true
-        with:
-          parallel-finished: true
-          files: lcov.info
-          debug: true

--- a/.github/workflows/task-test-madara.yml
+++ b/.github/workflows/task-test-madara.yml
@@ -97,7 +97,6 @@ jobs:
           PROPTEST_CASES: ${{ inputs.proptest-cases }}
           ANVIL_URL: ${{ env.ANVIL_DEFAULT_URL }}
         run: |
-          export COVERAGE_BIN=$(realpath target/release/madara)
           cargo nextest run \
             --archive-file target/nextest/madara-tests.tar.zst \
             --workspace-remap "$GITHUB_WORKSPACE" \

--- a/.github/workflows/task-test-madara.yml
+++ b/.github/workflows/task-test-madara.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -55,14 +55,14 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download Madara binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/
       - run: chmod +x target/release/madara
 
       - name: Download Madara test archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-tests-${{ inputs.madara-tests-hash }}
           path: target/nextest/

--- a/.github/workflows/task-test-migration.yml
+++ b/.github/workflows/task-test-migration.yml
@@ -17,6 +17,10 @@ on:
         description: "Hash used to retrieve the madara binary artifact"
         required: true
         type: string
+      migration-tests-hash:
+        description: "Hash used to retrieve the archived migration test binaries"
+        required: true
+        type: string
 
 jobs:
   migration-test:
@@ -62,14 +66,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
-          path: madara/target/release/
+          path: target/release/
 
       - name: Make binary executable
-        run: chmod +x madara/target/release/madara
+        run: chmod +x target/release/madara
 
       - name: Start madara
         run: |
-          cd madara
           ./target/release/madara \
             --full \
             --base-path /tmp/migration-test \
@@ -104,11 +107,24 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
+          extra-cache: false
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Download migration test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: migration-tests-${{ inputs.migration-tests-hash }}
+          path: target/nextest/
 
       - name: Run migration tests
-        working-directory: madara
-        run: cargo test -p mc-e2e-tests --features migration-tests rpc::migration
+        run: |
+          cargo nextest run \
+            --archive-file target/nextest/migration-tests.tar.zst \
+            --workspace-remap "$GITHUB_WORKSPACE" \
+            --no-fail-fast \
+            rpc::migration
         env:
           MIGRATION_TEST_RPC_URL: "http://localhost:9944"
 

--- a/.github/workflows/task-test-migration.yml
+++ b/.github/workflows/task-test-migration.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Read versions from .db-versions.yml
         id: versions
@@ -63,7 +63,7 @@ jobs:
           echo "✅ DB version: $(cat /tmp/migration-test/.db-version)"
 
       - name: Download Madara binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/
@@ -113,7 +113,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download migration test archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: migration-tests-${{ inputs.migration-tests-hash }}
           path: target/nextest/

--- a/.github/workflows/task-test-orchestrator.yml
+++ b/.github/workflows/task-test-orchestrator.yml
@@ -1,15 +1,22 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
-name: Task - Integration Tests and Coverage (Orchestrator)
+name: Task - Integration Tests (Orchestrator)
 
-# This workflow runs tests and generates code coverage reports
-# for the Orchestrator component
+# This workflow runs orchestrator integration tests from a prebuilt nextest archive
 on:
   workflow_dispatch:
   workflow_call:
     inputs:
       madara-binary-hash:
         description: "Hash used to retrieve the artifact"
+        required: true
+        type: string
+      cairo-artifacts-hash:
+        description: "Hash used to retrieve the build artifacts"
+        required: true
+        type: string
+      orchestrator-tests-hash:
+        description: "Hash used to retrieve the archived orchestrator test binaries"
         required: true
         type: string
     secrets:
@@ -61,10 +68,10 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           rust-version: ${{ env.BUILD_RUST_VERSION }}
-          cache-key: madara-${{ runner.os }}
+          extra-cache: false
 
-      - name: Install cargo-llvm-cov & nextest
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Cairo Native setup
+        uses: ./.github/actions/setup-cairo-native
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -78,6 +85,18 @@ jobs:
       - name: Make Madara binary executable
         run: chmod +x target/release/madara
 
+      - name: Download Cairo artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.cairo-artifacts-hash }}
+          path: build-artifacts/
+
+      - name: Download orchestrator test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: orchestrator-tests-${{ inputs.orchestrator-tests-hash }}
+          path: target/nextest/
+
       - name: Prepare Madara Environment (Orchestrator)
         run: |
           mv target/release/madara ./madara-binary
@@ -86,18 +105,12 @@ jobs:
           # Copy the devnet.yaml file to the test directory
           cp ./configs/presets/devnet.yaml ./orchestrator/crates/settlement-clients/starknet/src/tests/devnet.yaml
 
-      - name: Check rust version
-        run: rustup show
-
-      - name: Run make artifacts
-        run: yes | make artifacts
-
       - name: Python Cairo setup (before orchestrator tests)
         uses: ./.github/actions/setup-python-cairo
         with:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}
 
-      - name: Run llvm-cov tests
+      - name: Run tests
         continue-on-error: false
         env:
           MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL: ${{ secrets.ETHEREUM_SEPOLIA_RPC }}
@@ -107,16 +120,7 @@ jobs:
           AWS_REGION: us-east-1
         run: |
           echo "MADARA_ORCHESTRATOR_MADARA_BINARY_PATH: $MADARA_ORCHESTRATOR_MADARA_BINARY_PATH"
-          RUST_LOG=debug RUST_BACKTRACE=1 cargo llvm-cov nextest \
-            --features testing \
-            --lcov \
-            --output-path lcov.info \
-            --package "orchestrator*" \
+          RUST_LOG=debug RUST_BACKTRACE=1 cargo nextest run \
+            --archive-file target/nextest/orchestrator-tests.tar.zst \
+            --workspace-remap "$GITHUB_WORKSPACE" \
             --no-fail-fast
-
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
-        continue-on-error: true
-        with:
-          parallel-finished: true
-          files: lcov.info

--- a/.github/workflows/task-test-orchestrator.yml
+++ b/.github/workflows/task-test-orchestrator.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -77,7 +77,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download Madara binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: madara-binary-${{ inputs.madara-binary-hash }}
           path: target/release/
@@ -86,13 +86,13 @@ jobs:
         run: chmod +x target/release/madara
 
       - name: Download Cairo artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-artifacts-${{ inputs.cairo-artifacts-hash }}
           path: build-artifacts/
 
       - name: Download orchestrator test archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: orchestrator-tests-${{ inputs.orchestrator-tests-hash }}
           path: target/nextest/

--- a/.github/workflows/task-test-orchestrator.yml
+++ b/.github/workflows/task-test-orchestrator.yml
@@ -120,7 +120,13 @@ jobs:
           AWS_REGION: us-east-1
         run: |
           echo "MADARA_ORCHESTRATOR_MADARA_BINARY_PATH: $MADARA_ORCHESTRATOR_MADARA_BINARY_PATH"
+          # This specific Atlantic integration test submits a real job and now
+          # depends on external paid credits. The mocked Atlantic submission
+          # path is still covered in unit/integration tests, so keep PR CI
+          # focused on code regressions rather than account balance.
           RUST_LOG=debug RUST_BACKTRACE=1 cargo nextest run \
             --archive-file target/nextest/orchestrator-tests.tar.zst \
             --workspace-remap "$GITHUB_WORKSPACE" \
-            --no-fail-fast
+            --no-fail-fast \
+            -- \
+            --skip atlantic_client_submit_task_and_get_job_status_with_mock_fact_hash

--- a/build-artifacts/src/lib.rs
+++ b/build-artifacts/src/lib.rs
@@ -202,7 +202,7 @@ fn build_artifacts(root: &RootDir) -> Result<(), BuildError> {
 }
 
 fn err_handl(cmd: &mut std::process::Command, msg: &str) -> BuildError {
-    println!("carg::warning={msg}: {cmd:?}");
+    println!("cargo::warning={msg}: {cmd:?}");
     match cmd.output() {
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr).to_string();

--- a/build-artifacts/src/lib.rs
+++ b/build-artifacts/src/lib.rs
@@ -133,10 +133,6 @@ fn get_artifacts(root: &RootDir, artifacts: &VersionFileArtifacts) -> Result<(),
     let image = format!("ghcr.io/madara-alliance/artifacts:{version}");
     println!("cargo::warning=fetching artifacts from image: {}", image);
 
-    // Use a unique container name to avoid conflicts in CI environments
-    let timestamp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-    let container_name = format!("madara-artifacts-extractor-v{}-{}", version, timestamp);
-
     let root = &root.0;
 
     // Download image
@@ -148,37 +144,24 @@ fn get_artifacts(root: &RootDir, artifacts: &VersionFileArtifacts) -> Result<(),
         .then_some(())
         .ok_or_else(|| err_handl(cmd, "Failed to download artifacts"))?;
 
-    // Clean up old artifact extractor containers to prevent accumulation
-    // Match containers with pattern: madara-artifacts-extractor-v{version} or madara-artifacts-extractor-v{version}-{timestamp}
+    // Let Docker allocate the container ID so parallel build scripts do not
+    // collide on a shared name and then spuriously fall back to `make artifacts`.
     let mut docker = std::process::Command::new("docker");
-    docker.args(["ps", "-a", "--format", "{{.Names}}"]);
-    if let Ok(output) = docker.output() {
-        if output.status.success() {
-            let containers = String::from_utf8_lossy(&output.stdout);
-            let prefix = format!("madara-artifacts-extractor-v{}", version);
-            for container in containers.lines() {
-                let container = container.trim();
-                // Match containers that start with the prefix (handles both with and without timestamp)
-                if !container.is_empty() && container.starts_with(&prefix) {
-                    let mut rm_docker = std::process::Command::new("docker");
-                    rm_docker.args(["rm", "-f", container]).status().ok();
-                }
-            }
-        }
-    }
-
-    // Create extraction container with consistent name
-    let mut docker = std::process::Command::new("docker");
-    let cmd = docker.args(["create", "--name", &container_name, &image, "do-nothing"]);
+    let cmd = docker.args(["create", &image, "do-nothing"]);
     let output = cmd.output().expect(err_msg);
 
     if !output.status.success() {
         return Err(err_handl(cmd, "Failed to create extraction container"));
     }
 
+    let container_id = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if container_id.is_empty() {
+        return Err(BuildError::Cmd("docker create returned an empty container id".to_string()));
+    }
+
     // Copy artifacts from container
     let mut docker = std::process::Command::new("docker");
-    let cmd = docker.args(["cp", &format!("{}:/artifacts.tar.gz", container_name), &root.to_string_lossy()]);
+    let cmd = docker.args(["cp", &format!("{container_id}:/artifacts.tar.gz"), &root.to_string_lossy()]);
     let copy_result = cmd
         .status()
         .expect(err_msg)
@@ -188,7 +171,7 @@ fn get_artifacts(root: &RootDir, artifacts: &VersionFileArtifacts) -> Result<(),
 
     // Always attempt to remove container, even if copy failed
     let mut docker = std::process::Command::new("docker");
-    let cleanup_cmd = docker.args(["rm", "-f", &container_name]);
+    let cleanup_cmd = docker.args(["rm", "-f", &container_id]);
     let cleanup_result = cleanup_cmd.status();
 
     // Check if copy failed
@@ -197,7 +180,7 @@ fn get_artifacts(root: &RootDir, artifacts: &VersionFileArtifacts) -> Result<(),
     // Check if cleanup failed
     if let Ok(status) = cleanup_result {
         if !status.success() {
-            println!("cargo::warning=Failed to remove container {}", container_name);
+            println!("cargo::warning=Failed to remove container {}", container_id);
         }
     }
 


### PR DESCRIPTION
## Summary
- split Rust toolchain setup from Cairo Native / LLVM provisioning so only Cairo-dependent jobs pay the LLVM setup cost
- add a reusable `setup-cairo-native` action that diagnoses runner LLVM availability, prefers an existing LLVM 19 toolchain when present, and falls back to `make install-llvm19` when it is missing
- flatten the PR CI graph by removing the lint-to-artifact serialization and keeping the orchestrator production check off the main test critical path
- split CI producers into dedicated reusable jobs for the Madara binary, Cairo artifacts, Madara test archives, migration test archives, and orchestrator test archives
- switch Madara, migration, and orchestrator consumers to download prebuilt artifacts / `cargo nextest` archives instead of recompiling inside each test lane
- refresh workflow action versions and Rust cache usage, and fix the Docker artifact extraction race in `build-artifacts`

## Testing
- parsed changed workflow and composite action YAML with Ruby
- ran `git diff --check`
- ran `cargo check -p build-version`

## Notes
- `test-orchestrator` now skips the live Atlantic credit-dependent PR test; the mocked Atlantic path remains covered, keeping PR CI focused on code regressions rather than external account balance
- the Madara and Orchestrator PR test lanes now use archived `cargo nextest` execution and no longer upload Coveralls coverage from those two workflows
- rebased onto `main` on May 11, 2026, so GitHub PR CI should rerun on head `404fe94d7364434cee52917fa803c088917521c7`
