### PR TITLE
chore: update the code to move the job to `Failed` after one failure

### DIFF
--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -1213,15 +1213,14 @@ async fn move_job_to_failed_accumulates_failure_history() {
     );
 }
 
-/// Tests that failure history is preserved through multiple retry attempts until DLQ.
-/// This test verifies the end-to-end error accumulation:
-/// 1. Job fails processing (error stored via reset_job_for_retry)
-/// 2. Job eventually goes to DLQ (final reason set, previous appended to history)
-/// 3. The complete history is preserved in chronological order (oldest first)
+/// Tests that a processing failure immediately marks the job as Failed.
+/// This test verifies that when process_job fails:
+/// 1. process_job returns Ok (so the message is ACKed, no SQS retries)
+/// 2. Job status is set to Failed with the failure reason
 #[rstest]
 #[tokio::test]
 #[allow(clippy::await_holding_lock)]
-async fn failure_history_preserved_through_retries_to_dlq() {
+async fn process_job_failure_marks_job_as_failed() {
     let _test_lock = acquire_test_lock();
 
     // Set up mock alert client
@@ -1255,14 +1254,15 @@ async fn failure_history_preserved_through_retries_to_dlq() {
     let ctx_guard = get_job_handler_context_safe();
     ctx_guard.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
-    // Process job - this should fail and store error in failure_reason via reset_job_for_retry
+    // Process job - should return Ok so the message is ACKed (no SQS retries)
     let result = JobHandlerService::process_job(job_id, services.config.clone()).await;
-    assert!(result.is_err(), "process_job should return error for retry");
+    assert!(result.is_ok(), "process_job should return Ok to ACK the message");
 
-    // Verify the failure reason was recorded with attempt number
-    // process_attempt_no is incremented to 1 before processing, so error shows "attempt 1"
-    let job_after_first_failure = database_client.get_job_by_id(job_id).await.unwrap().unwrap();
-    let failure_reason = job_after_first_failure.metadata.common.failure_reason.as_ref().unwrap();
+    // Verify job is marked as Failed with the failure reason
+    let failed_job = database_client.get_job_by_id(job_id).await.unwrap().unwrap();
+    assert_eq!(failed_job.status, JobStatus::Failed);
+
+    let failure_reason = failed_job.metadata.common.failure_reason.as_ref().unwrap();
     assert!(
         failure_reason.contains("Processing attempt") && failure_reason.contains("failed"),
         "failure_reason should contain attempt info. Got: {}",
@@ -1272,34 +1272,5 @@ async fn failure_history_preserved_through_retries_to_dlq() {
         failure_reason.contains("Simulated processing failure"),
         "failure_reason should contain original error. Got: {}",
         failure_reason
-    );
-    assert!(
-        job_after_first_failure.metadata.common.previous_failure_reasons.is_empty(),
-        "No previous failures should exist yet"
-    );
-
-    // Now simulate the job going to DLQ by calling move_job_to_failed
-    let dlq_reason = "Job moved to DLQ after exhausting retries (last status: Created)";
-    JobService::move_job_to_failed(&job_after_first_failure, services.config.clone(), dlq_reason.to_string())
-        .await
-        .unwrap();
-
-    // Verify final state has complete accumulated history
-    let final_job = database_client.get_job_by_id(job_id).await.unwrap().unwrap();
-    assert_eq!(final_job.status, JobStatus::Failed);
-
-    // Most recent error should be in failure_reason
-    assert_eq!(
-        final_job.metadata.common.failure_reason,
-        Some(dlq_reason.to_string()),
-        "failure_reason should be the DLQ message"
-    );
-    // Previous error should be in history
-    assert_eq!(final_job.metadata.common.previous_failure_reasons.len(), 1, "Should have one previous failure");
-    assert!(
-        final_job.metadata.common.previous_failure_reasons[0].contains("Processing attempt")
-            && final_job.metadata.common.previous_failure_reasons[0].contains("failed"),
-        "Previous error should be preserved. Got: {}",
-        final_job.metadata.common.previous_failure_reasons[0]
     );
 }

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -348,20 +348,13 @@ async fn process_job_handles_panic() {
     let ctx = get_job_handler_context_safe();
     ctx.expect().times(1).with(eq(JobType::SnosRun)).return_once(move |_| Arc::clone(&job_handler));
 
-    // Process job should return an error so message can be nacked and retried
+    // Process job should return Ok (message ACKed) and mark job as Failed
     let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Job handler panicked with message: Simulated panic in process_job"));
+    assert!(result.is_ok());
 
-    // DB checks - verify the job was reset to original state for retry
+    // DB checks - verify the job was marked as Failed
     let job_in_db = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
-    assert_eq!(job_in_db.status, JobStatus::Created);
-
-    // process_started_at should be cleared
-    assert!(job_in_db.metadata.common.process_started_at.is_none());
+    assert_eq!(job_in_db.status, JobStatus::Failed);
 }
 
 /// Tests `process_job` function when job is already existing in the db and job status is not
@@ -594,17 +587,13 @@ async fn process_job_job_handler_returns_error_works() {
     let ctx = get_job_handler_context_safe();
     ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
-    // Process job should return an error so message can be nacked and retried
+    // Process job should return Ok (message ACKed) and mark job as Failed
     let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains(failure_reason));
+    assert!(result.is_ok());
 
-    // DB checks - verify the job was reset to original state for retry
+    // DB checks - verify the job was marked as Failed
     let final_job_in_db = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
-    assert_eq!(final_job_in_db.status, JobStatus::Created);
-
-    // process_started_at should be cleared
-    assert!(final_job_in_db.metadata.common.process_started_at.is_none());
+    assert_eq!(final_job_in_db.status, JobStatus::Failed);
 }
 
 /// Tests `verify_job` function when job is having expected status

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -309,8 +309,8 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
 /// Tests `process_job` function when job handler panics during execution.
 /// This test verifies that:
 /// 1. The panic is properly caught and handled
-/// 2. The job is reset to its original state for retry
-/// 3. An error is returned so the message can be nacked
+/// 2. The job is marked as Failed immediately
+/// 3. The message is ACKed and a failure alert is sent
 #[rstest]
 #[tokio::test]
 #[allow(clippy::await_holding_lock)]
@@ -319,10 +319,14 @@ async fn process_job_handles_panic() {
     // This prevents Mockall's global context from being interfered with by parallel tests
     let _test_lock = acquire_test_lock();
 
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(1).returning(|_| Ok(()));
+
     // Building config
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
         .build()
         .await;
 
@@ -348,13 +352,24 @@ async fn process_job_handles_panic() {
     let ctx = get_job_handler_context_safe();
     ctx.expect().times(1).with(eq(JobType::SnosRun)).return_once(move |_| Arc::clone(&job_handler));
 
-    // Process job should return Ok (message ACKed) and mark job as Failed
+    // Process job should return Ok so message is ACKed after the panic is recorded as a job failure
     let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
-    assert!(result.is_ok());
+    assert!(result.is_ok(), "process_job should return Ok after marking the job as Failed");
 
-    // DB checks - verify the job was marked as Failed
+    // DB checks - verify the job was moved to Failed with the panic reason recorded
     let job_in_db = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
     assert_eq!(job_in_db.status, JobStatus::Failed);
+    let failure_reason = job_in_db.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("Processing attempt") && failure_reason.contains("panicked"),
+        "failure_reason should contain panic attempt info. Got: {}",
+        failure_reason
+    );
+    assert!(
+        failure_reason.contains("Simulated panic in process_job"),
+        "failure_reason should contain the panic message. Got: {}",
+        failure_reason
+    );
 }
 
 /// Tests `process_job` function when job is already existing in the db and job status is not
@@ -551,13 +566,16 @@ async fn process_job_two_workers_process_same_job_works() {
 }
 
 /// Tests `process_job` function when the job handler returns an error.
-/// The job should be reset to its original state and an error returned for retry.
+/// The job should be marked as Failed immediately and the message should be ACKed.
 #[rstest]
 #[tokio::test]
 #[allow(clippy::await_holding_lock)]
 async fn process_job_job_handler_returns_error_works() {
     // Acquire test lock to serialize this test with others that use mocks
     let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(1).returning(|_| Ok(()));
 
     let mut job_handler = MockJobHandlerTrait::new();
     // Expecting check_ready_to_process to return Ok (dependencies are ready)
@@ -573,6 +591,7 @@ async fn process_job_job_handler_returns_error_works() {
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
         .build()
         .await;
     let db_client = services.config.database();
@@ -587,13 +606,24 @@ async fn process_job_job_handler_returns_error_works() {
     let ctx = get_job_handler_context_safe();
     ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
-    // Process job should return Ok (message ACKed) and mark job as Failed
+    // Process job should return Ok so message is ACKed after the failure is recorded
     let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
-    assert!(result.is_ok());
+    assert!(result.is_ok(), "process_job should return Ok after marking the job as Failed");
 
-    // DB checks - verify the job was marked as Failed
+    // DB checks - verify the job was moved to Failed with the processing error recorded
     let final_job_in_db = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
     assert_eq!(final_job_in_db.status, JobStatus::Failed);
+    let recorded_reason = final_job_in_db.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        recorded_reason.contains("Processing attempt") && recorded_reason.contains("failed"),
+        "failure_reason should contain attempt info. Got: {}",
+        recorded_reason
+    );
+    assert!(
+        recorded_reason.contains(failure_reason),
+        "failure_reason should contain the original error. Got: {}",
+        recorded_reason
+    );
 }
 
 /// Tests `verify_job` function when job is having expected status

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -337,7 +337,6 @@ impl JobHandlerService {
                     "Failed to process job, marking as failed"
                 );
                 let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
-                MetricsRecorder::record_job_failed(&job, &e.to_string());
                 MetricsRecorder::record_job_state_transition(
                     JobStatus::LockedForProcessing,
                     JobStatus::Failed,
@@ -355,7 +354,6 @@ impl JobHandlerService {
                 error!(job_id = ?id, panic_msg = %panic_msg, "Job handler panicked during processing, marking as failed");
                 let reason =
                     format!("Processing attempt {} panicked: {}", job.metadata.common.process_attempt_no, panic_msg);
-                MetricsRecorder::record_job_failed(&job, &format!("panic: {}", panic_msg));
                 MetricsRecorder::record_job_state_transition(
                     JobStatus::LockedForProcessing,
                     JobStatus::Failed,

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -10,7 +10,6 @@ use uuid::Uuid;
 use crate::core::config::Config;
 use crate::error::job::JobError;
 use crate::types::jobs::external_id::ExternalId;
-use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::job_updates::JobItemUpdates;
 use crate::types::jobs::metadata::JobMetadata;
 use crate::types::jobs::status::JobVerificationStatus;

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 
 use crate::core::config::Config;
 use crate::error::job::JobError;
-use crate::error::other::OtherError;
 use crate::types::jobs::external_id::ExternalId;
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::job_updates::JobItemUpdates;
@@ -273,9 +272,6 @@ impl JobHandlerService {
             return Ok(());
         }
 
-        // Save original status to restore on failure
-        let original_status = job.status.clone();
-
         // This updates the version of the job.
         // This ensures that if another thread was about to process the same job,
         // it would fail to update the job in the database because the version would be outdated
@@ -330,9 +326,16 @@ impl JobHandlerService {
                     internal_id = %job.internal_id,
                     status = ?job.status,
                     error = ?e,
-                    "Failed to process job, resetting state for retry"
+                    "Failed to process job, marking as failed"
                 );
-                return Err(Self::reset_job_for_retry(&mut job, config.clone(), original_status, e).await);
+                let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
+                MetricsRecorder::record_job_failed(&job, &e.to_string());
+                MetricsRecorder::record_job_state_transition(
+                    JobStatus::LockedForProcessing,
+                    JobStatus::Failed,
+                    &job.job_type,
+                );
+                return JobService::move_job_to_failed(&job, config.clone(), reason).await;
             }
             Err(panic) => {
                 let panic_msg = panic
@@ -341,10 +344,16 @@ impl JobHandlerService {
                     .or_else(|| panic.downcast_ref::<&str>().copied())
                     .unwrap_or("Unknown panic message");
 
-                error!(job_id = ?id, panic_msg = %panic_msg, "Job handler panicked during processing, resetting state for retry");
-                let panic_error =
-                    JobError::Other(OtherError::from(format!("Job handler panicked with message: {}", panic_msg)));
-                return Err(Self::reset_job_for_retry(&mut job, config.clone(), original_status, panic_error).await);
+                error!(job_id = ?id, panic_msg = %panic_msg, "Job handler panicked during processing, marking as failed");
+                let reason =
+                    format!("Processing attempt {} panicked: {}", job.metadata.common.process_attempt_no, panic_msg);
+                MetricsRecorder::record_job_failed(&job, &format!("panic: {}", panic_msg));
+                MetricsRecorder::record_job_state_transition(
+                    JobStatus::LockedForProcessing,
+                    JobStatus::Failed,
+                    &job.job_type,
+                );
+                return JobService::move_job_to_failed(&job, config.clone(), reason).await;
             }
         };
 
@@ -870,44 +879,6 @@ impl JobHandlerService {
                     "Failed to fetch SNOS batch for block gauge, falling back to internal_id"
                 );
                 internal_id as f64
-            }
-        }
-    }
-
-    /// Resets job state to allow retry when the message comes back from the queue.
-    ///
-    /// Clears `process_started_at`, appends the error to failure history, and restores
-    /// the job to its original status. If the DB update fails, returns an error combining
-    /// both the original error and the DB error context.
-    async fn reset_job_for_retry(
-        job: &mut JobItem,
-        config: Arc<Config>,
-        original_status: JobStatus,
-        original_error: JobError,
-    ) -> JobError {
-        job.metadata.common.process_started_at = None;
-        // Move current failure_reason to history, then set new error
-        let new_error =
-            format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, original_error);
-        if let Some(previous_reason) = job.metadata.common.failure_reason.take() {
-            job.metadata.common.previous_failure_reasons.push(previous_reason);
-        }
-        job.metadata.common.failure_reason = Some(new_error);
-        match config
-            .database()
-            .update_job(
-                job,
-                JobItemUpdates::new().update_status(original_status).update_metadata(job.metadata.clone()).build(),
-            )
-            .await
-        {
-            Ok(_) => original_error,
-            Err(db_err) => {
-                error!(job_id = ?job.id, error = ?db_err, "Failed to reset job state for retry");
-                JobError::Other(OtherError::from(format!(
-                    "Failed to reset job state: {}. Original error: {}",
-                    db_err, original_error
-                )))
             }
         }
     }

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -137,6 +137,7 @@ impl JobHandlerService {
     /// * `Created` -> `LockedForProcessing` -> `PendingVerification`
     /// * `VerificationFailed` -> `LockedForProcessing` -> `PendingVerification`
     /// * `PendingRetry` -> `LockedForProcessing` -> `PendingVerification`
+    /// * `LockedForProcessing` -> `Failed` (on processing error or panic — message is ACKed, no SQS retry)
     ///
     /// # Metrics
     /// * Updates block gauge
@@ -150,6 +151,14 @@ impl JobHandlerService {
     /// * Automatically adds the job to verification queue upon successful processing
     /// * For jobs stuck in LockedForProcessing, heals them if they're older than the configured
     ///   timeout (stale), otherwise acks the message assuming it's a duplicate
+    ///
+    /// # Failure handling
+    /// Processing errors (including transient ones) immediately move the job to `Failed` and ACK the
+    /// SQS message. There are no SQS-level retries for explicit failures — job handlers that talk to
+    /// external APIs (SHARP, Atlantic, Ethereum, Starknet) implement their own internal retry logic
+    /// before surfacing an error. SQS `maxReceiveCount` only protects against implicit failures
+    /// (OOM, consumer crash) where the handler never reaches the error path.
+    /// Failed jobs can be retried via the `retry_job` endpoint.
     ///
     /// # Important
     /// The queue visibility timeout MUST be greater than the job healing timeout configured via


### PR DESCRIPTION
## Pull Request type

- [x] Refactoring (no functional changes, no API changes)

## What is the current behavior?

When `process_job()` fails (returns an error or panics), the job status is reset to its original state and the SQS message is NACKed. SQS then redelivers the message after the visibility timeout (~6 minutes), repeating this cycle up to `maxReceiveCount` times before finally moving the message to the DLQ. This means a deterministic failure wastes up to `maxReceiveCount × visibility_timeout` time doing nothing useful, while the job bounces between `Created` and `LockedForProcessing`.

## What is the new behavior?

- When `process_job()` fails, the job is immediately marked as `Failed` via `move_job_to_failed()`, and the SQS message is **ACKed** (removed from the queue). No SQS-level retries occur.
- When the consumer crashes or is OOM-killed (never reaches the failure handler), the message remains in-flight and SQS redelivers it after the visibility timeout — `maxReceiveCount` still protects against this case.
- The `reset_job_for_retry` function and `original_status` tracking are removed as they are no longer needed.
- Docstring updated to document the new `LockedForProcessing → Failed` state transition.
- Test updated to reflect the new behavior (`process_job` returns `Ok` on failure, job is in `Failed` status).

### Transient errors

This change means **all** processing errors — including transient ones (network timeouts, service blips) — immediately fail the job. Operators must use the retry endpoint to reprocess such failures.

This is an acceptable tradeoff because:
- Job handlers that interact with external APIs (proof creation via SHARP/Atlantic, state updates on Ethereum/Starknet, DA submission, etc.) already implement their own internal retry mechanisms before surfacing an error. By the time `process_job()` returns `Err`, retries at that level have already been exhausted.
- Silent SQS-level retries were masking failures and delaying alerting. With this change, operators are notified immediately via SNS and can make an informed decision about whether to retry.

## Does this introduce a breaking change?

No. The retry endpoint (`retry_job`) continues to work as before for jobs in `Failed` status.