### PR TITLE
fix(e2e): remove obsolete --madara-version flag from orchestrator config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,9 +47,7 @@
         "--aws-sns",
         "--settle-on-ethereum",
         "--atlantic",
-        "--da-on-ethereum",
-        "--madara-version",
-        "0.13.3"
+        "--da-on-ethereum"
       ],
       // Working folder for execution. Change as necessary if program requires a different value:
       "cwd": "${workspaceFolder}",

--- a/Makefile
+++ b/Makefile
@@ -489,13 +489,13 @@ setup-l3-localstack:
 .PHONY: run-orchestrator-l2
 run-orchestrator-l2:
 	@echo -e "$(DIM)Running orchestrator...$(RESET)"
-	@cargo run --package orchestrator -- run --layer l2 --aws --aws-s3 --aws-sqs --aws-sns --settle-on-ethereum --atlantic --da-on-ethereum --madara-version 0.14.0 2>&1
+	@cargo run --package orchestrator -- run --layer l2 --aws --aws-s3 --aws-sqs --aws-sns --settle-on-ethereum --atlantic --da-on-ethereum 2>&1
 
 
 .PHONY: run-orchestrator-l3
 run-orchestrator-l3:
 	@echo -e "$(DIM)Running orchestrator...$(RESET)"
-	@cargo run --package orchestrator -- run --layer l3 --aws --aws-s3 --aws-sqs --aws-sns --settle-on-starknet --atlantic --mock-atlantic-server --da-on-starknet --madara-version 0.14.0 2>&1
+	@cargo run --package orchestrator -- run --layer l3 --aws --aws-s3 --aws-sqs --aws-sns --settle-on-starknet --atlantic --mock-atlantic-server --da-on-starknet 2>&1
 
 .PHONY: watch-orchestrator
 watch-orchestrator:

--- a/e2e-tests/src/node.rs
+++ b/e2e-tests/src/node.rs
@@ -67,7 +67,6 @@ impl Orchestrator {
             command.arg("--da-on-ethereum");
             command.arg("--sharp");
             command.arg("--mongodb");
-            command.arg("--madara-version=0.13.3");
 
             let port = get_free_port();
             let addr = format!("127.0.0.1:{}", port);

--- a/e2e/src/services/orchestrator/config.rs
+++ b/e2e/src/services/orchestrator/config.rs
@@ -93,7 +93,6 @@ pub struct OrchestratorConfig {
     // Block Processing
     max_block_to_process: Option<u64>,
     min_block_to_process: Option<u64>,
-    madara_version: String,
 
     // Admin
     admin_enabled: bool,
@@ -129,7 +128,6 @@ impl Default for OrchestratorConfig {
 
             max_block_to_process: None,
             min_block_to_process: None,
-            madara_version: "0.14.1".to_string(),
             admin_enabled: false,
             logs: (false, true),
         }
@@ -328,7 +326,6 @@ impl OrchestratorConfig {
             command.arg("--da-on-starknet");
         }
 
-        command.arg("--madara-version").arg(&self.madara_version);
         command.arg("--disable-peerdas");
 
         // Add prover flags
@@ -430,11 +427,6 @@ impl OrchestratorConfigBuilder {
     /// Set the port
     pub fn port(mut self, port: u16) -> Self {
         self.config.port = Some(port);
-        self
-    }
-
-    pub fn madara_version(mut self, version: &str) -> Self {
-        self.config.madara_version = version.to_string();
         self
     }
 


### PR DESCRIPTION
## Summary

The `--madara-version` CLI flag was removed from the orchestrator in #1029 (commit `5784c8138`) in favor of a hardcoded constant, but multiple callers were still passing it — the orchestrator exits with status 2 (`unexpected argument '--madara-version' found`) on those paths, which is what broke the nightly.

This PR drops the stale flag everywhere except the k8s deployment manifest:

- `e2e/src/services/orchestrator/config.rs` — removed the `madara_version` field, default, arg emission, and unused builder method (root cause of the nightly failure).
- `e2e-tests/src/node.rs` — removed the hardcoded `--madara-version=0.13.3` in the orchestrator-workflow test.
- `Makefile` — removed from `run-orchestrator-l2` and `run-orchestrator-l3` targets.
- `.vscode/launch.json` — removed from the debug launch config.

## Test plan

- [x] `cargo check -p e2e --release` passes
- [x] `cargo check -p e2e-tests --release` passes
- [x] `cargo clippy -p e2e --release -- -D warnings` passes
- [x] Nightly Run manually triggered on this branch — [run #178](https://github.com/madara-alliance/madara/actions/runs/24829073543) passed (`test-end-to-end` 27m40s, conclusion=success)

## Follow-up (not in this PR)

`infra/k8s/base/orchestrator.yaml:37` still passes `--madara-version 0.14.0`. Left out of this PR because it affects live deployment manifests; should be removed alongside the next rollout coordinated with the cluster owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)