### PR TITLE
fix(cairo-native): guard native cache by host fingerprint

### DIFF
--- a/.db-versions.yml
+++ b/.db-versions.yml
@@ -32,7 +32,7 @@ base_version: 8
 #   - description: (optional) Brief description of changes
 versions:
   - version: 13
-    description: "Clear Cairo Native disk cache before host metadata sidecar repopulation"
+    description: "Clear legacy Cairo Native disk cache so artifacts are rebuilt with host metadata sidecars"
   - version: 12
     description: "Reorg/revert L1-message cleanup consistency updates (no-op migration)"
   - version: 11

--- a/.db-versions.yml
+++ b/.db-versions.yml
@@ -18,7 +18,7 @@
 # Current database schema version.
 # This is the version that new databases will be created with,
 # and the version that existing databases will be migrated to.
-current_version: 12
+current_version: 13
 
 # Minimum version that can be migrated from.
 # Databases older than this must be deleted and re-synced from scratch.
@@ -31,6 +31,8 @@ base_version: 8
 #   - pr: The PR number that introduced this version
 #   - description: (optional) Brief description of changes
 versions:
+  - version: 13
+    description: "Clear Cairo Native disk cache before host metadata sidecar repopulation"
   - version: 12
     description: "Reorg/revert L1-message cleanup consistency updates (no-op migration)"
   - version: 11

--- a/madara/CLAUDE.md
+++ b/madara/CLAUDE.md
@@ -183,6 +183,17 @@ Key services run concurrently:
 **Multi-tier caching**: In-memory + disk-based compiled classes
 **Configuration**: Compilation semaphore, blocking vs async modes, retry logic, per-contract opt-out
 
+**Persisted native cache contract**:
+
+- On disk, one cache entry is the compiled `.so` plus its `.meta.json` sidecar
+- Lookup requires both files; if either file is missing or invalid, the remaining file is deleted and the class is recompiled
+- Bump `NATIVE_CACHE_ABI_VERSION` in `mc-class-exec` whenever a change:
+  - adds, removes, or reinterprets host fingerprint fields
+  - changes how persisted native artifacts are validated or loaded
+  - changes the metadata sidecar contract
+  - adopts a cairo-native/compiler/runtime change that should invalidate existing artifacts
+- Do not bump it for host-only differences already covered by fingerprint fields such as `arch`, `os`, or `cpu_vendor`
+
 ### RPC Server Architecture
 
 **Framework**: jsonrpsee (HTTP + WebSocket on same port)

--- a/madara/crates/client/cairo_native/Cargo.toml
+++ b/madara/crates/client/cairo_native/Cargo.toml
@@ -32,7 +32,7 @@ starknet_api = { workspace = true }
 # Other
 dashmap = { workspace = true }
 lazy_static = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }

--- a/madara/crates/client/cairo_native/src/cache.rs
+++ b/madara/crates/client/cairo_native/src/cache.rs
@@ -6,6 +6,12 @@
 //! - Memory cache lookups are bounded by `memory_cache_timeout` to avoid blocking validation.
 //! - Disk cache loads (`.so`) are bounded by `disk_cache_load_timeout` to avoid hanging on slow I/O/dynamic linking.
 //! - Timeouts are treated as cache misses (fall back to VM / recompilation) and recorded in metrics.
+//! - On disk, one native cache entry is the `.so` plus its `.meta.json` sidecar.
+//!   Lookup requires both files to be present. If either file is missing, the remaining file
+//!   is cleaned up and the entry is treated as a cache miss.
+//! - Eviction accounts for the `.so` and `.meta.json` together and removes them together.
+//! - Sidecar deletion is not atomic with `.so` deletion. The cache tolerates partial cleanup
+//!   by deleting any leftover file on the next lookup or eviction pass.
 
 use blockifier::execution::contract_class::RunnableCompiledClass;
 use cairo_native::executor::AotContractExecutor;
@@ -13,7 +19,7 @@ use cairo_vm::types::errors::program_errors::ProgramError;
 use dashmap::DashMap;
 use mp_convert::ToFelt;
 use starknet_api::core::ClassHash;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -124,15 +130,19 @@ pub(crate) fn get_native_cache_path(class_hash: &ClassHash, config: &config::Nat
         .join(filename)
 }
 
