### PR TITLE
fix: state root calculation for starknet version >= 0.14.0

### DIFF
--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -428,10 +428,10 @@ impl<D: MadaraStorage> MadaraBackend<D> {
     /// Failure to do so could result in errors and/or invalid state, which includes invalid state being saved to the database.
     /// The functions are still safe to use, since it's a logic error and not a memory safety issue.
     ///
-    /// In addition, all of the associated functions need to be called in a rayon thread pool context. **Do not call
+    /// In addition, all the associated functions need to be called in a rayon thread pool context. **Do not call
     /// them from the tokio pool!**
     // TODO: ensure exclusive access? all of these requirements could be checked relatively cheaply. There are also
-    // ways to make the aforementioned logic errors unrepreasentable by designing the API a little better.
+    // ways to make the aforementioned logic errors unrepresentable by designing the API a little better.
     pub fn write_access(self: &Arc<Self>) -> MadaraBackendWriter<D> {
         MadaraBackendWriter { inner: self.clone() }
     }
@@ -835,7 +835,7 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         metrics().block_commitments_compute_last.record(commitments_secs, &[]);
 
         let (global_state_root, merklization_timings) =
-            self.apply_to_global_trie(block.header.block_number, [&block.state_diff])?;
+            self.apply_to_global_trie(block.header.block_number, [&block.state_diff], block.header.protocol_version)?;
 
         // Copy merklization timings
         timings.merklization = merklization_timings.total;
@@ -958,8 +958,9 @@ impl<D: MadaraStorage> MadaraBackendWriter<D> {
         &self,
         start_block_n: u64,
         state_diffs: impl IntoIterator<Item = &'a StateDiff>,
+        protocol_version: mp_chain_config::StarknetVersion,
     ) -> Result<(Felt, rocksdb::global_trie::MerklizationTimings)> {
-        self.inner.db.apply_to_global_trie(start_block_n, state_diffs)
+        self.inner.db.apply_to_global_trie(start_block_n, state_diffs, protocol_version)
     }
 
     /// Lower level access to writing primitives. This is only used by the sync process, which

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -69,7 +69,7 @@ pub fn apply_to_global_trie<'a>(
     state_diffs: impl IntoIterator<Item = &'a StateDiff>,
     last_block_protocol_version: StarknetVersion,
 ) -> Result<(Felt, MerklizationTimings)> {
-    let mut last_trie_roots = None;
+    let mut state_root = None;
     let mut timings = MerklizationTimings::default();
 
     for (block_n, state_diff) in (start_block_n..).zip(state_diffs) {
@@ -113,8 +113,14 @@ pub fn apply_to_global_trie<'a>(
         let (contract_trie_root, contract_trie_timings) = contract_result?;
         let (class_trie_root, class_trie_timings) = class_result?;
 
-        // Keep the trie roots from the last iteration — state root is computed once after the loop.
-        last_trie_roots = Some((contract_trie_root, class_trie_root));
+        // NOTE: We compute the state root inside the loop (rather than only after it) so that
+        // the per-block timing metrics below include the cost of `calculate_state_root`.
+        //
+        // Because we use `last_block_protocol_version` for every iteration, intermediate state
+        // roots may be incorrect if the batch spans a protocol version boundary (e.g. 0.13.x →
+        // 0.14.0). This is harmless today — only the final root is returned and verified — but
+        // should be kept in mind if intermediate roots are ever used in the future.
+        state_root = Some(calculate_state_root(contract_trie_root, class_trie_root, last_block_protocol_version));
 
         // Capture timings
         timings.contract_trie_root = contract_duration;
@@ -129,11 +135,8 @@ pub fn apply_to_global_trie<'a>(
         metrics().apply_to_global_trie_last.record(block_secs, &[]);
     }
 
-    let (contract_trie_root, class_trie_root) =
-        last_trie_roots.context("Applying an empty batch to the global trie")?;
-    let state_root = calculate_state_root(contract_trie_root, class_trie_root, last_block_protocol_version);
-
-    Ok((state_root, timings))
+    let root = state_root.context("Applying an empty batch to the global trie")?;
+    Ok((root, timings))
 }
 
 /// "STARKNET_STATE_V0"

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -158,6 +158,7 @@ mod tests {
     use super::*;
     use crate::MadaraBackend;
     use mp_chain_config::ChainConfig;
+    use mp_state_update::{ContractStorageDiffItem, StorageEntry};
     use rstest::*;
     use std::sync::Arc;
 
@@ -190,5 +191,38 @@ mod tests {
     ) {
         let result = calculate_state_root(contracts_trie_root, classes_trie_root);
         assert_eq!(result, expected_result, "State root should match the expected result");
+    }
+
+    /// End-to-end regression for the Starknet ≥ 0.14.0 state root bug.
+    ///
+    /// Drives a real Starknet 0.14.1 genesis-shaped state diff (a single storage write on the
+    /// stateful-compression system contract `0x2`: `key=0x0 → value=0x80`) through
+    /// `apply_to_global_trie` and asserts the returned global state root.
+    ///
+    /// This pins the full path: bonsai insert → `contract_trie_root` (with system-contract leaf
+    /// hash: `class_hash=0, nonce=0`) → `calculate_state_root`. Against the old unconditional
+    /// `class_trie_root == 0 → contract_root` short-circuit this test fails, because the
+    /// short-circuit returns `0x3c538d…` (the contract trie root) instead of
+    /// `Poseidon(STARKNET_STATE_V0, 0x3c538d…, 0) = 0x68bcf9…`.
+    #[rstest]
+    fn test_apply_to_global_trie_v0_14_genesis(setup_test_backend: Arc<MadaraBackend>) {
+        let backend = setup_test_backend;
+
+        let state_diff = StateDiff {
+            storage_diffs: vec![ContractStorageDiffItem {
+                address: Felt::from_hex_unchecked("0x2"),
+                storage_entries: vec![StorageEntry { key: Felt::ZERO, value: Felt::from_hex_unchecked("0x80") }],
+            }],
+            ..Default::default()
+        };
+
+        let (state_root, _timings) =
+            apply_to_global_trie(&backend.db, 0, [&state_diff]).expect("apply_to_global_trie should succeed");
+
+        assert_eq!(
+            state_root,
+            Felt::from_hex_unchecked("0x68bcf9e9257ab6bffd9425833a208aaab6b85649fd21c787a546cb7cb9abf"),
+            "Global state root for 0.14.1 genesis state diff should equal Poseidon(STARKNET_STATE_V0, contract_root, 0)"
+        );
     }
 }

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -1,6 +1,7 @@
 use crate::metrics::metrics;
 use crate::rocksdb::trie::WrappedBonsaiError;
 use crate::{prelude::*, rocksdb::RocksDBStorage};
