### PR TITLE
fix: preserve exact integer STRK/ETH quotes

### DIFF
--- a/madara/crates/client/db/src/gas.rs
+++ b/madara/crates/client/db/src/gas.rs
@@ -98,3 +98,19 @@ fn calculate_gas_price(
         Ok(previous_gas_price.saturating_sub(price_change))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bigdecimal::{BigDecimal, ToPrimitive};
+    use mp_convert::FixedPoint;
+
+    #[test]
+    fn exact_one_strk_per_eth_keeps_fixed_l2_gas_price_in_wei() {
+        let strk_per_eth = FixedPoint::from(1.0);
+        let strk_per_eth = BigDecimal::new(strk_per_eth.value().into(), strk_per_eth.decimals().into());
+
+        let eth_l2_gas_price = (BigDecimal::from(25000u128) / strk_per_eth).to_u128().unwrap();
+
+        assert_eq!(eth_l2_gas_price, 25000);
+    }
+}

--- a/madara/crates/client/db/src/gas.rs
+++ b/madara/crates/client/db/src/gas.rs
@@ -103,14 +103,20 @@ fn calculate_gas_price(
 mod tests {
     use bigdecimal::{BigDecimal, ToPrimitive};
     use mp_convert::FixedPoint;
+    use rstest::rstest;
 
-    #[test]
-    fn exact_one_strk_per_eth_keeps_fixed_l2_gas_price_in_wei() {
-        let strk_per_eth = FixedPoint::from(1.0);
+    #[rstest]
+    #[case(1.0, 25000, 25000)]
+    fn exact_one_strk_per_eth_keeps_fixed_l2_gas_price_in_wei(
+        #[case] strk_per_eth_input: f64,
+        #[case] strk_l2_gas_price: u128,
+        #[case] expected_eth_l2_gas_price: u128,
+    ) {
+        let strk_per_eth = FixedPoint::from(strk_per_eth_input);
         let strk_per_eth = BigDecimal::new(strk_per_eth.value().into(), strk_per_eth.decimals().into());
 
-        let eth_l2_gas_price = (BigDecimal::from(25000u128) / strk_per_eth).to_u128().unwrap();
+        let eth_l2_gas_price = (BigDecimal::from(strk_l2_gas_price) / strk_per_eth).to_u128().unwrap();
 
-        assert_eq!(eth_l2_gas_price, 25000);
+        assert_eq!(eth_l2_gas_price, expected_eth_l2_gas_price);
     }
 }

--- a/madara/crates/primitives/convert/src/fixed.rs
+++ b/madara/crates/primitives/convert/src/fixed.rs
@@ -44,6 +44,9 @@ impl From<f64> for FixedPoint {
         }
 
         let max_u128 = u128::MAX as f64;
+        if value.fract() == 0.0 && value <= max_u128 {
+            return Self { value: value as u128, decimals: 0 };
+        }
 
         let mut scale = 0u32;
 
@@ -67,5 +70,21 @@ impl From<f64> for FixedPoint {
         let mantissa = scaled.round() as u128;
 
         Self { value: mantissa, decimals }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FixedPoint;
+
+    #[test]
+    fn integer_f64s_convert_exactly() {
+        let one = FixedPoint::from(1.0);
+        assert_eq!(one.value(), 1);
+        assert_eq!(one.decimals(), 0);
+
+        let two = FixedPoint::from(2.0);
+        assert_eq!(two.value(), 2);
+        assert_eq!(two.decimals(), 0);
     }
 }

--- a/madara/crates/primitives/convert/src/fixed.rs
+++ b/madara/crates/primitives/convert/src/fixed.rs
@@ -76,15 +76,14 @@ impl From<f64> for FixedPoint {
 #[cfg(test)]
 mod tests {
     use super::FixedPoint;
+    use rstest::rstest;
 
-    #[test]
-    fn integer_f64s_convert_exactly() {
-        let one = FixedPoint::from(1.0);
-        assert_eq!(one.value(), 1);
-        assert_eq!(one.decimals(), 0);
-
-        let two = FixedPoint::from(2.0);
-        assert_eq!(two.value(), 2);
-        assert_eq!(two.decimals(), 0);
+    #[rstest]
+    #[case(1.0, 1)]
+    #[case(2.0, 2)]
+    fn integer_f64s_convert_exactly(#[case] input: f64, #[case] expected_value: u128) {
+        let fixed_point = FixedPoint::from(input);
+        assert_eq!(fixed_point.value(), expected_value);
+        assert_eq!(fixed_point.decimals(), 0);
     }
 }


### PR DESCRIPTION
## Summary
- preserve exact integer `FixedPoint` conversions for whole-number `f64` inputs
- add a regression test for the fixed `strk_per_eth=1.0` L2 gas price conversion path
- prevent `eth_l2_gas_price` from truncating one unit low when `MADARA_STRK_PER_ETH=1`

## Root cause
`FixedPoint::from(f64)` represented `1.0` as a large mantissa with 37 decimals instead of exact integer form. In the gas price path that made `strk_per_eth` slightly larger than `1`, so dividing `25000 / strk_per_eth` truncated to `24999`.

## Testing
- `cargo test -p mp-convert integer_f64s_convert_exactly`
- runtime-validated locally against the affected Madara setup
- `cargo test -p mc-db exact_one_strk_per_eth_keeps_fixed_l2_gas_price_in_wei` was added but did not complete in this environment because the machine hit `No space left on device` during linking
