### PR TITLE
fix(orchestrator): use generate-pie 0.14.2 rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2#3af39ab119bd123ab998910b7e6b000bf154def6"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.0#ddc43290a508047104c712d7359d7436bc82dc71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12998,7 +12998,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2#3af39ab119bd123ab998910b7e6b000bf154def6"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.0#ddc43290a508047104c712d7359d7436bc82dc71"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14424,7 +14424,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2#3af39ab119bd123ab998910b7e6b000bf154def6"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.0#ddc43290a508047104c712d7359d7436bc82dc71"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 # SNOS 0.14.2 with Cairo 2.17 support needed for Sierra 1.8 declares during replay.
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.0" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }


### PR DESCRIPTION
## Summary
- Switches the SNOS generate-pie dependency to the 0.14.2 RC tag requested for main-line testing.
- Keeps the resolved SNOS packages aligned to the same RC revision.

## Validation
- Deferred to PR CI as requested.