+use mp_chain_config::StarknetVersion;
 use mp_state_update::StateDiff;
 use starknet_types_core::{
     felt::Felt,
@@ -47,16 +48,28 @@ pub mod bonsai_identifier {
     pub const CLASS: &[u8] = b"0xclass";
 }
 
-/// Update the global tries.
-/// Returns the new global state root and timing information.
-/// Multiple state diffs can be applied at once, only the latest state root and timings will be returned.
-/// Errors if the batch is empty.
+/// Update the global tries and compute the state root for the last block in the batch.
+///
+/// Applies each state diff to the contract and class tries in order. Only the state root of
+/// the **last** block is computed and returned — intermediate trie states are committed (so the
+/// bonsai trie is up to date) but their roots are not hashed into a state commitment.
+///
+/// # Arguments
+///
+/// * `last_block_protocol_version` — protocol version of the last block in the batch. Governs
+///   whether the `class_trie_root == 0` short-circuit applies in [`calculate_state_root`]
+///   (gated on `< 0.14.0`, matching pathfinder's `StateCommitment::calculate`).
+///
+/// # Errors
+///
+/// Returns an error if the batch is empty.
 pub fn apply_to_global_trie<'a>(
     backend: &RocksDBStorage,
     start_block_n: u64,
     state_diffs: impl IntoIterator<Item = &'a StateDiff>,
+    last_block_protocol_version: StarknetVersion,
 ) -> Result<(Felt, MerklizationTimings)> {
-    let mut state_root = None;
+    let mut last_trie_roots = None;
     let mut timings = MerklizationTimings::default();
 
     for (block_n, state_diff) in (start_block_n..).zip(state_diffs) {
@@ -100,7 +113,8 @@ pub fn apply_to_global_trie<'a>(
         let (contract_trie_root, contract_trie_timings) = contract_result?;
         let (class_trie_root, class_trie_timings) = class_result?;
 
-        state_root = Some(calculate_state_root(contract_trie_root, class_trie_root));
+        // Keep the trie roots from the last iteration — state root is computed once after the loop.
+        last_trie_roots = Some((contract_trie_root, class_trie_root));
 
         // Capture timings
         timings.contract_trie_root = contract_duration;
@@ -115,8 +129,11 @@ pub fn apply_to_global_trie<'a>(
         metrics().apply_to_global_trie_last.record(block_secs, &[]);
     }
 
-    let root = state_root.context("Applying an empty batch to the global trie")?;
-    Ok((root, timings))
+    let (contract_trie_root, class_trie_root) =
+        last_trie_roots.context("Applying an empty batch to the global trie")?;
+    let state_root = calculate_state_root(contract_trie_root, class_trie_root, last_block_protocol_version);
+
+    Ok((state_root, timings))
 }
 
 /// "STARKNET_STATE_V0"
