### PR TITLE
fix(docker): install LLVM 19 in bootstrapper-v2 image for cairo-native deps

### DIFF
--- a/bootstrapper-v2/Dockerfile
+++ b/bootstrapper-v2/Dockerfile
@@ -17,7 +17,50 @@ ENV RUSTC_WRAPPER=/bin/sccache
 
 ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
 
-RUN apt-get update -y && apt-get install -y wget clang
+# Copy Makefile for LLVM installation
+COPY Makefile /tmp/Makefile
+
+# Install LLVM 19 for Cairo Native support (required by transitive workspace deps
+# pulled in during `cargo chef cook`, notably tblgen/llvm-sys/mlir-sys).
+RUN apt-get update -y && apt-get install -y \
+  bash \
+  build-essential \
+  ca-certificates \
+  clang \
+  curl \
+  git \
+  gnupg \
+  libgmp3-dev \
+  libssl-dev \
+  make \
+  openssl \
+  software-properties-common \
+  wget && \
+  cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set LLVM environment variables for Cairo Native
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+
+# Set explicit compilers for Cairo Native runtime compilation
+ENV CC=clang-19
+ENV CXX=clang++-19
+
+# Configure linker search paths for Cairo Native runtime compilation.
+# DEB_HOST_MULTIARCH resolves to the correct lib directory for the build runner architecture.
+RUN DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
+  printf '%s\n' \
+    "export LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    "export LD_LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    > /etc/profile.d/cairo-native-libs.sh
+# Use bash (non-login) so BASH_ENV is honored. A login shell would source
+# /etc/profile, which on Debian unconditionally resets PATH and would wipe
+# /usr/local/cargo/bin and /usr/lib/llvm-19/bin from PATH for every later RUN.
+ENV BASH_ENV=/etc/profile.d/cairo-native-libs.sh
+SHELL ["/bin/bash", "-c"]
 
 # Install Python 3.9
 RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \


### PR DESCRIPTION
## Summary

The scheduled nightly \`build-nightly-and-publish-bootstrapper-v2\` is failing ([run #180 job](https://github.com/madara-alliance/madara/actions/runs/24870510649/job/72818921613)) at the Docker build's \`cargo chef cook\` step with:

\`\`\`
error: failed to run custom build command for \`tblgen v0.5.2\`
  --- stderr
  failed to find correct version (19.x.x) of llvm-config (found )
\`\`\`

### Why it broke

\`cargo chef cook --recipe-path recipe.json\` compiles **all** workspace dependencies to warm the dep cache, not just the crates that bootstrapper-v2 itself links. After #1011 (Madara reintegrated into root workspace) and #1013 (bootstrapper-v2 integrated), the workspace recipe now transitively includes cairo-native's \`tblgen\`/\`llvm-sys\`/\`mlir-sys\`, which all require LLVM 19 tooling. The bootstrapper-v2 Dockerfile was only installing \`wget clang\`, so the tblgen build script couldn't find \`llvm-config\` and failed.

This affects **every** path that uses \`./bootstrapper-v2/Dockerfile\`:
- scheduled nightly (\`nightly-run.yml\`)
- manual docker image build (\`manual-build-docker-images.yml\`)

### Fix

Mirror the LLVM 19 setup already applied to \`orchestrator/Dockerfile\` in #1021:

- Install prerequisite packages (\`build-essential\`, \`libgmp3-dev\`, \`libssl-dev\`, etc.)
- \`COPY Makefile /tmp/Makefile\` and run \`make -f Makefile install-llvm19 CODENAME=bookworm\`
- Set LLVM env vars: \`MLIR_SYS_190_PREFIX\`, \`LLVM_SYS_191_PREFIX\`, \`TABLEGEN_190_PREFIX\`, prepend \`/usr/lib/llvm-19/bin\` to PATH
- Set \`CC=clang-19\`, \`CXX=clang++-19\`
- Configure cairo-native library paths via \`BASH_ENV\`

BLST install is intentionally omitted — the failure trace shows tblgen as the only blocking build script, and bootstrapper-v2 doesn't link blst directly.

## Test plan

- [ ] Trigger the manual docker build workflow on this branch with \`build-bootstrapper-v2=true\` to confirm the image builds to completion
- [ ] After merge, verify the next scheduled nightly run has a green \`build-nightly-and-publish-bootstrapper-v2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)