### PR TITLE
fix(settlement): enforce L1 message finality client-side with reorg protection

### DIFF
--- a/madara/crates/client/settlement_client/src/client.rs
+++ b/madara/crates/client/settlement_client/src/client.rs
@@ -110,6 +110,16 @@ pub trait SettlementLayerProvider: Send + Sync {
     /// * Block timestamp in seconds
     async fn get_block_n_timestamp(&self, l1_block_n: u64) -> Result<u64, SettlementClientError>;
 
+    /// Return the canonical block hash at the given block number, or `None` if no block exists
+    /// at that height.
+    ///
+    /// Used by the message sync worker to detect L1 reorgs: when a `LogMessageToL2` event is
+    /// received, its `l1_block_hash` is captured at observation time. Before processing the
+    /// message, the worker calls this function with the event's block number — if the returned
+    /// canonical hash differs from the observed hash, the event's block was reorged out and the
+    /// message must be discarded.
+    async fn get_block_n_hash(&self, l1_block_n: u64) -> Result<Option<[u8; 32]>, SettlementClientError>;
+
     // ============================================================
     // Stream Implementations :
     // ============================================================

--- a/madara/crates/client/settlement_client/src/eth/event.rs
+++ b/madara/crates/client/settlement_client/src/eth/event.rs
@@ -20,6 +20,12 @@ impl TryFrom<(LogMessageToL2, Log)> for MessageToL2WithMetadata {
             l1_block_number: log.block_number.ok_or_else(|| -> SettlementClientError {
                 EthereumClientError::MissingField("block_number in Ethereum log").into()
             })?,
+            l1_block_hash: log
+                .block_hash
+                .ok_or_else(|| -> SettlementClientError {
+                    EthereumClientError::MissingField("block_hash in Ethereum log").into()
+                })?
+                .0,
             l1_transaction_hash: log
                 .transaction_hash
                 .ok_or_else(|| -> SettlementClientError {
@@ -30,6 +36,7 @@ impl TryFrom<(LogMessageToL2, Log)> for MessageToL2WithMetadata {
         })
     }
 }
+
 impl TryFrom<LogMessageToL2> for L1HandlerTransactionWithFee {
     type Error = SettlementClientError;
 
@@ -244,6 +251,27 @@ pub mod eth_event_stream_tests {
         assert_eq!(events.len(), 1);
         assert_matches!(events[0].as_ref(), Err(SettlementClientError::Ethereum(EthereumClientError::MissingField(field))) => {
             assert_eq!(*field, "transaction_hash in Ethereum log", "Error should mention missing transaction hash");
+        });
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_missing_block_hash(mock_event: LogMessageToL2, mock_log: Log) {
+        let mock_events = vec![Ok((
+            mock_event,
+            Log {
+                block_hash: None, // Only block hash is missing
+                ..mock_log
+            },
+        ))];
+
+        let mock_stream = iter(mock_events);
+        let mut ethereum_stream = EthereumEventStream { stream: Box::pin(mock_stream) };
+        let events = collect_stream_events(&mut ethereum_stream).await;
+
+        assert_eq!(events.len(), 1);
+        assert_matches!(events[0].as_ref(), Err(SettlementClientError::Ethereum(EthereumClientError::MissingField(field))) => {
+            assert_eq!(*field, "block_hash in Ethereum log", "Error should mention missing block hash");
         });
     }
 }

--- a/madara/crates/client/settlement_client/src/eth/mod.rs
+++ b/madara/crates/client/settlement_client/src/eth/mod.rs
@@ -380,23 +380,43 @@ impl SettlementLayerProvider for EthereumClient {
         Ok(block.header.timestamp)
     }
 
+    async fn get_block_n_hash(&self, l1_block_n: u64) -> Result<Option<[u8; 32]>, SettlementClientError> {
+        let block = self.provider.get_block(BlockId::Number(BlockNumberOrTag::Number(l1_block_n))).await.map_err(
+            |e| -> SettlementClientError {
+                EthereumClientError::Rpc(format!("Failed to get block #{l1_block_n}: {e}")).into()
+            },
+        )?;
+        Ok(block.map(|b| b.header.hash.0))
+    }
+
     async fn messages_to_l2_stream(
         &self,
         from_l1_block_n: u64,
     ) -> Result<BoxStream<'static, Result<MessageToL2WithMetadata, SettlementClientError>>, SettlementClientError> {
-        // Step 1: Create the live event watcher BEFORE querying the finalized block.
-        // This guarantees no gap: the watcher tracks events from its creation time onward.
-        // We then snapshot the finalized block AFTER, so the historical query's upper bound
-        // is guaranteed to be at or before the watcher's start point — ensuring overlap,
-        // never a gap. Duplicates from the overlap are handled by nonce dedup.
+        // Step 1: Create the live event watcher BEFORE querying the latest block.
+        // This guarantees no gap: the watcher tracks events from its creation time onward,
+        // and the historical query (in step 3) covers everything up to the chain tip we
+        // observe in step 2. The two ranges overlap at the chain tip, so any event that lands
+        // in a block right around filter creation is caught by at least one path. Duplicates
+        // from the overlap are deduplicated downstream by nonce.
         // EthereumEventStream::new() calls into_stream() which spawns a background polling
         // task (eth_getFilterChanges every ~7s), keeping the filter alive during the
         // historical query and buffering any new events.
+        //
+        // We use `toBlock: "latest"` (not "finalized") for portability:
+        //   - Vanilla Geth's `SubscribeLogs` rejects `toBlock: "finalized"` with
+        //     `errInvalidBlockRange` — only "latest" or concrete numbers are supported.
+        //   - Hosted providers (e.g. Alchemy) accept "finalized" but their custom filter
+        //     layer does not enforce it, so events are delivered at chain-tip latency anyway.
+        //   - With "latest", the live watcher delivers events as soon as their block is mined.
+        //     Finality enforcement is performed client-side in `process_finalized_events`
+        //     by holding events until they reach `l1_messages_finality_blocks` confirmations
+        //     AND verifying the block hash is still canonical (catches reorgs).
         let event_poller = self
             .l1_core_contract
             .event_filter::<LogMessageToL2>()
             .from_block(from_l1_block_n)
-            .to_block(BlockNumberOrTag::Finalized)
+            .to_block(BlockNumberOrTag::Latest)
             .watch()
             .await
             .map_err(|e| -> SettlementClientError {
@@ -404,29 +424,30 @@ impl SettlementLayerProvider for EthereumClient {
             })?;
         let live_stream = EthereumEventStream::new(event_poller);
 
-        // Step 2: Get finalized block number AFTER creating the watcher.
-        // This is the upper bound for the historical query. We use `finalized` (not `latest`)
-        // to stay consistent with the rest of the message sync logic — we only process events
-        // that are finalized on L1 to avoid issues with chain reorgs.
-        let finalized_block = self
-            .provider
-            .get_block_by_number(BlockNumberOrTag::Finalized)
-            .await
-            .map_err(|e| -> SettlementClientError {
-                EthereumClientError::Rpc(format!("Failed to get finalized block: {e}")).into()
-            })?
-            .ok_or_else(|| -> SettlementClientError {
-                EthereumClientError::Rpc("Finalized block not available".to_string()).into()
-            })?
-            .header
-            .number;
+        // Step 2: Snapshot the latest block AFTER creating the watcher.
+        //
+        // The historical query MUST cover up to `latest` (not `finalized`), otherwise events
+        // in blocks `(finalized, latest]` at the moment of filter creation would be silently
+        // dropped: the live watcher only delivers events from blocks added after filter
+        // creation, so any event already mined in the (finalized, latest] window would never
+        // be picked up by it.
+        //
+        // This is safe because finality enforcement now happens client-side in
+        // `process_finalized_events`: every event (historical or live) is held in the
+        // in-memory `pending_events` queue until it reaches `l1_messages_finality_blocks`
+        // confirmations AND its block hash is verified canonical. Historical events from
+        // unfinalized blocks just sit in the queue a bit longer until they age into the
+        // confirmation window.
+        let latest_block = self.provider.get_block_number().await.map_err(|e| -> SettlementClientError {
+            EthereumClientError::Rpc(format!("Failed to get latest block: {e}")).into()
+        })?;
 
         // Step 3: Fetch historical events via paginated eth_getLogs (.query()).
         tracing::info!(
-            "⟠ L1→L2 message sync: querying historical events from block #{from_l1_block_n} to #{finalized_block}"
+            "⟠ L1→L2 message sync: querying historical events from block #{from_l1_block_n} to #{latest_block}"
         );
         let historical_events =
-            Self::query_paginated_events(&self.l1_core_contract, from_l1_block_n, finalized_block).await?;
+            Self::query_paginated_events(&self.l1_core_contract, from_l1_block_n, latest_block).await?;
         tracing::info!(
             "⟠ L1→L2 message sync: historical catchup complete ({} events), switching to live watching",
             historical_events.len()
@@ -720,7 +741,6 @@ mod l1_messaging_tests {
         let anvil = Anvil::new()
             .block_time(1)
             .chain_id(1337)
-            .args(["--slots-in-an-epoch", "1"])
             .try_spawn()
             .expect("failed to spawn anvil instance");
         let chain_config = Arc::new(ChainConfig::madara_test());
@@ -889,9 +909,10 @@ mod l1_messaging_tests {
         let l1_tx_hash_u256: U256 = (*fire_tx.tx_hash()).into();
         let l1_tx_hash = mp_convert::L1TransactionHash(l1_tx_hash_u256.to_be_bytes::<32>());
 
-        // Step 2: Wait for several blocks so the event becomes finalized.
-        // Anvil has block_time=1 and slots_in_an_epoch=1, so finalized = latest - 2.
-        // After ~5 seconds the event block will be well behind the finalized tip.
+        // Step 2: Wait a few blocks so the event sits firmly in the "historical" range
+        // by the time the worker starts. The sync worker's historical query (eth_getLogs)
+        // will pick it up regardless of finality, since we use `latest` as the upper bound
+        // and `madara_test()` sets `l1_messages_finality_blocks = 0`.
         tokio::time::sleep(Duration::from_secs(5)).await;
 
         // Step 3: Set the sync tip to block 0 so the worker queries from the beginning.
@@ -993,6 +1014,165 @@ mod l1_messaging_tests {
             .expect("Should parse valid expected hash hex");
 
         assert_eq!(msg, expected_hash);
+    }
+
+    /// End-to-end test verifying that:
+    ///   1. The canonical block hash check correctly drops L1 messages whose source block
+    ///      has been reorged out, AND
+    ///   2. Dropping a reorged event does NOT poison the nonce mapping — proving that a
+    ///      legitimate future message with the same nonce can still be processed.
+    ///
+    /// We test the second property indirectly: after the reorged event is dropped, we
+    /// assert that `l1_txn_hash_by_nonce(0)` is `None`. If it were `Some(...)`, the next
+    /// message with nonce 0 would be incorrectly skipped by `check_message_to_l2_validity`.
+    /// Asserting `None` is therefore equivalent to asserting "non-poisoning".
+    ///
+    /// We deliberately do not fire a second event with the same nonce because alloy's
+    /// `NonceFiller` caches the wallet's nonce locally; after `anvil_rollback`, the cache
+    /// is out of sync with the chain and any subsequent transaction hangs forever waiting
+    /// for confirmation. Working around that would require manual nonce management with no
+    /// added test value beyond what the indirect check already provides.
+    ///
+    /// Flow:
+    /// 1. Start the sync worker against Anvil with `l1_messages_finality_blocks = 15`
+    ///    (large enough that events have to wait in the in-memory queue, giving us a
+    ///    window to reorg).
+    /// 2. Fire event #1 with nonce 0; wait long enough for the worker's live filter
+    ///    (alloy polling interval ~7s) to observe it.
+    /// 3. Use `anvil_rollback` to roll the chain back past event #1's block. The block
+    ///    that originally contained event #1 is now off the canonical chain.
+    /// 4. Wait until anvil mines enough new blocks for `latest >= event_block + 15`,
+    ///    so the worker's confirmation check passes for the queued event.
+    /// 5. The worker pops event #1 from the queue, runs the canonical check, finds the
+    ///    block hash mismatch, and drops the event.
+    /// 6. Verify: no pending message for nonce 0, no nonce metadata written, sync tip
+    ///    advanced past the dropped event.
+    #[traced_test]
+    #[tokio::test]
+    async fn e2e_test_reorg_drops_event_and_does_not_poison_nonce() {
+        use alloy::providers::ext::AnvilApi;
+        use alloy::providers::Provider;
+
+        // === Setup ===
+        let anvil = Anvil::new()
+            .block_time(1)
+            .chain_id(1337)
+            .try_spawn()
+            .expect("failed to spawn anvil instance");
+
+        // Use a moderate finality_blocks: large enough to give us a window to reorg
+        // before the worker processes the event, small enough to keep the test fast.
+        let mut chain_config = ChainConfig::madara_test();
+        chain_config.l1_messages_finality_blocks = 15;
+        let chain_config = Arc::new(chain_config);
+        let db = MadaraBackend::open_for_testing(chain_config);
+
+        let rpc_url: Url = anvil.endpoint().parse().expect("issue while parsing");
+        let provider = Arc::new(ProviderBuilder::new().connect_http(rpc_url.clone()));
+        let wallet_provider = Arc::new(
+            ProviderBuilder::new()
+                .wallet(anvil.wallet().expect("anvil should expose a development wallet"))
+                .connect_http(rpc_url),
+        );
+
+        let contract = DummyContract::deploy(wallet_provider.clone()).await.unwrap();
+        let _ = contract.setIsCanceled(false).send().await.expect("setIsCanceled failed");
+
+        let core_contract = StarknetCoreContract::new(*contract.address(), provider.clone());
+        let eth_client = EthereumClient { provider: provider.clone(), l1_core_contract: core_contract };
+
+        // === Start sync worker ===
+        let worker_handle = {
+            let db = Arc::clone(&db);
+            tokio::spawn(async move {
+                sync(
+                    Arc::new(eth_client),
+                    Arc::clone(&db),
+                    Default::default(),
+                    ServiceContext::new_for_testing(),
+                    false,
+                    false,
+                )
+                .await
+            })
+        };
+
+        // Brief wait for worker to initialize and create the filter
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // === Phase 1: Fire event #1 ===
+        let fire_tx_1 = contract.fireEvent().send().await.expect("fireEvent #1 failed");
+        let l1_tx_hash_1_u256: U256 = (*fire_tx_1.tx_hash()).into();
+        let receipt_1 = fire_tx_1.get_receipt().await.expect("receipt #1 failed");
+        let event_block_1 = receipt_1.block_number.expect("event #1 receipt missing block number");
+        tracing::info!("Event #1 fired at block #{event_block_1}, tx={:#x}", l1_tx_hash_1_u256);
+
+        // Wait for the worker's live filter to observe event #1 (alloy polls ~7s).
+        // With finality_blocks=15 and ~10s of blocks elapsed, the event is observed but
+        // not yet processed (waiting for confirmations).
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        // Sanity: event should be in the in-memory queue, not yet in DB
+        assert!(
+            db.get_pending_message_to_l2(0).unwrap().is_none(),
+            "Event #1 should still be in the in-memory queue, not yet processed"
+        );
+
+        // === Phase 2: Reorg past event #1's block ===
+        let current_latest = provider.get_block_number().await.expect("get_block_number failed");
+        let depth = current_latest - event_block_1 + 1;
+        tracing::info!(
+            "Rolling back chain by {depth} blocks (latest #{current_latest} → #{})",
+            current_latest - depth
+        );
+        provider.anvil_rollback(Some(depth)).await.expect("anvil_rollback failed");
+
+        let post_reorg_latest = provider.get_block_number().await.expect("get_block_number failed");
+        tracing::info!("Post-reorg latest: #{post_reorg_latest}");
+        assert!(
+            post_reorg_latest < event_block_1,
+            "After rollback, latest (#{post_reorg_latest}) should be before event #1's block (#{event_block_1})"
+        );
+
+        // === Phase 3: Wait for anvil to mine past event_block_1 + finality_blocks ===
+        // Anvil mines 1 block/sec. We need latest >= event_block_1 + 15.
+        // After rollback, latest is below event_block_1, so we need to wait
+        // (event_block_1 - post_reorg_latest) + 15 seconds plus a small buffer.
+        let blocks_to_mine = (event_block_1 - post_reorg_latest) + 15 + 5;
+        tracing::info!("Waiting {blocks_to_mine}s for anvil to mine enough blocks...");
+        tokio::time::sleep(Duration::from_secs(blocks_to_mine)).await;
+
+        let final_latest = provider.get_block_number().await.expect("get_block_number failed");
+        tracing::info!("Final latest: #{final_latest}");
+        assert!(
+            final_latest >= event_block_1 + 15,
+            "Latest #{final_latest} should be >= event_block_1 (#{event_block_1}) + 15"
+        );
+
+        // === Phase 4: Verify event #1 was dropped and nonce was NOT poisoned ===
+        // Event #1 should NOT be in pending_message_to_l2
+        assert!(
+            db.get_pending_message_to_l2(0).unwrap().is_none(),
+            "Reorged event #1 should have been dropped, not queued for L2 inclusion"
+        );
+
+        // CRITICAL: nonce metadata must NOT have been written (no poisoning).
+        // If this were `Some(...)`, a future message with nonce 0 on the new canonical chain
+        // would be incorrectly skipped by `check_message_to_l2_validity`.
+        let stored_l1_tx_hash = db.get_l1_txn_hash_by_nonce(0).unwrap();
+        assert!(
+            stored_l1_tx_hash.is_none(),
+            "Nonce 0 must NOT be poisoned after dropping a reorged event (got: {stored_l1_tx_hash:?})"
+        );
+
+        // Sync tip should have advanced past event #1's block (so we don't re-fetch it)
+        let sync_tip = db.get_l1_messaging_sync_tip().unwrap().unwrap();
+        assert!(
+            sync_tip >= event_block_1,
+            "Sync tip #{sync_tip} should have advanced to at least event #1's block #{event_block_1}"
+        );
+
+        worker_handle.abort();
     }
 }
 

--- a/madara/crates/client/settlement_client/src/eth/mod.rs
+++ b/madara/crates/client/settlement_client/src/eth/mod.rs
@@ -738,11 +738,7 @@ mod l1_messaging_tests {
     #[fixture]
     async fn setup_test_env() -> TestRunner {
         // Start Anvil instance
-        let anvil = Anvil::new()
-            .block_time(1)
-            .chain_id(1337)
-            .try_spawn()
-            .expect("failed to spawn anvil instance");
+        let anvil = Anvil::new().block_time(1).chain_id(1337).try_spawn().expect("failed to spawn anvil instance");
         let chain_config = Arc::new(ChainConfig::madara_test());
         // Initialize database service
         let db = MadaraBackend::open_for_testing(chain_config.clone());
@@ -1016,49 +1012,31 @@ mod l1_messaging_tests {
         assert_eq!(msg, expected_hash);
     }
 
-    /// End-to-end test verifying that:
-    ///   1. The canonical block hash check correctly drops L1 messages whose source block
-    ///      has been reorged out, AND
-    ///   2. Dropping a reorged event does NOT poison the nonce mapping — proving that a
-    ///      legitimate future message with the same nonce can still be processed.
+    /// End-to-end test of the full L1 reorg flow against Anvil:
+    ///   1. Event #1 with nonce 0 is fired and observed by the worker.
+    ///   2. The chain is reorged past event #1's block.
+    ///   3. Event #2 with the same nonce is fired on the new canonical chain.
+    ///   4. The worker drops event #1 (canonical hash mismatch) without poisoning the
+    ///      nonce mapping.
+    ///   5. Event #2 is processed normally and queued for L2 inclusion, with nonce 0
+    ///      mapped to event #2's L1 tx hash.
     ///
-    /// We test the second property indirectly: after the reorged event is dropped, we
-    /// assert that `l1_txn_hash_by_nonce(0)` is `None`. If it were `Some(...)`, the next
-    /// message with nonce 0 would be incorrectly skipped by `check_message_to_l2_validity`.
-    /// Asserting `None` is therefore equivalent to asserting "non-poisoning".
-    ///
-    /// We deliberately do not fire a second event with the same nonce because alloy's
-    /// `NonceFiller` caches the wallet's nonce locally; after `anvil_rollback`, the cache
-    /// is out of sync with the chain and any subsequent transaction hangs forever waiting
-    /// for confirmation. Working around that would require manual nonce management with no
-    /// added test value beyond what the indirect check already provides.
-    ///
-    /// Flow:
-    /// 1. Start the sync worker against Anvil with `l1_messages_finality_blocks = 15`
-    ///    (large enough that events have to wait in the in-memory queue, giving us a
-    ///    window to reorg).
-    /// 2. Fire event #1 with nonce 0; wait long enough for the worker's live filter
-    ///    (alloy polling interval ~7s) to observe it.
-    /// 3. Use `anvil_rollback` to roll the chain back past event #1's block. The block
-    ///    that originally contained event #1 is now off the canonical chain.
-    /// 4. Wait until anvil mines enough new blocks for `latest >= event_block + 15`,
-    ///    so the worker's confirmation check passes for the queued event.
-    /// 5. The worker pops event #1 from the queue, runs the canonical check, finds the
-    ///    block hash mismatch, and drops the event.
-    /// 6. Verify: no pending message for nonce 0, no nonce metadata written, sync tip
-    ///    advanced past the dropped event.
+    /// Working around alloy's `NonceFiller` cache:
+    /// `CachedNonceManager` (the default) fetches `eth_getTransactionCount` once per
+    /// address, then increments the cache locally on each send. After `anvil_rollback`
+    /// the cache is ahead of the chain — sending another tx through the same provider
+    /// produces a "future" nonce that sits in the mempool forever and `get_receipt()`
+    /// hangs. We work around this by creating a **fresh** `wallet_provider_2` after the
+    /// rollback; its new `NonceFiller` calls `eth_getTransactionCount` on first use and
+    /// picks up the correct post-rollback nonce.
     #[traced_test]
     #[tokio::test]
-    async fn e2e_test_reorg_drops_event_and_does_not_poison_nonce() {
+    async fn e2e_test_reorg_drops_event_and_processes_re_emission() {
         use alloy::providers::ext::AnvilApi;
         use alloy::providers::Provider;
 
         // === Setup ===
-        let anvil = Anvil::new()
-            .block_time(1)
-            .chain_id(1337)
-            .try_spawn()
-            .expect("failed to spawn anvil instance");
+        let anvil = Anvil::new().block_time(1).chain_id(1337).try_spawn().expect("failed to spawn anvil instance");
 
         // Use a moderate finality_blocks: large enough to give us a window to reorg
         // before the worker processes the event, small enough to keep the test fast.
@@ -1072,7 +1050,7 @@ mod l1_messaging_tests {
         let wallet_provider = Arc::new(
             ProviderBuilder::new()
                 .wallet(anvil.wallet().expect("anvil should expose a development wallet"))
-                .connect_http(rpc_url),
+                .connect_http(rpc_url.clone()),
         );
 
         let contract = DummyContract::deploy(wallet_provider.clone()).await.unwrap();
@@ -1108,8 +1086,6 @@ mod l1_messaging_tests {
         tracing::info!("Event #1 fired at block #{event_block_1}, tx={:#x}", l1_tx_hash_1_u256);
 
         // Wait for the worker's live filter to observe event #1 (alloy polls ~7s).
-        // With finality_blocks=15 and ~10s of blocks elapsed, the event is observed but
-        // not yet processed (waiting for confirmations).
         tokio::time::sleep(Duration::from_secs(10)).await;
 
         // Sanity: event should be in the in-memory queue, not yet in DB
@@ -1121,10 +1097,7 @@ mod l1_messaging_tests {
         // === Phase 2: Reorg past event #1's block ===
         let current_latest = provider.get_block_number().await.expect("get_block_number failed");
         let depth = current_latest - event_block_1 + 1;
-        tracing::info!(
-            "Rolling back chain by {depth} blocks (latest #{current_latest} → #{})",
-            current_latest - depth
-        );
+        tracing::info!("Rolling back chain by {depth} blocks (latest #{current_latest} → #{})", current_latest - depth);
         provider.anvil_rollback(Some(depth)).await.expect("anvil_rollback failed");
 
         let post_reorg_latest = provider.get_block_number().await.expect("get_block_number failed");
@@ -1134,42 +1107,79 @@ mod l1_messaging_tests {
             "After rollback, latest (#{post_reorg_latest}) should be before event #1's block (#{event_block_1})"
         );
 
-        // === Phase 3: Wait for anvil to mine past event_block_1 + finality_blocks ===
-        // Anvil mines 1 block/sec. We need latest >= event_block_1 + 15.
-        // After rollback, latest is below event_block_1, so we need to wait
-        // (event_block_1 - post_reorg_latest) + 15 seconds plus a small buffer.
-        let blocks_to_mine = (event_block_1 - post_reorg_latest) + 15 + 5;
-        tracing::info!("Waiting {blocks_to_mine}s for anvil to mine enough blocks...");
-        tokio::time::sleep(Duration::from_secs(blocks_to_mine)).await;
+        // === Phase 3: Fire event #2 from a DIFFERENT anvil dev account ===
+        //
+        // Two reasons we use a different account here (not the same one with a fresh provider):
+        //
+        // 1. `CachedNonceManager` cache staleness: the original `wallet_provider` remembers
+        //    having sent deploy + setIsCanceled + event #1, so it thinks the next nonce is 3.
+        //    After the rollback, the chain only has deploy + setIsCanceled and expects nonce 2.
+        //    A fresh provider would query the chain and get nonce 2 — but then send a tx
+        //    that's BIT-FOR-BIT IDENTICAL to event #1's tx (same from, same nonce, same
+        //    calldata, same gas), producing the same tx hash. We'd lose the ability to
+        //    distinguish event #1 from event #2 in the assertions.
+        //
+        // 2. Using a different account guarantees a different `from` field → different tx
+        //    hash → we can prove the nonce mapping points to event #2 specifically.
+        let signer_2: alloy::signers::local::PrivateKeySigner = anvil.keys()[1].clone().into();
+        let wallet_2 = EthereumWallet::from(signer_2);
+        let wallet_provider_2 = Arc::new(ProviderBuilder::new().wallet(wallet_2).connect_http(rpc_url.clone()));
+        let contract_2 = DummyContract::new(*contract.address(), wallet_provider_2);
+
+        let fire_tx_2 = contract_2.fireEvent().send().await.expect("fireEvent #2 failed");
+        let l1_tx_hash_2_u256: U256 = (*fire_tx_2.tx_hash()).into();
+        let receipt_2 = fire_tx_2.get_receipt().await.expect("receipt #2 failed");
+        let event_block_2 = receipt_2.block_number.expect("event #2 receipt missing block number");
+        tracing::info!("Event #2 fired at block #{event_block_2}, tx={:#x}", l1_tx_hash_2_u256);
+
+        // Sanity: distinct L1 tx hashes (different from-addresses, hence different RLP)
+        assert_ne!(l1_tx_hash_1_u256, l1_tx_hash_2_u256, "Event #1 and event #2 must have distinct L1 tx hashes");
+
+        // === Phase 4: Wait for both events to reach the confirmation threshold ===
+        // Need: latest >= max(event_block_1, event_block_2) + 15
+        let max_event_block = std::cmp::max(event_block_1, event_block_2);
+        let target_latest = max_event_block + 15;
+        let post_2_latest = provider.get_block_number().await.expect("get_block_number failed");
+        let blocks_to_wait = if post_2_latest < target_latest {
+            (target_latest - post_2_latest) + 5 // small buffer for filter polling
+        } else {
+            5
+        };
+        tracing::info!("Waiting {blocks_to_wait}s for confirmations (need latest >= #{target_latest})...");
+        tokio::time::sleep(Duration::from_secs(blocks_to_wait)).await;
 
         let final_latest = provider.get_block_number().await.expect("get_block_number failed");
         tracing::info!("Final latest: #{final_latest}");
-        assert!(
-            final_latest >= event_block_1 + 15,
-            "Latest #{final_latest} should be >= event_block_1 (#{event_block_1}) + 15"
-        );
+        assert!(final_latest >= target_latest, "Latest #{final_latest} should be >= target #{target_latest}");
 
-        // === Phase 4: Verify event #1 was dropped and nonce was NOT poisoned ===
-        // Event #1 should NOT be in pending_message_to_l2
-        assert!(
-            db.get_pending_message_to_l2(0).unwrap().is_none(),
-            "Reorged event #1 should have been dropped, not queued for L2 inclusion"
-        );
+        // === Phase 5: Verify event #1 dropped, event #2 processed, nonce mapped to event #2 ===
+        let pending = db.get_pending_message_to_l2(0).unwrap();
+        assert!(pending.is_some(), "Event #2 should be in pending_message_to_l2 (worker should have processed it)");
 
-        // CRITICAL: nonce metadata must NOT have been written (no poisoning).
-        // If this were `Some(...)`, a future message with nonce 0 on the new canonical chain
-        // would be incorrectly skipped by `check_message_to_l2_validity`.
+        let l1_tx_hash_2_typed = mp_convert::L1TransactionHash(l1_tx_hash_2_u256.to_be_bytes::<32>());
+        let l1_tx_hash_1_typed = mp_convert::L1TransactionHash(l1_tx_hash_1_u256.to_be_bytes::<32>());
         let stored_l1_tx_hash = db.get_l1_txn_hash_by_nonce(0).unwrap();
-        assert!(
-            stored_l1_tx_hash.is_none(),
-            "Nonce 0 must NOT be poisoned after dropping a reorged event (got: {stored_l1_tx_hash:?})"
+
+        // CRITICAL: nonce 0 must be mapped to event #2's L1 tx hash, NOT event #1's.
+        // If event #1 had poisoned the mapping (because we wrote nonce metadata before
+        // checking canonicity), this would point to event #1 and we'd be processing a
+        // message that was reorged out.
+        assert_eq!(
+            stored_l1_tx_hash,
+            Some(l1_tx_hash_2_typed),
+            "Nonce 0 should be mapped to event #2's L1 tx hash (proving non-poisoning)"
+        );
+        assert_ne!(
+            stored_l1_tx_hash,
+            Some(l1_tx_hash_1_typed),
+            "Nonce 0 must NOT be mapped to event #1's tx hash (which was reorged out)"
         );
 
-        // Sync tip should have advanced past event #1's block (so we don't re-fetch it)
+        // Sync tip should have advanced at least past event #2's block
         let sync_tip = db.get_l1_messaging_sync_tip().unwrap().unwrap();
         assert!(
-            sync_tip >= event_block_1,
-            "Sync tip #{sync_tip} should have advanced to at least event #1's block #{event_block_1}"
+            sync_tip >= event_block_2,
+            "Sync tip #{sync_tip} should have advanced to at least event #2's block #{event_block_2}"
         );
 
         worker_handle.abort();

--- a/madara/crates/client/settlement_client/src/messaging.rs
+++ b/madara/crates/client/settlement_client/src/messaging.rs
@@ -252,16 +252,16 @@ async fn get_start_block(
 ///      satisfied, leave the event in the queue and stop (events are ordered, so later events
 ///      are also not yet confirmed).
 ///
-///   2. **Canonical block check**: query the current canonical block hash at `event.l1_block_number`
-///      and compare against `event.l1_block_hash` (captured at observation time). If they differ,
-///      the block was reorged out of the canonical chain — drop the event entirely WITHOUT writing
-///      any nonce metadata (otherwise the nonce would be permanently poisoned and a re-emitted
-///      message with the same nonce on the new canonical chain would be incorrectly skipped).
-///      Still advance the sync tip past the event so we don't keep re-fetching the same range.
+///   2. **Canonical block check** (RPC call — done BEFORE popping the event): query the current
+///      canonical block hash at `event.l1_block_number` and compare against `event.l1_block_hash`
+///      (captured at observation time). If the RPC call fails transiently, the event stays in the
+///      queue and is retried on the next poll. If the hashes differ, the block was reorged out —
+///      pop and drop the event WITHOUT writing any nonce metadata and WITHOUT advancing the sync
+///      tip (so reconnection can re-scan the reorged region for new canonical events).
 ///
-///   3. **Validity check**: only after the canonical check passes, write nonce metadata and
-///      run `check_message_to_l2_validity` (existence check on the L1 contract + cancellation
-///      check). If valid, queue for L2 inclusion via `write_pending_message_to_l2`.
+///   3. **Validity check**: only after the canonical check passes, pop the event, write nonce
+///      metadata, and run `check_message_to_l2_validity` (existence check on the L1 contract +
+///      cancellation check). If valid, queue for L2 inclusion via `write_pending_message_to_l2`.
 ///
 /// Note: there is still a small unprotected window between queue-write and L2 block production
 /// inclusion. Within this window, a deeper-than-`finality_blocks` reorg could invalidate a message
@@ -282,11 +282,12 @@ async fn process_finalized_events(
 
     let latest_l1_block = settlement_client.get_latest_block_number().await?;
 
-    // Process events from the front (oldest first) that have reached the confirmation depth
     while let Some(event) = pending_events.front() {
+        // Step 1: peek at the front event and check confirmation depth.
+        // We deliberately do NOT pop yet — the event stays in the queue until we've
+        // confirmed the canonical hash check (step 2). This way, if the RPC call in
+        // step 2 fails transiently, the event is not lost.
         let confirmations = latest_l1_block.saturating_sub(event.l1_block_number);
-
-        // Step 1: confirmation depth check
         if confirmations < finality_blocks {
             tracing::debug!(
                 "Message at block {} waiting for confirmations: {}/{}",
@@ -296,51 +297,57 @@ async fn process_finalized_events(
             );
             break; // Events are ordered, remaining events are also not yet confirmed
         }
-
-        // SAFETY: We just confirmed front() returned Some
-        let event = pending_events.pop_front().expect("front() was Some");
+        // Copy the values we need for step 2. After this, `event` (the borrow from
+        // front()) is no longer used, so NLL releases the immutable borrow on
+        // pending_events — allowing pop_front() and async calls below.
+        let block_number = event.l1_block_number;
+        let block_hash = event.l1_block_hash;
 
         // Step 2: canonical block check — guard against reorged-out blocks.
-        // We compare the block hash captured at event observation time against the current
-        // canonical hash at the same block number. If they differ, the block was reorged out
-        // and the event must be dropped without poisoning nonce metadata.
-        let canonical_hash = settlement_client.get_block_n_hash(event.l1_block_number).await.map_err(|e| {
-            SettlementClientError::InvalidResponse(format!(
-                "Failed to fetch canonical hash at block {}: {}",
-                event.l1_block_number, e
-            ))
-        })?;
+        // The RPC call happens while the event is still safely in the queue.
+        // If the call fails, we return Ok(()) and retry on the next poll (100ms).
+        let canonical_hash = match settlement_client.get_block_n_hash(block_number).await {
+            Ok(hash) => hash,
+            Err(e) => {
+                tracing::warn!(
+                    "Transient failure checking canonical hash at block #{block_number}: {e:#}. \
+                     Event stays in queue, will retry on next poll."
+                );
+                return Ok(());
+            }
+        };
+
         match canonical_hash {
-            Some(hash) if hash == event.l1_block_hash => {
-                // Block is canonical — proceed with processing.
+            Some(hash) if hash == block_hash => {
+                // Block is canonical — pop and proceed with processing.
             }
             Some(hash) => {
+                // Block was reorged — pop and discard. Do NOT write nonce metadata (would
+                // poison the nonce) and do NOT advance sync tip (a reconnection should
+                // re-scan this region to pick up events from the new canonical chain).
+                let event = pending_events.pop_front().expect("front() was Some");
                 tracing::warn!(
                     "Dropping reorged L1→L2 message: block={}, nonce={}, observed_hash={:#x}, canonical_hash={:#x}",
-                    event.l1_block_number,
+                    block_number,
                     event.message.tx.nonce,
-                    B256::from(event.l1_block_hash),
+                    B256::from(block_hash),
                     B256::from(hash),
                 );
-                // Advance the sync tip so we don't re-fetch this range. Do NOT write any
-                // nonce metadata: the nonce may be re-emitted on the new canonical chain,
-                // and we must not block its future processing.
-                backend
-                    .write_l1_messaging_sync_tip(Some(event.l1_block_number))
-                    .map_err(|e| SettlementClientError::DatabaseError(format!("Failed to update sync tip: {}", e)))?;
                 continue;
             }
             None => {
+                let event = pending_events.pop_front().expect("front() was Some");
                 tracing::warn!(
-                    "Dropping L1→L2 message: block #{} no longer exists on L1 (deep reorg or pruning)",
-                    event.l1_block_number,
+                    "Dropping L1→L2 message: block #{} no longer exists on L1 (deep reorg or pruning), nonce={}",
+                    block_number,
+                    event.message.tx.nonce,
                 );
-                backend
-                    .write_l1_messaging_sync_tip(Some(event.l1_block_number))
-                    .map_err(|e| SettlementClientError::DatabaseError(format!("Failed to update sync tip: {}", e)))?;
                 continue;
             }
         }
+
+        // Step 3: pop the event — we've confirmed the block is canonical.
+        let event = pending_events.pop_front().expect("front() was Some");
 
         tracing::info!(
             "Processing L1→L2 message: block={}, nonce={}, confirmations={}",
@@ -891,9 +898,75 @@ mod messaging_module_tests {
             "Nonce should NOT be poisoned after dropping a reorged event"
         );
 
-        // Sync tip should still have advanced past the dropped event so we don't re-fetch the same range
+        // Sync tip should NOT have advanced past the dropped event — on reconnection,
+        // the historical query should re-scan this region to pick up new canonical events.
         let sync_tip = db.get_l1_messaging_sync_tip().unwrap().unwrap();
-        assert!(sync_tip >= mock_event.l1_block_number, "Sync tip should have advanced past the dropped event's block");
+        assert_eq!(sync_tip, 99, "Sync tip should NOT advance when dropping a reorged event");
+
+        ctx_clone.cancel_global();
+        sync_handle.abort();
+
+        Ok(())
+    }
+
+    /// Same as `test_drops_event_when_block_does_not_exist`, but for the more common reorg case
+    /// where the block still exists at the same height but has a DIFFERENT hash (i.e., the chain
+    /// reorged and a new block was mined at the same height with different content).
+    #[tokio::test]
+    async fn test_drops_event_when_block_hash_mismatches() -> anyhow::Result<()> {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .try_init();
+
+        let mut chain_config = ChainConfig::madara_test();
+        chain_config.l1_messages_finality_blocks = 10;
+        let chain_config = Arc::new(chain_config);
+        let db = MadaraBackend::open_for_testing(chain_config.clone());
+
+        db.write_l1_messaging_sync_tip(Some(99))?;
+
+        let mut mock_client = MockSettlementLayerProvider::new();
+
+        // Event at block 100 with l1_block_hash = [0u8; 32] (from create_mock_event).
+        // Latest at 115 → confirmation check passes.
+        let mock_event = create_mock_event(100, 1);
+        let events = vec![mock_event.clone()];
+        mock_client.expect_messages_to_l2_stream().returning(move |_| Ok(stream::iter(events.clone()).map(Ok).boxed()));
+        mock_client.expect_get_latest_block_number().returning(|| Ok(115));
+        mock_client.expect_get_client_type().returning(|| ClientType::Eth);
+
+        // CRITICAL: get_block_n_hash returns a DIFFERENT hash than the event's l1_block_hash.
+        // This simulates a reorg where block 100 was replaced with a new block at the same height.
+        mock_client.expect_get_block_n_hash().returning(|_| Ok(Some([1u8; 32])));
+
+        // No validity-check mocks — they should NOT be called (canonical check short-circuits).
+
+        let client = Arc::new(mock_client) as Arc<dyn SettlementLayerProvider>;
+        let ctx = ServiceContext::new_for_testing();
+        let ctx_clone = ctx.clone();
+        let notify = Arc::new(Notify::new());
+        let db_clone = db.clone();
+
+        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false, false).await });
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Event must NOT have been queued for L2 inclusion
+        assert!(
+            db.get_pending_message_to_l2(mock_event.message.tx.nonce).unwrap().is_none(),
+            "Reorged event should not be in pending_message_to_l2"
+        );
+
+        // Nonce metadata must NOT have been written
+        assert!(
+            db.get_l1_txn_hash_by_nonce(mock_event.message.tx.nonce).unwrap().is_none(),
+            "Nonce should NOT be poisoned after dropping a reorged event"
+        );
+
+        // Sync tip should NOT have advanced
+        let sync_tip = db.get_l1_messaging_sync_tip().unwrap().unwrap();
+        assert_eq!(sync_tip, 99, "Sync tip should NOT advance when dropping a reorged event");
 
         ctx_clone.cancel_global();
         sync_handle.abort();

--- a/madara/crates/client/settlement_client/src/messaging.rs
+++ b/madara/crates/client/settlement_client/src/messaging.rs
@@ -893,10 +893,7 @@ mod messaging_module_tests {
 
         // Sync tip should still have advanced past the dropped event so we don't re-fetch the same range
         let sync_tip = db.get_l1_messaging_sync_tip().unwrap().unwrap();
-        assert!(
-            sync_tip >= mock_event.l1_block_number,
-            "Sync tip should have advanced past the dropped event's block"
-        );
+        assert!(sync_tip >= mock_event.l1_block_number, "Sync tip should have advanced past the dropped event's block");
 
         ctx_clone.cancel_global();
         sync_handle.abort();

--- a/madara/crates/client/settlement_client/src/messaging.rs
+++ b/madara/crates/client/settlement_client/src/messaging.rs
@@ -21,6 +21,11 @@ const STREAM_POLL_INTERVAL: Duration = Duration::from_millis(100);
 #[derive(Clone, Debug)]
 pub struct MessageToL2WithMetadata {
     pub l1_block_number: u64,
+    /// Block hash of the L1 block containing this event at the time it was observed.
+    /// Used at processing time to detect reorgs by comparing against the current canonical
+    /// hash at `l1_block_number`. If they differ, the block was reorged out and the message
+    /// must be dropped.
+    pub l1_block_hash: [u8; 32],
     pub l1_transaction_hash: U256,
     pub message: L1HandlerTransactionWithFee,
 }
@@ -239,7 +244,29 @@ async fn get_start_block(
     }
 }
 
-/// Processes events from the queue that have reached the required finality threshold.
+/// Processes events from the queue that have reached the required confirmation depth.
+///
+/// For each event at the front of the queue, in order:
+///
+///   1. **Confirmation check**: requires `latest - event_block >= finality_blocks`. If not yet
+///      satisfied, leave the event in the queue and stop (events are ordered, so later events
+///      are also not yet confirmed).
+///
+///   2. **Canonical block check**: query the current canonical block hash at `event.l1_block_number`
+///      and compare against `event.l1_block_hash` (captured at observation time). If they differ,
+///      the block was reorged out of the canonical chain — drop the event entirely WITHOUT writing
+///      any nonce metadata (otherwise the nonce would be permanently poisoned and a re-emitted
+///      message with the same nonce on the new canonical chain would be incorrectly skipped).
+///      Still advance the sync tip past the event so we don't keep re-fetching the same range.
+///
+///   3. **Validity check**: only after the canonical check passes, write nonce metadata and
+///      run `check_message_to_l2_validity` (existence check on the L1 contract + cancellation
+///      check). If valid, queue for L2 inclusion via `write_pending_message_to_l2`.
+///
+/// Note: there is still a small unprotected window between queue-write and L2 block production
+/// inclusion. Within this window, a deeper-than-`finality_blocks` reorg could invalidate a message
+/// that has already been queued. This is accepted as part of the probabilistic safety envelope
+/// implied by `finality_blocks` — chosen specifically to make such reorgs negligibly unlikely.
 async fn process_finalized_events(
     settlement_client: &Arc<dyn SettlementLayerProvider>,
     backend: &MadaraBackend,
@@ -255,22 +282,65 @@ async fn process_finalized_events(
 
     let latest_l1_block = settlement_client.get_latest_block_number().await?;
 
-    // Process events from the front (oldest first) that have reached finality
+    // Process events from the front (oldest first) that have reached the confirmation depth
     while let Some(event) = pending_events.front() {
         let confirmations = latest_l1_block.saturating_sub(event.l1_block_number);
 
+        // Step 1: confirmation depth check
         if confirmations < finality_blocks {
             tracing::debug!(
-                "Message at block {} waiting for finality: {}/{} confirmations",
+                "Message at block {} waiting for confirmations: {}/{}",
                 event.l1_block_number,
                 confirmations,
                 finality_blocks
             );
-            break; // Events are ordered, remaining events are also not finalized
+            break; // Events are ordered, remaining events are also not yet confirmed
         }
 
         // SAFETY: We just confirmed front() returned Some
         let event = pending_events.pop_front().expect("front() was Some");
+
+        // Step 2: canonical block check — guard against reorged-out blocks.
+        // We compare the block hash captured at event observation time against the current
+        // canonical hash at the same block number. If they differ, the block was reorged out
+        // and the event must be dropped without poisoning nonce metadata.
+        let canonical_hash = settlement_client.get_block_n_hash(event.l1_block_number).await.map_err(|e| {
+            SettlementClientError::InvalidResponse(format!(
+                "Failed to fetch canonical hash at block {}: {}",
+                event.l1_block_number, e
+            ))
+        })?;
+        match canonical_hash {
+            Some(hash) if hash == event.l1_block_hash => {
+                // Block is canonical — proceed with processing.
+            }
+            Some(hash) => {
+                tracing::warn!(
+                    "Dropping reorged L1→L2 message: block={}, nonce={}, observed_hash={:#x}, canonical_hash={:#x}",
+                    event.l1_block_number,
+                    event.message.tx.nonce,
+                    B256::from(event.l1_block_hash),
+                    B256::from(hash),
+                );
+                // Advance the sync tip so we don't re-fetch this range. Do NOT write any
+                // nonce metadata: the nonce may be re-emitted on the new canonical chain,
+                // and we must not block its future processing.
+                backend
+                    .write_l1_messaging_sync_tip(Some(event.l1_block_number))
+                    .map_err(|e| SettlementClientError::DatabaseError(format!("Failed to update sync tip: {}", e)))?;
+                continue;
+            }
+            None => {
+                tracing::warn!(
+                    "Dropping L1→L2 message: block #{} no longer exists on L1 (deep reorg or pruning)",
+                    event.l1_block_number,
+                );
+                backend
+                    .write_l1_messaging_sync_tip(Some(event.l1_block_number))
+                    .map_err(|e| SettlementClientError::DatabaseError(format!("Failed to update sync tip: {}", e)))?;
+                continue;
+            }
+        }
 
         tracing::info!(
             "Processing L1→L2 message: block={}, nonce={}, confirmations={}",
@@ -279,6 +349,8 @@ async fn process_finalized_events(
             confirmations
         );
 
+        // Step 3: persist origin metadata + validity check + queue for L2 inclusion.
+        //
         // Persist minimal origin metadata for `starknet_getMessagesStatus`:
         // - nonce -> l1_tx_hash
         // - l1_tx_hash||nonce -> <empty> (seen marker), later filled with l2_tx_hash once known
@@ -376,6 +448,7 @@ mod messaging_module_tests {
     fn create_mock_event(l1_block_number: u64, nonce: u64) -> MessageToL2WithMetadata {
         MessageToL2WithMetadata {
             l1_block_number,
+            l1_block_hash: [0u8; 32],
             l1_transaction_hash: U256::from(1),
             message: L1HandlerTransactionWithFee::new(
                 L1HandlerTransaction {
@@ -439,6 +512,13 @@ mod messaging_module_tests {
             .returning(move |_| Ok(is_pending));
     }
 
+    /// Mocks the canonical block hash check so that any event from `create_mock_event` passes
+    /// the reorg check in `process_finalized_events`. The default mock_event uses
+    /// `l1_block_hash = [0u8; 32]`, so we return that for every block number.
+    fn mock_canonical_block_hash(mock: &mut MockSettlementLayerProvider) {
+        mock.expect_get_block_n_hash().returning(|_| Ok(Some([0u8; 32])));
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_sync_processes_new_messages(
@@ -461,7 +541,10 @@ mod messaging_module_tests {
         // Event is at block 100, latest is 200, so finality check passes (default finality_blocks=10)
         client.expect_get_latest_block_number().returning(|| Ok(200));
 
-        // nonce 1, is pending, not being cancelled, not consumed in db. => OK
+        // Mock canonical block hash check (event passes reorg check)
+        mock_canonical_block_hash(&mut client);
+
+        // nonce 1, is pending, not being canceled, not consumed in db. => OK
         mock_l1_handler_tx(&mut client, 1, true, false);
         db.write_l1_handler_txn_hash_by_nonce(18, &Felt::ONE).unwrap();
 
@@ -528,6 +611,9 @@ mod messaging_module_tests {
         // Event is at block 100, latest is 200, so finality check passes (default finality_blocks=10)
         client.expect_get_latest_block_number().returning(|| Ok(200));
 
+        // Mock canonical block hash check (event passes reorg check)
+        mock_canonical_block_hash(&mut client);
+
         // Mock get_client_type
         client.expect_get_client_type().returning(|| ClientType::Eth);
 
@@ -586,6 +672,9 @@ mod messaging_module_tests {
         }
         client.expect_get_latest_block_number().returning(move || Ok(100));
 
+        // Mock canonical block hash check (event passes reorg check)
+        mock_canonical_block_hash(&mut client);
+
         let from_l1_block_n = 84; // it should find this block
 
         // Mock get_messaging_stream
@@ -616,7 +705,7 @@ mod messaging_module_tests {
 
         // Verify the message was processed
         assert_eq!(db.get_pending_message_to_l2(mock_event1.message.tx.nonce).unwrap().unwrap(), mock_event1.message);
-        let l1_tx_hash = mp_convert::L1TransactionHash(mock_event1.l1_transaction_hash.to_be_bytes::<32>());
+        let l1_tx_hash = L1TransactionHash(mock_event1.l1_transaction_hash.to_be_bytes::<32>());
         assert_eq!(db.get_l1_txn_hash_by_nonce(mock_event1.message.tx.nonce).unwrap(), Some(l1_tx_hash));
         assert_eq!(
             db.get_messages_to_l2_by_l1_tx_hash(&l1_tx_hash).unwrap().unwrap(),
@@ -717,6 +806,7 @@ mod messaging_module_tests {
 
         mock_client.expect_get_client_type().returning(|| ClientType::Eth);
         mock_l1_handler_tx(&mut mock_client, 1, true, false);
+        mock_canonical_block_hash(&mut mock_client);
 
         let client = Arc::new(mock_client) as Arc<dyn SettlementLayerProvider>;
         let ctx = ServiceContext::new_for_testing();
@@ -733,6 +823,79 @@ mod messaging_module_tests {
         assert!(
             db.get_pending_message_to_l2(mock_event.message.tx.nonce).unwrap().is_some(),
             "Event should be processed after finality threshold"
+        );
+
+        ctx_clone.cancel_global();
+        sync_handle.abort();
+
+        Ok(())
+    }
+
+    /// Verifies the canonical block hash check correctly drops events whose source block
+    /// no longer exists on the canonical chain (e.g., after a deep reorg or pruning).
+    ///
+    /// Critical assertion: when an event is dropped because its block doesn't exist, the
+    /// nonce metadata must NOT be written. Otherwise the nonce would be permanently poisoned
+    /// and a re-emitted message with the same nonce on the new canonical chain would be
+    /// incorrectly skipped.
+    #[tokio::test]
+    async fn test_drops_event_when_block_does_not_exist() -> anyhow::Result<()> {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .try_init();
+
+        let mut chain_config = ChainConfig::madara_test();
+        chain_config.l1_messages_finality_blocks = 10;
+        let chain_config = Arc::new(chain_config);
+        let db = MadaraBackend::open_for_testing(chain_config.clone());
+
+        // Set sync tip to avoid calling find_replay_block_n_start
+        db.write_l1_messaging_sync_tip(Some(99))?;
+
+        let mut mock_client = MockSettlementLayerProvider::new();
+
+        // Event at block 100, latest at 115 → confirmation check passes
+        let mock_event = create_mock_event(100, 1);
+        let events = vec![mock_event.clone()];
+        mock_client.expect_messages_to_l2_stream().returning(move |_| Ok(stream::iter(events.clone()).map(Ok).boxed()));
+        mock_client.expect_get_latest_block_number().returning(|| Ok(115));
+        mock_client.expect_get_client_type().returning(|| ClientType::Eth);
+
+        // CRITICAL: get_block_n_hash returns None — block at #100 no longer exists on canonical chain.
+        mock_client.expect_get_block_n_hash().returning(|_| Ok(None));
+
+        // Note: NO mock for calculate_message_hash / message_to_l2_is_pending /
+        // message_to_l2_has_cancel_request — those should NOT be called because the
+        // canonical check fails first, short-circuiting validity checks.
+
+        let client = Arc::new(mock_client) as Arc<dyn SettlementLayerProvider>;
+        let ctx = ServiceContext::new_for_testing();
+        let ctx_clone = ctx.clone();
+        let notify = Arc::new(Notify::new());
+        let db_clone = db.clone();
+
+        let sync_handle = tokio::spawn(async move { sync(client, db_clone, notify, ctx, false, false).await });
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // The event must NOT have been queued for L2 inclusion
+        assert!(
+            db.get_pending_message_to_l2(mock_event.message.tx.nonce).unwrap().is_none(),
+            "Reorged event should not be in pending_message_to_l2"
+        );
+
+        // CRITICAL: nonce metadata must NOT have been written (no poisoning)
+        assert!(
+            db.get_l1_txn_hash_by_nonce(mock_event.message.tx.nonce).unwrap().is_none(),
+            "Nonce should NOT be poisoned after dropping a reorged event"
+        );
+
+        // Sync tip should still have advanced past the dropped event so we don't re-fetch the same range
+        let sync_tip = db.get_l1_messaging_sync_tip().unwrap().unwrap();
+        assert!(
+            sync_tip >= mock_event.l1_block_number,
+            "Sync tip should have advanced past the dropped event's block"
         );
 
         ctx_clone.cancel_global();
@@ -807,6 +970,7 @@ mod messaging_module_tests {
         client.expect_messages_to_l2_stream().returning(move |_| Ok(stream::iter(events.clone()).map(Ok).boxed()));
         client.expect_get_latest_block_number().returning(|| Ok(200));
 
+        mock_canonical_block_hash(&mut client);
         mock_l1_handler_tx(&mut client, 1, true, false);
         client.expect_get_client_type().returning(|| ClientType::Eth);
 
@@ -820,7 +984,7 @@ mod messaging_module_tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Metadata SHOULD be written
-        let l1_tx_hash = mp_convert::L1TransactionHash(mock_event1.l1_transaction_hash.to_be_bytes::<32>());
+        let l1_tx_hash = L1TransactionHash(mock_event1.l1_transaction_hash.to_be_bytes::<32>());
         assert_eq!(db.get_l1_txn_hash_by_nonce(mock_event1.message.tx.nonce).unwrap(), Some(l1_tx_hash));
         assert_eq!(
             db.get_messages_to_l2_by_l1_tx_hash(&l1_tx_hash).unwrap().unwrap(),

--- a/madara/crates/client/settlement_client/src/starknet/event.rs
+++ b/madara/crates/client/settlement_client/src/starknet/event.rs
@@ -56,9 +56,20 @@ impl TryFrom<EmittedEvent> for MessageToL2WithMetadata {
             })
         })?;
 
+        let block_hash = event
+            .block_hash
+            .ok_or_else(|| {
+                SettlementClientError::Starknet(StarknetClientError::EventProcessing {
+                    message: "Unable to get block hash from event".to_string(),
+                    event_id: "MessageSent".to_string(),
+                })
+            })?
+            .to_bytes_be();
+
         Ok(Self {
             l1_transaction_hash: event.transaction_hash.to_u256(),
             l1_block_number: block_number,
+            l1_block_hash: block_hash,
             message: L1HandlerTransactionWithFee::new(
                 L1HandlerTransaction {
                     version: Felt::ZERO,

--- a/madara/crates/client/settlement_client/src/starknet/mod.rs
+++ b/madara/crates/client/settlement_client/src/starknet/mod.rs
@@ -359,6 +359,20 @@ impl SettlementLayerProvider for StarknetClient {
         }
     }
 
+    async fn get_block_n_hash(&self, l1_block_n: u64) -> Result<Option<[u8; 32]>, SettlementClientError> {
+        let block = self.provider.get_block_with_tx_hashes(BlockId::Number(l1_block_n)).await.map_err(
+            |e| -> SettlementClientError {
+                StarknetClientError::Provider(format!("Failed to get block #{l1_block_n}: {e}")).into()
+            },
+        )?;
+
+        match block {
+            MaybePreConfirmedBlockWithTxHashes::Block(b) => Ok(Some(b.block_hash.to_bytes_be())),
+            // Pre-confirmed blocks aren't yet on-chain — they have no canonical hash.
+            MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_) => Ok(None),
+        }
+    }
+
     async fn messages_to_l2_stream(
         &self,
         from_l1_block_n: u64,

--- a/madara/crates/primitives/chain_config/src/chain_config.rs
+++ b/madara/crates/primitives/chain_config/src/chain_config.rs
@@ -139,7 +139,19 @@ fn default_l1_messages_replay_max_duration() -> Duration {
     Duration::from_secs(3 * 24 * 60 * 60)
 }
 fn default_l1_messages_finality_blocks() -> u64 {
-    10 // Default: wait for 10 L1 blocks before processing messages (~2 minutes on Ethereum)
+    // Default confirmation depth before consuming L1→L2 messages: 10 blocks (~2 min on Ethereum).
+    //
+    // Rationale:
+    // - The deepest observed post-PoS Ethereum reorg is 7 blocks (Beacon Chain, May 2022,
+    //   Proposer Boost rollout incident). 10 blocks gives a 3-block safety margin over that.
+    // - Stricter alternatives: 32 (one epoch, ~6.4 min) for full epoch-justification semantics,
+    //   or 64 (two epochs, ~12.8 min) for full Casper-FFG finalization equivalence.
+    // - We deliberately do NOT use `eth_newFilter` with `toBlock: "finalized"` because (a) Geth
+    //   rejects it with errInvalidBlockRange, and (b) Alchemy's hosted filter layer accepts it
+    //   but does not enforce it. Instead, the message sync worker uses `toBlock: "latest"` and
+    //   enforces this confirmation depth + a per-event canonical block hash check client-side.
+    // - Chains with stronger latency requirements should override this in their chain config.
+    10
 }
 fn default_mempool_min_tip_bump() -> f64 {
     0.1
@@ -296,10 +308,15 @@ pub struct ChainConfigV1 {
     )]
     pub l1_messages_replay_max_duration: Duration,
 
-    /// Number of L1 blocks to wait before considering a message finalized.
-    /// This provides protection against L1 chain reorganizations.
-    /// Default: 0 (rely on L1's "finalized" block tag).
-    /// Recommended: 12 for Ethereum mainnet (~2.5 minutes).
+    /// Number of L1 blocks to wait behind `latest` before consuming an L1→L2 message.
+    /// Provides probabilistic reorg protection: a message is only processed once its source
+    /// block is at least this many confirmations deep AND its block hash still matches the
+    /// canonical hash on L1 (the latter is checked at processing time to detect reorgs that
+    /// occurred while the message was sitting in the queue).
+    ///
+    /// Default: 10 blocks (~2 min on Ethereum). This clears the deepest observed post-PoS
+    /// reorg (7 blocks, May 2022) with a 3-block margin. See `default_l1_messages_finality_blocks`
+    /// for the full rationale.
     #[serde(default = "default_l1_messages_finality_blocks")]
     pub l1_messages_finality_blocks: u64,
 }
@@ -419,10 +436,15 @@ pub struct ChainConfig {
     )]
     pub l1_messages_replay_max_duration: Duration,
 
-    /// Number of L1 blocks to wait before considering a message finalized.
-    /// This provides protection against L1 chain reorganizations.
-    /// Default: 0 (rely on L1's "finalized" block tag).
-    /// Recommended: 12 for Ethereum mainnet (~2.5 minutes).
+    /// Number of L1 blocks to wait behind `latest` before consuming an L1→L2 message.
+    /// Provides probabilistic reorg protection: a message is only processed once its source
+    /// block is at least this many confirmations deep AND its block hash still matches the
+    /// canonical hash on L1 (the latter is checked at processing time to detect reorgs that
+    /// occurred while the message was sitting in the queue).
+    ///
+    /// Default: 10 blocks (~2 min on Ethereum). This clears the deepest observed post-PoS
+    /// reorg (7 blocks, May 2022) with a 3-block margin. See `default_l1_messages_finality_blocks`
+    /// for the full rationale.
     #[serde(default = "default_l1_messages_finality_blocks")]
     pub l1_messages_finality_blocks: u64,
 }
@@ -817,7 +839,7 @@ where
 
 pub fn serialize_starknet_version<S>(version: &StarknetVersion, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: serde::Serializer,
+    S: Serializer,
 {
     version.to_string().serialize(serializer)
 }


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [x] Testing

## What is the current behavior?

The L1→L2 message sync uses `eth_newFilter` with `toBlock: "finalized"` for the live watcher and `eth_getLogs` with `toBlock: "finalized"` for the historical query. This has three problems:

1. **Not portable across providers**: Geth rejects `toBlock: "finalized"` in `eth_newFilter` with `errInvalidBlockRange`. Alchemy accepts it but silently ignores it — events are delivered at chain-tip latency, not finality latency.
2. **Coverage gap**: events in the `(finalized, latest]` window at filter creation time are missed by both the historical query and the live watcher.
3. **No reorg protection**: if an event's L1 block is reorged out, the message is processed anyway and the nonce mapping is poisoned — preventing a legitimate re-emission on the new canonical chain from being picked up.

Resolves: #NA

## What is the new behavior?

- **Live watcher uses `toBlock: "latest"`** — works on Geth, Reth, and all hosted providers.
- **Historical query covers up to `latest`** — closes the coverage gap between finalized and latest at filter creation time.
- **Client-side finality enforcement** in `process_finalized_events`:
  1. Confirmation depth check (`l1_messages_finality_blocks`, default 10 blocks / ~2 min).
  2. Canonical block hash check — compares the hash captured at event observation time against the current canonical hash. Drops reorged events without poisoning nonce metadata and without advancing the sync tip (so reconnection re-scans the reorged region).
  3. Transient RPC failures during the canonical check leave the event safely in the queue (peek-before-pop pattern) for retry on the next poll.
- **Default `l1_messages_finality_blocks` bumped to 10** — clears the deepest observed post-PoS reorg (7 blocks, May 2022) with a 3-block margin.

### Tests

- **`e2e_test_reorg_drops_event_and_processes_re_emission`** (Anvil): fires event, triggers `anvil_rollback`, fires a second event with the same nonce on the new canonical chain. Verifies event #1 is dropped, event #2 is processed, and the nonce mapping points to event #2.
- **`test_drops_event_when_block_does_not_exist`** (mock): `get_block_n_hash` returns `None` → event dropped, nonce not poisoned, sync tip unchanged.
- **`test_drops_event_when_block_hash_mismatches`** (mock): `get_block_n_hash` returns a different hash → same assertions.
- **`test_missing_block_hash`** (unit): verifies the new `block_hash` field requirement on event conversion.

## Does this introduce a breaking change?

No. The `l1_messages_finality_blocks` config field already existed; only the default changed (0 → 10). The new `get_block_n_hash` trait method is additive.

## Other information

The `--slots-in-an-epoch 1` Anvil flag was removed from the test setup — it was only needed for the `Finalized` block tag, which is no longer used in the message sync path.