@@ -124,31 +141,37 @@ const STARKNET_STATE_PREFIX: Felt = Felt::from_hex_unchecked("0x535441524b4e4554
 
 /// Computes the global state root from the contract and class trie roots.
 ///
-/// Matches Starknet ≥ 0.14.0 / Cairo-OS `commitment.cairo`: always hashes unless both
-/// trie roots are zero.
+/// Mirrors pathfinder's `StateCommitment::calculate` (`pathfinder/crates/common/src/lib.rs`):
 ///
-/// NOTE: pre-0.14.0 chains historically short-circuited `class_trie_root == 0 → contract_root`.
-/// That case is not handled here — if/when madara needs to sync pre-0.14.0 chains from genesis,
-/// thread `StarknetVersion` through `apply_to_global_trie` and gate the short-circuit on
-/// `version < 0.14.0`, matching `pathfinder/crates/common/src/lib.rs::StateCommitment::calculate`.
-fn calculate_state_root(contracts_trie_root: Felt, classes_trie_root: Felt) -> Felt {
-    tracing::trace!("global state root calc contracts={contracts_trie_root:#x} classes={classes_trie_root:#x}");
+/// 1. If both roots are zero, the result is zero (any version).
+/// 2. For `version < 0.14.0` with `class_trie_root == 0`, returns `contract_trie_root`
+///    directly (legacy behavior — the class trie didn't exist yet).
+/// 3. Otherwise (including all `>= 0.14.0` blocks, even when `class_trie_root == 0`),
+///    the result is `Poseidon(STARKNET_STATE_V0, contract_trie_root, class_trie_root)`.
+fn calculate_state_root(contracts_trie_root: Felt, classes_trie_root: Felt, protocol_version: StarknetVersion) -> Felt {
+    tracing::trace!(
+        "global state root calc contracts={contracts_trie_root:#x} classes={classes_trie_root:#x} version={protocol_version}"
+    );
 
     if contracts_trie_root == Felt::ZERO && classes_trie_root == Felt::ZERO {
         return Felt::ZERO;
     }
 
+    if classes_trie_root == Felt::ZERO && protocol_version < StarknetVersion::V0_14_0 {
+        return contracts_trie_root;
+    }
+
     Poseidon::hash_array(&[STARKNET_STATE_PREFIX, contracts_trie_root, classes_trie_root])
 }
 
-pub fn get_state_root(backend: &RocksDBStorage) -> Result<Felt> {
+pub fn get_state_root(backend: &RocksDBStorage, protocol_version: StarknetVersion) -> Result<Felt> {
     let contract_trie = backend.contract_trie();
     let contract_trie_root_hash = contract_trie.root_hash(bonsai_identifier::CONTRACT).map_err(WrappedBonsaiError)?;
 
     let class_trie = backend.class_trie();
     let class_trie_root_hash = class_trie.root_hash(bonsai_identifier::CLASS).map_err(WrappedBonsaiError)?;
 
-    let state_root = calculate_state_root(contract_trie_root_hash, class_trie_root_hash);
+    let state_root = calculate_state_root(contract_trie_root_hash, class_trie_root_hash, protocol_version);
 
     Ok(state_root)
 }
@@ -169,33 +192,47 @@ mod tests {
     }
 
     /// Test cases for the `calculate_state_root` function.
+    ///
+    /// Cases 1-4 use version ≥ 0.14.0 (always hash unless both zero).
+    /// Case 5 tests the pre-0.14.0 short-circuit (class_root == 0 → return contract_root).
     #[rstest]
     #[case::non_zero_inputs(
         Felt::from_hex_unchecked("0x123456"),
         Felt::from_hex_unchecked("0x789abc"),
+        StarknetVersion::V0_14_1,
         // Poseidon(STARKNET_STATE_V0, 0x123456, 0x789abc)
         Felt::from_hex_unchecked("0x6beb971880d4b4996b10fe613b8d49fa3dda8f8b63156c919077e08c534d06e")
     )]
     // Regression test for Starknet ≥ 0.14.0: the `class_trie_root == 0` short-circuit must
     // NOT fire — the result is Poseidon(STARKNET_STATE_V0, contract_root, 0), not contract_root.
-    #[case::zero_class_trie_root(
+    #[case::zero_class_trie_root_post_0_14(
         Felt::from_hex_unchecked("0x3c538d437670f4c6f72dd799f215a007720ec7d19bc64195c96399145d8746f"),
         Felt::ZERO,
+        StarknetVersion::V0_14_1,
         Felt::from_hex_unchecked("0x68bcf9e9257ab6bffd9425833a208aaab6b85649fd21c787a546cb7cb9abf")
     )]
     #[case::zero_contract_trie_root(
         Felt::ZERO,
         Felt::from_hex_unchecked("0x789abc"),
