### PR TITLE
fix(docker): use Python 3.9-specific get-pip.py URL

### DIFF
--- a/bootstrapper-v2/Dockerfile
+++ b/bootstrapper-v2/Dockerfile
@@ -72,7 +72,7 @@ RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
     && rm -rf Python-3.9.16 Python-3.9.16.tgz
 
 # Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/get-pip.py \
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
     && python3.9 get-pip.py \
     && rm get-pip.py \
     && python3.9 -m pip install virtualenv

--- a/bootstrapper/Dockerfile
+++ b/bootstrapper/Dockerfile
@@ -61,7 +61,7 @@ RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
     && rm -rf Python-3.9.16 Python-3.9.16.tgz
 
 # Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/get-pip.py \
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
     && python3.9 get-pip.py \
     && rm get-pip.py \
     && python3.9 -m pip install virtualenv

--- a/madara/Dockerfile
+++ b/madara/Dockerfile
@@ -57,7 +57,7 @@ RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
     && rm -rf Python-3.9.16 Python-3.9.16.tgz
 
 # Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/get-pip.py \
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
     && python3.9 get-pip.py \
     && rm get-pip.py \
     && python3.9 -m pip install virtualenv

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -92,7 +92,7 @@ RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
   && rm -rf Python-3.9.16 Python-3.9.16.tgz
 
 # Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/get-pip.py \
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
   && python3.9 get-pip.py \
   && rm get-pip.py \
   && python3.9 -m pip install virtualenv


### PR DESCRIPTION
## Summary
- The default `get-pip.py` bootstrap script (`bootstrap.pypa.io/get-pip.py`) dropped Python 3.9 support, causing Docker builds to fail for orchestrator and bootstrapper-v2 with: `ERROR: This script does not work on Python 3.9. The minimum supported Python version is 3.10.`
- Updated all four Dockerfiles (madara, orchestrator, bootstrapper, bootstrapper-v2) to use the Python 3.9-specific URL: `bootstrap.pypa.io/pip/3.9/get-pip.py`
- Fixes https://github.com/madara-alliance/madara/actions/runs/25280851827

## Test plan
- [ ] Re-run the Manual Docker Image Build workflow and verify orchestrator + bootstrapper-v2 builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)