### PR TITLE
Clear stale runtime exec config across mode changes

### DIFF
--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -322,6 +322,7 @@ pub struct BlockProductionTask {
     l1_client: Arc<dyn SettlementClient>,
     bypass_tx_input: Option<mpsc::Receiver<ValidatedTransaction>>,
     no_charge_fee: bool,
+    discard_preconfirmed_on_startup: bool,
 }
 
 impl BlockProductionTask {
@@ -330,6 +331,8 @@ impl BlockProductionTask {
     /// # Parameters
     ///
     /// * `no_charge_fee`: Determines whether fees are charged during transaction execution.
+    /// * `discard_preconfirmed_on_startup`: Drops any recovered preconfirmed block instead of
+    ///   re-executing and closing it during sequencer startup.
     ///
     /// # TODO(mohit 18/11/2025): Update the code to use config same as pre-close
     pub fn new(
@@ -338,6 +341,7 @@ impl BlockProductionTask {
         metrics: Arc<BlockProductionMetrics>,
         l1_client: Arc<dyn SettlementClient>,
         no_charge_fee: bool,
+        discard_preconfirmed_on_startup: bool,
     ) -> Self {
         let (sender, recv) = mpsc::unbounded_channel();
         let (bypass_input_sender, bypass_tx_input) = mpsc::channel(16);
@@ -352,6 +356,7 @@ impl BlockProductionTask {
             l1_client,
             bypass_tx_input: Some(bypass_tx_input),
             no_charge_fee,
+            discard_preconfirmed_on_startup,
         }
     }
 
@@ -657,6 +662,31 @@ impl BlockProductionTask {
             // Even if there's no preconfirmed block, save the current runtime exec config
             // This ensures the config is persisted for future restarts
             self.save_current_runtime_exec_config()?;
+            return Ok(());
+        }
+
+        if self.discard_preconfirmed_on_startup {
+            let preconfirmed_view =
+                self.backend.block_view_on_preconfirmed().context("Getting preconfirmed block view")?;
+            let block_number = preconfirmed_view.block_number();
+            let n_txs = preconfirmed_view.num_executed_transactions();
+
+            tracing::warn!(
+                "Discarding preconfirmed block #{} with {} transactions on startup because discard_preconfirmed_on_startup is enabled",
+                block_number,
+                n_txs
+            );
+
+            let backend = self.backend.clone();
+            global_spawn_rayon_task(move || {
+                backend.write_access().clear_preconfirmed().context("Discarding preconfirmed block on startup")
+            })
+            .await?;
+
+            self.save_current_runtime_exec_config()
+                .context("Saving runtime execution config after discarding preconfirmed block")?;
+
+            tracing::info!("🧹 Discarded preconfirmed block #{} on startup", block_number);
             return Ok(());
         }
 
@@ -1134,6 +1164,7 @@ pub(crate) mod tests {
                 self.metrics.clone(),
                 Arc::new(self.l1_client.clone()),
                 false, /* no_charge_fee = false */
+                false, /* discard_preconfirmed_on_startup = false */
             )
         }
     }
@@ -1997,6 +2028,7 @@ pub(crate) mod tests {
             original_devnet_setup.metrics.clone(),
             Arc::new(original_devnet_setup.l1_client.clone()),
             initial_no_charge_fee,
+            false,
         );
 
         let mut notifications = block_production_task.subscribe_state_notifications();
@@ -2027,6 +2059,7 @@ pub(crate) mod tests {
             original_devnet_setup.metrics.clone(),
             Arc::new(original_devnet_setup.l1_client.clone()),
             restart_no_charge_fee, // Current config: no_charge_fee = false
+            false,
         );
 
         // Start the block production task.
@@ -2056,6 +2089,83 @@ pub(crate) mod tests {
         assert_eq!(
             updated_config.no_charge_fee, restart_no_charge_fee,
             "Config should be updated with current value after re-execution completes"
+        );
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(30))]
+    #[tokio::test]
+    async fn test_discard_preconfirmed_on_startup_replaces_runtime_exec_config(
+        #[future]
+        #[from(devnet_setup)]
+        devnet_setup: DevnetSetup,
+    ) {
+        let devnet_setup = devnet_setup.await;
+
+        let initial_no_charge_fee = true;
+        let tx_validator_with_no_fee = Arc::new(TransactionValidator::new(
+            Arc::clone(&devnet_setup.mempool) as _,
+            Arc::clone(&devnet_setup.backend),
+            TransactionValidatorConfig { disable_validation: false, disable_fee: initial_no_charge_fee },
+        ));
+
+        sign_and_add_invoke_tx(
+            &devnet_setup.contracts.0[0],
+            &devnet_setup.contracts.0[1],
+            &devnet_setup.backend,
+            &tx_validator_with_no_fee,
+            Felt::ZERO,
+        )
+        .await;
+
+        let mut initial_block_production_task = BlockProductionTask::new(
+            devnet_setup.backend.clone(),
+            devnet_setup.mempool.clone(),
+            devnet_setup.metrics.clone(),
+            Arc::new(devnet_setup.l1_client.clone()),
+            initial_no_charge_fee,
+            false,
+        );
+
+        let mut notifications = initial_block_production_task.subscribe_state_notifications();
+        let initial_task = AbortOnDrop::spawn(async move {
+            initial_block_production_task.run(ServiceContext::new_for_testing()).await.unwrap()
+        });
+
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::BatchExecuted);
+        assert!(devnet_setup.backend.has_preconfirmed_block());
+
+        drop(initial_task);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let current_no_charge_fee = false;
+        let mut restart_block_production_task = BlockProductionTask::new(
+            devnet_setup.backend.clone(),
+            devnet_setup.mempool.clone(),
+            devnet_setup.metrics.clone(),
+            Arc::new(devnet_setup.l1_client.clone()),
+            current_no_charge_fee,
+            true,
+        );
+
+        restart_block_production_task.setup_initial_state().await.unwrap();
+
+        assert!(!devnet_setup.backend.has_preconfirmed_block(), "Preconfirmed block should be discarded on startup");
+        assert_eq!(
+            devnet_setup.backend.latest_confirmed_block_n(),
+            Some(0),
+            "Discarding startup recovery should keep the latest confirmed block unchanged"
+        );
+
+        let updated_config = devnet_setup
+            .backend
+            .get_runtime_exec_config()
+            .expect("Should be able to read runtime exec config")
+            .expect("Runtime exec config should exist after discarding");
+
+        assert_eq!(
+            updated_config.no_charge_fee, current_no_charge_fee,
+            "Discarding startup recovery should replace the saved runtime config with the current one"
         );
     }
 

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -672,7 +672,7 @@ impl BlockProductionTask {
             let n_txs = preconfirmed_view.num_executed_transactions();
 
             tracing::warn!(
-                "Discarding preconfirmed block #{} with {} transactions on startup because discard_preconfirmed_on_startup is enabled",
+                "Discarding preconfirmed block #{} with {} transactions on startup because discard_preconfirmed_on_startup is enabled; these transactions are permanently lost and will not be re-queued",
                 block_number,
                 n_txs
             );
@@ -1109,14 +1109,19 @@ pub(crate) mod tests {
     use crate::BlockProductionStateNotification;
     use crate::{metrics::BlockProductionMetrics, BlockProductionTask};
     use blockifier::bouncer::{BouncerConfig, BouncerWeights};
-    use mc_db::MadaraBackend;
+    use mc_db::{
+        preconfirmed::{PreconfirmedBlock, PreconfirmedExecutedTransaction},
+        test_utils::l1_handler_tx_with_receipt,
+        MadaraBackend,
+    };
     use mc_devnet::{
         Call, ChainGenesisDescription, DevnetKeys, DevnetPredeployedContract, Multicall, Selector, UDC_CONTRACT_ADDRESS,
     };
     use mc_mempool::{Mempool, MempoolConfig};
     use mc_settlement_client::L1ClientMock;
     use mc_submit_tx::{SubmitTransaction, TransactionValidator, TransactionValidatorConfig};
-    use mp_chain_config::ChainConfig;
+    use mp_block::header::PreconfirmedHeader;
+    use mp_chain_config::{ChainConfig, RuntimeExecutionConfig};
     use mp_convert::ToFelt;
     use mp_receipt::{Event, ExecutionResult};
     use mp_rpc::v0_9_0::{
@@ -2103,40 +2108,30 @@ pub(crate) mod tests {
         let devnet_setup = devnet_setup.await;
 
         let initial_no_charge_fee = true;
-        let tx_validator_with_no_fee = Arc::new(TransactionValidator::new(
-            Arc::clone(&devnet_setup.mempool) as _,
-            Arc::clone(&devnet_setup.backend),
-            TransactionValidatorConfig { disable_validation: false, disable_fee: initial_no_charge_fee },
-        ));
+        let chain_config = devnet_setup.backend.chain_config();
+        let exec_constants =
+            chain_config.exec_constants_by_protocol_version(chain_config.latest_protocol_version).unwrap();
+        let saved_runtime_config =
+            RuntimeExecutionConfig::from_current_config(chain_config, exec_constants, initial_no_charge_fee).unwrap();
 
-        sign_and_add_invoke_tx(
-            &devnet_setup.contracts.0[0],
-            &devnet_setup.contracts.0[1],
-            &devnet_setup.backend,
-            &tx_validator_with_no_fee,
-            Felt::ZERO,
-        )
-        .await;
+        devnet_setup.backend.write_access().write_runtime_exec_config(&saved_runtime_config).unwrap();
+        devnet_setup
+            .backend
+            .write_access()
+            .new_preconfirmed(PreconfirmedBlock::new_with_content(
+                PreconfirmedHeader { block_number: 1, ..Default::default() },
+                vec![PreconfirmedExecutedTransaction {
+                    transaction: l1_handler_tx_with_receipt(55, Felt::from(0x1234_u64)),
+                    state_diff: Default::default(),
+                    declared_class: None,
+                    arrived_at: Default::default(),
+                    paid_fee_on_l1: Some(0),
+                }],
+                [],
+            ))
+            .unwrap();
 
-        let mut initial_block_production_task = BlockProductionTask::new(
-            devnet_setup.backend.clone(),
-            devnet_setup.mempool.clone(),
-            devnet_setup.metrics.clone(),
-            Arc::new(devnet_setup.l1_client.clone()),
-            initial_no_charge_fee,
-            false,
-        );
-
-        let mut notifications = initial_block_production_task.subscribe_state_notifications();
-        let initial_task = AbortOnDrop::spawn(async move {
-            initial_block_production_task.run(ServiceContext::new_for_testing()).await.unwrap()
-        });
-
-        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::BatchExecuted);
         assert!(devnet_setup.backend.has_preconfirmed_block());
-
-        drop(initial_task);
-        tokio::time::sleep(Duration::from_millis(200)).await;
 
         let current_no_charge_fee = false;
         let mut restart_block_production_task = BlockProductionTask::new(

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -670,8 +670,15 @@ impl BlockProductionTask {
                 self.backend.block_view_on_preconfirmed().context("Getting preconfirmed block view")?;
             let block_number = preconfirmed_view.block_number();
             let n_txs = preconfirmed_view.num_executed_transactions();
+            let tx_hashes: Vec<_> = preconfirmed_view
+                .get_block_info()
+                .tx_hashes
+                .into_iter()
+                .map(|tx_hash| format!("{tx_hash:#x}"))
+                .collect();
 
             tracing::warn!(
+                discarded_transaction_hashes = ?tx_hashes,
                 "Discarding preconfirmed block #{} with {} transactions on startup because discard_preconfirmed_on_startup is enabled; these transactions are permanently lost and will not be re-queued",
                 block_number,
                 n_txs

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -676,6 +676,13 @@ impl<D: MadaraStorageRead> MadaraBackend<D> {
     }
 }
 
+impl<D: MadaraStorage> MadaraBackend<D> {
+    /// Clear any saved runtime execution configuration from the database.
+    pub fn clear_runtime_exec_config(&self) -> Result<()> {
+        self.db.clear_runtime_exec_config()
+    }
+}
+
 /// Structure holding exclusive access to write the blocks and the tip of the chain.
 ///
 /// Note: All of the associated functions need to be called in a rayon thread pool context.

--- a/madara/crates/client/db/src/rocksdb/meta.rs
+++ b/madara/crates/client/db/src/rocksdb/meta.rs
@@ -248,6 +248,13 @@ impl RocksDBStorageInner {
         Ok(())
     }
 
+    /// Clear the saved runtime execution configuration from the database.
+    #[tracing::instrument(skip(self))]
+    pub(super) fn clear_runtime_exec_config(&self) -> Result<()> {
+        self.db.delete_cf_opt(&self.get_column(META_COLUMN), META_RUNTIME_EXEC_CONFIG_KEY, &self.writeopts)?;
+        Ok(())
+    }
+
     /// Get the runtime execution configuration from the database.
     /// Note: This requires a backend_chain_config to reconstruct the full ChainConfig.
     #[tracing::instrument(skip(self))]

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -592,6 +592,10 @@ impl MadaraStorageWrite for RocksDBStorage {
         tracing::debug!("Writing runtime execution config");
         self.inner.write_runtime_exec_config(config).context("Writing runtime execution config")
     }
+    fn clear_runtime_exec_config(&self) -> Result<()> {
+        tracing::debug!("Clearing runtime execution config");
+        self.inner.clear_runtime_exec_config().context("Clearing runtime execution config")
+    }
     fn write_snap_sync_latest_block(&self, block_n: &Option<u64>) -> Result<()> {
         tracing::debug!("Write snap sync latest block block_n={block_n:?}");
         self.inner.write_snap_sync_latest_block(block_n).context("Writing snap sync latest block")

--- a/madara/crates/client/db/src/storage.rs
+++ b/madara/crates/client/db/src/storage.rs
@@ -221,6 +221,7 @@ pub trait MadaraStorageWrite: Send + Sync + 'static {
     fn write_chain_info(&self, info: &StoredChainInfo) -> Result<()>;
     fn write_latest_applied_trie_update(&self, block_n: &Option<u64>) -> Result<()>;
     fn write_runtime_exec_config(&self, config: &mp_chain_config::RuntimeExecutionConfig) -> Result<()>;
+    fn clear_runtime_exec_config(&self) -> Result<()>;
     fn write_snap_sync_latest_block(&self, block_n: &Option<u64>) -> Result<()>;
 
     fn remove_mempool_transactions(&self, tx_hashes: impl IntoIterator<Item = Felt>) -> Result<()>;

--- a/madara/crates/client/db/src/tests.rs
+++ b/madara/crates/client/db/src/tests.rs
@@ -5,3 +5,4 @@ pub mod test_messages_status;
 pub mod test_migration;
 pub mod test_open;
 pub mod test_reorg_l1_messages;
+pub mod test_runtime_exec_config;

--- a/madara/crates/client/db/src/tests/test_runtime_exec_config.rs
+++ b/madara/crates/client/db/src/tests/test_runtime_exec_config.rs
@@ -1,0 +1,19 @@
+#![cfg(test)]
+
+use crate::MadaraBackend;
+use mp_chain_config::{ChainConfig, RuntimeExecutionConfig};
+
+#[test]
+fn test_clear_runtime_exec_config() {
+    let backend = MadaraBackend::open_for_testing(ChainConfig::madara_test().into());
+    let chain_config = backend.chain_config();
+    let exec_constants = chain_config.exec_constants_by_protocol_version(chain_config.latest_protocol_version).unwrap();
+    let runtime_config = RuntimeExecutionConfig::from_current_config(chain_config, exec_constants, false).unwrap();
+
+    backend.write_access().write_runtime_exec_config(&runtime_config).unwrap();
+    assert!(backend.get_runtime_exec_config().unwrap().is_some());
+
+    backend.clear_runtime_exec_config().unwrap();
+
+    assert!(backend.get_runtime_exec_config().unwrap().is_none());
+}

--- a/madara/crates/client/devnet/src/lib.rs
+++ b/madara/crates/client/devnet/src/lib.rs
@@ -409,6 +409,7 @@ mod tests {
             Arc::new(metrics),
             Arc::new(mc_settlement_client::L1SyncDisabledClient) as _,
             true,
+            false,
         );
 
         let tx_validator = Arc::new(TransactionValidator::new(

--- a/madara/node/src/cli/block_production.rs
+++ b/madara/node/src/cli/block_production.rs
@@ -11,6 +11,7 @@ pub struct BlockProductionParams {
     /// Discard any open preconfirmed block on sequencer startup instead of re-executing and closing it.
     /// This permanently drops the preconfirmed transactions: they are neither replayed nor re-queued.
     /// The current runtime execution config is then persisted for subsequent block production.
+    #[serde(default)]
     #[arg(env = "MADARA_DISCARD_PRECONFIRMED_ON_STARTUP", long)]
     pub discard_preconfirmed_on_startup: bool,
 

--- a/madara/node/src/cli/block_production.rs
+++ b/madara/node/src/cli/block_production.rs
@@ -9,6 +9,7 @@ pub struct BlockProductionParams {
     pub block_production_disabled: bool,
 
     /// Discard any open preconfirmed block on sequencer startup instead of re-executing and closing it.
+    /// This permanently drops the preconfirmed transactions: they are neither replayed nor re-queued.
     /// The current runtime execution config is then persisted for subsequent block production.
     #[arg(env = "MADARA_DISCARD_PRECONFIRMED_ON_STARTUP", long)]
     pub discard_preconfirmed_on_startup: bool,

--- a/madara/node/src/cli/block_production.rs
+++ b/madara/node/src/cli/block_production.rs
@@ -8,6 +8,11 @@ pub struct BlockProductionParams {
     #[arg(env = "MADARA_BLOCK_PRODUCTION_DISABLED", long, alias = "no-block-production")]
     pub block_production_disabled: bool,
 
+    /// Discard any open preconfirmed block on sequencer startup instead of re-executing and closing it.
+    /// The current runtime execution config is then persisted for subsequent block production.
+    #[arg(env = "MADARA_DISCARD_PRECONFIRMED_ON_STARTUP", long)]
+    pub discard_preconfirmed_on_startup: bool,
+
     /// Create this number of contracts in the genesis block for the devnet configuration.
     #[arg(env = "MADARA_DEVNET_CONTRACTS", long, default_value_t = 10)]
     pub devnet_contracts: u64,

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -353,7 +353,10 @@ impl RunCmd {
 mod tests {
     use super::RunCmd;
     use clap::Parser;
-    use figment::{providers::Json, Figment};
+    use figment::{
+        providers::{Format, Json},
+        Figment,
+    };
 
     #[test]
     fn full_node_does_not_run_or_save_mempool() {
@@ -381,7 +384,7 @@ mod tests {
 
     #[test]
     fn config_file_without_discard_preconfirmed_on_startup_defaults_to_false() {
-        let config_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../configs/args/config.json");
+        let config_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../configs/args/config.json");
         let run_cmd: RunCmd =
             Figment::new().merge(Json::file(config_path)).extract().expect("config fixture should deserialize");
 

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -353,6 +353,7 @@ impl RunCmd {
 mod tests {
     use super::RunCmd;
     use clap::Parser;
+    use figment::{providers::Json, Figment};
 
     #[test]
     fn full_node_does_not_run_or_save_mempool() {
@@ -376,6 +377,15 @@ mod tests {
 
         assert!(run_cmd.should_run_mempool());
         assert!(!run_cmd.should_save_mempool_to_db());
+    }
+
+    #[test]
+    fn config_file_without_discard_preconfirmed_on_startup_defaults_to_false() {
+        let config_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../configs/args/config.json");
+        let run_cmd: RunCmd =
+            Figment::new().merge(Json::file(config_path)).extract().expect("config fixture should deserialize");
+
+        assert!(!run_cmd.block_production_params.discard_preconfirmed_on_startup);
     }
 }
 

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -268,6 +268,11 @@ async fn main() -> anyhow::Result<()> {
     )
     .context("Starting madara backend")?;
 
+    if !run_cmd.is_sequencer() {
+        backend.clear_runtime_exec_config().context("Clearing saved runtime execution config for full-node startup")?;
+        tracing::info!("🧹 Ensured full-node startup is not carrying saved sequencer runtime execution config");
+    }
+
     let chain_tip = backend.db.get_chain_tip().expect("Chain tip should have been fetched.");
     tracing::info!("💼 Starting chain with block: {}", chain_tip);
 

--- a/madara/node/src/service/block_production.rs
+++ b/madara/node/src/service/block_production.rs
@@ -27,7 +27,14 @@ impl BlockProductionService {
 
         Ok(Self {
             backend: backend.clone(),
-            task: Some(BlockProductionTask::new(backend.clone(), mempool, metrics, l1_client, no_charge_fee)),
+            task: Some(BlockProductionTask::new(
+                backend.clone(),
+                mempool,
+                metrics,
+                l1_client,
+                no_charge_fee,
+                config.discard_preconfirmed_on_startup,
+            )),
             n_devnet_contracts: config.devnet_contracts,
             disabled: config.block_production_disabled,
         })


### PR DESCRIPTION
## Summary
- clear saved runtime execution config on full-node startup so sequencer-only recovery metadata is not carried across mode changes
- add a sequencer startup flag to discard an open preconfirmed block and resave the current runtime config instead of re-executing it
- add focused coverage for runtime-config clearing and discard-on-startup recovery

## Testing
- cargo test -p mc-db test_clear_runtime_exec_config
- cargo test -p mc-block-production test_discard_preconfirmed_on_startup_replaces_runtime_exec_config

## Notes
- I stopped a broad `cargo check -p madara --bin madara` after the focused tests passed because it was still chewing through the full dependency graph; the node wiring changed in `main.rs`, `BlockProductionService`, and the block-production CLI params.