### PR TITLE
fix(docker): restore orchestrator build dependencies for Cairo Native

### DIFF
--- a/bootstrapper/Dockerfile
+++ b/bootstrapper/Dockerfile
@@ -19,7 +19,37 @@ ENV RUSTC_WRAPPER=/bin/sccache
 
 ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
 
-RUN apt-get update -y && apt-get install -y wget clang
+# Copy Makefile for LLVM installation
+COPY Makefile /tmp/Makefile
+
+# Install LLVM 19 build prerequisites. Required because the unified root
+# workspace transitively pulls in cairo-native crates (tblgen, mlir-sys, etc.)
+# whose build scripts need llvm-config 19 even when only the bootstrapper
+# binary is being built.
+RUN apt-get update -y && apt-get install -y \
+    bash \
+    build-essential \
+    ca-certificates \
+    clang \
+    curl \
+    git \
+    gnupg \
+    libssl-dev \
+    make \
+    openssl \
+    software-properties-common \
+    wget && \
+    cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set LLVM environment variables so cairo-native build scripts (tblgen,
+# llvm-sys, mlir-sys) can locate LLVM 19. CC is intentionally NOT pinned to
+# clang-19 here — bootstrapper does not run Cairo Native at runtime, and the
+# default gcc keeps Python's --enable-optimizations PGO build working below.
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
 
 # Install Python 3.9
 RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \

--- a/madara/Dockerfile
+++ b/madara/Dockerfile
@@ -43,10 +43,15 @@ ENV LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
 ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
 
 # Install Python 3.9
+# Note: --enable-optimizations (PGO) is intentionally omitted. Python here is
+# only used at build time to run cairo-compile for SNOS dependencies, so
+# runtime perf is irrelevant and skipping PGO halves this step's build time
+# (PGO builds Python twice). With CC=clang-19 below, PGO would also require
+# llvm-profdata which adds further fragility.
 RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
     && tar xzf Python-3.9.16.tgz \
     && cd Python-3.9.16 \
-    && ./configure --enable-optimizations \
+    && ./configure \
     && make altinstall \
     && cd .. \
     && rm -rf Python-3.9.16 Python-3.9.16.tgz

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -56,8 +56,11 @@ RUN DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
     "export LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
     "export LD_LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
     > /etc/profile.d/cairo-native-libs.sh
+# Use bash (non-login) so BASH_ENV is honored. A login shell would source
+# /etc/profile, which on Debian unconditionally resets PATH and would wipe
+# /usr/local/cargo/bin and /usr/lib/llvm-19/bin from PATH for every later RUN.
 ENV BASH_ENV=/etc/profile.d/cairo-native-libs.sh
-SHELL ["/bin/bash", "-lc"]
+SHELL ["/bin/bash", "-c"]
 
 # Install BLST from source
 RUN git clone --depth 1 --branch v0.3.15 https://github.com/supranational/blst.git /tmp/blst && \
@@ -76,11 +79,10 @@ ENV RUSTFLAGS="-L /usr/local/lib -l blst"
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/blst.conf && ldconfig
 
 # Install Python 3.9
-# Note: --enable-optimizations (PGO) is intentionally omitted. With CC=clang-19
-# set above for Cairo Native, PGO would require llvm-profdata on PATH, which is
-# not present in login shells (/etc/profile resets PATH). Python here is only
-# used at build time to run cairo-compile, so runtime perf is irrelevant and
-# skipping PGO also halves this step's build time.
+# Note: --enable-optimizations (PGO) is intentionally omitted. Python here is
+# only used at build time to run cairo-compile for SNOS dependencies, so
+# runtime perf is irrelevant and skipping PGO halves this step's build time
+# (PGO builds Python twice).
 RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
   && tar xzf Python-3.9.16.tgz \
   && cd Python-3.9.16 \

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -76,10 +76,15 @@ ENV RUSTFLAGS="-L /usr/local/lib -l blst"
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/blst.conf && ldconfig
 
 # Install Python 3.9
+# Note: --enable-optimizations (PGO) is intentionally omitted. With CC=clang-19
+# set above for Cairo Native, PGO would require llvm-profdata on PATH, which is
+# not present in login shells (/etc/profile resets PATH). Python here is only
+# used at build time to run cairo-compile, so runtime perf is irrelevant and
+# skipping PGO also halves this step's build time.
 RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
   && tar xzf Python-3.9.16.tgz \
   && cd Python-3.9.16 \
-  && ./configure --enable-optimizations \
+  && ./configure \
   && make altinstall \
   && cd .. \
   && rm -rf Python-3.9.16 Python-3.9.16.tgz

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -19,14 +19,45 @@ ENV RUSTC_WRAPPER=/bin/sccache
 
 ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
 
-# Install system dependencies including OpenSSL
-RUN apt-get update && apt-get install -y \
-  git libgmp3-dev wget bash curl \
-  build-essential clang \
-  libssl-dev openssl \
+# Copy Makefile for LLVM installation
+COPY Makefile /tmp/Makefile
+
+# Install LLVM 19 for Cairo Native support using Makefile target
+RUN apt-get update -y && apt-get install -y \
+  bash \
+  build-essential \
   ca-certificates \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  curl \
+  git \
+  gnupg \
+  libgmp3-dev \
+  libssl-dev \
+  make \
+  openssl \
+  software-properties-common \
+  wget && \
+  cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set LLVM environment variables for Cairo Native
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+
+# Set explicit compilers for Cairo Native runtime compilation
+ENV CC=clang-19
+ENV CXX=clang++-19
+
+# Configure linker search paths for Cairo Native runtime compilation.
+# DEB_HOST_MULTIARCH resolves to the correct lib directory for the build runner architecture.
+RUN DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
+  printf '%s\n' \
+    "export LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    "export LD_LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    > /etc/profile.d/cairo-native-libs.sh
+ENV BASH_ENV=/etc/profile.d/cairo-native-libs.sh
+SHELL ["/bin/bash", "-lc"]
 
 # Install BLST from source
 RUN git clone --depth 1 --branch v0.3.15 https://github.com/supranational/blst.git /tmp/blst && \


### PR DESCRIPTION
## Summary
Restore the Docker image builds for `orchestrator`, `madara`, and `bootstrapper` after #1011 silently made `cairo-native` a transitive dependency of every binary in the root workspace, breaking builds without LLVM 19 installed.

## Root cause
#1011 reintegrated madara into the root Cargo workspace and added `mc-class-exec` and `generate-pie[cairo_native]` as workspace deps. This pulled cairo-native crates (`tblgen`, `mlir-sys`, `melior`, …) into the build graph of every binary, including `orchestrator` and `bootstrapper`. Both now need LLVM 19 at build time even though neither runs Cairo Native at runtime.

## Fix
- **`orchestrator/Dockerfile`** — install LLVM 19 + matching env vars (`MLIR_SYS_190_PREFIX`, `LLVM_SYS_191_PREFIX`, `TABLEGEN_190_PREFIX`, `CC=clang-19`, `CXX=clang++-19`). Use `SHELL ["/bin/bash", "-c"]` instead of `-lc`: a login shell sources `/etc/profile`, which on Debian unconditionally resets `PATH` and would wipe `/usr/local/cargo/bin` and `/usr/lib/llvm-19/bin` from every later `RUN`. Drop `--enable-optimizations` from the Python build (Python here is build-time only for `cairo-compile`, so PGO doubles build time for no runtime gain).
- **`madara/Dockerfile`** — drop `--enable-optimizations` for the same reason.
- **`bootstrapper/Dockerfile`** — install LLVM 19 + the same env vars so `tblgen v0.5.2`'s build script can find `llvm-config 19`. `CC` is intentionally **not** pinned to `clang-19` here — bootstrapper does not run Cairo Native at runtime, and keeping the default `gcc` lets Python's existing PGO build work without further changes.

## Validation
Validated locally with `docker buildx build --check` on all three Dockerfiles (no warnings).

Manual Docker Image Build on `docker-cairo-native-llvm19`, both ✅:
- [Run 24068076077](https://github.com/madara-alliance/madara/actions/runs/24068076077) — cold caches, **29m44s**
- [Run 24069258638](https://github.com/madara-alliance/madara/actions/runs/24069258638) — warm caches, **10m11s**

The 30 → 10 min drop on the warm run shows the new per-image cache keys from #1015 are committing/restoring correctly and steady-state wallclock is ~10 min.

## Test plan
- [x] `docker buildx build --check` passes for all three Dockerfiles
- [x] Manual Docker Image Build workflow green on `docker-cairo-native-llvm19` (cold + warm)