+        StarknetVersion::V0_14_1,
         // Poseidon(STARKNET_STATE_V0, 0, 0x789abc)
         Felt::from_hex_unchecked("0x39eb9ca5f6c6dfdd4d91e3d1c03181b3c9bbc2bfe85e0d39b011bcd07cac79a")
     )]
-    #[case::both_zero(Felt::ZERO, Felt::ZERO, Felt::ZERO)]
+    #[case::both_zero(Felt::ZERO, Felt::ZERO, StarknetVersion::V0_14_1, Felt::ZERO)]
+    // Pre-0.14.0: class_root == 0 should short-circuit to contract_root (no hashing).
+    #[case::zero_class_trie_root_pre_0_14(
+        Felt::from_hex_unchecked("0x123456"),
+        Felt::ZERO,
+        StarknetVersion::V0_13_2,
+        Felt::from_hex_unchecked("0x123456")  // contract_root returned directly
+    )]
     fn test_calculate_state_root(
         #[case] contracts_trie_root: Felt,
         #[case] classes_trie_root: Felt,
+        #[case] version: StarknetVersion,
         #[case] expected_result: Felt,
     ) {
-        let result = calculate_state_root(contracts_trie_root, classes_trie_root);
+        let result = calculate_state_root(contracts_trie_root, classes_trie_root, version);
         assert_eq!(result, expected_result, "State root should match the expected result");
     }
 
@@ -222,8 +259,8 @@ mod tests {
             ..Default::default()
         };
 
