### PR TITLE
fix: bump pathfinder to v0.14.1-alpha.4 for genesis state root fix

### DIFF
--- a/.github/workflows/pull-request-main-ci.yml
+++ b/.github/workflows/pull-request-main-ci.yml
@@ -204,8 +204,7 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/task-do-nothing-build-nightly-and-publish.yml
 
-  # TEMPORARY: run E2E on PRs to validate pathfinder alpha.4. Revert before merging.
+  # E2E tests run nightly only (see nightly-run.yml)
   test-end-to-end:
     if: github.event.pull_request.draft == false && github.base_ref == 'main'
-    uses: ./.github/workflows/task-test-end-to-end.yml
-    secrets: inherit
+    uses: ./.github/workflows/task-do-nothing-test-end-to-end.yml

--- a/.github/workflows/pull-request-main-ci.yml
+++ b/.github/workflows/pull-request-main-ci.yml
@@ -204,7 +204,8 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/task-do-nothing-build-nightly-and-publish.yml
 
-  # E2E tests run nightly only (see nightly-run.yml)
+  # TEMPORARY: run E2E on PRs to validate pathfinder alpha.4. Revert before merging.
   test-end-to-end:
     if: github.event.pull_request.draft == false && github.base_ref == 'main'
-    uses: ./.github/workflows/task-do-nothing-test-end-to-end.yml
+    uses: ./.github/workflows/task-test-end-to-end.yml
+    secrets: inherit

--- a/.github/workflows/task-test-end-to-end.yml
+++ b/.github/workflows/task-test-end-to-end.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Download and extract Pathfinder binary
         run: |
           mkdir -p target/release/
-          curl -L -o pathfinder.tar.gz https://github.com/karnotxyz/pathfinder/releases/download/v0.14.1-alpha.3/pathfinder-x86_64-unknown-linux-gnu.tar.gz
+          curl -L -o pathfinder.tar.gz https://github.com/karnotxyz/pathfinder/releases/download/v0.14.1-alpha.4/pathfinder-x86_64-unknown-linux-gnu.tar.gz
           tar -xf pathfinder.tar.gz -C target/release/
           rm pathfinder.tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ VENV_ACTIVATE  := . $(VENV)/bin/activate
 # Configuration for E2E bridge tests
 CARGO_TARGET_DIR ?= target
 AWS_REGION ?= us-east-1
-PATHFINDER_URL_MAC = https://github.com/karnotxyz/pathfinder/releases/download/v0.14.1-alpha.3/pathfinder-aarch64-apple-darwin.tar.gz
+PATHFINDER_URL_MAC = https://github.com/karnotxyz/pathfinder/releases/download/v0.14.1-alpha.4/pathfinder-aarch64-apple-darwin.tar.gz
 
 # dim white italic
 DIM            := \033[2;3;37m


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [x] Build-related changes

## What is the current behavior?

Madara's genesis root calculation was updated in https://github.com/madara-alliance/madara/pull/1022. Pathfinder was still on the old logic, so during the full-node sync phase of the nightly E2E it hit a state root mismatch at genesis and crashed.

Resolves: #NA

## What is the new behavior?

- The same fix has been applied in Pathfinder and released as \`v0.14.1-alpha.4\`. This PR bumps the Pathfinder download URL in \`task-test-end-to-end.yml\` and \`Makefile\` from \`v0.14.1-alpha.3\` to \`v0.14.1-alpha.4\` so E2E no longer hits the mismatch.
- **TEMPORARY**: wires \`pull-request-main-ci.yml\` to run the real \`task-test-end-to-end.yml\` (with \`secrets: inherit\`) instead of the \`do-nothing\` stub, so the fix can be validated on this PR. To be reverted before merge.

## Does this introduce a breaking change?

No.

## Other information

The temporary PR-run commit (\`7fb014be5\`) should be dropped before merging — E2E is meant to run nightly only (see \`nightly-run.yml\`).