### PR TITLE
feat(ci): add TODO-to-issue tracking workflow

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
           IDENTIFIERS: '[{"name": "TODO", "labels": ["todo"]}, {"name": "FIXME", "labels": ["todo:fixme"]}, {"name": "HACK", "labels": ["todo:hack"]}]'
 
       - name: Comment on closed issues with resolving PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const sha = context.sha;

--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -1,0 +1,106 @@
+name: TODO to Issue
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  todo-to-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TODO to Issue
+        id: todo-to-issue
+        uses: alstr/todo-to-issue-action@v5
+        with:
+          CLOSE_ISSUES: "true"
+          INSERT_ISSUE_URLS: "false"
+          AUTO_ASSIGN: "true"
+          IDENTIFIERS: '[{"name": "TODO", "labels": ["todo"]}, {"name": "FIXME", "labels": ["todo:fixme"]}, {"name": "HACK", "labels": ["todo:hack"]}]'
+
+      - name: Comment on closed issues with resolving PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha;
+
+            // Find the PR associated with this merge commit
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            });
+
+            const mergedPr = prs.find(pr => pr.merge_commit_sha === sha);
+            if (!mergedPr) {
+              console.log('No merged PR found for this commit, skipping.');
+              return;
+            }
+
+            const prNumber = mergedPr.number;
+            console.log(`Found merged PR #${prNumber}`);
+
+            // Search for issues with "todo" label closed in the last 2 minutes
+            const now = new Date();
+            const twoMinutesAgo = new Date(now.getTime() - 2 * 60 * 1000);
+            const since = twoMinutesAgo.toISOString();
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              labels: 'todo',
+              since: since,
+              per_page: 100,
+            });
+
+            // Also check todo:fixme and todo:hack labels
+            const { data: fixmeIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              labels: 'todo:fixme',
+              since: since,
+              per_page: 100,
+            });
+
+            const { data: hackIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              labels: 'todo:hack',
+              since: since,
+              per_page: 100,
+            });
+
+            // Deduplicate by issue number
+            const allIssues = new Map();
+            [...issues, ...fixmeIssues, ...hackIssues].forEach(issue => {
+              if (!issue.pull_request) {
+                allIssues.set(issue.number, issue);
+              }
+            });
+
+            console.log(`Found ${allIssues.size} recently closed TODO issues`);
+
+            for (const [issueNumber, issue] of allIssues) {
+              // Verify the issue was closed recently (within this workflow run)
+              const closedAt = new Date(issue.closed_at);
+              if (closedAt >= twoMinutesAgo) {
+                console.log(`Commenting on issue #${issueNumber}`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Resolved by the merge of #${prNumber} to main.`,
+                });
+              }
+            }

--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -17,9 +17,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Record pre-action timestamp
+        id: pre-action
+        run: echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: TODO to Issue
         id: todo-to-issue
-        uses: alstr/todo-to-issue-action@v5
+        uses: alstr/todo-to-issue-action@64aca8fda7023259aada83ba44ad988c4c443657 # v5.1.14
         with:
           CLOSE_ISSUES: "true"
           INSERT_ISSUE_URLS: "false"
@@ -31,8 +35,8 @@ jobs:
         with:
           script: |
             const sha = context.sha;
+            const since = '${{ steps.pre-action.outputs.timestamp }}';
 
-            // Find the PR associated with this merge commit
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -48,53 +52,30 @@ jobs:
             const prNumber = mergedPr.number;
             console.log(`Found merged PR #${prNumber}`);
 
-            // Search for issues with "todo" label closed in the last 2 minutes
-            const now = new Date();
-            const twoMinutesAgo = new Date(now.getTime() - 2 * 60 * 1000);
-            const since = twoMinutesAgo.toISOString();
-
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed',
-              labels: 'todo',
-              since: since,
-              per_page: 100,
-            });
-
-            // Also check todo:fixme and todo:hack labels
-            const { data: fixmeIssues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed',
-              labels: 'todo:fixme',
-              since: since,
-              per_page: 100,
-            });
-
-            const { data: hackIssues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed',
-              labels: 'todo:hack',
-              since: since,
-              per_page: 100,
-            });
-
-            // Deduplicate by issue number
+            const labels = ['todo', 'todo:fixme', 'todo:hack'];
             const allIssues = new Map();
-            [...issues, ...fixmeIssues, ...hackIssues].forEach(issue => {
-              if (!issue.pull_request) {
-                allIssues.set(issue.number, issue);
-              }
-            });
 
-            console.log(`Found ${allIssues.size} recently closed TODO issues`);
+            for (const label of labels) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed',
+                labels: label,
+                since: since,
+              });
+              issues.forEach(issue => {
+                if (!issue.pull_request) {
+                  allIssues.set(issue.number, issue);
+                }
+              });
+            }
 
+            console.log(`Found ${allIssues.size} closed TODO issues since action started`);
+
+            const sinceDate = new Date(since);
             for (const [issueNumber, issue] of allIssues) {
-              // Verify the issue was closed recently (within this workflow run)
               const closedAt = new Date(issue.closed_at);
-              if (closedAt >= twoMinutesAgo) {
+              if (closedAt >= sinceDate) {
                 console.log(`Commenting on issue #${issueNumber}`);
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically creates issues from TODO/FIXME/HACK comments when PRs merge to main
- Auto-closes issues when the corresponding TODO is removed in a future PR
- Posts a "Resolved by the merge of #X to main" comment on closed issues

## Details
Uses [alstr/todo-to-issue-action](https://github.com/alstr/todo-to-issue-action) with:
- **Zero noise**: no source code modifications, no extra commits on main
- **Duplicate prevention**: diff-based detection (each merge commit processed exactly once)
- **Auto-assign**: issues assigned to the PR author
- **Labels**: `todo`, `todo:fixme`, `todo:hack` based on the identifier

## Test plan
- [ ] Merge a PR with a new TODO comment → verify issue is created with correct label
- [ ] Merge a PR that removes that TODO → verify issue is closed with resolving PR comment
- [ ] Merge a PR with no TODO changes → verify no issues created/closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)