-        let (state_root, _timings) =
-            apply_to_global_trie(&backend.db, 0, [&state_diff]).expect("apply_to_global_trie should succeed");
+        let (state_root, _timings) = apply_to_global_trie(&backend.db, 0, [&state_diff], StarknetVersion::V0_14_1)
+            .expect("apply_to_global_trie should succeed");
 
         assert_eq!(
             state_root,

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -122,13 +122,23 @@ pub fn apply_to_global_trie<'a>(
 /// "STARKNET_STATE_V0"
 const STARKNET_STATE_PREFIX: Felt = Felt::from_hex_unchecked("0x535441524b4e45545f53544154455f5630");
 
+/// Computes the global state root from the contract and class trie roots.
+///
+/// Matches Starknet ≥ 0.14.0 / Cairo-OS `commitment.cairo`: always hashes unless both
+/// trie roots are zero.
+///
+/// NOTE: pre-0.14.0 chains historically short-circuited `class_trie_root == 0 → contract_root`.
+/// That case is not handled here — if/when madara needs to sync pre-0.14.0 chains from genesis,
+/// thread `StarknetVersion` through `apply_to_global_trie` and gate the short-circuit on
+/// `version < 0.14.0`, matching `pathfinder/crates/common/src/lib.rs::StateCommitment::calculate`.
 fn calculate_state_root(contracts_trie_root: Felt, classes_trie_root: Felt) -> Felt {
-    tracing::trace!("global state root calc {contracts_trie_root:#x} {classes_trie_root:#x}");
-    if classes_trie_root == Felt::ZERO {
-        contracts_trie_root
-    } else {
-        Poseidon::hash_array(&[STARKNET_STATE_PREFIX, contracts_trie_root, classes_trie_root])
+    tracing::trace!("global state root calc contracts={contracts_trie_root:#x} classes={classes_trie_root:#x}");
+
+    if contracts_trie_root == Felt::ZERO && classes_trie_root == Felt::ZERO {
+        return Felt::ZERO;
     }
+
+    Poseidon::hash_array(&[STARKNET_STATE_PREFIX, contracts_trie_root, classes_trie_root])
 }
 
 pub fn get_state_root(backend: &RocksDBStorage) -> Result<Felt> {
@@ -158,33 +168,27 @@ mod tests {
     }
 
     /// Test cases for the `calculate_state_root` function.
-    ///
-    /// This test uses `rstest` to parameterize different scenarios for calculating
-    /// the state root. It verifies that the function correctly handles various
-    /// input combinations and produces the expected results.
     #[rstest]
     #[case::non_zero_inputs(
-        Felt::from_hex_unchecked("0x123456"),  // Non-zero contracts trie root
-        Felt::from_hex_unchecked("0x789abc"),  // Non-zero classes trie root
-        // Expected result: Poseidon hash of STARKNET_STATE_PREFIX and both non-zero roots
+        Felt::from_hex_unchecked("0x123456"),
+        Felt::from_hex_unchecked("0x789abc"),
+        // Poseidon(STARKNET_STATE_V0, 0x123456, 0x789abc)
         Felt::from_hex_unchecked("0x6beb971880d4b4996b10fe613b8d49fa3dda8f8b63156c919077e08c534d06e")
     )]
+    // Regression test for Starknet ≥ 0.14.0: the `class_trie_root == 0` short-circuit must
+    // NOT fire — the result is Poseidon(STARKNET_STATE_V0, contract_root, 0), not contract_root.
     #[case::zero_class_trie_root(
-        Felt::from_hex_unchecked("0x123456"),  // Non-zero contracts trie root
-        Felt::from_hex_unchecked("0x0"),       // Zero classes trie root
-        Felt::from_hex_unchecked("0x123456")   // Expected result: same as contracts trie root
+        Felt::from_hex_unchecked("0x3c538d437670f4c6f72dd799f215a007720ec7d19bc64195c96399145d8746f"),
+        Felt::ZERO,
+        Felt::from_hex_unchecked("0x68bcf9e9257ab6bffd9425833a208aaab6b85649fd21c787a546cb7cb9abf")
     )]
+    #[case::both_zero(Felt::ZERO, Felt::ZERO, Felt::ZERO)]
     fn test_calculate_state_root(
         #[case] contracts_trie_root: Felt,
         #[case] classes_trie_root: Felt,
         #[case] expected_result: Felt,
     ) {
-        // GIVEN: We have a contracts trie root and a classes trie root
-
-        // WHEN: We calculate the state root using these inputs
         let result = calculate_state_root(contracts_trie_root, classes_trie_root);
-
-        // THEN: The calculated state root should match the expected result
         assert_eq!(result, expected_result, "State root should match the expected result");
     }
 }

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -141,7 +141,10 @@ const STARKNET_STATE_PREFIX: Felt = Felt::from_hex_unchecked("0x535441524b4e4554
 
 /// Computes the global state root from the contract and class trie roots.
 ///
-/// Mirrors pathfinder's `StateCommitment::calculate` (`pathfinder/crates/common/src/lib.rs`):
+/// Implements `calculate_global_state_root` from the Starknet OS
+/// (`starkware/starknet/core/os/state/commitment.cairo` in the sequencer repo).
+/// Pathfinder's `StateCommitment::calculate` (`crates/common/src/lib.rs`) is a
+/// compatible independent implementation used as a cross-reference.
 ///
 /// 1. If both roots are zero, the result is zero (any version).
 /// 2. For `version < 0.14.0` with `class_trie_root == 0`, returns `contract_trie_root`

--- a/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/global_trie/mod.rs
@@ -183,6 +183,12 @@ mod tests {
         Felt::ZERO,
         Felt::from_hex_unchecked("0x68bcf9e9257ab6bffd9425833a208aaab6b85649fd21c787a546cb7cb9abf")
     )]