-pub(crate) fn remove_native_cache_artifacts(path: &std::path::Path) {
+/// Best-effort cleanup for one native cache entry: the `.so` and its metadata sidecar.
+///
+/// This is intentionally tolerant of partial cleanup. If the process stops after deleting
+/// one file but before deleting the other, future lookup or eviction will remove the leftover.
+pub(crate) fn remove_native_cache_artifacts(path: &Path) {
     let _ = std::fs::remove_file(path);
     let _ = std::fs::remove_file(host_fingerprint::metadata_path_for_so(path));
 }
 
-fn remove_disk_cache_entry(path: &std::path::Path) -> Result<(), std::io::Error> {
+fn remove_disk_cache_entry(path: &Path) -> Result<(), std::io::Error> {
     std::fs::remove_file(path)?;
 
-    if is_native_so_path(path) {
+    if path.extension().and_then(|extension| extension.to_str()) == Some("so") {
         match std::fs::remove_file(host_fingerprint::metadata_path_for_so(path)) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -143,24 +153,10 @@ fn remove_disk_cache_entry(path: &std::path::Path) -> Result<(), std::io::Error>
     Ok(())
 }
 
-fn is_native_so_path(path: &std::path::Path) -> bool {
-    path.extension().and_then(|extension| extension.to_str()) == Some("so")
-}
-
-fn metadata_sidecar_so_path(path: &std::path::Path) -> Option<PathBuf> {
-    let file_name = path.file_name()?.to_str()?;
-    let so_file_name = file_name.strip_suffix(".meta.json")?;
-    Some(path.with_file_name(so_file_name))
-}
-
-fn should_skip_standalone_sidecar(path: &std::path::Path) -> bool {
-    metadata_sidecar_so_path(path).is_some_and(|so_path| so_path.exists())
-}
-
-fn disk_cache_entry_size(path: &std::path::Path, metadata: &std::fs::Metadata) -> u64 {
+fn disk_cache_entry_size(path: &Path, metadata: &std::fs::Metadata) -> u64 {
     let mut size = metadata.len();
 
-    if is_native_so_path(path) {
+    if path.extension().and_then(|extension| extension.to_str()) == Some("so") {
         if let Ok(metadata) = std::fs::metadata(host_fingerprint::metadata_path_for_so(path)) {
             size += metadata.len();
         }
@@ -174,12 +170,18 @@ fn disk_cache_entry_size(path: &std::path::Path, metadata: &std::fs::Metadata) -
 /// When the disk cache grows too large, this function removes the oldest unused files
 /// to make room for new ones. Files are sorted by when they were last accessed,
 /// and the oldest files are deleted until the cache size is within the limit.
+/// This is a Madara-managed cache budget check, not an operating-system low-disk callback.
 ///
 /// **How it works**:
 /// - Tracks when each cached file was last used
 /// - When the cache exceeds the size limit, removes files that haven't been used recently
 /// - This ensures frequently used classes stay in cache while rarely used ones are removed
 /// - Works across different filesystems, automatically adapting to system capabilities
+/// - Treats one native cache entry as the `.so` and its metadata sidecar together
+/// - Skips healthy `.meta.json` sidecars as standalone eviction candidates because they are
+///   counted and removed with their owning `.so`
+/// - If a sidecar is orphaned because cleanup stopped halfway through, it is treated as its
+///   own file and can be removed by a later eviction pass
 ///
 /// Called automatically after saving new files to disk to keep the cache size manageable.
 pub(crate) fn enforce_disk_cache_limit(cache_dir: &PathBuf, max_size: Option<u64>) -> Result<(), std::io::Error> {
@@ -194,7 +196,13 @@ pub(crate) fn enforce_disk_cache_limit(cache_dir: &PathBuf, max_size: Option<u64
         let metadata = entry.metadata()?;
         if metadata.is_file() {
             let path = entry.path();
-            if should_skip_standalone_sidecar(&path) {
+            let is_metadata_sidecar = path
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .and_then(|file_name| file_name.strip_suffix(".meta.json"))
+                .is_some_and(|so_file_name| path.with_file_name(so_file_name).exists());
+
+            if is_metadata_sidecar {
                 continue;
             }
 
@@ -614,6 +622,13 @@ fn try_load_executor_with_timeout(
 /// Returns `Some(RunnableCompiledClass)` if successfully loaded, `None` otherwise.
 /// On success, also adds the class to the memory cache.
 ///
+/// A valid on-disk native cache entry requires both:
+/// - `{class_hash}.so`
+/// - `{class_hash}.so.meta.json`
+///
+/// If either file is missing, the remaining file is cleaned up and the entry is
+/// treated as a cache miss so the class can be recompiled.
+///
 /// **Guard Clause**: Skips disk cache if compilation is in progress to avoid loading incomplete files.
 pub(crate) fn try_get_from_disk_cache(
     class_hash: &ClassHash,
@@ -639,6 +654,14 @@ pub(crate) fn try_get_from_disk_cache(
     let path = get_native_cache_path(class_hash, config);
 
     if !path.exists() {
+        // Enforce the "both files must exist" invariant during lookup. If the .so is gone
+        // but the metadata sidecar remains, remove the orphaned sidecar and treat this as
+        // a normal cache miss so the caller can recompile.
+        let metadata_path = host_fingerprint::metadata_path_for_so(&path);
+        if metadata_path.exists() {
+            let _ = std::fs::remove_file(&metadata_path);
+        }
+
         let elapsed = start.elapsed();
         super::metrics::metrics().record_cache_disk_file_not_found();
         tracing::debug!(
@@ -981,6 +1004,36 @@ mod tests {
             CACHE_METADATA_INVALID: 1,
             CACHE_DISK_LOAD_ERROR: 0,
         );
+    }
+
+    #[test]
+    fn test_disk_cache_eviction_cleans_orphaned_metadata_sidecar() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let orphan_sidecar_path = temp_dir.path().join("0x1.so.meta.json");
+        std::fs::write(&orphan_sidecar_path, b"{\"arch\":\"orphan\"}").expect("orphaned metadata should be written");
+
+        enforce_disk_cache_limit(&temp_dir.path().to_path_buf(), Some(0)).expect("eviction should succeed");
+
+        assert!(!orphan_sidecar_path.exists(), "orphaned metadata sidecar should be evicted");
+    }
+
+    #[rstest]
+    fn test_disk_cache_missing_so_cleans_orphaned_metadata_sidecar(
+        sierra_class: SierraConvertedClass,
+        temp_dir: TempDir,
+    ) {
+        cache_clear();
+
+        let class_hash = create_unique_test_class_hash();
+        let test_config = crate::test_utils::create_test_config(&temp_dir, None, false);
+        let so_path = get_native_cache_path(&class_hash, &test_config);
+        let metadata_path = crate::host_fingerprint::metadata_path_for_so(&so_path);
+        std::fs::write(&metadata_path, b"{\"arch\":\"orphan\"}").expect("orphaned metadata should be written");
+
+        let disk_result = try_get_from_disk_cache(&class_hash, &sierra_class, &test_config);
+
+        assert!(disk_result.expect("missing .so should not error").is_none());
+        assert!(!metadata_path.exists(), "orphaned metadata sidecar should be deleted during lookup");
     }
 
     #[rstest]

--- a/madara/crates/client/cairo_native/src/cache.rs
+++ b/madara/crates/client/cairo_native/src/cache.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use super::config;
+use super::host_fingerprint::{self, NativeCacheMetadataError};
 use super::native_class::NativeCompiledClass;
 use mp_class::SierraConvertedClass;
 
@@ -123,6 +124,51 @@ pub(crate) fn get_native_cache_path(class_hash: &ClassHash, config: &config::Nat
         .join(filename)
 }
 
+pub(crate) fn remove_native_cache_artifacts(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(host_fingerprint::metadata_path_for_so(path));
+}
+
+fn remove_disk_cache_entry(path: &std::path::Path) -> Result<(), std::io::Error> {
+    std::fs::remove_file(path)?;
+
+    if is_native_so_path(path) {
+        match std::fs::remove_file(host_fingerprint::metadata_path_for_so(path)) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
+}
+
+fn is_native_so_path(path: &std::path::Path) -> bool {
+    path.extension().and_then(|extension| extension.to_str()) == Some("so")
+}
+
+fn metadata_sidecar_so_path(path: &std::path::Path) -> Option<PathBuf> {
+    let file_name = path.file_name()?.to_str()?;
+    let so_file_name = file_name.strip_suffix(".meta.json")?;
+    Some(path.with_file_name(so_file_name))
+}
+
+fn should_skip_standalone_sidecar(path: &std::path::Path) -> bool {
+    metadata_sidecar_so_path(path).is_some_and(|so_path| so_path.exists())
+}
+
+fn disk_cache_entry_size(path: &std::path::Path, metadata: &std::fs::Metadata) -> u64 {
+    let mut size = metadata.len();
+
+    if is_native_so_path(path) {
+        if let Ok(metadata) = std::fs::metadata(host_fingerprint::metadata_path_for_so(path)) {
+            size += metadata.len();
+        }
+    }
+
+    size
+}
+
 /// Enforce disk cache size limit by removing least recently accessed files.
 ///
 /// When the disk cache grows too large, this function removes the oldest unused files
@@ -147,6 +193,11 @@ pub(crate) fn enforce_disk_cache_limit(cache_dir: &PathBuf, max_size: Option<u64
         let entry = entry?;
         let metadata = entry.metadata()?;
         if metadata.is_file() {
+            let path = entry.path();
+            if should_skip_standalone_sidecar(&path) {
+                continue;
+            }
+
             // Determine when this file was last accessed for LRU eviction
             // Try to use the system's access time first, but fall back to modification time
             // if access time tracking is disabled (common on modern filesystems for performance)
@@ -158,8 +209,8 @@ pub(crate) fn enforce_disk_cache_limit(cache_dir: &PathBuf, max_size: Option<u64
                 .or_else(|| metadata.modified().ok())
                 .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
 
-            let size = metadata.len();
-            entries.push((entry.path(), access_time, size));
+            let size = disk_cache_entry_size(&path, &metadata);
+            entries.push((path, access_time, size));
         }
     }
 
@@ -187,7 +238,7 @@ pub(crate) fn enforce_disk_cache_limit(cache_dir: &PathBuf, max_size: Option<u64
             if to_remove >= bytes_to_remove {
                 break;
             }
-            std::fs::remove_file(&path)?;
+            remove_disk_cache_entry(&path)?;
             to_remove += size;
             files_removed += 1;
         }
@@ -207,6 +258,74 @@ pub(crate) fn enforce_disk_cache_limit(cache_dir: &PathBuf, max_size: Option<u64
     }
 
     Ok(())
+}
+
+fn handle_metadata_validation_error(
+    class_hash: &ClassHash,
+    path: &std::path::Path,
+    error: NativeCacheMetadataError,
+    start: Instant,
+) {
+    let elapsed = start.elapsed();
+
+    match error {
+        NativeCacheMetadataError::Missing { path: metadata_path } => {
+            super::metrics::metrics().record_cache_metadata_missing();
+            tracing::warn!(
+                target: "madara_cairo_native",
+                class_hash = %format!("{:#x}", class_hash.to_felt()),
+                path = %path.display(),
+                metadata_path = %metadata_path.display(),
+                current_fingerprint = ?host_fingerprint::NativeHostFingerprint::current(),
+                elapsed = ?elapsed,
+                elapsed_ms = elapsed.as_millis(),
+                "native_cache_metadata_missing_skipping_disk_load"
+            );
+        }
+        NativeCacheMetadataError::Invalid { path: metadata_path, reason } => {
+            super::metrics::metrics().record_cache_metadata_invalid();
+            tracing::warn!(
+                target: "madara_cairo_native",
+                class_hash = %format!("{:#x}", class_hash.to_felt()),
+                path = %path.display(),
+                metadata_path = %metadata_path.display(),
+                error = %reason,
+                current_fingerprint = ?host_fingerprint::NativeHostFingerprint::current(),
+                elapsed = ?elapsed,
+                elapsed_ms = elapsed.as_millis(),
+                "native_cache_metadata_invalid_skipping_disk_load"
+            );
+        }
+        NativeCacheMetadataError::Mismatch { path: metadata_path, cached, current } => {
+            super::metrics::metrics().record_cache_host_mismatch();
+            tracing::warn!(
+                target: "madara_cairo_native",
+                class_hash = %format!("{:#x}", class_hash.to_felt()),
+                path = %path.display(),
+                metadata_path = %metadata_path.display(),
+                cached_fingerprint = ?cached,
+                current_fingerprint = ?current,
+                elapsed = ?elapsed,
+                elapsed_ms = elapsed.as_millis(),
+                "native_cache_host_mismatch_skipping_disk_load"
+            );
+        }
+        NativeCacheMetadataError::Write { path: metadata_path, reason } => {
+            super::metrics::metrics().record_cache_metadata_write_error();
+            tracing::warn!(
+                target: "madara_cairo_native",
+                class_hash = %format!("{:#x}", class_hash.to_felt()),
+                path = %path.display(),
+                metadata_path = %metadata_path.display(),
+                error = %reason,
+                elapsed = ?elapsed,
+                elapsed_ms = elapsed.as_millis(),
+                "native_cache_metadata_write_error_skipping_disk_load"
+            );
+        }
+    }
+
+    remove_native_cache_artifacts(path);
 }
 
 /// Evict entries from the memory cache if it exceeds the size limit.
@@ -549,7 +668,7 @@ pub(crate) fn try_get_from_disk_cache(
             target: "madara_cairo_native",
             class_hash = %format!("{:#x}", class_hash.to_felt()),
             path = %path.display(),
-                file_size_bytes = file_size,
+            file_size_bytes = file_size,
             "attempting_disk_load"
         );
     } else {
@@ -560,6 +679,11 @@ pub(crate) fn try_get_from_disk_cache(
             path = %path.display(),
             "disk_cache_file_metadata_error_skipping"
         );
+        return Ok(None);
+    }
+
+    if let Err(e) = host_fingerprint::validate_metadata_for_so(&path) {
+        handle_metadata_validation_error(class_hash, &path, e, start);
         return Ok(None);
     }
 
@@ -595,7 +719,7 @@ pub(crate) fn try_get_from_disk_cache(
                         "disk_hit_conversion_failed"
                     );
                     // Corrupted file removal attempted
-                    let _ = std::fs::remove_file(&path);
+                    remove_native_cache_artifacts(&path);
                     return Err(ProgramError::Parse(serde::de::Error::custom(format!(
                         "Failed to convert cached class: {}",
                         e
@@ -684,7 +808,12 @@ mod tests {
             temp_dir.path().join(format!("{:#x}.so", class_hash.to_felt()))
         };
 
-        crate::test_utils::create_native_class_internal(sierra, &so_path)
+        let native_class = crate::test_utils::create_native_class_internal(sierra, &so_path)?;
+        if config.is_some() {
+            crate::host_fingerprint::write_current_metadata_for_so(&so_path)?;
+        }
+
+        Ok(native_class)
     }
 
     #[rstest]
@@ -742,6 +871,10 @@ mod tests {
         let _native_class = create_test_native_class(&sierra_class, &temp_dir, class_hash, Some(&test_config))
             .expect("Failed to create and save native class to disk");
         assert!(path.exists(), "Native class file should exist on disk");
+        assert!(
+            crate::host_fingerprint::metadata_path_for_so(&path).exists(),
+            "Native cache metadata should exist on disk"
+        );
 
         // Clear memory cache to ensure we start fresh
         cache_remove(&class_hash);
@@ -758,6 +891,96 @@ mod tests {
         // Request the class again - should hit memory cache (not disk)
         let result = try_get_from_memory_cache(&class_hash, &test_config);
         assert!(result.is_some(), "Should hit memory cache after disk load");
+    }
+
+    #[rstest]
+    fn test_disk_cache_missing_metadata_skips_native_load(sierra_class: SierraConvertedClass, temp_dir: TempDir) {
+        use crate::metrics::test_counters;
+        let _metrics_guard = test_counters::acquire_and_reset();
+        cache_clear();
+
+        let class_hash = create_unique_test_class_hash();
+        let test_config = crate::test_utils::create_test_config(&temp_dir, None, false);
+        let path = get_native_cache_path(&class_hash, &test_config);
+        std::fs::write(&path, b"invalid native artifact").expect("invalid so should be written");
+
+        let disk_result = try_get_from_disk_cache(&class_hash, &sierra_class, &test_config);
+
+        assert!(disk_result.expect("metadata miss should not error").is_none());
+        assert_counters!(
+            CACHE_METADATA_MISSING: 1,
+            CACHE_DISK_LOAD_ERROR: 0,
+        );
+    }
+
+    #[rstest]
+    fn test_disk_cache_mismatched_arch_skips_native_load(sierra_class: SierraConvertedClass, temp_dir: TempDir) {
+        use crate::metrics::test_counters;
+        let _metrics_guard = test_counters::acquire_and_reset();
+        cache_clear();
+
+        let class_hash = create_unique_test_class_hash();
+        let test_config = crate::test_utils::create_test_config(&temp_dir, None, false);
+        let path = get_native_cache_path(&class_hash, &test_config);
+        std::fs::write(&path, b"invalid native artifact").expect("invalid so should be written");
+
+        let mut cached = crate::host_fingerprint::NativeHostFingerprint::current().clone();
+        cached.arch = "different-arch".to_string();
+        crate::host_fingerprint::write_metadata_for_so(&path, &cached).expect("metadata should be written");
+
+        let disk_result = try_get_from_disk_cache(&class_hash, &sierra_class, &test_config);
+
+        assert!(disk_result.expect("host mismatch should not error").is_none());
+        assert_counters!(
+            CACHE_HOST_MISMATCH: 1,
+            CACHE_DISK_LOAD_ERROR: 0,
+        );
+    }
+
+    #[rstest]
+    fn test_disk_cache_mismatched_cpu_vendor_skips_native_load(sierra_class: SierraConvertedClass, temp_dir: TempDir) {
+        use crate::metrics::test_counters;
+        let _metrics_guard = test_counters::acquire_and_reset();
+        cache_clear();
+
+        let class_hash = create_unique_test_class_hash();
+        let test_config = crate::test_utils::create_test_config(&temp_dir, None, false);
+        let path = get_native_cache_path(&class_hash, &test_config);
+        std::fs::write(&path, b"invalid native artifact").expect("invalid so should be written");
+
+        let mut cached = crate::host_fingerprint::NativeHostFingerprint::current().clone();
+        cached.cpu_vendor = "DifferentVendor".to_string();
+        crate::host_fingerprint::write_metadata_for_so(&path, &cached).expect("metadata should be written");
+
+        let disk_result = try_get_from_disk_cache(&class_hash, &sierra_class, &test_config);
+
+        assert!(disk_result.expect("host mismatch should not error").is_none());
+        assert_counters!(
+            CACHE_HOST_MISMATCH: 1,
+            CACHE_DISK_LOAD_ERROR: 0,
+        );
+    }
+
+    #[rstest]
+    fn test_disk_cache_malformed_metadata_skips_native_load(sierra_class: SierraConvertedClass, temp_dir: TempDir) {
+        use crate::metrics::test_counters;
+        let _metrics_guard = test_counters::acquire_and_reset();
+        cache_clear();
+
+        let class_hash = create_unique_test_class_hash();
+        let test_config = crate::test_utils::create_test_config(&temp_dir, None, false);
+        let path = get_native_cache_path(&class_hash, &test_config);
+        std::fs::write(&path, b"invalid native artifact").expect("invalid so should be written");
+        std::fs::write(crate::host_fingerprint::metadata_path_for_so(&path), b"{not-json")
+            .expect("metadata should be written");
+
+        let disk_result = try_get_from_disk_cache(&class_hash, &sierra_class, &test_config);
+
+        assert!(disk_result.expect("invalid metadata should not error").is_none());
+        assert_counters!(
+            CACHE_METADATA_INVALID: 1,
+            CACHE_DISK_LOAD_ERROR: 0,
+        );
     }
 
     #[rstest]
@@ -954,7 +1177,7 @@ mod tests {
         assert!(path_1.exists(), "File 1 should exist on disk");
         std::thread::sleep(Duration::from_millis(10)); // Small delay to ensure time difference
 
-        let file_size = std::fs::metadata(&path_1).expect("File 1 should exist").len();
+        let file_size = disk_cache_entry_size(&path_1, &std::fs::metadata(&path_1).expect("File 1 should exist"));
 
         // Set disk cache limit to accommodate exactly 2 files (with some margin)
         // We want to ensure that deleting file_1 alone brings us under the limit
@@ -1010,8 +1233,8 @@ mod tests {
         assert!(cache_contains(&class_hash_2), "Class should be loaded into memory cache after disk hit");
 
         // Verify both files exist and total size is within limit
-        let total_size = std::fs::metadata(&path_1).expect("File 1 should exist").len()
-            + std::fs::metadata(&path_2).expect("File 2 should exist").len();
+        let total_size = disk_cache_entry_size(&path_1, &std::fs::metadata(&path_1).expect("File 1 should exist"))
+            + disk_cache_entry_size(&path_2, &std::fs::metadata(&path_2).expect("File 2 should exist"));
         assert!(total_size <= max_disk_size, "Total size {} should be within limit {}", total_size, max_disk_size);
 
         // Create and save third class - should trigger eviction
@@ -1023,9 +1246,11 @@ mod tests {
         assert!(path_3.exists(), "File 3 should exist on disk");
 
         // Get file sizes before eviction to verify files are complete after eviction
-        let file_1_size = std::fs::metadata(&path_1).expect("File 1 should exist").len();
-        let file_2_size = std::fs::metadata(&path_2).expect("File 2 should exist").len();
-        let file_3_size = std::fs::metadata(&path_3).expect("File 3 should exist").len();
+        let file_2_so_size = std::fs::metadata(&path_2).expect("File 2 should exist").len();
+        let file_3_so_size = std::fs::metadata(&path_3).expect("File 3 should exist").len();
+        let file_1_size = disk_cache_entry_size(&path_1, &std::fs::metadata(&path_1).expect("File 1 should exist"));
+        let file_2_size = disk_cache_entry_size(&path_2, &std::fs::metadata(&path_2).expect("File 2 should exist"));
+        let file_3_size = disk_cache_entry_size(&path_3, &std::fs::metadata(&path_3).expect("File 3 should exist"));
 
         // Verify total size exceeds limit (will trigger eviction)
         let total_size_before = file_1_size + file_2_size + file_3_size;
@@ -1063,23 +1288,29 @@ mod tests {
 
         // Verify file_1 (oldest, LRU) was completely deleted
         assert!(!path_1.exists(), "File 1 (oldest, LRU) should be completely deleted");
+        assert!(
+            !crate::host_fingerprint::metadata_path_for_so(&path_1).exists(),
+            "File 1 metadata should be deleted with the .so"
+        );
 
         // Verify file_2 and file_3 still exist and are complete (not truncated)
         assert!(path_2.exists(), "File 2 (more recently accessed) should still exist");
         assert!(path_3.exists(), "File 3 (newest) should still exist");
+        assert!(crate::host_fingerprint::metadata_path_for_so(&path_2).exists(), "File 2 metadata should still exist");
+        assert!(crate::host_fingerprint::metadata_path_for_so(&path_3).exists(), "File 3 metadata should still exist");
 
         let file_2_current_size = std::fs::metadata(&path_2).expect("File 2 should exist").len();
         let file_3_current_size = std::fs::metadata(&path_3).expect("File 3 should exist").len();
 
         assert_eq!(
-            file_2_current_size, file_2_size,
+            file_2_current_size, file_2_so_size,
             "File 2 should be complete (not truncated). Original size: {}, Current size: {}",
-            file_2_size, file_2_current_size
+            file_2_so_size, file_2_current_size
         );
         assert_eq!(
-            file_3_current_size, file_3_size,
+            file_3_current_size, file_3_so_size,
             "File 3 should be complete (not truncated). Original size: {}, Current size: {}",
-            file_3_size, file_3_current_size
+            file_3_so_size, file_3_current_size
         );
 
         // Verify total size is now within limit (config limit is respected)

--- a/madara/crates/client/cairo_native/src/cache.rs
+++ b/madara/crates/client/cairo_native/src/cache.rs
@@ -318,18 +318,8 @@ fn handle_metadata_validation_error(
                 "native_cache_host_mismatch_skipping_disk_load"
             );
         }
-        NativeCacheMetadataError::Write { path: metadata_path, reason } => {
-            super::metrics::metrics().record_cache_metadata_write_error();
-            tracing::warn!(
-                target: "madara_cairo_native",
-                class_hash = %format!("{:#x}", class_hash.to_felt()),
-                path = %path.display(),
-                metadata_path = %metadata_path.display(),
-                error = %reason,
-                elapsed = ?elapsed,
-                elapsed_ms = elapsed.as_millis(),
-                "native_cache_metadata_write_error_skipping_disk_load"
-            );
+        NativeCacheMetadataError::Write { .. } => {
+            unreachable!("validate_metadata_for_so only returns read-phase metadata errors")
         }
     }
 

--- a/madara/crates/client/cairo_native/src/compilation.rs
+++ b/madara/crates/client/cairo_native/src/compilation.rs
@@ -7,7 +7,7 @@ use cairo_native::executor::AotContractExecutor;
 use dashmap::DashMap;
 use mp_convert::ToFelt;
 use starknet_api::core::ClassHash;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -17,7 +17,7 @@ use super::error::NativeCompilationError;
 use super::native_class::NativeCompiledClass;
 use mp_class::SierraConvertedClass;
 
-use super::cache;
+use super::{cache, host_fingerprint};
 
 /// Tracks which classes are currently being compiled to avoid duplicate compilations.
 ///
@@ -304,8 +304,8 @@ pub(crate) fn convert_sierra_to_blockifier_class(
 /// Called on compilation timeout or failure to remove partial artifacts.
 /// The .lock file is created by cairo-native's compile_to_native() function.
 /// Safe to call even if files don't exist (errors are silently ignored).
-fn cleanup_compilation_artifacts(path: &PathBuf) {
-    let _ = std::fs::remove_file(path); // .so file
+fn cleanup_compilation_artifacts(path: &Path) {
+    cache::remove_native_cache_artifacts(path); // .so file and metadata sidecar
     let _ = std::fs::remove_file(path.with_extension("lock")); // .lock file
 }
 
@@ -315,14 +315,14 @@ fn cleanup_compilation_artifacts(path: &PathBuf) {
 /// This is a pure function that only performs compilation - no caching or metrics.
 fn execute_native_compilation(
     sierra: &SierraConvertedClass,
-    path: &PathBuf,
+    path: &Path,
     timeout: Duration,
     timer: super::metrics::CompilationTimer,
 ) -> Result<AotContractExecutor, NativeCompilationError> {
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         // Async context detected - spawn_blocking used with timeout
         let sierra_clone = Arc::new(sierra.clone());
-        let path_clone = path.clone();
+        let path_clone = path.to_path_buf();
         let compilation_future =
             tokio::task::spawn_blocking(move || sierra_clone.info.contract_class.compile_to_native(&path_clone));
 
@@ -330,10 +330,12 @@ fn execute_native_compilation(
             Ok(Ok(Ok(executor))) => Ok(executor),
             Ok(Ok(Err(e))) => {
                 timer.finish(false, false);
+                cleanup_compilation_artifacts(path);
                 Err(NativeCompilationError::CompilationFailed(format!("{:#}", e)))
             }
             Ok(Err(e)) => {
                 timer.finish(false, false);
+                cleanup_compilation_artifacts(path);
                 Err(NativeCompilationError::CompilationFailed(format!("Task panicked: {:#}", e)))
             }
             Err(_) => {
@@ -345,7 +347,7 @@ fn execute_native_compilation(
     } else {
         // Blocking context detected - compilation executed directly with timeout using std::thread
         let sierra_clone = Arc::new(sierra.clone());
-        let path_clone = path.clone();
+        let path_clone = path.to_path_buf();
         let (tx, rx) = std::sync::mpsc::channel();
 
         std::thread::spawn(move || {
@@ -358,6 +360,7 @@ fn execute_native_compilation(
             Ok(Ok(executor)) => Ok(executor),
             Ok(Err(e)) => {
                 timer.finish(false, false);
+                cleanup_compilation_artifacts(path);
                 Err(NativeCompilationError::CompilationFailed(format!("{:#}", e)))
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
@@ -367,6 +370,7 @@ fn execute_native_compilation(
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 timer.finish(false, false);
+                cleanup_compilation_artifacts(path);
                 Err(NativeCompilationError::CompilationFailed("Compilation thread disconnected".to_string()))
             }
         }
@@ -458,8 +462,22 @@ pub(crate) fn compile_native_blocking(
         }
     };
 
+    if let Err(e) = host_fingerprint::write_current_metadata_for_so(&path) {
+        super::metrics::metrics().record_cache_metadata_write_error();
+        cleanup_compilation_artifacts(&path);
+        super::metrics::metrics().record_compilation_end(start.elapsed().as_millis() as u64, false, false);
+        return Err(NativeCompilationError::CacheMetadataError(e.to_string()));
+    }
+
     // Converted to blockifier class using common logic
-    let blockifier_compiled_class = convert_sierra_to_blockifier_class(sierra)?;
+    let blockifier_compiled_class = match convert_sierra_to_blockifier_class(sierra) {
+        Ok(compiled) => compiled,
+        Err(e) => {
+            cleanup_compilation_artifacts(&path);
+            super::metrics::metrics().record_compilation_end(start.elapsed().as_millis() as u64, false, false);
+            return Err(e);
+        }
+    };
 
     let elapsed = start.elapsed();
     tracing::debug!(
@@ -484,6 +502,7 @@ fn handle_async_compilation_success(
     class_hash: ClassHash,
     executor: AotContractExecutor,
     sierra: &SierraConvertedClass,
+    path: &Path,
     start: Instant,
     timer: super::metrics::CompilationTimer,
     config: &config::NativeConfig,
@@ -499,16 +518,27 @@ fn handle_async_compilation_success(
                 error = %e,
                 "compilation_async_conversion_failed"
             );
+            cleanup_compilation_artifacts(path);
             timer.finish(false, false);
-            // Mark this class as failed (with timestamp for eviction)
-            let exec_config = config
-                .execution_config()
-                .expect("handle_async_compilation_success should only be called when native execution is enabled");
-            evict_failed_compilations_if_needed(exec_config.max_failed_compilations);
-            FAILED_COMPILATIONS.insert(class_hash, Instant::now());
+            mark_async_compilation_failed(class_hash, config);
             return;
         }
     };
+
+    if let Err(e) = host_fingerprint::write_current_metadata_for_so(path) {
+        super::metrics::metrics().record_cache_metadata_write_error();
+        tracing::error!(
+            target: "madara_cairo_native",
+            class_hash = %format!("{:#x}", class_hash.to_felt()),
+            path = %path.display(),
+            error = %e,
+            "compilation_async_metadata_write_failed"
+        );
+        cleanup_compilation_artifacts(path);
+        timer.finish(false, false);
+        mark_async_compilation_failed(class_hash, config);
+        return;
+    }
 
     let compile_elapsed = start.elapsed();
 
@@ -535,7 +565,7 @@ fn handle_async_compilation_failure(
     class_hash: ClassHash,
     error_kind: &str,
     error_msg: String,
-    path: &PathBuf,
+    path: &Path,
     timer: super::metrics::CompilationTimer,
     is_timeout: bool,
     config: &config::NativeConfig,
@@ -549,8 +579,6 @@ fn handle_async_compilation_failure(
             error_kind = error_kind,
             "compilation_async_timeout"
         );
-        // Partial file cleanup attempted
-        cleanup_compilation_artifacts(path);
         timer.finish(false, true);
     } else {
         // Other failures are errors
@@ -564,10 +592,14 @@ fn handle_async_compilation_failure(
         timer.finish(false, false);
     }
 
-    // Mark this class as failed (with timestamp for eviction)
+    cleanup_compilation_artifacts(path);
+    mark_async_compilation_failed(class_hash, config);
+}
+
+fn mark_async_compilation_failed(class_hash: ClassHash, config: &config::NativeConfig) {
     let exec_config = config
         .execution_config()
-        .expect("handle_async_compilation_failure should only be called when native execution is enabled");
+        .expect("async compilation failure handling should only be called when native execution is enabled");
     evict_failed_compilations_if_needed(exec_config.max_failed_compilations);
     mark_failed_compilation(class_hash, Instant::now());
 }
@@ -741,7 +773,7 @@ pub(crate) fn spawn_compilation_if_needed(
         // Only one branch will execute, so moving timer is fine
         match compilation_result {
             Ok(Ok(Ok(executor))) => {
-                handle_async_compilation_success(class_hash, executor, &sierra, start, timer, &config);
+                handle_async_compilation_success(class_hash, executor, &sierra, &path, start, timer, &config);
             }
             Ok(Ok(Err(e))) => {
                 handle_async_compilation_failure(
@@ -925,17 +957,21 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
         let so_path = temp_dir.path().join("test_class.so");
         let lock_path = temp_dir.path().join("test_class.lock");
+        let metadata_path = crate::host_fingerprint::metadata_path_for_so(&so_path);
 
-        // Create both files
+        // Create all cache artifacts
         std::fs::write(&so_path, b"test").expect("Failed to create .so file");
         std::fs::write(&lock_path, b"test").expect("Failed to create .lock file");
+        std::fs::write(&metadata_path, b"test").expect("Failed to create metadata file");
         assert!(so_path.exists());
         assert!(lock_path.exists());
+        assert!(metadata_path.exists());
 
-        // Cleanup should remove both
+        // Cleanup should remove all artifacts
         cleanup_compilation_artifacts(&so_path);
         assert!(!so_path.exists(), ".so file should be removed");
         assert!(!lock_path.exists(), ".lock file should be removed");
+        assert!(!metadata_path.exists(), "metadata file should be removed");
 
         // Cleanup on non-existent files should not panic
         cleanup_compilation_artifacts(&so_path);

--- a/madara/crates/client/cairo_native/src/error.rs
+++ b/madara/crates/client/cairo_native/src/error.rs
@@ -42,6 +42,9 @@ pub enum NativeCompilationError {
     #[error("Failed to create cache directory: {0}")]
     CacheDirectoryError(String),
 
+    #[error("Failed to write native cache metadata: {0}")]
+    CacheMetadataError(String),
+
     #[error("Failed to load native class from disk: {0}")]
     DiskLoadError(String),
 }

--- a/madara/crates/client/cairo_native/src/execution.rs
+++ b/madara/crates/client/cairo_native/src/execution.rs
@@ -452,6 +452,7 @@ mod tests {
 
         // Use shared function to create native class (this compiles and saves to disk)
         let native_class = crate::test_utils::create_native_class_internal(sierra, &so_path)?;
+        crate::host_fingerprint::write_current_metadata_for_so(&so_path)?;
 
         // Optionally insert into memory cache
         if cache_in_memory {
@@ -566,6 +567,7 @@ mod tests {
         let so_path = cache::get_native_cache_path(&class_hash, &async_config);
         let _native_class = crate::test_utils::create_native_class_internal(&sierra_class, &so_path)
             .expect("Failed to create native class");
+        crate::host_fingerprint::write_current_metadata_for_so(&so_path).expect("Failed to write metadata");
         assert!(so_path.exists(), "Native class file should exist on disk");
 
         // Verify memory cache still doesn't have it
@@ -671,6 +673,11 @@ mod tests {
 
         // Assert that the returned class IS Cairo Native (not VM)
         assert_is_native_class(&runnable);
+        let so_path = cache::get_native_cache_path(&class_hash, &blocking_config);
+        assert!(
+            crate::host_fingerprint::metadata_path_for_so(&so_path).exists(),
+            "Blocking compilation should write native cache metadata"
+        );
         // Compilation should be complete, so not in progress
         assert!(
             !compilation::is_compilation_in_progress(&class_hash),
@@ -735,6 +742,11 @@ mod tests {
 
         // Verify compilation completed and class is cached
         assert!(cache::cache_contains(&class_hash), "Class should be in memory cache after compilation completes");
+        let so_path = cache::get_native_cache_path(&class_hash, &async_config);
+        assert!(
+            crate::host_fingerprint::metadata_path_for_so(&so_path).exists(),
+            "Async compilation should write native cache metadata"
+        );
         assert!(
             !compilation::is_compilation_in_progress(&class_hash),
             "Class should not be in compilation_in_progress after completion"
@@ -775,6 +787,7 @@ mod tests {
         // Use the config's cache directory path
         let so_path = cache::get_native_cache_path(&class_hash, &async_config);
         std::fs::write(&so_path, b"invalid binary data").expect("Failed to write invalid file");
+        crate::host_fingerprint::write_current_metadata_for_so(&so_path).expect("Failed to write metadata");
 
         // Disk error handled gracefully, falls back to compilation
         let result = handle_sierra_class(
@@ -1088,6 +1101,49 @@ mod tests {
             CACHE_HITS_DISK: 0,
             CACHE_DISK_MISS: 1,
             CACHE_DISK_LOAD_TIMEOUT: 1,
+            VM_FALLBACKS: 1,
+            COMPILATIONS_STARTED: 1,
+            COMPILATIONS_SUCCEEDED: 1,
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_handle_sierra_class_missing_metadata_falls_back_to_vm(
+        sierra_class: SierraConvertedClass,
+        temp_dir: TempDir,
+    ) {
+        let _guard = test_counters::acquire_and_reset();
+
+        let class_hash = create_unique_test_class_hash();
+        let async_config =
+            crate::test_utils::create_test_config_arc(&temp_dir, Some(config::NativeCompilationMode::Async), true);
+
+        let so_path = cache::get_native_cache_path(&class_hash, &async_config);
+        std::fs::write(&so_path, b"invalid binary data").expect("Failed to write invalid file");
+
+        let result = handle_sierra_class(
+            &sierra_class,
+            &class_hash.to_felt(),
+            &sierra_class.compiled,
+            &sierra_class.info,
+            async_config.clone(),
+        );
+
+        assert!(result.is_ok(), "Should return VM class in async mode");
+        assert_is_vm_class(&result.unwrap());
+
+        let compilation_completed = wait_for_compilation_completion_async(&class_hash, 20).await;
+        assert!(compilation_completed, "Compilation should complete after metadata miss");
+        assert!(
+            crate::host_fingerprint::metadata_path_for_so(&so_path).exists(),
+            "Fresh compilation should write metadata"
+        );
+
+        assert_counters!(
+            CACHE_METADATA_MISSING: 1,
+            CACHE_DISK_LOAD_ERROR: 0,
             VM_FALLBACKS: 1,
             COMPILATIONS_STARTED: 1,
             COMPILATIONS_SUCCEEDED: 1,

--- a/madara/crates/client/cairo_native/src/host_fingerprint.rs
+++ b/madara/crates/client/cairo_native/src/host_fingerprint.rs
@@ -5,14 +5,21 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
-const SCHEMA_VERSION: u32 = 1;
+// Maintainers:
+// Bump this when persisted native artifacts should be considered incompatible
+// even on the same host. Typical reasons:
+// - changing how Madara interprets or validates cached native artifacts
+// - changing the metadata sidecar contract
+// - adopting a cairo-native/compiler/runtime change that should force recompilation
+//
+// Do not bump this for host-only differences such as `arch`, `os`, or `cpu_vendor`;
+// those are already part of the fingerprint and are validated separately.
 const NATIVE_CACHE_ABI_VERSION: &str = "madara-cairo-native-v1";
 
 static CURRENT_FINGERPRINT: LazyLock<NativeHostFingerprint> = LazyLock::new(NativeHostFingerprint::detect);
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct NativeHostFingerprint {
-    pub(crate) schema_version: u32,
     pub(crate) native_cache_abi_version: String,
     pub(crate) arch: String,
     pub(crate) cpu_vendor: String,
@@ -26,7 +33,6 @@ impl NativeHostFingerprint {
 
     fn detect() -> Self {
         Self {
-            schema_version: SCHEMA_VERSION,
             native_cache_abi_version: NATIVE_CACHE_ABI_VERSION.to_string(),
             arch: std::env::consts::ARCH.to_string(),
             cpu_vendor: detect_cpu_vendor(),

--- a/madara/crates/client/cairo_native/src/host_fingerprint.rs
+++ b/madara/crates/client/cairo_native/src/host_fingerprint.rs
@@ -1,0 +1,224 @@
+//! Host compatibility metadata for persisted Cairo Native artifacts.
+
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+const SCHEMA_VERSION: u32 = 1;
+const NATIVE_CACHE_ABI_VERSION: &str = "madara-cairo-native-v1";
+
+static CURRENT_FINGERPRINT: LazyLock<NativeHostFingerprint> = LazyLock::new(NativeHostFingerprint::detect);
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct NativeHostFingerprint {
+    pub(crate) schema_version: u32,
+    pub(crate) native_cache_abi_version: String,
+    pub(crate) arch: String,
+    pub(crate) cpu_vendor: String,
+    pub(crate) os: String,
+}
+
+impl NativeHostFingerprint {
+    pub(crate) fn current() -> &'static Self {
+        &CURRENT_FINGERPRINT
+    }
+
+    fn detect() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            native_cache_abi_version: NATIVE_CACHE_ABI_VERSION.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            cpu_vendor: detect_cpu_vendor(),
+            os: std::env::consts::OS.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum NativeCacheMetadataError {
+    #[error("metadata is missing at {path}")]
+    Missing { path: PathBuf },
+    #[error("metadata is invalid at {path}: {reason}")]
+    Invalid { path: PathBuf, reason: String },
+    #[error("metadata does not match current host at {path}")]
+    Mismatch { path: PathBuf, cached: Box<NativeHostFingerprint>, current: Box<NativeHostFingerprint> },
+    #[error("failed to write metadata at {path}: {reason}")]
+    Write { path: PathBuf, reason: String },
+}
+
+pub(crate) fn metadata_path_for_so(so_path: &Path) -> PathBuf {
+    let mut path = so_path.as_os_str().to_os_string();
+    path.push(".meta.json");
+    PathBuf::from(path)
+}
+
+pub(crate) fn validate_metadata_for_so(so_path: &Path) -> Result<NativeHostFingerprint, NativeCacheMetadataError> {
+    let cached = read_metadata_for_so(so_path)?;
+    let current = NativeHostFingerprint::current();
+
+    if &cached == current {
+        Ok(cached)
+    } else {
+        Err(NativeCacheMetadataError::Mismatch {
+            path: metadata_path_for_so(so_path),
+            cached: Box::new(cached),
+            current: Box::new(current.clone()),
+        })
+    }
+}
+
+pub(crate) fn write_current_metadata_for_so(so_path: &Path) -> Result<(), NativeCacheMetadataError> {
+    write_metadata_for_so(so_path, NativeHostFingerprint::current())
+}
+
+pub(crate) fn write_metadata_for_so(
+    so_path: &Path,
+    metadata: &NativeHostFingerprint,
+) -> Result<(), NativeCacheMetadataError> {
+    let metadata_path = metadata_path_for_so(so_path);
+    let tmp_path = tmp_metadata_path(&metadata_path);
+
+    if let Some(parent) = metadata_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| NativeCacheMetadataError::Write { path: metadata_path.clone(), reason: e.to_string() })?;
+    }
+
+    let bytes = serde_json::to_vec_pretty(metadata)
+        .map_err(|e| NativeCacheMetadataError::Write { path: metadata_path.clone(), reason: e.to_string() })?;
+
+    let write_result = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(&bytes)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&tmp_path, &metadata_path)?;
+
+        if let Some(parent) = metadata_path.parent() {
+            let _ = std::fs::File::open(parent).and_then(|dir| dir.sync_all());
+        }
+
+        Ok(())
+    })();
+
+    write_result.map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        NativeCacheMetadataError::Write { path: metadata_path, reason: e.to_string() }
+    })
+}
+
+fn read_metadata_for_so(so_path: &Path) -> Result<NativeHostFingerprint, NativeCacheMetadataError> {
+    let metadata_path = metadata_path_for_so(so_path);
+    let bytes = match std::fs::read(&metadata_path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(NativeCacheMetadataError::Missing { path: metadata_path });
+        }
+        Err(e) => {
+            return Err(NativeCacheMetadataError::Invalid { path: metadata_path, reason: e.to_string() });
+        }
+    };
+
+    serde_json::from_slice(&bytes)
+        .map_err(|e| NativeCacheMetadataError::Invalid { path: metadata_path, reason: e.to_string() })
+}
+
+fn tmp_metadata_path(metadata_path: &Path) -> PathBuf {
+    let mut path = metadata_path.as_os_str().to_os_string();
+    path.push(".tmp");
+    PathBuf::from(path)
+}
+
+fn detect_cpu_vendor() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        read_linux_cpuinfo_value("vendor_id").unwrap_or_else(|| "unknown".to_string())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        "unknown".to_string()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_cpuinfo_value(key: &str) -> Option<String> {
+    let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+
+    cpuinfo.lines().find_map(|line| {
+        let (field, value) = line.split_once(':')?;
+        if field.trim() == key {
+            let value = value.trim();
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_path_for_so_appends_sidecar_suffix() {
+        let so_path = PathBuf::from("/tmp/native_classes/0x1.so");
+
+        assert_eq!(metadata_path_for_so(&so_path), PathBuf::from("/tmp/native_classes/0x1.so.meta.json"));
+    }
+
+    #[test]
+    fn write_current_metadata_for_so_creates_matching_sidecar() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir should be created");
+        let so_path = temp_dir.path().join("0x1.so");
+        std::fs::write(&so_path, b"native").expect("test so should be written");
+
+        write_current_metadata_for_so(&so_path).expect("metadata should be written");
+
+        let cached = validate_metadata_for_so(&so_path).expect("metadata should match current host");
+        assert_eq!(&cached, NativeHostFingerprint::current());
+    }
+
+    #[test]
+    fn validate_metadata_for_so_returns_missing_when_sidecar_absent() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir should be created");
+        let so_path = temp_dir.path().join("0x1.so");
+        std::fs::write(&so_path, b"native").expect("test so should be written");
+
+        let error = validate_metadata_for_so(&so_path).expect_err("metadata should be missing");
+
+        assert!(matches!(error, NativeCacheMetadataError::Missing { .. }));
+    }
+
+    #[test]
+    fn validate_metadata_for_so_returns_invalid_when_sidecar_is_malformed() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir should be created");
+        let so_path = temp_dir.path().join("0x1.so");
+        std::fs::write(&so_path, b"native").expect("test so should be written");
+        std::fs::write(metadata_path_for_so(&so_path), b"{not-json").expect("metadata should be written");
+
+        let error = validate_metadata_for_so(&so_path).expect_err("metadata should be invalid");
+
+        assert!(matches!(error, NativeCacheMetadataError::Invalid { .. }));
+    }
+
+    #[test]
+    fn validate_metadata_for_so_returns_mismatch_when_arch_differs() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir should be created");
+        let so_path = temp_dir.path().join("0x1.so");
+        std::fs::write(&so_path, b"native").expect("test so should be written");
+
+        let mut cached = NativeHostFingerprint::current().clone();
+        cached.arch = "different-arch".to_string();
+        write_metadata_for_so(&so_path, &cached).expect("metadata should be written");
+
+        let error = validate_metadata_for_so(&so_path).expect_err("metadata should mismatch");
+
+        assert!(matches!(error, NativeCacheMetadataError::Mismatch { .. }));
+    }
+}

--- a/madara/crates/client/cairo_native/src/host_fingerprint.rs
+++ b/madara/crates/client/cairo_native/src/host_fingerprint.rs
@@ -7,10 +7,14 @@ use std::sync::LazyLock;
 
 // Maintainers:
 // Bump this when persisted native artifacts should be considered incompatible
-// even on the same host. Typical reasons:
-// - changing how Madara interprets or validates cached native artifacts
-// - changing the metadata sidecar contract
-// - adopting a cairo-native/compiler/runtime change that should force recompilation
+// even on the same host. Update it in the same change that:
+// - adds, removes, or reinterprets fields in `NativeHostFingerprint`
+// - changes how Madara validates or loads persisted native artifacts
+// - changes the `.meta.json` sidecar contract
+// - adopts a cairo-native/compiler/runtime change that should force recompilation
+//
+// Mirror the reason in `madara/CLAUDE.md` so follow-up agents know why the cache
+// was invalidated and what future changes should update this value again.
 //
 // Do not bump this for host-only differences such as `arch`, `os`, or `cpu_vendor`;
 // those are already part of the fingerprint and are validated separately.
@@ -144,6 +148,9 @@ fn detect_cpu_vendor() -> String {
 
     #[cfg(not(target_os = "linux"))]
     {
+        // Production nodes share Cairo Native disk cache only on Linux today.
+        // Keep non-Linux builds working for local development and tests without
+        // adding platform-specific probes that do not affect deployed nodes.
         "unknown".to_string()
     }
 }

--- a/madara/crates/client/cairo_native/src/lib.rs
+++ b/madara/crates/client/cairo_native/src/lib.rs
@@ -16,6 +16,7 @@
 //! - [`cache`]: In-memory and disk-based caching of compiled classes
 //! - [`compilation`]: Compilation orchestration (blocking/async modes, retry logic)
 //! - [`execution`]: Main execution flow and class handling
+//! - [`host_fingerprint`]: Host compatibility metadata for persisted native artifacts
 //! - [`to_blockifier`]: Conversion to Blockifier's `RunnableCompiledClass` with native execution support
 
 pub mod cache;
@@ -23,6 +24,7 @@ pub mod compilation;
 pub mod config;
 pub mod error;
 pub mod execution;
+pub mod host_fingerprint;
 pub mod metrics;
 pub mod native_class;
 pub mod to_blockifier;

--- a/madara/crates/client/cairo_native/src/metrics.rs
+++ b/madara/crates/client/cairo_native/src/metrics.rs
@@ -85,6 +85,10 @@ pub mod test_counters {
     pub static CACHE_DISK_FILE_NOT_FOUND: AtomicU64 = AtomicU64::new(0);
     pub static CACHE_DISK_FILE_EMPTY: AtomicU64 = AtomicU64::new(0);
     pub static CACHE_DISK_METADATA_ERROR: AtomicU64 = AtomicU64::new(0);
+    pub static CACHE_METADATA_MISSING: AtomicU64 = AtomicU64::new(0);
+    pub static CACHE_METADATA_INVALID: AtomicU64 = AtomicU64::new(0);
+    pub static CACHE_HOST_MISMATCH: AtomicU64 = AtomicU64::new(0);
+    pub static CACHE_METADATA_WRITE_ERROR: AtomicU64 = AtomicU64::new(0);
 
     // Compilation metrics
     pub static COMPILATIONS_STARTED: AtomicU64 = AtomicU64::new(0);
@@ -118,6 +122,10 @@ pub mod test_counters {
         CACHE_DISK_FILE_NOT_FOUND.store(0, Ordering::Relaxed);
         CACHE_DISK_FILE_EMPTY.store(0, Ordering::Relaxed);
         CACHE_DISK_METADATA_ERROR.store(0, Ordering::Relaxed);
+        CACHE_METADATA_MISSING.store(0, Ordering::Relaxed);
+        CACHE_METADATA_INVALID.store(0, Ordering::Relaxed);
+        CACHE_HOST_MISMATCH.store(0, Ordering::Relaxed);
+        CACHE_METADATA_WRITE_ERROR.store(0, Ordering::Relaxed);
 
         COMPILATIONS_STARTED.store(0, Ordering::Relaxed);
         COMPILATIONS_SUCCEEDED.store(0, Ordering::Relaxed);
@@ -155,6 +163,10 @@ pub struct NativeMetrics {
     cache_disk_file_not_found_counter: Counter<u64>,
     cache_disk_file_empty_counter: Counter<u64>,
     cache_disk_metadata_error_counter: Counter<u64>,
+    cache_metadata_missing_counter: Counter<u64>,
+    cache_metadata_invalid_counter: Counter<u64>,
+    cache_host_mismatch_counter: Counter<u64>,
+    cache_metadata_write_error_counter: Counter<u64>,
 
     // Cache latency histograms
     cache_lookup_time_memory_histogram: Histogram<f64>,
@@ -285,6 +297,30 @@ impl NativeMetrics {
             &meter,
             "cairo_native_cache_disk_metadata_error".to_string(),
             "Number of disk cache file metadata errors".to_string(),
+            "error".to_string(),
+        );
+        let cache_metadata_missing_counter = register_counter_metric_instrument(
+            &meter,
+            "cairo_native_cache_metadata_missing".to_string(),
+            "Number of disk cache artifacts skipped because host metadata is missing".to_string(),
+            "miss".to_string(),
+        );
+        let cache_metadata_invalid_counter = register_counter_metric_instrument(
+            &meter,
+            "cairo_native_cache_metadata_invalid".to_string(),
+            "Number of disk cache artifacts skipped because host metadata is unreadable or malformed".to_string(),
+            "error".to_string(),
+        );
+        let cache_host_mismatch_counter = register_counter_metric_instrument(
+            &meter,
+            "cairo_native_cache_host_mismatch".to_string(),
+            "Number of disk cache artifacts skipped because host metadata does not match this process".to_string(),
+            "mismatch".to_string(),
+        );
+        let cache_metadata_write_error_counter = register_counter_metric_instrument(
+            &meter,
+            "cairo_native_cache_metadata_write_error".to_string(),
+            "Number of Cairo Native metadata sidecar write errors".to_string(),
             "error".to_string(),
         );
 
@@ -418,6 +454,10 @@ impl NativeMetrics {
             cache_disk_file_not_found_counter,
             cache_disk_file_empty_counter,
             cache_disk_metadata_error_counter,
+            cache_metadata_missing_counter,
+            cache_metadata_invalid_counter,
+            cache_host_mismatch_counter,
+            cache_metadata_write_error_counter,
             cache_lookup_time_memory_histogram,
             cache_lookup_time_disk_histogram,
             cache_conversion_time_histogram,
@@ -527,6 +567,30 @@ impl NativeMetrics {
         self.cache_disk_metadata_error_counter.add(1, &[]);
         #[cfg(test)]
         test_counters::CACHE_DISK_METADATA_ERROR.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn record_cache_metadata_missing(&self) {
+        self.cache_metadata_missing_counter.add(1, &[]);
+        #[cfg(test)]
+        test_counters::CACHE_METADATA_MISSING.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn record_cache_metadata_invalid(&self) {
+        self.cache_metadata_invalid_counter.add(1, &[]);
+        #[cfg(test)]
+        test_counters::CACHE_METADATA_INVALID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn record_cache_host_mismatch(&self) {
+        self.cache_host_mismatch_counter.add(1, &[]);
+        #[cfg(test)]
+        test_counters::CACHE_HOST_MISMATCH.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn record_cache_metadata_write_error(&self) {
+        self.cache_metadata_write_error_counter.add(1, &[]);
+        #[cfg(test)]
+        test_counters::CACHE_METADATA_WRITE_ERROR.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     // Cache latency recording

--- a/madara/crates/client/db/src/migration/MIGRATION.md
+++ b/madara/crates/client/db/src/migration/MIGRATION.md
@@ -141,6 +141,9 @@ impl MigrationContext {
     /// Get a reference to the RocksDB instance
     pub fn db(&self) -> &DB;
 
+    /// Get the Madara base path that owns db/ and sidecar runtime directories
+    pub fn base_path(&self) -> &Path;
+
     /// Get the source version (migrating FROM)
     pub fn from_version(&self) -> u32;
 

--- a/madara/crates/client/db/src/migration/context.rs
+++ b/madara/crates/client/db/src/migration/context.rs
@@ -1,6 +1,7 @@
 //! Migration context provided to each migration function.
 
 use rocksdb::{DBWithThreadMode, MultiThreaded};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -25,13 +26,14 @@ pub type ProgressCallback = Box<dyn Fn(MigrationProgress) + Send + Sync>;
 /// Context provided to each migration function.
 pub struct MigrationContext<'a> {
     db: &'a DB,
+    base_path: PathBuf,
     progress_callback: Option<ProgressCallback>,
     abort_flag: Arc<AtomicBool>,
 }
 
 impl<'a> MigrationContext<'a> {
-    pub fn new(db: &'a DB, abort_flag: Arc<AtomicBool>) -> Self {
-        Self { db, progress_callback: None, abort_flag }
+    pub fn new(db: &'a DB, base_path: &Path, abort_flag: Arc<AtomicBool>) -> Self {
+        Self { db, base_path: base_path.to_path_buf(), progress_callback: None, abort_flag }
     }
 
     pub fn with_progress_callback(mut self, callback: ProgressCallback) -> Self {
@@ -41,6 +43,10 @@ impl<'a> MigrationContext<'a> {
 
     pub fn db(&self) -> &DB {
         self.db
+    }
+
+    pub fn base_path(&self) -> &Path {
+        &self.base_path
     }
 
     pub fn report_progress(&self, progress: MigrationProgress) {

--- a/madara/crates/client/db/src/migration/mod.rs
+++ b/madara/crates/client/db/src/migration/mod.rs
@@ -273,9 +273,11 @@ impl MigrationRunner {
                 migration.to_version
             );
 
-            let context = MigrationContext::new(db, self.abort_flag.clone()).with_progress_callback(Box::new(|p| {
-                tracing::info!("   [{}/{}] {}", p.current_step, p.total_steps, p.message);
-            }));
+            let context = MigrationContext::new(db, &self.base_path, self.abort_flag.clone()).with_progress_callback(
+                Box::new(|p| {
+                    tracing::info!("   [{}/{}] {}", p.current_step, p.total_steps, p.message);
+                }),
+            );
 
             let start = std::time::Instant::now();
             if let Err(e) = (migration.migrate)(&context) {

--- a/madara/crates/client/db/src/migration/registry.rs
+++ b/madara/crates/client/db/src/migration/registry.rs
@@ -68,6 +68,12 @@ pub fn get_migrations() -> &'static [Migration] {
             name: "v11→v12: revert L1-message cleanup consistency (no-op)",
             migrate: super::revisions::revision_0012::migrate,
         },
+        Migration {
+            from_version: 12,
+            to_version: 13,
+            name: "v12→v13: clear Cairo Native disk cache for metadata sidecars",
+            migrate: super::revisions::revision_0013::migrate,
+        },
     ]
 }
 

--- a/madara/crates/client/db/src/migration/revisions/mod.rs
+++ b/madara/crates/client/db/src/migration/revisions/mod.rs
@@ -12,3 +12,4 @@ pub mod revision_0009;
 pub mod revision_0010;
 pub mod revision_0011;
 pub mod revision_0012;
+pub mod revision_0013;

--- a/madara/crates/client/db/src/migration/revisions/revision_0013.rs
+++ b/madara/crates/client/db/src/migration/revisions/revision_0013.rs
@@ -1,0 +1,82 @@
+//! Migration from v12 to v13: clear Cairo Native disk cache.
+
+use crate::migration::{MigrationContext, MigrationError, MigrationProgress};
+use std::path::Path;
+
+const NATIVE_CACHE_DIR: &str = "native_classes";
+
+pub fn migrate(ctx: &MigrationContext<'_>) -> Result<(), MigrationError> {
+    tracing::info!("Starting v12→v13 migration: clearing Cairo Native disk cache");
+    ctx.report_progress(MigrationProgress::new(0, 2, "Locating Cairo Native disk cache"));
+
+    if ctx.should_abort() {
+        return Err(MigrationError::Aborted);
+    }
+
+    let native_cache_path = ctx.base_path().join(NATIVE_CACHE_DIR);
+    ctx.report_progress(MigrationProgress::new(1, 2, "Clearing Cairo Native disk cache"));
+    let cleared = clear_native_cache_path(&native_cache_path)?;
+
+    if cleared {
+        tracing::info!(
+            target: "madara_db_migration",
+            path = %native_cache_path.display(),
+            "cleared_cairo_native_disk_cache"
+        );
+    } else {
+        tracing::info!(
+            target: "madara_db_migration",
+            path = %native_cache_path.display(),
+            "cairo_native_disk_cache_not_present"
+        );
+    }
+
+    ctx.report_progress(MigrationProgress::new(2, 2, "Cairo Native disk cache cleared"));
+    Ok(())
+}
+
+fn clear_native_cache_path(path: &Path) -> Result<bool, MigrationError> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+
+    if metadata.file_type().is_dir() {
+        std::fs::remove_dir_all(path)?;
+    } else {
+        std::fs::remove_file(path)?;
+    }
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clear_native_cache_path_removes_existing_directory() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir should be created");
+        let native_cache_path = temp_dir.path().join(NATIVE_CACHE_DIR);
+        std::fs::create_dir_all(&native_cache_path).expect("native cache dir should be created");
+        std::fs::write(native_cache_path.join("0x1.so"), b"native").expect("native artifact should be written");
+        std::fs::write(native_cache_path.join("0x1.so.meta.json"), b"metadata")
+            .expect("metadata artifact should be written");
+
+        let cleared = clear_native_cache_path(&native_cache_path).expect("native cache should be cleared");
+
+        assert!(cleared);
+        assert!(!native_cache_path.exists());
+    }
+
+    #[test]
+    fn clear_native_cache_path_succeeds_when_directory_is_absent() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir should be created");
+        let native_cache_path = temp_dir.path().join(NATIVE_CACHE_DIR);
+
+        let cleared = clear_native_cache_path(&native_cache_path).expect("missing native cache should not error");
+
+        assert!(!cleared);
+    }
+}

--- a/madara/crates/client/db/src/tests/test_migration.rs
+++ b/madara/crates/client/db/src/tests/test_migration.rs
@@ -115,6 +115,34 @@ async fn test_same_version_opens_without_migration() {
     assert!(matches!(runner.check_status().unwrap(), MigrationStatus::NoMigrationNeeded));
 }
 
+#[tokio::test]
+async fn test_migration_from_v12_clears_native_cache_directory() {
+    let (temp_dir, chain_config, native_config) = setup_test_env();
+    let native_cache_dir = temp_dir.path().join("native_classes");
+    fs::create_dir_all(&native_cache_dir).unwrap();
+    fs::write(native_cache_dir.join("0x1.so"), b"native").unwrap();
+    fs::write(native_cache_dir.join("0x1.so.meta.json"), b"metadata").unwrap();
+    fs::write(temp_dir.path().join(DB_VERSION_FILE), "12").unwrap();
+
+    let backend = MadaraBackend::open_rocksdb(
+        temp_dir.path(),
+        chain_config,
+        Default::default(),
+        RocksDBConfig::default(),
+        native_config,
+    )
+    .expect("v12 database should migrate");
+
+    assert!(!native_cache_dir.exists(), "Native cache directory should be cleared during v12→v13 migration");
+
+    let expected_db_version = expected_db_version();
+    let runner = MigrationRunner::new(temp_dir.path(), expected_db_version, expected_db_version);
+    let version = runner.read_version_file().unwrap();
+    assert_eq!(version, expected_db_version);
+
+    drop(backend);
+}
+
 // =============================================================================
 // Version Mismatch Tests (parameterized)
 // =============================================================================

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -4159,9 +4159,45 @@
           "expr": "rate(cairo_native_cache_disk_load_error_error_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Disk Load Error/s",
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_metadata_missing_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Metadata Missing/s",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_metadata_invalid_error_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Metadata Invalid/s",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_host_mismatch_mismatch_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Host Mismatch/s",
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(cairo_native_cache_metadata_write_error_error_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Metadata Write Error/s",
+          "refId": "G"
         }
       ],
-      "title": "Cache Errors",
+      "title": "Cache Errors & Metadata Guards",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Summary
Backports the Cairo Native host-fingerprint cache guard and one-time native cache reset to `main-v0.14.1`.

```mermaid
flowchart TD
    A[DB upgrade to v13] --> B[Clear native_classes cache]
    B --> C[Runtime native lookup]
    C --> D{Metadata matches host?}
    D -->|yes| E[Load native executor]
    D -->|missing / invalid / mismatch| F[Record metric + remove stale artifact]
    F --> G[Return cache miss]
    G --> H{Compilation mode}
    H -->|async| I[Return VM now + compile native in background]
    H -->|blocking| J[Compile native before returning]
    I --> K[Write artifact + metadata]
    J --> K
```

## Validation
- Format check
- Clippy on `mc-class-exec` and `mc-db`
- Cairo Native tests
- DB migration tests