+    #[case::zero_contract_trie_root(
+        Felt::ZERO,
+        Felt::from_hex_unchecked("0x789abc"),
+        // Poseidon(STARKNET_STATE_V0, 0, 0x789abc)
+        Felt::from_hex_unchecked("0x39eb9ca5f6c6dfdd4d91e3d1c03181b3c9bbc2bfe85e0d39b011bcd07cac79a")
+    )]
     #[case::both_zero(Felt::ZERO, Felt::ZERO, Felt::ZERO)]
     fn test_calculate_state_root(
         #[case] contracts_trie_root: Felt,

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -21,6 +21,7 @@ use blockifier::bouncer::BouncerWeights;
 use bonsai_trie::id::BasicId;
 
 use mp_block::{EventWithInfo, MadaraBlockInfo, TransactionWithReceipt};
+use mp_chain_config::StarknetVersion;
 use mp_class::ConvertedClass;
 use mp_convert::Felt;
 use mp_state_update::StateDiff;
@@ -625,9 +626,11 @@ impl MadaraStorageWrite for RocksDBStorage {
         &self,
         start_block_n: u64,
         state_diffs: impl IntoIterator<Item = &'a StateDiff>,
+        protocol_version: StarknetVersion,
     ) -> Result<(Felt, MerklizationTimings)> {
         tracing::debug!("Applying state diff to global trie start_block_n={start_block_n}");
-        apply_to_global_trie(self, start_block_n, state_diffs).context("Applying state diff to global trie")
+        apply_to_global_trie(self, start_block_n, state_diffs, protocol_version)
+            .context("Applying state diff to global trie")
     }
 
     fn flush(&self) -> Result<()> {
@@ -651,7 +654,9 @@ impl MadaraStorageWrite for RocksDBStorage {
     }
 
     fn get_state_root_hash(&self) -> Result<Felt> {
-        get_state_root(self)
+        // This method has no callers outside the trait definition. Use LATEST as default.
+        // If pre-0.14.0 chains need this, thread the version through the trait method.
+        get_state_root(self, StarknetVersion::LATEST)
     }
 
     /// Reverts the blockchain state to a specific block hash during a chain reorganization.

--- a/madara/crates/client/db/src/storage.rs
+++ b/madara/crates/client/db/src/storage.rs
@@ -6,6 +6,7 @@ use blockifier::bouncer::BouncerWeights;
 use mp_block::{
     header::PreconfirmedHeader, BlockHeaderWithSignatures, EventWithInfo, MadaraBlockInfo, TransactionWithReceipt,
 };
+use mp_chain_config::StarknetVersion;
 use mp_class::{ClassInfo, CompiledSierra, ConvertedClass};
 use mp_receipt::{Event, EventWithTransactionHash};
 use mp_state_update::StateDiff;
@@ -229,10 +230,14 @@ pub trait MadaraStorageWrite: Send + Sync + 'static {
 
     /// Write a state diff to the global tries.
     /// Returns the new state root and timing information.
+    ///
+    /// `protocol_version` governs whether the `class_trie_root == 0` short-circuit applies
+    /// in state root computation (gated on `< 0.14.0`, matching pathfinder).
     fn apply_to_global_trie<'a>(
         &self,
         start_block_n: u64,
         state_diffs: impl IntoIterator<Item = &'a StateDiff>,
+        protocol_version: StarknetVersion,
     ) -> Result<(Felt, MerklizationTimings)>;
 
     fn flush(&self) -> Result<()>;

--- a/madara/crates/client/sync/src/apply_state.rs
+++ b/madara/crates/client/sync/src/apply_state.rs
@@ -5,7 +5,7 @@ use crate::{
     pipeline::{ApplyOutcome, PipelineController, PipelineSteps},
 };
 use anyhow::Context;
-use mc_db::MadaraBackend;
+use mc_db::{MadaraBackend, MadaraStorageRead};
 use mp_state_update::StateDiff;
 use std::{ops::Range, sync::Arc};
 use tokio::sync::Mutex;
@@ -181,8 +181,20 @@ impl ApplyStateSteps {
                 // latest_block is block_range.end (exclusive), so actual last processed block is latest_block - 1
                 // This ensures fallback DB queries in contract_state_leaf_hash fetch state at the correct block number
                 let trie_block_number = latest_block.saturating_sub(1);
-                let (global_state_root, _timings) =
-                    backend.write_access().apply_to_global_trie(trie_block_number, [accumulated_state_diff].iter())?;
+
+                // Fetch protocol version for version-gated state root computation.
+                let protocol_version = backend
+                    .db
+                    .get_block_info(trie_block_number)?
+                    .context("Block header can't be found for protocol version lookup in snap sync")?
+                    .header
+                    .protocol_version;
+
+                let (global_state_root, _timings) = backend.write_access().apply_to_global_trie(
+                    trie_block_number,
+                    [accumulated_state_diff].iter(),
+                    protocol_version,
+                )?;
 
                 let block_number = &latest_block.checked_sub(1);
                 backend.write_latest_applied_trie_update(block_number)?;

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -606,22 +606,28 @@ impl BlockImporterCtx {
 
         tracing::debug!("🔄 Applying state diff for blocks {:?} to global trie", block_range);
 
-        let (got, _timings) =
-            self.backend.write_access().apply_to_global_trie(block_range.start, state_diffs).map_err(|error| {
-                BlockImportError::InternalDb { error, context: "Applying state diff to global trie".into() }
+        // Fetch the last block's protocol version for version-gated state root computation.
+        let last_block_info = self
+            .backend
+            .db
+            .get_block_info(last_block_n)?
+            .context("Block header can't be found for protocol version lookup")?;
+        let protocol_version = last_block_info.header.protocol_version;
+
+        let (got, _timings) = self
+            .backend
+            .write_access()
+            .apply_to_global_trie(block_range.start, state_diffs, protocol_version)
+            .map_err(|error| BlockImportError::InternalDb {
+                error,
+                context: "Applying state diff to global trie".into(),
             })?;
 
         self.backend.write_latest_applied_trie_update(&block_range.end.checked_sub(1))?;
 
         // Sanity check: verify state root.
         if !self.config.no_check && !self.config.trust_state_root {
-            let expected = self
-                .backend
-                .db
-                .get_block_info(last_block_n)? // Raw get
-                .context("Block header can't be found")?
-                .header
-                .global_state_root;
+            let expected = last_block_info.header.global_state_root;
 
             if expected != got {
                 return Err(BlockImportError::GlobalStateRoot { got, expected });
@@ -655,8 +661,10 @@ mod tests {
     /// produces the expected results or errors.
     #[rstest]
     #[case::success(
-            // A non-zero global state root
-            felt!("0x738e796f750b21ddb3ce528ca88f7e35fad580768bd58571995b19a6809bb4a"),
+            // Global state root: Poseidon(STARKNET_STATE_V0, contract_trie_root, 0)
+            // because default protocol_version is LATEST (>= 0.14.0), class_trie_root is zero,
+            // and the >= 0.14.0 formula always hashes.
+            felt!("0x34d3e676a44c29cff0939ab2285ec02ffc3efd9eb548d85f59a6c7dd544e64d"),
             // A non-empty state diff with deployed contracts and storage changes
             StateDiff {
                 deployed_contracts: vec![(DeployedContractItem { address: felt!("0x1"), class_hash: felt!("0x1") })],

--- a/madara/crates/primitives/block/src/header.rs
+++ b/madara/crates/primitives/block/src/header.rs
@@ -437,6 +437,52 @@ mod tests {
         assert_eq!(hash, expected_hash);
     }
 
+    /// Pins `Header::compute_hash` against a real Starknet 0.14.1 genesis block with:
+    ///   - no transactions / events / receipts
+    ///   - one storage diff at system contract 0x2 (stateful compression init)
+    ///
+    /// Exercises the v1 hash formula (`STARKNET_BLOCK_HASH1`) including the gas-prices sub-hash
+    /// and the `concat_counts` field.
+    #[test]
+    fn test_header_hash_v0_14_1_genesis() {
+        let header = Header {
+            parent_block_hash: Felt::ZERO,
+            block_number: 0,
+            global_state_root: Felt::from_hex_unchecked(
+                "0x68bcf9e9257ab6bffd9425833a208aaab6b85649fd21c787a546cb7cb9abf",
+            ),
+            sequencer_address: Felt::from_hex_unchecked(
+                "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+            ),
+            block_timestamp: BlockTimestamp(1774447484),
+            transaction_count: 0,
+            transaction_commitment: Felt::ZERO,
+            event_count: 0,
+            event_commitment: Felt::ZERO,
+            state_diff_length: Some(1),
+            state_diff_commitment: Some(Felt::from_hex_unchecked(
+                "0x2a3ce358b96a4a26ac9c0ef4f7a8f878a9f3b1a4757e716874cac711617ca87",
+            )),
+            receipt_commitment: Some(Felt::ZERO),
+            protocol_version: StarknetVersion::V0_14_1,
+            gas_prices: GasPrices {
+                eth_l1_gas_price: 0x3b9aca27,
+                strk_l1_gas_price: 0x351026c4d376,
+                eth_l1_data_gas_price: 0x1,
+                strk_l1_data_gas_price: 0xe3e7,
+                eth_l2_gas_price: 0x2179e,
+                strk_l2_gas_price: 0x1dcd65000,
+            },
+            l1_da_mode: L1DataAvailabilityMode::Blob,
+        };
+
+        // chain_id is unused for >= 0.7 blocks, pass any value.
+        let hash = header.compute_hash(Felt::ZERO, false);
+        let expected_hash =
+            Felt::from_hex_unchecked("0x2c79e569f5759f7da943af68bc3d21e24fe280a39b9b0cefa2bc4d9a528f80b");
+        assert_eq!(hash, expected_hash);
+    }
+
     fn dummy_header(protocol_version: StarknetVersion) -> Header {
         Header {
             parent_block_hash: Felt::from(1),


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [x] Testing

## What is the current behavior?

`calculate_state_root` unconditionally short-circuits when `class_trie_root == 0`, returning `contract_trie_root` directly without hashing. This is correct for Starknet < 0.14.0 (where the class trie didn't exist), but **wrong for >= 0.14.0** where the formula is always `Poseidon(STARKNET_STATE_V0, contract_root, class_root)` — even when `class_root` is zero.

This causes madara to compute incorrect state roots for any >= 0.14.0 chain where the class trie is empty (e.g. early blocks of a new L3 chain), which in turn produces wrong block hashes and fails sync verification.

## What is the new behavior?

- `calculate_state_root` now takes a `StarknetVersion` parameter and gates the short-circuit on `version < 0.14.0`, matching `calculate_global_state_root` from the Starknet OS (`commitment.cairo`) and pathfinder's `StateCommitment::calculate`.
- `apply_to_global_trie` accepts `last_block_protocol_version` and passes it through. Callers (`write_new_confirmed_inner`, sync `import.rs`, snap sync `apply_state.rs`) each provide the version from the block header.
- Intermediate state roots in a batch use the last block's version — a comment documents that these can be imprecise across version boundaries, but only the final root is returned and verified.

### Test coverage

- **5 unit test cases** for `calculate_state_root` covering the full matrix:
  - `(non-zero, non-zero)` — hash
  - `(non-zero, zero)` with >= 0.14.0 — hash (regression test)
  - `(zero, non-zero)` — hash
  - `(zero, zero)` — zero
  - `(non-zero, zero)` with < 0.14.0 — short-circuit (pre-0.14.0 legacy behavior)
- **End-to-end test** applying a real 0.14.1 genesis state diff through `apply_to_global_trie` and verifying the returned root.
- **Block hash test** pinning `Header::compute_hash` against a real Starknet 0.14.1 genesis block with known-good values.
- Updated `test_update_tries::case_1_success` expected state root to match the >= 0.14.0 formula.

## Does this introduce a breaking change?

No. The `apply_to_global_trie` function signature gains a `StarknetVersion` parameter, but this is an internal API — no external consumers are affected.

## Other information

- The fix matches the canonical implementation in `calculate_global_state_root` from `starkware/starknet/core/os/state/commitment.cairo` in the sequencer repo.
- Pre-existing build break in `mp-block/src/commitments.rs` (`starknet_api::felt!` no longer re-exported) was fixed incidentally to unblock `cargo test -p mp-block`.