### PR TITLE
Add SNOS batch details endpoint for alert consumers

### DIFF
--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -15,6 +15,31 @@ use async_trait::async_trait;
 pub use error::DatabaseError;
 use std::time::Instant;
 
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum BatchIndexSort {
+    #[default]
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct SnosBatchDbQuery {
+    pub indexes: Option<Vec<u64>>,
+    pub statuses: Option<Vec<SnosBatchStatus>>,
+    pub limit: Option<i64>,
+    pub orchestrator_version: Option<String>,
+    pub sort: BatchIndexSort,
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct AggregatorBatchDbQuery {
+    pub indexes: Option<Vec<u64>>,
+    pub statuses: Option<Vec<AggregatorBatchStatus>>,
+    pub limit: Option<i64>,
+    pub orchestrator_version: Option<String>,
+    pub sort: BatchIndexSort,
+}
+
 /// Trait defining database operations for the orchestrator
 ///
 /// This trait provides a comprehensive interface for all database operations
@@ -196,18 +221,8 @@ pub trait DatabaseClient: Send + Sync {
     /// Returns the SNOS batch with the highest `snos_batch_id`, or `None` if no batches exist.
     async fn get_latest_snos_batch(&self) -> Result<Option<SnosBatch>, DatabaseError>;
 
-    /// Get SNOS batches by their sequential IDs
-    ///
-    /// # Arguments
-    /// * `indexes` - Vector of SNOS batch IDs to retrieve
-    async fn get_snos_batches_by_indices(&self, indexes: Vec<u64>) -> Result<Vec<SnosBatch>, DatabaseError>;
-
-    /// Get SNOS batches ordered by index.
-    ///
-    /// # Arguments
-    /// * `limit` - Optional limit on number of results
-    /// * `descending` - Whether to sort by descending index
-    async fn get_snos_batches(&self, limit: Option<i64>, descending: bool) -> Result<Vec<SnosBatch>, DatabaseError>;
+    /// Get SNOS batches ordered by index, optionally filtered by index, status, and orchestrator version.
+    async fn get_snos_batches(&self, query: SnosBatchDbQuery) -> Result<Vec<SnosBatch>, DatabaseError>;
 
     /// Update SNOS batch status by its sequential ID
     ///
@@ -219,20 +234,6 @@ pub trait DatabaseClient: Send + Sync {
         index: u64,
         status: SnosBatchStatus,
     ) -> Result<SnosBatch, DatabaseError>;
-
-    /// Get SNOS batches by status
-    ///
-    /// # Arguments
-    /// * `status` - The status to filter by
-    /// * `limit` - Optional limit on number of results
-    /// * `orchestrator_version` - Optional orchestrator version filter
-    async fn get_snos_batches_by_status(
-        &self,
-        status: SnosBatchStatus,
-        limit: Option<i64>,
-        orchestrator_version: Option<String>,
-        descending: bool,
-    ) -> Result<Vec<SnosBatch>, DatabaseError>;
 
     /// Get SNOS batches that don't have corresponding SNOS jobs
     ///
@@ -302,22 +303,10 @@ pub trait DatabaseClient: Send + Sync {
         orchestrator_version: Option<String>,
     ) -> Result<Option<AggregatorBatch>, DatabaseError>;
 
-    /// Get aggregator batches by their indexes
-    ///
-    /// # Arguments
-    /// * `indexes` - Vector of aggregator batch indexes to retrieve
-    async fn get_aggregator_batches_by_indexes(&self, indexes: Vec<u64>)
-        -> Result<Vec<AggregatorBatch>, DatabaseError>;
-
-    /// Get aggregator batches ordered by index.
-    ///
-    /// # Arguments
-    /// * `limit` - Optional limit on number of results
-    /// * `descending` - Whether to sort by descending index
+    /// Get aggregator batches ordered by index, optionally filtered by index, status, and orchestrator version.
     async fn get_aggregator_batches(
         &self,
-        limit: Option<i64>,
-        descending: bool,
+        query: AggregatorBatchDbQuery,
     ) -> Result<Vec<AggregatorBatch>, DatabaseError>;
 
     /// Update aggregator batch status by its index
@@ -380,20 +369,6 @@ pub trait DatabaseClient: Send + Sync {
         &self,
         aggregator_index: u64,
     ) -> Result<Option<SnosBatch>, DatabaseError>;
-
-    /// Get aggregator batches by status
-    ///
-    /// # Arguments
-    /// * `status` - The status to filter by
-    /// * `limit` - Optional limit on number of results
-    /// * `orchestrator_version` - Optional orchestrator version filter
-    async fn get_aggregator_batches_by_status(
-        &self,
-        status: AggregatorBatchStatus,
-        limit: Option<i64>,
-        orchestrator_version: Option<String>,
-        descending: bool,
-    ) -> Result<Vec<AggregatorBatch>, DatabaseError>;
 
     // ================================================================================
     // Batch Relationship Management Methods

--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -202,6 +202,13 @@ pub trait DatabaseClient: Send + Sync {
     /// * `indexes` - Vector of SNOS batch IDs to retrieve
     async fn get_snos_batches_by_indices(&self, indexes: Vec<u64>) -> Result<Vec<SnosBatch>, DatabaseError>;
 
+    /// Get SNOS batches ordered by index.
+    ///
+    /// # Arguments
+    /// * `limit` - Optional limit on number of results
+    /// * `descending` - Whether to sort by descending index
+    async fn get_snos_batches(&self, limit: Option<i64>, descending: bool) -> Result<Vec<SnosBatch>, DatabaseError>;
+
     /// Update SNOS batch status by its sequential ID
     ///
     /// # Arguments
@@ -224,6 +231,7 @@ pub trait DatabaseClient: Send + Sync {
         status: SnosBatchStatus,
         limit: Option<i64>,
         orchestrator_version: Option<String>,
+        descending: bool,
     ) -> Result<Vec<SnosBatch>, DatabaseError>;
 
     /// Get SNOS batches that don't have corresponding SNOS jobs
@@ -301,6 +309,17 @@ pub trait DatabaseClient: Send + Sync {
     async fn get_aggregator_batches_by_indexes(&self, indexes: Vec<u64>)
         -> Result<Vec<AggregatorBatch>, DatabaseError>;
 
+    /// Get aggregator batches ordered by index.
+    ///
+    /// # Arguments
+    /// * `limit` - Optional limit on number of results
+    /// * `descending` - Whether to sort by descending index
+    async fn get_aggregator_batches(
+        &self,
+        limit: Option<i64>,
+        descending: bool,
+    ) -> Result<Vec<AggregatorBatch>, DatabaseError>;
+
     /// Update aggregator batch status by its index
     ///
     /// # Arguments
@@ -373,6 +392,7 @@ pub trait DatabaseClient: Send + Sync {
         status: AggregatorBatchStatus,
         limit: Option<i64>,
         orchestrator_version: Option<String>,
+        descending: bool,
     ) -> Result<Vec<AggregatorBatch>, DatabaseError>;
 
     // ================================================================================

--- a/orchestrator/src/core/client/database/mongodb.rs
+++ b/orchestrator/src/core/client/database/mongodb.rs
@@ -1078,6 +1078,22 @@ impl DatabaseClient for MongoDbClient {
         Ok(batches)
     }
 
+    async fn get_snos_batches(&self, limit: Option<i64>, descending: bool) -> Result<Vec<SnosBatch>, DatabaseError> {
+        let start = Instant::now();
+        let sort_direction = if descending { -1 } else { 1 };
+        let find_options = FindOptions::builder().sort(doc! { "index": sort_direction }).limit(limit).build();
+
+        let batches: Vec<SnosBatch> =
+            self.get_snos_batch_collection().find(doc! {}, find_options).await?.try_collect().await?;
+
+        debug!(batch_count = batches.len(), descending, category = "db_call", "Retrieved SNOS batches");
+        let attributes = [KeyValue::new("db_operation_name", "get_snos_batches")];
+        let duration = start.elapsed();
+        MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
+
+        Ok(batches)
+    }
+
     async fn update_snos_batch_status_by_index(
         &self,
         index: u64,
@@ -1115,6 +1131,26 @@ impl DatabaseClient for MongoDbClient {
         let attributes = [KeyValue::new("db_operation_name", "get_aggregator_batches_by_indexes")];
         let duration = start.elapsed();
         MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
+        Ok(batches)
+    }
+
+    async fn get_aggregator_batches(
+        &self,
+        limit: Option<i64>,
+        descending: bool,
+    ) -> Result<Vec<AggregatorBatch>, DatabaseError> {
+        let start = Instant::now();
+        let sort_direction = if descending { -1 } else { 1 };
+        let find_options = FindOptions::builder().sort(doc! { "index": sort_direction }).limit(limit).build();
+
+        let batches: Vec<AggregatorBatch> =
+            self.get_aggregator_batch_collection().find(doc! {}, find_options).await?.try_collect().await?;
+
+        debug!(batch_count = batches.len(), descending, category = "db_call", "Retrieved aggregator batches");
+        let attributes = [KeyValue::new("db_operation_name", "get_aggregator_batches")];
+        let duration = start.elapsed();
+        MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
+
         Ok(batches)
     }
 
@@ -1448,6 +1484,7 @@ impl DatabaseClient for MongoDbClient {
         status: AggregatorBatchStatus,
         limit: Option<i64>,
         orchestrator_version: Option<String>,
+        descending: bool,
     ) -> Result<Vec<AggregatorBatch>, DatabaseError> {
         let start = Instant::now();
         let mut filter = doc! {
@@ -1456,13 +1493,13 @@ impl DatabaseClient for MongoDbClient {
         if let Some(version) = &orchestrator_version {
             filter.insert("orchestrator_version", version.as_str());
         }
-        let find_options_builder = FindOptions::builder().sort(doc! {"index": 1});
-        let find_options = limit.map(|val| find_options_builder.limit(Some(val)).build());
+        let sort_direction = if descending { -1 } else { 1 };
+        let find_options = FindOptions::builder().sort(doc! {"index": sort_direction}).limit(limit).build();
 
         let batches: Vec<AggregatorBatch> =
             self.get_aggregator_batch_collection().find(filter, find_options).await?.try_collect().await?;
 
-        debug!("Retrieved aggregator batches by status");
+        debug!(status = %status, batch_count = batches.len(), descending, "Retrieved aggregator batches by status");
         let attributes = [KeyValue::new("db_operation_name", "get_aggregator_batches_by_status")];
         let duration = start.elapsed();
         MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
@@ -1476,6 +1513,7 @@ impl DatabaseClient for MongoDbClient {
         status: SnosBatchStatus,
         limit: Option<i64>,
         orchestrator_version: Option<String>,
+        descending: bool,
     ) -> Result<Vec<SnosBatch>, DatabaseError> {
         let start = Instant::now();
         let mut filter = doc! {
@@ -1484,8 +1522,8 @@ impl DatabaseClient for MongoDbClient {
         if let Some(version) = &orchestrator_version {
             filter.insert("orchestrator_version", version.as_str());
         }
-        let find_options_builder = FindOptions::builder().sort(doc! {"index": 1});
-        let find_options = limit.map(|val| find_options_builder.limit(Some(val)).build());
+        let sort_direction = if descending { -1 } else { 1 };
+        let find_options = FindOptions::builder().sort(doc! {"index": sort_direction}).limit(limit).build();
 
         let batches: Vec<SnosBatch> =
             self.get_snos_batch_collection().find(filter, find_options).await?.try_collect().await?;
@@ -1493,6 +1531,7 @@ impl DatabaseClient for MongoDbClient {
         tracing::debug!(
             status = %status,
             batch_count = batches.len(),
+            descending,
             category = "db_call",
             "Retrieved SNOS batches by status"
         );

--- a/orchestrator/src/core/client/database/mongodb.rs
+++ b/orchestrator/src/core/client/database/mongodb.rs
@@ -2,7 +2,7 @@ use super::error::DatabaseError;
 use crate::core::client::database::constant::{
     AGGREGATOR_BATCHES_COLLECTION, BLOCK_BATCH_LOOKUPS_COLLECTION, JOBS_COLLECTION, SNOS_BATCHES_COLLECTION,
 };
-use crate::core::client::database::DatabaseClient;
+use crate::core::client::database::{AggregatorBatchDbQuery, BatchIndexSort, DatabaseClient, SnosBatchDbQuery};
 use crate::core::client::lock::constant::LOCKS_COLLECTION;
 use crate::types::batch::{
     AggregatorBatch, AggregatorBatchStatus, AggregatorBatchUpdates, BlockBatchLookup, SnosBatch, SnosBatchStatus,
@@ -1062,31 +1062,30 @@ impl DatabaseClient for MongoDbClient {
         Ok(batch)
     }
 
-    async fn get_snos_batches_by_indices(&self, indexes: Vec<u64>) -> Result<Vec<SnosBatch>, DatabaseError> {
+    async fn get_snos_batches(&self, query: SnosBatchDbQuery) -> Result<Vec<SnosBatch>, DatabaseError> {
         let start = Instant::now();
-        let filter = doc! {
-            "index": {
-                "$in": indexes.iter().map(|id| bson::to_bson(id).unwrap_or(Bson::Null)).collect::<Vec<Bson>>()
-            }
+        let mut filter = doc! {};
+        if let Some(indexes) = query.indexes {
+            let serialized_indexes: Result<Vec<Bson>, _> = indexes.iter().map(bson::to_bson).collect();
+            filter.insert("index", doc! { "$in": serialized_indexes? });
+        }
+        if let Some(statuses) = query.statuses {
+            let serialized_statuses: Result<Vec<Bson>, _> = statuses.iter().map(bson::to_bson).collect();
+            filter.insert("status", doc! { "$in": serialized_statuses? });
+        }
+        if let Some(version) = &query.orchestrator_version {
+            filter.insert("orchestrator_version", version.as_str());
+        }
+        let sort_direction = match query.sort {
+            BatchIndexSort::Asc => 1,
+            BatchIndexSort::Desc => -1,
         };
-
-        let batches: Vec<SnosBatch> = self.get_snos_batch_collection().find(filter, None).await?.try_collect().await?;
-        debug!(batch_count = batches.len(), category = "db_call", "Retrieved SNOS batches by indices");
-        let attributes = [KeyValue::new("db_operation_name", "get_snos_batches_by_indices")];
-        let duration = start.elapsed();
-        MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
-        Ok(batches)
-    }
-
-    async fn get_snos_batches(&self, limit: Option<i64>, descending: bool) -> Result<Vec<SnosBatch>, DatabaseError> {
-        let start = Instant::now();
-        let sort_direction = if descending { -1 } else { 1 };
-        let find_options = FindOptions::builder().sort(doc! { "index": sort_direction }).limit(limit).build();
+        let find_options = FindOptions::builder().sort(doc! { "index": sort_direction }).limit(query.limit).build();
 
         let batches: Vec<SnosBatch> =
-            self.get_snos_batch_collection().find(doc! {}, find_options).await?.try_collect().await?;
+            self.get_snos_batch_collection().find(filter, find_options).await?.try_collect().await?;
 
-        debug!(batch_count = batches.len(), descending, category = "db_call", "Retrieved SNOS batches");
+        debug!(batch_count = batches.len(), sort = ?query.sort, category = "db_call", "Retrieved SNOS batches");
         let attributes = [KeyValue::new("db_operation_name", "get_snos_batches")];
         let duration = start.elapsed();
         MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
@@ -1114,39 +1113,33 @@ impl DatabaseClient for MongoDbClient {
         self.update_snos_batch(filter, update, options, start, index).await
     }
 
-    async fn get_aggregator_batches_by_indexes(
-        &self,
-        indexes: Vec<u64>,
-    ) -> Result<Vec<AggregatorBatch>, DatabaseError> {
-        let start = Instant::now();
-        let filter = doc! {
-            "index": {
-                "$in": indexes.iter().map(|index| bson::to_bson(index).unwrap_or(Bson::Null)).collect::<Vec<Bson>>()
-            }
-        };
-
-        let batches: Vec<AggregatorBatch> =
-            self.get_aggregator_batch_collection().find(filter, None).await?.try_collect().await?;
-        debug!(batch_count = batches.len(), category = "db_call", "Retrieved aggregator batches by indexes");
-        let attributes = [KeyValue::new("db_operation_name", "get_aggregator_batches_by_indexes")];
-        let duration = start.elapsed();
-        MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
-        Ok(batches)
-    }
-
     async fn get_aggregator_batches(
         &self,
-        limit: Option<i64>,
-        descending: bool,
+        query: AggregatorBatchDbQuery,
     ) -> Result<Vec<AggregatorBatch>, DatabaseError> {
         let start = Instant::now();
-        let sort_direction = if descending { -1 } else { 1 };
-        let find_options = FindOptions::builder().sort(doc! { "index": sort_direction }).limit(limit).build();
+        let mut filter = doc! {};
+        if let Some(indexes) = query.indexes {
+            let serialized_indexes: Result<Vec<Bson>, _> = indexes.iter().map(bson::to_bson).collect();
+            filter.insert("index", doc! { "$in": serialized_indexes? });
+        }
+        if let Some(statuses) = query.statuses {
+            let serialized_statuses: Result<Vec<Bson>, _> = statuses.iter().map(bson::to_bson).collect();
+            filter.insert("status", doc! { "$in": serialized_statuses? });
+        }
+        if let Some(version) = &query.orchestrator_version {
+            filter.insert("orchestrator_version", version.as_str());
+        }
+        let sort_direction = match query.sort {
+            BatchIndexSort::Asc => 1,
+            BatchIndexSort::Desc => -1,
+        };
+        let find_options = FindOptions::builder().sort(doc! { "index": sort_direction }).limit(query.limit).build();
 
         let batches: Vec<AggregatorBatch> =
-            self.get_aggregator_batch_collection().find(doc! {}, find_options).await?.try_collect().await?;
+            self.get_aggregator_batch_collection().find(filter, find_options).await?.try_collect().await?;
 
-        debug!(batch_count = batches.len(), descending, category = "db_call", "Retrieved aggregator batches");
+        debug!(batch_count = batches.len(), sort = ?query.sort, category = "db_call", "Retrieved aggregator batches");
         let attributes = [KeyValue::new("db_operation_name", "get_aggregator_batches")];
         let duration = start.elapsed();
         MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
@@ -1478,70 +1471,6 @@ impl DatabaseClient for MongoDbClient {
         Ok(result)
     }
 
-    /// Get aggregator batches filtered by status
-    async fn get_aggregator_batches_by_status(
-        &self,
-        status: AggregatorBatchStatus,
-        limit: Option<i64>,
-        orchestrator_version: Option<String>,
-        descending: bool,
-    ) -> Result<Vec<AggregatorBatch>, DatabaseError> {
-        let start = Instant::now();
-        let mut filter = doc! {
-            "status": status.to_string(),
-        };
-        if let Some(version) = &orchestrator_version {
-            filter.insert("orchestrator_version", version.as_str());
-        }
-        let sort_direction = if descending { -1 } else { 1 };
-        let find_options = FindOptions::builder().sort(doc! {"index": sort_direction}).limit(limit).build();
-
-        let batches: Vec<AggregatorBatch> =
-            self.get_aggregator_batch_collection().find(filter, find_options).await?.try_collect().await?;
-
-        debug!(status = %status, batch_count = batches.len(), descending, "Retrieved aggregator batches by status");
-        let attributes = [KeyValue::new("db_operation_name", "get_aggregator_batches_by_status")];
-        let duration = start.elapsed();
-        MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
-
-        Ok(batches)
-    }
-
-    /// Get SNOS batches filtered by status
-    async fn get_snos_batches_by_status(
-        &self,
-        status: SnosBatchStatus,
-        limit: Option<i64>,
-        orchestrator_version: Option<String>,
-        descending: bool,
-    ) -> Result<Vec<SnosBatch>, DatabaseError> {
-        let start = Instant::now();
-        let mut filter = doc! {
-            "status": status.to_string(),
-        };
-        if let Some(version) = &orchestrator_version {
-            filter.insert("orchestrator_version", version.as_str());
-        }
-        let sort_direction = if descending { -1 } else { 1 };
-        let find_options = FindOptions::builder().sort(doc! {"index": sort_direction}).limit(limit).build();
-
-        let batches: Vec<SnosBatch> =
-            self.get_snos_batch_collection().find(filter, find_options).await?.try_collect().await?;
-
-        tracing::debug!(
-            status = %status,
-            batch_count = batches.len(),
-            descending,
-            category = "db_call",
-            "Retrieved SNOS batches by status"
-        );
-        let attributes = [KeyValue::new("db_operation_name", "get_snos_batches_by_status")];
-        let duration = start.elapsed();
-        MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
-
-        Ok(batches)
-    }
-
     async fn get_snos_batches_without_jobs(
         &self,
         snos_batch_status: SnosBatchStatus,
@@ -1550,13 +1479,13 @@ impl DatabaseClient for MongoDbClient {
     ) -> Result<Vec<SnosBatch>, DatabaseError> {
         let start = Instant::now();
 
-        // Convert enums to Bson strings for MongoDB queries
-        let snos_batch_status_str = snos_batch_status.to_string();
+        // Keep the query value aligned with serde's stored enum representation.
+        let snos_batch_status_bson = bson::to_bson(&snos_batch_status)?;
         let snos_job_type_bson = Bson::String(format!("{:?}", JobType::SnosRun));
 
         // Build match filter with optional orchestrator version
         let mut match_filter = doc! {
-            "status": snos_batch_status_str
+            "status": snos_batch_status_bson
         };
         if let Some(version) = &orchestrator_version {
             match_filter.insert("orchestrator_version", version.as_str());

--- a/orchestrator/src/server/error.rs
+++ b/orchestrator/src/server/error.rs
@@ -149,6 +149,10 @@ pub enum BlockRouteError {
     #[error("Invalid Block Number: {0}")]
     InvalidBlockNumber(String),
 
+    /// Indicates that the provided query parameters are invalid
+    #[error("Invalid query: {0}")]
+    InvalidQuery(String),
+
     /// Indicates that the requested block could not be found in the system
     #[error("Batch not found: {0}")]
     NotFound(String),
@@ -181,6 +185,10 @@ impl IntoResponse for BlockRouteError {
         match self {
             BlockRouteError::InvalidBlockNumber(id) => {
                 (StatusCode::BAD_REQUEST, Json(ApiResponse::error(format!("Invalid Block Number: {}", id))))
+                    .into_response()
+            }
+            BlockRouteError::InvalidQuery(message) => {
+                (StatusCode::BAD_REQUEST, Json(ApiResponse::error(format!("Invalid query: {}", message))))
                     .into_response()
             }
             BlockRouteError::NotFound(id) => {

--- a/orchestrator/src/server/route/admin.rs
+++ b/orchestrator/src/server/route/admin.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use super::super::error::JobRouteError;
 use super::super::service::admin::{AdminService, BulkJobResult};
 use super::super::types::{ApiResponse, JobRouteResult};
+use crate::core::client::database::{AggregatorBatchDbQuery, SnosBatchDbQuery};
 use crate::core::config::Config;
 use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
 use crate::types::jobs::types::JobType;
@@ -206,8 +207,13 @@ async fn handle_close_open_batches(State(config): State<Arc<Config>>) -> JobRout
 
     let db = config.database();
 
-    let open_agg_batches =
-        db.get_aggregator_batches_by_status(AggregatorBatchStatus::Open, None, None, false).await.map_err(|e| {
+    let open_agg_batches = db
+        .get_aggregator_batches(AggregatorBatchDbQuery {
+            statuses: Some(vec![AggregatorBatchStatus::Open]),
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| {
             error!(error = %e, "Failed to fetch open aggregator batches");
             JobRouteError::ProcessingError(e.to_string())
         })?;
@@ -225,8 +231,10 @@ async fn handle_close_open_batches(State(config): State<Arc<Config>>) -> JobRout
         }
     }
 
-    let open_snos_batches =
-        db.get_snos_batches_by_status(SnosBatchStatus::Open, None, None, false).await.map_err(|e| {
+    let open_snos_batches = db
+        .get_snos_batches(SnosBatchDbQuery { statuses: Some(vec![SnosBatchStatus::Open]), ..Default::default() })
+        .await
+        .map_err(|e| {
             error!(error = %e, "Failed to fetch open SNOS batches");
             JobRouteError::ProcessingError(e.to_string())
         })?;

--- a/orchestrator/src/server/route/admin.rs
+++ b/orchestrator/src/server/route/admin.rs
@@ -207,7 +207,7 @@ async fn handle_close_open_batches(State(config): State<Arc<Config>>) -> JobRout
     let db = config.database();
 
     let open_agg_batches =
-        db.get_aggregator_batches_by_status(AggregatorBatchStatus::Open, None, None).await.map_err(|e| {
+        db.get_aggregator_batches_by_status(AggregatorBatchStatus::Open, None, None, false).await.map_err(|e| {
             error!(error = %e, "Failed to fetch open aggregator batches");
             JobRouteError::ProcessingError(e.to_string())
         })?;
@@ -225,10 +225,11 @@ async fn handle_close_open_batches(State(config): State<Arc<Config>>) -> JobRout
         }
     }
 
-    let open_snos_batches = db.get_snos_batches_by_status(SnosBatchStatus::Open, None, None).await.map_err(|e| {
-        error!(error = %e, "Failed to fetch open SNOS batches");
-        JobRouteError::ProcessingError(e.to_string())
-    })?;
+    let open_snos_batches =
+        db.get_snos_batches_by_status(SnosBatchStatus::Open, None, None, false).await.map_err(|e| {
+            error!(error = %e, "Failed to fetch open SNOS batches");
+            JobRouteError::ProcessingError(e.to_string())
+        })?;
 
     let mut snos_closed = 0u64;
     for batch in &open_snos_batches {

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -1,73 +1,242 @@
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::{Query, State};
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
-use tracing::{instrument, warn};
+use tracing::instrument;
 
 use super::super::error::BlockRouteError;
 use super::super::types::{
-    AggregatorBatchDetailsResponse, ApiResponse, BatchDetailsResponse, BlockRouteResult,
-    SettlementAggregatorBatchResponse, SettlementSnosBatchResponse, SnosBatchDetailsResponse, SnosBatchMetricsResponse,
+    AggregatorBatchDetailsResponse, AggregatorBatchListResponse, AggregatorBatchQuery, ApiResponse, BatchSortOrder,
+    BlockRouteResult, SettlementAggregatorBatchResponse, SettlementSnosBatchResponse, SnosBatchDetailsResponse,
+    SnosBatchListResponse, SnosBatchMetricsResponse, SnosBatchQuery,
 };
 use crate::core::config::Config;
-use crate::types::batch::{AggregatorBatch, SnosBatch};
+use crate::types::batch::{AggregatorBatch, AggregatorBatchStatus, SnosBatch, SnosBatchStatus};
 
-#[instrument(skip(config), fields(snos_batch_index = %snos_batch_index))]
-async fn handle_snos_batch_details(
-    Path(snos_batch_index): Path<u64>,
+enum SnosBatchStatusFilter {
+    Closed,
+    Exact(SnosBatchStatus),
+}
+
+enum AggregatorBatchStatusFilter {
+    Closed,
+    Exact(AggregatorBatchStatus),
+}
+
+#[instrument(skip(config), fields(index = ?query.index, status = ?query.status, limit = ?query.limit, sort = ?query.sort))]
+async fn handle_query_snos_batches(
+    Query(query): Query<SnosBatchQuery>,
     State(config): State<Arc<Config>>,
 ) -> BlockRouteResult {
-    let snos_batch = config
-        .database()
-        .get_snos_batches_by_indices(vec![snos_batch_index])
-        .await
-        .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
-        .into_iter()
-        .next()
-        .ok_or_else(|| BlockRouteError::NotFound(format!("No SNOS batch found for index {}", snos_batch_index)))?;
+    let limit = validate_limit(query.limit)?;
+    let descending = matches!(query.sort, BatchSortOrder::Desc);
+    let status_filter = parse_snos_status(query.status.as_deref())?;
 
-    let aggregator_batch = match snos_batch.aggregator_batch_index {
-        Some(aggregator_batch_index) => config
+    let batches = if let Some(index) = query.index {
+        let mut batches = config
             .database()
-            .get_aggregator_batches_by_indexes(vec![aggregator_batch_index])
+            .get_snos_batches_by_indices(vec![index])
+            .await
+            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
+
+        if let Some(filter) = status_filter {
+            batches.retain(|batch| matches_snos_status(batch, &filter));
+        }
+
+        batches
+    } else if let Some(filter) = status_filter {
+        match filter {
+            SnosBatchStatusFilter::Exact(status) => config
+                .database()
+                .get_snos_batches_by_status(status, limit, None, descending)
+                .await
+                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
+            SnosBatchStatusFilter::Closed => {
+                let mut batches = config
+                    .database()
+                    .get_snos_batches(None, descending)
+                    .await
+                    .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
+                batches.retain(|batch| batch.status.is_closed());
+                apply_limit(&mut batches, limit);
+                batches
+            }
+        }
+    } else {
+        config
+            .database()
+            .get_snos_batches(limit, descending)
             .await
             .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
-            .into_iter()
-            .next(),
-        None => None,
     };
 
-    if snos_batch.aggregator_batch_index.is_some() && aggregator_batch.is_none() {
-        warn!(
-            snos_batch_index = %snos_batch.index,
-            aggregator_batch_index = ?snos_batch.aggregator_batch_index,
-            "SNOS batch references a missing aggregator batch"
-        );
-    }
-
-    Ok(Json(ApiResponse::<BatchDetailsResponse>::success_with_data(
-        BatchDetailsResponse {
-            snos_batch: snapshot_snos_batch_details(&snos_batch),
-            aggregator_batch: aggregator_batch.as_ref().map(snapshot_aggregator_batch_details),
-        },
-        Some(format!("Successfully fetched details for SNOS batch {}", snos_batch_index)),
+    Ok(Json(ApiResponse::<SnosBatchListResponse>::success_with_data(
+        SnosBatchListResponse { batches: batches.iter().map(snapshot_snos_batch_details).collect() },
+        Some("Successfully fetched SNOS batches".to_string()),
     ))
     .into_response())
 }
 
+#[instrument(skip(config), fields(index = ?query.index, status = ?query.status, limit = ?query.limit, sort = ?query.sort))]
+async fn handle_query_aggregator_batches(
+    Query(query): Query<AggregatorBatchQuery>,
+    State(config): State<Arc<Config>>,
+) -> BlockRouteResult {
+    let limit = validate_limit(query.limit)?;
+    let descending = matches!(query.sort, BatchSortOrder::Desc);
+    let status_filter = parse_aggregator_status(query.status.as_deref())?;
+
+    let batches = if let Some(index) = query.index {
+        let mut batches = config
+            .database()
+            .get_aggregator_batches_by_indexes(vec![index])
+            .await
+            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
+
+        if let Some(filter) = status_filter {
+            batches.retain(|batch| matches_aggregator_status(batch, &filter));
+        }
+
+        batches
+    } else if let Some(filter) = status_filter {
+        match filter {
+            AggregatorBatchStatusFilter::Exact(status) => config
+                .database()
+                .get_aggregator_batches_by_status(status, limit, None, descending)
+                .await
+                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
+            AggregatorBatchStatusFilter::Closed => {
+                let mut batches = config
+                    .database()
+                    .get_aggregator_batches(None, descending)
+                    .await
+                    .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
+                batches.retain(|batch| batch.status.is_closed());
+                apply_limit(&mut batches, limit);
+                batches
+            }
+        }
+    } else {
+        config
+            .database()
+            .get_aggregator_batches(limit, descending)
+            .await
+            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
+    };
+
+    Ok(Json(ApiResponse::<AggregatorBatchListResponse>::success_with_data(
+        AggregatorBatchListResponse { batches: batches.iter().map(snapshot_aggregator_batch_details).collect() },
+        Some("Successfully fetched aggregator batches".to_string()),
+    ))
+    .into_response())
+}
+
+fn validate_limit(limit: Option<i64>) -> Result<Option<i64>, BlockRouteError> {
+    match limit {
+        Some(value) if value <= 0 => Err(BlockRouteError::InvalidQuery("limit must be a positive integer".to_string())),
+        other => Ok(other),
+    }
+}
+
+fn apply_limit<T>(items: &mut Vec<T>, limit: Option<i64>) {
+    if let Some(limit) = limit {
+        items.truncate(limit as usize);
+    }
+}
+
+fn parse_snos_status(status: Option<&str>) -> Result<Option<SnosBatchStatusFilter>, BlockRouteError> {
+    let Some(status) = status else {
+        return Ok(None);
+    };
+
+    let parsed = match status.trim().to_ascii_lowercase().as_str() {
+        "open" => SnosBatchStatusFilter::Exact(SnosBatchStatus::Open),
+        "closed" => SnosBatchStatusFilter::Closed,
+        "snosjobcreated" | "snos_job_created" | "snos-job-created" => {
+            SnosBatchStatusFilter::Exact(SnosBatchStatus::SnosJobCreated)
+        }
+        "completed" => SnosBatchStatusFilter::Exact(SnosBatchStatus::Completed),
+        _ => return Err(BlockRouteError::InvalidQuery(format!("unsupported snos batch status '{}'", status))),
+    };
+
+    Ok(Some(parsed))
+}
+
+fn matches_snos_status(batch: &SnosBatch, filter: &SnosBatchStatusFilter) -> bool {
+    match filter {
+        SnosBatchStatusFilter::Closed => batch.status.is_closed(),
+        SnosBatchStatusFilter::Exact(status) => &batch.status == status,
+    }
+}
+
+fn parse_aggregator_status(status: Option<&str>) -> Result<Option<AggregatorBatchStatusFilter>, BlockRouteError> {
+    let Some(status) = status else {
+        return Ok(None);
+    };
+
+    let parsed = match status.trim().to_ascii_lowercase().as_str() {
+        "open" => AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::Open),
+        "closed" => AggregatorBatchStatusFilter::Closed,
+        "pendingaggregatorrun" | "pending_aggregator_run" | "pending-aggregator-run" => {
+            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorRun)
+        }
+        "pendingaggregatorverification" | "pending_aggregator_verification" | "pending-aggregator-verification" => {
+            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorVerification)
+        }
+        "readyforstateupdate" | "ready_for_state_update" | "ready-for-state-update" => {
+            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::ReadyForStateUpdate)
+        }
+        "completed" => AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::Completed),
+        "aggregationfailed" | "aggregation_failed" | "aggregation-failed" => {
+            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::AggregationFailed)
+        }
+        "verificationfailed" | "verification_failed" | "verification-failed" => {
+            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::VerificationFailed)
+        }
+        "stateupdatefailed" | "state_update_failed" | "state-update-failed" => {
+            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::StateUpdateFailed)
+        }
+        _ => return Err(BlockRouteError::InvalidQuery(format!("unsupported aggregator batch status '{}'", status))),
+    };
+
+    Ok(Some(parsed))
+}
+
+fn matches_aggregator_status(batch: &AggregatorBatch, filter: &AggregatorBatchStatusFilter) -> bool {
+    match filter {
+        AggregatorBatchStatusFilter::Closed => batch.status.is_closed(),
+        AggregatorBatchStatusFilter::Exact(status) => &batch.status == status,
+    }
+}
+
+pub(super) fn snapshot_snos_batch(batch: &SnosBatch) -> SettlementSnosBatchResponse {
+    SettlementSnosBatchResponse {
+        index: batch.index,
+        aggregator_batch_index: batch.aggregator_batch_index,
+        start_block: batch.start_block,
+        end_block: batch.end_block,
+        status: batch.status.clone(),
+        created_at: batch.created_at,
+        updated_at: batch.updated_at,
+    }
+}
+
+pub(super) fn snapshot_aggregator_batch(batch: &AggregatorBatch) -> SettlementAggregatorBatchResponse {
+    SettlementAggregatorBatchResponse {
+        index: batch.index,
+        start_block: batch.start_block,
+        end_block: batch.end_block,
+        status: batch.status.clone(),
+        created_at: batch.created_at,
+        updated_at: batch.updated_at,
+    }
+}
+
 fn snapshot_snos_batch_details(batch: &SnosBatch) -> SnosBatchDetailsResponse {
     SnosBatchDetailsResponse {
-        batch: SettlementSnosBatchResponse {
-            index: batch.index,
-            aggregator_batch_index: batch.aggregator_batch_index,
-            start_block: batch.start_block,
-            end_block: batch.end_block,
-            status: batch.status.clone(),
-            created_at: batch.created_at,
-            updated_at: batch.updated_at,
-        },
+        batch: snapshot_snos_batch(batch),
         metrics: SnosBatchMetricsResponse {
             state_diff_size: batch.builtin_weights.state_diff_size,
             sierra_gas: batch.builtin_weights.sierra_gas.0,
@@ -77,19 +246,12 @@ fn snapshot_snos_batch_details(batch: &SnosBatch) -> SnosBatchDetailsResponse {
 }
 
 fn snapshot_aggregator_batch_details(batch: &AggregatorBatch) -> AggregatorBatchDetailsResponse {
-    AggregatorBatchDetailsResponse {
-        batch: SettlementAggregatorBatchResponse {
-            index: batch.index,
-            start_block: batch.start_block,
-            end_block: batch.end_block,
-            status: batch.status.clone(),
-            created_at: batch.created_at,
-            updated_at: batch.updated_at,
-        },
-        blob_len: batch.blob_len,
-    }
+    AggregatorBatchDetailsResponse { batch: snapshot_aggregator_batch(batch), blob_len: batch.blob_len }
 }
 
 pub(super) fn batch_router(config: Arc<Config>) -> Router {
-    Router::new().route("/snos/:snos_batch_index/details", get(handle_snos_batch_details)).with_state(config)
+    Router::new()
+        .route("/snos", get(handle_query_snos_batches))
+        .route("/aggregator", get(handle_query_aggregator_batches))
+        .with_state(config)
 }

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
@@ -140,57 +141,51 @@ fn apply_limit<T>(items: &mut Vec<T>, limit: Option<i64>) {
 }
 
 fn parse_snos_status(status: Option<&str>) -> Result<Option<BatchStatusFilter<SnosBatchStatus>>, BlockRouteError> {
-    let Some(status) = status else {
-        return Ok(None);
-    };
-
-    let parsed = match status.trim().to_ascii_lowercase().as_str() {
-        "closed" => BatchStatusFilter::Closed,
-        "open" => BatchStatusFilter::Exact(SnosBatchStatus::Open),
-        "snosjobcreated" => BatchStatusFilter::Exact(SnosBatchStatus::SnosJobCreated),
-        "completed" => BatchStatusFilter::Exact(SnosBatchStatus::Completed),
-        _ => return Err(BlockRouteError::InvalidQuery(format!("unsupported snos batch status '{}'", status))),
-    };
-
-    Ok(Some(parsed))
+    parse_status("snos", status)
 }
 
 fn matches_snos_status(batch: &SnosBatch, filter: &BatchStatusFilter<SnosBatchStatus>) -> bool {
-    match filter {
-        BatchStatusFilter::Closed => batch.status.is_closed(),
-        BatchStatusFilter::Exact(status) => &batch.status == status,
-    }
+    matches_status(&batch.status, filter, SnosBatchStatus::is_closed)
 }
 
 fn parse_aggregator_status(
     status: Option<&str>,
 ) -> Result<Option<BatchStatusFilter<AggregatorBatchStatus>>, BlockRouteError> {
-    let Some(status) = status else {
-        return Ok(None);
-    };
-
-    let parsed = match status.trim().to_ascii_lowercase().as_str() {
-        "closed" => BatchStatusFilter::Closed,
-        "open" => BatchStatusFilter::Exact(AggregatorBatchStatus::Open),
-        "pendingaggregatorrun" => BatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorRun),
-        "pendingaggregatorverification" => {
-            BatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorVerification)
-        }
-        "readyforstateupdate" => BatchStatusFilter::Exact(AggregatorBatchStatus::ReadyForStateUpdate),
-        "completed" => BatchStatusFilter::Exact(AggregatorBatchStatus::Completed),
-        "aggregationfailed" => BatchStatusFilter::Exact(AggregatorBatchStatus::AggregationFailed),
-        "verificationfailed" => BatchStatusFilter::Exact(AggregatorBatchStatus::VerificationFailed),
-        "stateupdatefailed" => BatchStatusFilter::Exact(AggregatorBatchStatus::StateUpdateFailed),
-        _ => return Err(BlockRouteError::InvalidQuery(format!("unsupported aggregator batch status '{}'", status))),
-    };
-
-    Ok(Some(parsed))
+    parse_status("aggregator", status)
 }
 
 fn matches_aggregator_status(batch: &AggregatorBatch, filter: &BatchStatusFilter<AggregatorBatchStatus>) -> bool {
+    matches_status(&batch.status, filter, AggregatorBatchStatus::is_closed)
+}
+
+fn parse_status<T>(kind: &str, status: Option<&str>) -> Result<Option<BatchStatusFilter<T>>, BlockRouteError>
+where
+    T: FromStr,
+{
+    let Some(status) = status else {
+        return Ok(None);
+    };
+    let status = status.trim();
+
+    if status.eq_ignore_ascii_case("closed") {
+        return Ok(Some(BatchStatusFilter::Closed));
+    }
+
+    status
+        .to_ascii_lowercase()
+        .parse()
+        .map(BatchStatusFilter::Exact)
+        .map(Some)
+        .map_err(|_| BlockRouteError::InvalidQuery(format!("unsupported {kind} batch status '{status}'")))
+}
+
+fn matches_status<T>(status: &T, filter: &BatchStatusFilter<T>, is_closed: impl Fn(&T) -> bool) -> bool
+where
+    T: PartialEq,
+{
     match filter {
-        BatchStatusFilter::Closed => batch.status.is_closed(),
-        BatchStatusFilter::Exact(status) => &batch.status == status,
+        BatchStatusFilter::Closed => is_closed(status),
+        BatchStatusFilter::Exact(expected) => status == expected,
     }
 }
 

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -8,26 +8,19 @@ use tracing::instrument;
 
 use super::super::error::BlockRouteError;
 use super::super::types::{
-    AggregatorBatchDetailsResponse, AggregatorBatchListResponse, AggregatorBatchQuery, ApiResponse, BatchSortOrder,
-    BlockRouteResult, SettlementAggregatorBatchResponse, SettlementSnosBatchResponse, SnosBatchDetailsResponse,
-    SnosBatchListResponse, SnosBatchMetricsResponse, SnosBatchQuery,
+    AggregatorBatchListResponse, ApiResponse, BatchQuery, BatchSortOrder, BlockRouteResult, SnosBatchListResponse,
 };
 use crate::core::config::Config;
 use crate::types::batch::{AggregatorBatch, AggregatorBatchStatus, SnosBatch, SnosBatchStatus};
 
-enum SnosBatchStatusFilter {
+enum BatchStatusFilter<T> {
     Closed,
-    Exact(SnosBatchStatus),
-}
-
-enum AggregatorBatchStatusFilter {
-    Closed,
-    Exact(AggregatorBatchStatus),
+    Exact(T),
 }
 
 #[instrument(skip(config), fields(index = ?query.index, status = ?query.status, limit = ?query.limit, sort = ?query.sort))]
 async fn handle_query_snos_batches(
-    Query(query): Query<SnosBatchQuery>,
+    Query(query): Query<BatchQuery>,
     State(config): State<Arc<Config>>,
 ) -> BlockRouteResult {
     let limit = validate_limit(query.limit)?;
@@ -48,12 +41,12 @@ async fn handle_query_snos_batches(
         batches
     } else if let Some(filter) = status_filter {
         match filter {
-            SnosBatchStatusFilter::Exact(status) => config
+            BatchStatusFilter::Exact(status) => config
                 .database()
                 .get_snos_batches_by_status(status, limit, None, descending)
                 .await
                 .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-            SnosBatchStatusFilter::Closed => {
+            BatchStatusFilter::Closed => {
                 let mut batches = config
                     .database()
                     .get_snos_batches(None, descending)
@@ -73,7 +66,7 @@ async fn handle_query_snos_batches(
     };
 
     Ok(Json(ApiResponse::<SnosBatchListResponse>::success_with_data(
-        SnosBatchListResponse { batches: batches.iter().map(snapshot_snos_batch_details).collect() },
+        SnosBatchListResponse { batches: batches.iter().map(Into::into).collect() },
         Some("Successfully fetched SNOS batches".to_string()),
     ))
     .into_response())
@@ -81,7 +74,7 @@ async fn handle_query_snos_batches(
 
 #[instrument(skip(config), fields(index = ?query.index, status = ?query.status, limit = ?query.limit, sort = ?query.sort))]
 async fn handle_query_aggregator_batches(
-    Query(query): Query<AggregatorBatchQuery>,
+    Query(query): Query<BatchQuery>,
     State(config): State<Arc<Config>>,
 ) -> BlockRouteResult {
     let limit = validate_limit(query.limit)?;
@@ -102,12 +95,12 @@ async fn handle_query_aggregator_batches(
         batches
     } else if let Some(filter) = status_filter {
         match filter {
-            AggregatorBatchStatusFilter::Exact(status) => config
+            BatchStatusFilter::Exact(status) => config
                 .database()
                 .get_aggregator_batches_by_status(status, limit, None, descending)
                 .await
                 .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-            AggregatorBatchStatusFilter::Closed => {
+            BatchStatusFilter::Closed => {
                 let mut batches = config
                     .database()
                     .get_aggregator_batches(None, descending)
@@ -127,7 +120,7 @@ async fn handle_query_aggregator_batches(
     };
 
     Ok(Json(ApiResponse::<AggregatorBatchListResponse>::success_with_data(
-        AggregatorBatchListResponse { batches: batches.iter().map(snapshot_aggregator_batch_details).collect() },
+        AggregatorBatchListResponse { batches: batches.iter().map(Into::into).collect() },
         Some("Successfully fetched aggregator batches".to_string()),
     ))
     .into_response())
@@ -146,107 +139,63 @@ fn apply_limit<T>(items: &mut Vec<T>, limit: Option<i64>) {
     }
 }
 
-fn parse_snos_status(status: Option<&str>) -> Result<Option<SnosBatchStatusFilter>, BlockRouteError> {
+fn parse_snos_status(status: Option<&str>) -> Result<Option<BatchStatusFilter<SnosBatchStatus>>, BlockRouteError> {
     let Some(status) = status else {
         return Ok(None);
     };
 
-    let parsed = match status.trim().to_ascii_lowercase().as_str() {
-        "open" => SnosBatchStatusFilter::Exact(SnosBatchStatus::Open),
-        "closed" => SnosBatchStatusFilter::Closed,
-        "snosjobcreated" | "snos_job_created" | "snos-job-created" => {
-            SnosBatchStatusFilter::Exact(SnosBatchStatus::SnosJobCreated)
-        }
-        "completed" => SnosBatchStatusFilter::Exact(SnosBatchStatus::Completed),
+    let parsed = match normalize_status_token(status).as_str() {
+        "closed" => BatchStatusFilter::Closed,
+        "open" => BatchStatusFilter::Exact(SnosBatchStatus::Open),
+        "snosjobcreated" => BatchStatusFilter::Exact(SnosBatchStatus::SnosJobCreated),
+        "completed" => BatchStatusFilter::Exact(SnosBatchStatus::Completed),
         _ => return Err(BlockRouteError::InvalidQuery(format!("unsupported snos batch status '{}'", status))),
     };
 
     Ok(Some(parsed))
 }
 
-fn matches_snos_status(batch: &SnosBatch, filter: &SnosBatchStatusFilter) -> bool {
+fn matches_snos_status(batch: &SnosBatch, filter: &BatchStatusFilter<SnosBatchStatus>) -> bool {
     match filter {
-        SnosBatchStatusFilter::Closed => batch.status.is_closed(),
-        SnosBatchStatusFilter::Exact(status) => &batch.status == status,
+        BatchStatusFilter::Closed => batch.status.is_closed(),
+        BatchStatusFilter::Exact(status) => &batch.status == status,
     }
 }
 
-fn parse_aggregator_status(status: Option<&str>) -> Result<Option<AggregatorBatchStatusFilter>, BlockRouteError> {
+fn parse_aggregator_status(
+    status: Option<&str>,
+) -> Result<Option<BatchStatusFilter<AggregatorBatchStatus>>, BlockRouteError> {
     let Some(status) = status else {
         return Ok(None);
     };
 
-    let parsed = match status.trim().to_ascii_lowercase().as_str() {
-        "open" => AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::Open),
-        "closed" => AggregatorBatchStatusFilter::Closed,
-        "pendingaggregatorrun" | "pending_aggregator_run" | "pending-aggregator-run" => {
-            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorRun)
+    let parsed = match normalize_status_token(status).as_str() {
+        "closed" => BatchStatusFilter::Closed,
+        "open" => BatchStatusFilter::Exact(AggregatorBatchStatus::Open),
+        "pendingaggregatorrun" => BatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorRun),
+        "pendingaggregatorverification" => {
+            BatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorVerification)
         }
-        "pendingaggregatorverification" | "pending_aggregator_verification" | "pending-aggregator-verification" => {
-            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorVerification)
-        }
-        "readyforstateupdate" | "ready_for_state_update" | "ready-for-state-update" => {
-            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::ReadyForStateUpdate)
-        }
-        "completed" => AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::Completed),
-        "aggregationfailed" | "aggregation_failed" | "aggregation-failed" => {
-            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::AggregationFailed)
-        }
-        "verificationfailed" | "verification_failed" | "verification-failed" => {
-            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::VerificationFailed)
-        }
-        "stateupdatefailed" | "state_update_failed" | "state-update-failed" => {
-            AggregatorBatchStatusFilter::Exact(AggregatorBatchStatus::StateUpdateFailed)
-        }
+        "readyforstateupdate" => BatchStatusFilter::Exact(AggregatorBatchStatus::ReadyForStateUpdate),
+        "completed" => BatchStatusFilter::Exact(AggregatorBatchStatus::Completed),
+        "aggregationfailed" => BatchStatusFilter::Exact(AggregatorBatchStatus::AggregationFailed),
+        "verificationfailed" => BatchStatusFilter::Exact(AggregatorBatchStatus::VerificationFailed),
+        "stateupdatefailed" => BatchStatusFilter::Exact(AggregatorBatchStatus::StateUpdateFailed),
         _ => return Err(BlockRouteError::InvalidQuery(format!("unsupported aggregator batch status '{}'", status))),
     };
 
     Ok(Some(parsed))
 }
 
-fn matches_aggregator_status(batch: &AggregatorBatch, filter: &AggregatorBatchStatusFilter) -> bool {
+fn normalize_status_token(status: &str) -> String {
+    status.chars().filter(|ch| ch.is_ascii_alphanumeric()).flat_map(char::to_lowercase).collect()
+}
+
+fn matches_aggregator_status(batch: &AggregatorBatch, filter: &BatchStatusFilter<AggregatorBatchStatus>) -> bool {
     match filter {
-        AggregatorBatchStatusFilter::Closed => batch.status.is_closed(),
-        AggregatorBatchStatusFilter::Exact(status) => &batch.status == status,
+        BatchStatusFilter::Closed => batch.status.is_closed(),
+        BatchStatusFilter::Exact(status) => &batch.status == status,
     }
-}
-
-pub(super) fn snapshot_snos_batch(batch: &SnosBatch) -> SettlementSnosBatchResponse {
-    SettlementSnosBatchResponse {
-        index: batch.index,
-        aggregator_batch_index: batch.aggregator_batch_index,
-        start_block: batch.start_block,
-        end_block: batch.end_block,
-        status: batch.status.clone(),
-        created_at: batch.created_at,
-        updated_at: batch.updated_at,
-    }
-}
-
-pub(super) fn snapshot_aggregator_batch(batch: &AggregatorBatch) -> SettlementAggregatorBatchResponse {
-    SettlementAggregatorBatchResponse {
-        index: batch.index,
-        start_block: batch.start_block,
-        end_block: batch.end_block,
-        status: batch.status.clone(),
-        created_at: batch.created_at,
-        updated_at: batch.updated_at,
-    }
-}
-
-fn snapshot_snos_batch_details(batch: &SnosBatch) -> SnosBatchDetailsResponse {
-    SnosBatchDetailsResponse {
-        batch: snapshot_snos_batch(batch),
-        metrics: SnosBatchMetricsResponse {
-            state_diff_size: batch.builtin_weights.state_diff_size,
-            sierra_gas: batch.builtin_weights.sierra_gas.0,
-            proving_gas: batch.builtin_weights.proving_gas.0,
-        },
-    }
-}
-
-fn snapshot_aggregator_batch_details(batch: &AggregatorBatch) -> AggregatorBatchDetailsResponse {
-    AggregatorBatchDetailsResponse { batch: snapshot_aggregator_batch(batch), blob_len: batch.blob_len }
 }
 
 pub(super) fn batch_router(config: Arc<Config>) -> Router {

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
@@ -7,58 +6,21 @@ use axum::routing::get;
 use axum::{Json, Router};
 use tracing::instrument;
 
-use super::super::error::BlockRouteError;
+use super::super::service::batches::BatchService;
 use super::super::types::{
-    AggregatorBatchListResponse, ApiResponse, BatchQuery, BatchSortOrder, BlockRouteResult, SnosBatchListResponse,
+    AggregatorBatchListResponse, ApiResponse, BatchQuery, BlockRouteResult, SnosBatchListResponse,
 };
 use crate::core::config::Config;
-use crate::types::batch::{AggregatorBatch, AggregatorBatchStatus, SnosBatch, SnosBatchStatus};
-
-enum BatchStatusFilter<T> {
-    Closed,
-    Exact(T),
-}
 
 #[instrument(skip(config))]
 async fn handle_query_snos_batches(
     Query(query): Query<BatchQuery>,
     State(config): State<Arc<Config>>,
 ) -> BlockRouteResult {
-    let limit = validate_limit(query.limit)?;
-    let descending = matches!(query.sort, BatchSortOrder::Desc);
-    let status_filter = parse_snos_status(query.status.as_deref())?;
-
-    let batches = if let Some(index) = query.index {
-        let mut batches = config
-            .database()
-            .get_snos_batches_by_indices(vec![index])
-            .await
-            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
-
-        if let Some(filter) = status_filter {
-            batches.retain(|batch| matches_snos_status(batch, &filter));
-        }
-
-        batches
-    } else if let Some(filter) = status_filter {
-        match filter {
-            BatchStatusFilter::Exact(status) => config
-                .database()
-                .get_snos_batches_by_status(status, limit, None, descending)
-                .await
-                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-            BatchStatusFilter::Closed => get_closed_snos_batches(config.as_ref(), limit, descending).await?,
-        }
-    } else {
-        config
-            .database()
-            .get_snos_batches(limit, descending)
-            .await
-            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
-    };
+    let response = BatchService::query_snos_batches(config.as_ref(), query).await?;
 
     Ok(Json(ApiResponse::<SnosBatchListResponse>::success_with_data(
-        SnosBatchListResponse { batches: batches.iter().map(Into::into).collect() },
+        response,
         Some("Successfully fetched SNOS batches".to_string()),
     ))
     .into_response())
@@ -69,165 +31,13 @@ async fn handle_query_aggregator_batches(
     Query(query): Query<BatchQuery>,
     State(config): State<Arc<Config>>,
 ) -> BlockRouteResult {
-    let limit = validate_limit(query.limit)?;
-    let descending = matches!(query.sort, BatchSortOrder::Desc);
-    let status_filter = parse_aggregator_status(query.status.as_deref())?;
-
-    let batches = if let Some(index) = query.index {
-        let mut batches = config
-            .database()
-            .get_aggregator_batches_by_indexes(vec![index])
-            .await
-            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
-
-        if let Some(filter) = status_filter {
-            batches.retain(|batch| matches_aggregator_status(batch, &filter));
-        }
-
-        batches
-    } else if let Some(filter) = status_filter {
-        match filter {
-            BatchStatusFilter::Exact(status) => config
-                .database()
-                .get_aggregator_batches_by_status(status, limit, None, descending)
-                .await
-                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-            BatchStatusFilter::Closed => get_closed_aggregator_batches(config.as_ref(), limit, descending).await?,
-        }
-    } else {
-        config
-            .database()
-            .get_aggregator_batches(limit, descending)
-            .await
-            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
-    };
+    let response = BatchService::query_aggregator_batches(config.as_ref(), query).await?;
 
     Ok(Json(ApiResponse::<AggregatorBatchListResponse>::success_with_data(
-        AggregatorBatchListResponse { batches: batches.iter().map(Into::into).collect() },
+        response,
         Some("Successfully fetched aggregator batches".to_string()),
     ))
     .into_response())
-}
-
-fn validate_limit(limit: Option<i64>) -> Result<Option<i64>, BlockRouteError> {
-    match limit {
-        Some(value) if value <= 0 => Err(BlockRouteError::InvalidQuery("limit must be a positive integer".to_string())),
-        other => Ok(other),
-    }
-}
-
-fn apply_limit<T>(items: &mut Vec<T>, limit: Option<i64>) {
-    if let Some(limit) = limit {
-        items.truncate(limit as usize);
-    }
-}
-
-async fn get_closed_snos_batches(
-    config: &Config,
-    limit: Option<i64>,
-    descending: bool,
-) -> Result<Vec<SnosBatch>, BlockRouteError> {
-    let mut batches = Vec::new();
-
-    for status in [SnosBatchStatus::SnosJobCreated, SnosBatchStatus::Completed] {
-        batches.extend(
-            config
-                .database()
-                .get_snos_batches_by_status(status, limit, None, descending)
-                .await
-                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-        );
-    }
-
-    batches.sort_by_key(|batch| batch.index);
-    if descending {
-        batches.reverse();
-    }
-    apply_limit(&mut batches, limit);
-    Ok(batches)
-}
-
-async fn get_closed_aggregator_batches(
-    config: &Config,
-    limit: Option<i64>,
-    descending: bool,
-) -> Result<Vec<AggregatorBatch>, BlockRouteError> {
-    let mut batches = Vec::new();
-
-    for status in [
-        AggregatorBatchStatus::Closed,
-        AggregatorBatchStatus::PendingAggregatorRun,
-        AggregatorBatchStatus::PendingAggregatorVerification,
-        AggregatorBatchStatus::ReadyForStateUpdate,
-        AggregatorBatchStatus::Completed,
-        AggregatorBatchStatus::AggregationFailed,
-        AggregatorBatchStatus::VerificationFailed,
-        AggregatorBatchStatus::StateUpdateFailed,
-    ] {
-        batches.extend(
-            config
-                .database()
-                .get_aggregator_batches_by_status(status, limit, None, descending)
-                .await
-                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-        );
-    }
-
-    batches.sort_by_key(|batch| batch.index);
-    if descending {
-        batches.reverse();
-    }
-    apply_limit(&mut batches, limit);
-    Ok(batches)
-}
-
-fn parse_snos_status(status: Option<&str>) -> Result<Option<BatchStatusFilter<SnosBatchStatus>>, BlockRouteError> {
-    parse_status("snos", status)
-}
-
-fn matches_snos_status(batch: &SnosBatch, filter: &BatchStatusFilter<SnosBatchStatus>) -> bool {
-    matches_status(&batch.status, filter, SnosBatchStatus::is_closed)
-}
-
-fn parse_aggregator_status(
-    status: Option<&str>,
-) -> Result<Option<BatchStatusFilter<AggregatorBatchStatus>>, BlockRouteError> {
-    parse_status("aggregator", status)
-}
-
-fn matches_aggregator_status(batch: &AggregatorBatch, filter: &BatchStatusFilter<AggregatorBatchStatus>) -> bool {
-    matches_status(&batch.status, filter, AggregatorBatchStatus::is_closed)
-}
-
-fn parse_status<T>(kind: &str, status: Option<&str>) -> Result<Option<BatchStatusFilter<T>>, BlockRouteError>
-where
-    T: FromStr,
-{
-    let Some(status) = status else {
-        return Ok(None);
-    };
-    let status = status.trim();
-
-    if status.eq_ignore_ascii_case("closed") {
-        return Ok(Some(BatchStatusFilter::Closed));
-    }
-
-    status
-        .to_ascii_lowercase()
-        .parse()
-        .map(BatchStatusFilter::Exact)
-        .map(Some)
-        .map_err(|_| BlockRouteError::InvalidQuery(format!("unsupported {kind} batch status '{status}'")))
-}
-
-fn matches_status<T>(status: &T, filter: &BatchStatusFilter<T>, is_closed: impl Fn(&T) -> bool) -> bool
-where
-    T: PartialEq,
-{
-    match filter {
-        BatchStatusFilter::Closed => is_closed(status),
-        BatchStatusFilter::Exact(expected) => status == expected,
-    }
 }
 
 pub(super) fn batch_router(config: Arc<Config>) -> Router {

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -18,7 +18,7 @@ enum BatchStatusFilter<T> {
     Exact(T),
 }
 
-#[instrument(skip(config), fields(index = ?query.index, status = ?query.status, limit = ?query.limit, sort = ?query.sort))]
+#[instrument(skip(config))]
 async fn handle_query_snos_batches(
     Query(query): Query<BatchQuery>,
     State(config): State<Arc<Config>>,
@@ -72,7 +72,7 @@ async fn handle_query_snos_batches(
     .into_response())
 }
 
-#[instrument(skip(config), fields(index = ?query.index, status = ?query.status, limit = ?query.limit, sort = ?query.sort))]
+#[instrument(skip(config))]
 async fn handle_query_aggregator_batches(
     Query(query): Query<BatchQuery>,
     State(config): State<Arc<Config>>,
@@ -144,7 +144,7 @@ fn parse_snos_status(status: Option<&str>) -> Result<Option<BatchStatusFilter<Sn
         return Ok(None);
     };
 
-    let parsed = match normalize_status_token(status).as_str() {
+    let parsed = match status.trim().to_ascii_lowercase().as_str() {
         "closed" => BatchStatusFilter::Closed,
         "open" => BatchStatusFilter::Exact(SnosBatchStatus::Open),
         "snosjobcreated" => BatchStatusFilter::Exact(SnosBatchStatus::SnosJobCreated),
@@ -169,7 +169,7 @@ fn parse_aggregator_status(
         return Ok(None);
     };
 
-    let parsed = match normalize_status_token(status).as_str() {
+    let parsed = match status.trim().to_ascii_lowercase().as_str() {
         "closed" => BatchStatusFilter::Closed,
         "open" => BatchStatusFilter::Exact(AggregatorBatchStatus::Open),
         "pendingaggregatorrun" => BatchStatusFilter::Exact(AggregatorBatchStatus::PendingAggregatorRun),
@@ -185,10 +185,6 @@ fn parse_aggregator_status(
     };
 
     Ok(Some(parsed))
-}
-
-fn normalize_status_token(status: &str) -> String {
-    status.chars().filter(|ch| ch.is_ascii_alphanumeric()).flat_map(char::to_lowercase).collect()
 }
 
 fn matches_aggregator_status(batch: &AggregatorBatch, filter: &BatchStatusFilter<AggregatorBatchStatus>) -> bool {

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+
+use super::super::error::BlockRouteError;
+use super::super::types::{
+    AggregatorBatchDetailsResponse, ApiResponse, BatchDetailsResponse, BlockRouteResult, SnosBatchDetailsResponse,
+    SnosBatchMetricsResponse,
+};
+use crate::core::config::Config;
+use crate::types::batch::{AggregatorBatch, SnosBatch};
+
+async fn handle_snos_batch_details(
+    Path(snos_batch_index): Path<u64>,
+    State(config): State<Arc<Config>>,
+) -> BlockRouteResult {
+    let snos_batch = config
+        .database()
+        .get_snos_batches_by_indices(vec![snos_batch_index])
+        .await
+        .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| BlockRouteError::NotFound(format!("No SNOS batch found for index {}", snos_batch_index)))?;
+
+    let aggregator_batch = match snos_batch.aggregator_batch_index {
+        Some(aggregator_batch_index) => config
+            .database()
+            .get_aggregator_batches_by_indexes(vec![aggregator_batch_index])
+            .await
+            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
+            .into_iter()
+            .next(),
+        None => None,
+    };
+
+    Ok(Json(ApiResponse::<BatchDetailsResponse>::success_with_data(
+        BatchDetailsResponse {
+            snos_batch: snapshot_snos_batch_details(&snos_batch),
+            aggregator_batch: aggregator_batch.as_ref().map(snapshot_aggregator_batch_details),
+        },
+        Some(format!("Successfully fetched details for SNOS batch {}", snos_batch_index)),
+    ))
+    .into_response())
+}
+
+fn snapshot_snos_batch_details(batch: &SnosBatch) -> SnosBatchDetailsResponse {
+    SnosBatchDetailsResponse {
+        index: batch.index,
+        aggregator_batch_index: batch.aggregator_batch_index,
+        start_block: batch.start_block,
+        end_block: batch.end_block,
+        status: batch.status.clone(),
+        created_at: batch.created_at,
+        updated_at: batch.updated_at,
+        metrics: SnosBatchMetricsResponse {
+            state_diff_size: batch.builtin_weights.state_diff_size,
+            sierra_gas: batch.builtin_weights.sierra_gas.0,
+            proving_gas: batch.builtin_weights.proving_gas.0,
+        },
+    }
+}
+
+fn snapshot_aggregator_batch_details(batch: &AggregatorBatch) -> AggregatorBatchDetailsResponse {
+    AggregatorBatchDetailsResponse {
+        index: batch.index,
+        start_block: batch.start_block,
+        end_block: batch.end_block,
+        status: batch.status.clone(),
+        created_at: batch.created_at,
+        updated_at: batch.updated_at,
+        blob_len: batch.blob_len,
+    }
+}
+
+pub(super) fn batch_router(config: Arc<Config>) -> Router {
+    Router::new().route("/snos/:snos_batch_index/details", get(handle_snos_batch_details)).with_state(config)
+}

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -47,16 +47,7 @@ async fn handle_query_snos_batches(
                 .get_snos_batches_by_status(status, limit, None, descending)
                 .await
                 .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-            BatchStatusFilter::Closed => {
-                let mut batches = config
-                    .database()
-                    .get_snos_batches(None, descending)
-                    .await
-                    .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
-                batches.retain(|batch| batch.status.is_closed());
-                apply_limit(&mut batches, limit);
-                batches
-            }
+            BatchStatusFilter::Closed => get_closed_snos_batches(config.as_ref(), limit, descending).await?,
         }
     } else {
         config
@@ -101,16 +92,7 @@ async fn handle_query_aggregator_batches(
                 .get_aggregator_batches_by_status(status, limit, None, descending)
                 .await
                 .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
-            BatchStatusFilter::Closed => {
-                let mut batches = config
-                    .database()
-                    .get_aggregator_batches(None, descending)
-                    .await
-                    .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
-                batches.retain(|batch| batch.status.is_closed());
-                apply_limit(&mut batches, limit);
-                batches
-            }
+            BatchStatusFilter::Closed => get_closed_aggregator_batches(config.as_ref(), limit, descending).await?,
         }
     } else {
         config
@@ -138,6 +120,65 @@ fn apply_limit<T>(items: &mut Vec<T>, limit: Option<i64>) {
     if let Some(limit) = limit {
         items.truncate(limit as usize);
     }
+}
+
+async fn get_closed_snos_batches(
+    config: &Config,
+    limit: Option<i64>,
+    descending: bool,
+) -> Result<Vec<SnosBatch>, BlockRouteError> {
+    let mut batches = Vec::new();
+
+    for status in [SnosBatchStatus::SnosJobCreated, SnosBatchStatus::Completed] {
+        batches.extend(
+            config
+                .database()
+                .get_snos_batches_by_status(status, limit, None, descending)
+                .await
+                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
+        );
+    }
+
+    batches.sort_by_key(|batch| batch.index);
+    if descending {
+        batches.reverse();
+    }
+    apply_limit(&mut batches, limit);
+    Ok(batches)
+}
+
+async fn get_closed_aggregator_batches(
+    config: &Config,
+    limit: Option<i64>,
+    descending: bool,
+) -> Result<Vec<AggregatorBatch>, BlockRouteError> {
+    let mut batches = Vec::new();
+
+    for status in [
+        AggregatorBatchStatus::Closed,
+        AggregatorBatchStatus::PendingAggregatorRun,
+        AggregatorBatchStatus::PendingAggregatorVerification,
+        AggregatorBatchStatus::ReadyForStateUpdate,
+        AggregatorBatchStatus::Completed,
+        AggregatorBatchStatus::AggregationFailed,
+        AggregatorBatchStatus::VerificationFailed,
+        AggregatorBatchStatus::StateUpdateFailed,
+    ] {
+        batches.extend(
+            config
+                .database()
+                .get_aggregator_batches_by_status(status, limit, None, descending)
+                .await
+                .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?,
+        );
+    }
+
+    batches.sort_by_key(|batch| batch.index);
+    if descending {
+        batches.reverse();
+    }
+    apply_limit(&mut batches, limit);
+    Ok(batches)
 }
 
 fn parse_snos_status(status: Option<&str>) -> Result<Option<BatchStatusFilter<SnosBatchStatus>>, BlockRouteError> {

--- a/orchestrator/src/server/route/batches.rs
+++ b/orchestrator/src/server/route/batches.rs
@@ -4,15 +4,17 @@ use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
+use tracing::{instrument, warn};
 
 use super::super::error::BlockRouteError;
 use super::super::types::{
-    AggregatorBatchDetailsResponse, ApiResponse, BatchDetailsResponse, BlockRouteResult, SnosBatchDetailsResponse,
-    SnosBatchMetricsResponse,
+    AggregatorBatchDetailsResponse, ApiResponse, BatchDetailsResponse, BlockRouteResult,
+    SettlementAggregatorBatchResponse, SettlementSnosBatchResponse, SnosBatchDetailsResponse, SnosBatchMetricsResponse,
 };
 use crate::core::config::Config;
 use crate::types::batch::{AggregatorBatch, SnosBatch};
 
+#[instrument(skip(config), fields(snos_batch_index = %snos_batch_index))]
 async fn handle_snos_batch_details(
     Path(snos_batch_index): Path<u64>,
     State(config): State<Arc<Config>>,
@@ -37,6 +39,14 @@ async fn handle_snos_batch_details(
         None => None,
     };
 
+    if snos_batch.aggregator_batch_index.is_some() && aggregator_batch.is_none() {
+        warn!(
+            snos_batch_index = %snos_batch.index,
+            aggregator_batch_index = ?snos_batch.aggregator_batch_index,
+            "SNOS batch references a missing aggregator batch"
+        );
+    }
+
     Ok(Json(ApiResponse::<BatchDetailsResponse>::success_with_data(
         BatchDetailsResponse {
             snos_batch: snapshot_snos_batch_details(&snos_batch),
@@ -49,13 +59,15 @@ async fn handle_snos_batch_details(
 
 fn snapshot_snos_batch_details(batch: &SnosBatch) -> SnosBatchDetailsResponse {
     SnosBatchDetailsResponse {
-        index: batch.index,
-        aggregator_batch_index: batch.aggregator_batch_index,
-        start_block: batch.start_block,
-        end_block: batch.end_block,
-        status: batch.status.clone(),
-        created_at: batch.created_at,
-        updated_at: batch.updated_at,
+        batch: SettlementSnosBatchResponse {
+            index: batch.index,
+            aggregator_batch_index: batch.aggregator_batch_index,
+            start_block: batch.start_block,
+            end_block: batch.end_block,
+            status: batch.status.clone(),
+            created_at: batch.created_at,
+            updated_at: batch.updated_at,
+        },
         metrics: SnosBatchMetricsResponse {
             state_diff_size: batch.builtin_weights.state_diff_size,
             sierra_gas: batch.builtin_weights.sierra_gas.0,
@@ -66,12 +78,14 @@ fn snapshot_snos_batch_details(batch: &SnosBatch) -> SnosBatchDetailsResponse {
 
 fn snapshot_aggregator_batch_details(batch: &AggregatorBatch) -> AggregatorBatchDetailsResponse {
     AggregatorBatchDetailsResponse {
-        index: batch.index,
-        start_block: batch.start_block,
-        end_block: batch.end_block,
-        status: batch.status.clone(),
-        created_at: batch.created_at,
-        updated_at: batch.updated_at,
+        batch: SettlementAggregatorBatchResponse {
+            index: batch.index,
+            start_block: batch.start_block,
+            end_block: batch.end_block,
+            status: batch.status.clone(),
+            created_at: batch.created_at,
+            updated_at: batch.updated_at,
+        },
         blob_len: batch.blob_len,
     }
 }

--- a/orchestrator/src/server/route/blocks.rs
+++ b/orchestrator/src/server/route/blocks.rs
@@ -8,10 +8,11 @@ use axum::{Json, Router};
 use tracing::{error, instrument};
 
 use super::super::types::{
-    ApiResponse, BlockAggregatorBatchResponse, BlockRouteResult, BlockSettlementStatusResponse, BlockSnosBatchResponse,
-    BlockStatusResponse, SettlementAggregatorBatchResponse, SettlementJobResponseItem, SettlementJobTimestampsResponse,
+    ApiResponse, BlockRouteResult, BlockSettlementStatusResponse, BlockStatusResponse,
+    SettlementAggregatorBatchResponse, SettlementJobResponseItem, SettlementJobTimestampsResponse,
     SettlementSnosBatchResponse,
 };
+use crate::core::client::database::{AggregatorBatchDbQuery, SnosBatchDbQuery};
 use crate::core::config::Config;
 use crate::server::error::BlockRouteError;
 use crate::types::batch::{AggregatorBatch, SnosBatchStatus};
@@ -26,52 +27,6 @@ async fn handle_block_to_batch(Path(block_number): Path<u64>, State(config): Sta
     Ok(Json(ApiResponse::<BlockStatusResponse>::success_with_data(
         BlockStatusResponse { batch_number: batch.index },
         Some(format!("Successfully fetched batch for block {}", block_number)),
-    ))
-    .into_response())
-}
-
-#[instrument(skip(config), fields(block_number = %block_number))]
-async fn handle_block_to_snos_batch(
-    Path(block_number): Path<u64>,
-    State(config): State<Arc<Config>>,
-) -> BlockRouteResult {
-    let block_lookup = config
-        .database()
-        .get_block_batch_lookup(block_number)
-        .await
-        .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
-
-    let Some(snos_batch_index) = block_lookup.and_then(|lookup| lookup.snos_batch_index) else {
-        tracing::warn!("No SNOS batch found for block {}, skipping for now", block_number);
-        return Err(BlockRouteError::NotFound(format!("No SNOS batch found for block {}", block_number)));
-    };
-
-    let snos_batch = config
-        .database()
-        .get_snos_batches_by_indices(vec![snos_batch_index])
-        .await
-        .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
-        .into_iter()
-        .next()
-        .ok_or_else(|| BlockRouteError::NotFound(format!("No SNOS batch found for block {}", block_number)))?;
-
-    Ok(Json(ApiResponse::<BlockSnosBatchResponse>::success_with_data(
-        BlockSnosBatchResponse { block_number, batch: (&snos_batch).into() },
-        Some(format!("Successfully fetched SNOS batch for block {}", block_number)),
-    ))
-    .into_response())
-}
-
-#[instrument(skip(config), fields(block_number = %block_number))]
-async fn handle_block_to_aggregator_batch(
-    Path(block_number): Path<u64>,
-    State(config): State<Arc<Config>>,
-) -> BlockRouteResult {
-    let batch = get_aggregator_batch_for_block(block_number, &config).await?;
-
-    Ok(Json(ApiResponse::<BlockAggregatorBatchResponse>::success_with_data(
-        BlockAggregatorBatchResponse { block_number, batch: (&batch).into() },
-        Some(format!("Successfully fetched aggregator batch for block {}", block_number)),
     ))
     .into_response())
 }
@@ -96,7 +51,10 @@ async fn handle_block_settlement_status(
     let aggregator_batch = match block_lookup.as_ref().and_then(|lookup| lookup.aggregator_batch_index) {
         Some(aggregator_batch_index) => config
             .database()
-            .get_aggregator_batches_by_indexes(vec![aggregator_batch_index])
+            .get_aggregator_batches(AggregatorBatchDbQuery {
+                indexes: Some(vec![aggregator_batch_index]),
+                ..Default::default()
+            })
             .await
             .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
             .into_iter()
@@ -111,7 +69,7 @@ async fn handle_block_settlement_status(
     let block_snos_batch = match block_lookup.as_ref().and_then(|lookup| lookup.snos_batch_index) {
         Some(snos_batch_index) => config
             .database()
-            .get_snos_batches_by_indices(vec![snos_batch_index])
+            .get_snos_batches(SnosBatchDbQuery { indexes: Some(vec![snos_batch_index]), ..Default::default() })
             .await
             .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
             .into_iter()
@@ -259,8 +217,6 @@ fn derive_snos_batch_status_from_job(job_status: JobStatus) -> SnosBatchStatus {
 pub(super) fn block_router(config: Arc<Config>) -> Router {
     Router::new()
         .route("/batch-for-block/:block_number", get(handle_block_to_batch))
-        .route("/:block_number/snos-batch", get(handle_block_to_snos_batch))
-        .route("/:block_number/aggregator-batch", get(handle_block_to_aggregator_batch))
         .route("/settlement-status/:block_number", get(handle_block_settlement_status))
         .with_state(config)
 }

--- a/orchestrator/src/server/route/blocks.rs
+++ b/orchestrator/src/server/route/blocks.rs
@@ -8,31 +8,66 @@ use axum::{Json, Router};
 use tracing::{error, instrument};
 
 use super::super::types::{
-    ApiResponse, BlockRouteResult, BlockSettlementStatusResponse, BlockStatusResponse,
-    SettlementAggregatorBatchResponse, SettlementJobResponseItem, SettlementJobTimestampsResponse,
-    SettlementSnosBatchResponse,
+    ApiResponse, BlockAggregatorBatchResponse, BlockRouteResult, BlockSettlementStatusResponse, BlockSnosBatchResponse,
+    SettlementJobResponseItem, SettlementJobTimestampsResponse, SettlementSnosBatchResponse,
 };
+use super::batches::{snapshot_aggregator_batch, snapshot_snos_batch};
 use crate::core::config::Config;
 use crate::server::error::BlockRouteError;
-use crate::types::batch::{AggregatorBatch, SnosBatch, SnosBatchStatus};
+use crate::types::batch::SnosBatchStatus;
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::metadata::JobSpecificMetadata;
 use crate::types::jobs::types::{JobStatus, JobType};
 
 #[instrument(skip(config), fields(block_number = %block_number))]
-async fn handle_block_to_batch(Path(block_number): Path<u64>, State(config): State<Arc<Config>>) -> BlockRouteResult {
+async fn handle_block_to_snos_batch(
+    Path(block_number): Path<u64>,
+    State(config): State<Arc<Config>>,
+) -> BlockRouteResult {
+    let block_lookup = config
+        .database()
+        .get_block_batch_lookup(block_number)
+        .await
+        .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
+
+    let Some(snos_batch_index) = block_lookup.and_then(|lookup| lookup.snos_batch_index) else {
+        tracing::warn!("No SNOS batch found for block {}, skipping for now", block_number);
+        return Err(BlockRouteError::NotFound(format!("No SNOS batch found for block {}", block_number)));
+    };
+
+    let snos_batch = config
+        .database()
+        .get_snos_batches_by_indices(vec![snos_batch_index])
+        .await
+        .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| BlockRouteError::NotFound(format!("No SNOS batch found for block {}", block_number)))?;
+
+    Ok(Json(ApiResponse::<BlockSnosBatchResponse>::success_with_data(
+        BlockSnosBatchResponse { block_number, batch: snapshot_snos_batch(&snos_batch) },
+        Some(format!("Successfully fetched SNOS batch for block {}", block_number)),
+    ))
+    .into_response())
+}
+
+#[instrument(skip(config), fields(block_number = %block_number))]
+async fn handle_block_to_aggregator_batch(
+    Path(block_number): Path<u64>,
+    State(config): State<Arc<Config>>,
+) -> BlockRouteResult {
     match config.database().get_aggregator_batch_for_block(block_number).await {
-        Ok(Some(batch)) => Ok(Json(ApiResponse::<BlockStatusResponse>::success_with_data(
-            BlockStatusResponse { batch_number: batch.index },
-            Some(format!("Successfully fetched batch for block {}", block_number)),
+        Ok(Some(batch)) => Ok(Json(ApiResponse::<BlockAggregatorBatchResponse>::success_with_data(
+            BlockAggregatorBatchResponse { block_number, batch: snapshot_aggregator_batch(&batch) },
+            Some(format!("Successfully fetched aggregator batch for block {}", block_number)),
         ))
         .into_response()),
         Ok(None) => {
-            tracing::warn!("No batch found for block {}, skipping for now", block_number);
-            Err(BlockRouteError::NotFound(format!("No batch found for block {}", block_number)))
+            tracing::warn!("No aggregator batch found for block {}, skipping for now", block_number);
+            Err(BlockRouteError::NotFound(format!("No aggregator batch found for block {}", block_number)))
         }
         Err(e) => {
-            error!(error = %e, "Failed to fetch batch for block");
+            error!(error = %e, "Failed to fetch aggregator batch for block");
             Err(BlockRouteError::DatabaseError(e.to_string()))
         }
     }
@@ -194,29 +229,6 @@ fn snapshot_job(job: &JobItem) -> SettlementJobResponseItem {
     }
 }
 
-fn snapshot_snos_batch(batch: &SnosBatch) -> SettlementSnosBatchResponse {
-    SettlementSnosBatchResponse {
-        index: batch.index,
-        aggregator_batch_index: batch.aggregator_batch_index,
-        start_block: batch.start_block,
-        end_block: batch.end_block,
-        status: batch.status.clone(),
-        created_at: batch.created_at,
-        updated_at: batch.updated_at,
-    }
-}
-
-fn snapshot_aggregator_batch(batch: &AggregatorBatch) -> SettlementAggregatorBatchResponse {
-    SettlementAggregatorBatchResponse {
-        index: batch.index,
-        start_block: batch.start_block,
-        end_block: batch.end_block,
-        status: batch.status.clone(),
-        created_at: batch.created_at,
-        updated_at: batch.updated_at,
-    }
-}
-
 fn derive_snos_batch_status_from_job(job_status: JobStatus) -> SnosBatchStatus {
     match job_status {
         JobStatus::Completed => SnosBatchStatus::Completed,
@@ -226,7 +238,8 @@ fn derive_snos_batch_status_from_job(job_status: JobStatus) -> SnosBatchStatus {
 
 pub(super) fn block_router(config: Arc<Config>) -> Router {
     Router::new()
-        .route("/batch-for-block/:block_number", get(handle_block_to_batch))
+        .route("/:block_number/snos-batch", get(handle_block_to_snos_batch))
+        .route("/:block_number/aggregator-batch", get(handle_block_to_aggregator_batch))
         .route("/settlement-status/:block_number", get(handle_block_settlement_status))
         .with_state(config)
 }

--- a/orchestrator/src/server/route/blocks.rs
+++ b/orchestrator/src/server/route/blocks.rs
@@ -9,15 +9,26 @@ use tracing::{error, instrument};
 
 use super::super::types::{
     ApiResponse, BlockAggregatorBatchResponse, BlockRouteResult, BlockSettlementStatusResponse, BlockSnosBatchResponse,
-    SettlementAggregatorBatchResponse, SettlementJobResponseItem, SettlementJobTimestampsResponse,
+    BlockStatusResponse, SettlementAggregatorBatchResponse, SettlementJobResponseItem, SettlementJobTimestampsResponse,
     SettlementSnosBatchResponse,
 };
 use crate::core::config::Config;
 use crate::server::error::BlockRouteError;
-use crate::types::batch::SnosBatchStatus;
+use crate::types::batch::{AggregatorBatch, SnosBatchStatus};
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::metadata::JobSpecificMetadata;
 use crate::types::jobs::types::{JobStatus, JobType};
+
+#[instrument(skip(config), fields(block_number = %block_number))]
+async fn handle_block_to_batch(Path(block_number): Path<u64>, State(config): State<Arc<Config>>) -> BlockRouteResult {
+    let batch = get_aggregator_batch_for_block(block_number, &config).await?;
+
+    Ok(Json(ApiResponse::<BlockStatusResponse>::success_with_data(
+        BlockStatusResponse { batch_number: batch.index },
+        Some(format!("Successfully fetched batch for block {}", block_number)),
+    ))
+    .into_response())
+}
 
 #[instrument(skip(config), fields(block_number = %block_number))]
 async fn handle_block_to_snos_batch(
@@ -56,21 +67,13 @@ async fn handle_block_to_aggregator_batch(
     Path(block_number): Path<u64>,
     State(config): State<Arc<Config>>,
 ) -> BlockRouteResult {
-    match config.database().get_aggregator_batch_for_block(block_number).await {
-        Ok(Some(batch)) => Ok(Json(ApiResponse::<BlockAggregatorBatchResponse>::success_with_data(
-            BlockAggregatorBatchResponse { block_number, batch: (&batch).into() },
-            Some(format!("Successfully fetched aggregator batch for block {}", block_number)),
-        ))
-        .into_response()),
-        Ok(None) => {
-            tracing::warn!("No aggregator batch found for block {}, skipping for now", block_number);
-            Err(BlockRouteError::NotFound(format!("No aggregator batch found for block {}", block_number)))
-        }
-        Err(e) => {
-            error!(error = %e, "Failed to fetch aggregator batch for block");
-            Err(BlockRouteError::DatabaseError(e.to_string()))
-        }
-    }
+    let batch = get_aggregator_batch_for_block(block_number, &config).await?;
+
+    Ok(Json(ApiResponse::<BlockAggregatorBatchResponse>::success_with_data(
+        BlockAggregatorBatchResponse { block_number, batch: (&batch).into() },
+        Some(format!("Successfully fetched aggregator batch for block {}", block_number)),
+    ))
+    .into_response())
 }
 
 #[instrument(skip(config), fields(block_number = %block_number))]
@@ -212,6 +215,23 @@ fn push_job_if_missing(jobs: &mut Vec<JobItem>, job: JobItem) {
     jobs.push(job);
 }
 
+async fn get_aggregator_batch_for_block(
+    block_number: u64,
+    config: &Arc<Config>,
+) -> Result<AggregatorBatch, BlockRouteError> {
+    match config.database().get_aggregator_batch_for_block(block_number).await {
+        Ok(Some(batch)) => Ok(batch),
+        Ok(None) => {
+            tracing::warn!("No aggregator batch found for block {}, skipping for now", block_number);
+            Err(BlockRouteError::NotFound(format!("No aggregator batch found for block {}", block_number)))
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to fetch aggregator batch for block");
+            Err(BlockRouteError::DatabaseError(e.to_string()))
+        }
+    }
+}
+
 fn snapshot_job(job: &JobItem) -> SettlementJobResponseItem {
     SettlementJobResponseItem {
         job_type: job.job_type.clone(),
@@ -238,6 +258,7 @@ fn derive_snos_batch_status_from_job(job_status: JobStatus) -> SnosBatchStatus {
 
 pub(super) fn block_router(config: Arc<Config>) -> Router {
     Router::new()
+        .route("/batch-for-block/:block_number", get(handle_block_to_batch))
         .route("/:block_number/snos-batch", get(handle_block_to_snos_batch))
         .route("/:block_number/aggregator-batch", get(handle_block_to_aggregator_batch))
         .route("/settlement-status/:block_number", get(handle_block_settlement_status))

--- a/orchestrator/src/server/route/blocks.rs
+++ b/orchestrator/src/server/route/blocks.rs
@@ -9,9 +9,9 @@ use tracing::{error, instrument};
 
 use super::super::types::{
     ApiResponse, BlockAggregatorBatchResponse, BlockRouteResult, BlockSettlementStatusResponse, BlockSnosBatchResponse,
-    SettlementJobResponseItem, SettlementJobTimestampsResponse, SettlementSnosBatchResponse,
+    SettlementAggregatorBatchResponse, SettlementJobResponseItem, SettlementJobTimestampsResponse,
+    SettlementSnosBatchResponse,
 };
-use super::batches::{snapshot_aggregator_batch, snapshot_snos_batch};
 use crate::core::config::Config;
 use crate::server::error::BlockRouteError;
 use crate::types::batch::SnosBatchStatus;
@@ -45,7 +45,7 @@ async fn handle_block_to_snos_batch(
         .ok_or_else(|| BlockRouteError::NotFound(format!("No SNOS batch found for block {}", block_number)))?;
 
     Ok(Json(ApiResponse::<BlockSnosBatchResponse>::success_with_data(
-        BlockSnosBatchResponse { block_number, batch: snapshot_snos_batch(&snos_batch) },
+        BlockSnosBatchResponse { block_number, batch: (&snos_batch).into() },
         Some(format!("Successfully fetched SNOS batch for block {}", block_number)),
     ))
     .into_response())
@@ -58,7 +58,7 @@ async fn handle_block_to_aggregator_batch(
 ) -> BlockRouteResult {
     match config.database().get_aggregator_batch_for_block(block_number).await {
         Ok(Some(batch)) => Ok(Json(ApiResponse::<BlockAggregatorBatchResponse>::success_with_data(
-            BlockAggregatorBatchResponse { block_number, batch: snapshot_aggregator_batch(&batch) },
+            BlockAggregatorBatchResponse { block_number, batch: (&batch).into() },
             Some(format!("Successfully fetched aggregator batch for block {}", block_number)),
         ))
         .into_response()),
@@ -145,7 +145,7 @@ async fn handle_block_settlement_status(
             .collect::<HashMap<_, _>>();
 
         if let Some(block_snos_batch) = matching_snos_batch {
-            snos_batch_response = Some(snapshot_snos_batch(block_snos_batch));
+            snos_batch_response = Some(block_snos_batch.into());
 
             if let Some(proof_job) = proof_jobs_by_internal_id.get(&block_snos_batch.index).cloned() {
                 push_job_if_missing(&mut block_jobs, proof_job);
@@ -176,7 +176,7 @@ async fn handle_block_settlement_status(
             }
         }
     } else {
-        snos_batch_response = block_snos_batch.as_ref().map(snapshot_snos_batch).or_else(|| {
+        snos_batch_response = block_snos_batch.as_ref().map(SettlementSnosBatchResponse::from).or_else(|| {
             block_jobs.iter().find_map(|job| match &job.metadata.specific {
                 JobSpecificMetadata::Snos(metadata) => Some(SettlementSnosBatchResponse {
                     index: metadata.snos_batch_index,
@@ -196,7 +196,7 @@ async fn handle_block_settlement_status(
         BlockSettlementStatusResponse {
             block_number,
             snos_batch: snos_batch_response,
-            aggregator_batch: aggregator_batch.as_ref().map(snapshot_aggregator_batch),
+            aggregator_batch: aggregator_batch.as_ref().map(SettlementAggregatorBatchResponse::from),
             block_jobs: block_jobs.iter().map(snapshot_job).collect(),
             aggregator_proof_jobs,
         },

--- a/orchestrator/src/server/route/mod.rs
+++ b/orchestrator/src/server/route/mod.rs
@@ -2,12 +2,14 @@ use crate::core::config::Config;
 use alloy::transports::http::reqwest::StatusCode;
 use axum::response::IntoResponse;
 use axum::Router;
+use batches::batch_router;
 use blocks::block_router;
 use jobs::job_router;
 use public::local_route;
 use std::sync::Arc;
 
 pub mod admin;
+pub(super) mod batches;
 pub(super) mod blocks;
 pub(super) mod jobs;
 
@@ -46,6 +48,7 @@ pub(crate) fn server_router(config: Arc<Config>) -> Router {
         .nest("/", local_route())
         .nest("/api", v1_routes)
         .nest("/jobs", job_router(config.clone()))
+        .nest("/batches", batch_router(config.clone()))
         .nest("/blocks", block_router(config.clone()));
 
     // Conditionally add admin routes if enabled

--- a/orchestrator/src/server/service/batches.rs
+++ b/orchestrator/src/server/service/batches.rs
@@ -1,0 +1,113 @@
+use std::str::FromStr;
+
+use crate::core::client::database::{AggregatorBatchDbQuery, BatchIndexSort, SnosBatchDbQuery};
+use crate::core::config::Config;
+use crate::server::error::BlockRouteError;
+use crate::server::types::{AggregatorBatchListResponse, BatchQuery, BatchSortOrder, SnosBatchListResponse};
+use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
+
+const DEFAULT_BATCH_QUERY_LIMIT: i64 = 50;
+const MAX_BATCH_QUERY_LIMIT: i64 = 500;
+
+pub struct BatchService;
+
+impl BatchService {
+    pub async fn query_snos_batches(
+        config: &Config,
+        query: BatchQuery,
+    ) -> Result<SnosBatchListResponse, BlockRouteError> {
+        let db_query = SnosBatchDbQuery {
+            indexes: query.index.map(|index| vec![index]),
+            statuses: parse_snos_statuses(query.status.as_deref())?,
+            limit: Some(validate_limit(query.limit)?),
+            orchestrator_version: None,
+            sort: sort_from_query(query.sort),
+        };
+
+        let batches = config
+            .database()
+            .get_snos_batches(db_query)
+            .await
+            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
+
+        Ok(SnosBatchListResponse { batches: batches.iter().map(Into::into).collect() })
+    }
+
+    pub async fn query_aggregator_batches(
+        config: &Config,
+        query: BatchQuery,
+    ) -> Result<AggregatorBatchListResponse, BlockRouteError> {
+        let db_query = AggregatorBatchDbQuery {
+            indexes: query.index.map(|index| vec![index]),
+            statuses: parse_aggregator_statuses(query.status.as_deref())?,
+            limit: Some(validate_limit(query.limit)?),
+            orchestrator_version: None,
+            sort: sort_from_query(query.sort),
+        };
+
+        let batches = config
+            .database()
+            .get_aggregator_batches(db_query)
+            .await
+            .map_err(|e| BlockRouteError::DatabaseError(e.to_string()))?;
+
+        Ok(AggregatorBatchListResponse { batches: batches.iter().map(Into::into).collect() })
+    }
+}
+
+fn validate_limit(limit: Option<i64>) -> Result<i64, BlockRouteError> {
+    match limit {
+        Some(value) if value <= 0 => Err(BlockRouteError::InvalidQuery("limit must be a positive integer".to_string())),
+        Some(value) if value > MAX_BATCH_QUERY_LIMIT => {
+            Err(BlockRouteError::InvalidQuery(format!("limit must be less than or equal to {MAX_BATCH_QUERY_LIMIT}")))
+        }
+        Some(value) => Ok(value),
+        None => Ok(DEFAULT_BATCH_QUERY_LIMIT),
+    }
+}
+
+fn sort_from_query(sort: BatchSortOrder) -> BatchIndexSort {
+    match sort {
+        BatchSortOrder::Asc => BatchIndexSort::Asc,
+        BatchSortOrder::Desc => BatchIndexSort::Desc,
+    }
+}
+
+fn parse_snos_statuses(status: Option<&str>) -> Result<Option<Vec<SnosBatchStatus>>, BlockRouteError> {
+    parse_statuses("snos", status, || {
+        vec![SnosBatchStatus::Closed, SnosBatchStatus::SnosJobCreated, SnosBatchStatus::Completed]
+    })
+}
+
+fn parse_aggregator_statuses(status: Option<&str>) -> Result<Option<Vec<AggregatorBatchStatus>>, BlockRouteError> {
+    parse_statuses("aggregator", status, || {
+        vec![
+            AggregatorBatchStatus::Closed,
+            AggregatorBatchStatus::PendingAggregatorRun,
+            AggregatorBatchStatus::PendingAggregatorVerification,
+            AggregatorBatchStatus::ReadyForStateUpdate,
+            AggregatorBatchStatus::Completed,
+            AggregatorBatchStatus::AggregationFailed,
+            AggregatorBatchStatus::VerificationFailed,
+            AggregatorBatchStatus::StateUpdateFailed,
+        ]
+    })
+}
+
+fn parse_statuses<T>(
+    kind: &str,
+    status: Option<&str>,
+    closed_statuses: impl FnOnce() -> Vec<T>,
+) -> Result<Option<Vec<T>>, BlockRouteError>
+where
+    T: FromStr,
+{
+    match status.map(str::trim) {
+        None | Some("") => Ok(None),
+        Some(status) if status.eq_ignore_ascii_case("closed") => Ok(Some(closed_statuses())),
+        Some(status) => status
+            .parse()
+            .map(|status| Some(vec![status]))
+            .map_err(|_| BlockRouteError::InvalidQuery(format!("unsupported {kind} batch status '{status}'"))),
+    }
+}

--- a/orchestrator/src/server/service/mod.rs
+++ b/orchestrator/src/server/service/mod.rs
@@ -1,1 +1,2 @@
 pub mod admin;
+pub mod batches;

--- a/orchestrator/src/server/types.rs
+++ b/orchestrator/src/server/types.rs
@@ -172,18 +172,6 @@ pub struct BlockStatusResponse {
     pub batch_number: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BlockSnosBatchResponse {
-    pub block_number: u64,
-    pub batch: SettlementSnosBatchResponse,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BlockAggregatorBatchResponse {
-    pub block_number: u64,
-    pub batch: SettlementAggregatorBatchResponse,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SettlementJobTimestampsResponse {
     #[serde(default, with = "chrono::serde::ts_seconds_option")]

--- a/orchestrator/src/server/types.rs
+++ b/orchestrator/src/server/types.rs
@@ -1,4 +1,4 @@
-use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
+use crate::types::batch::{AggregatorBatch, AggregatorBatchStatus, SnosBatch, SnosBatchStatus};
 use crate::types::jobs::types::{JobStatus, JobType};
 use axum::response::Response;
 use chrono::{DateTime, Utc};
@@ -38,16 +38,7 @@ pub enum BatchSortOrder {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct SnosBatchQuery {
-    pub index: Option<u64>,
-    pub status: Option<String>,
-    pub limit: Option<i64>,
-    #[serde(default)]
-    pub sort: BatchSortOrder,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct AggregatorBatchQuery {
+pub struct BatchQuery {
     pub index: Option<u64>,
     pub status: Option<String>,
     pub limit: Option<i64>,
@@ -276,13 +267,6 @@ pub struct AggregatorBatchDetailsResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct BatchDetailsResponse {
-    pub snos_batch: SnosBatchDetailsResponse,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub aggregator_batch: Option<AggregatorBatchDetailsResponse>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SnosBatchListResponse {
     pub batches: Vec<SnosBatchDetailsResponse>,
 }
@@ -290,4 +274,50 @@ pub struct SnosBatchListResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AggregatorBatchListResponse {
     pub batches: Vec<AggregatorBatchDetailsResponse>,
+}
+
+impl From<&SnosBatch> for SettlementSnosBatchResponse {
+    fn from(batch: &SnosBatch) -> Self {
+        Self {
+            index: batch.index,
+            aggregator_batch_index: batch.aggregator_batch_index,
+            start_block: batch.start_block,
+            end_block: batch.end_block,
+            status: batch.status.clone(),
+            created_at: batch.created_at,
+            updated_at: batch.updated_at,
+        }
+    }
+}
+
+impl From<&AggregatorBatch> for SettlementAggregatorBatchResponse {
+    fn from(batch: &AggregatorBatch) -> Self {
+        Self {
+            index: batch.index,
+            start_block: batch.start_block,
+            end_block: batch.end_block,
+            status: batch.status.clone(),
+            created_at: batch.created_at,
+            updated_at: batch.updated_at,
+        }
+    }
+}
+
+impl From<&SnosBatch> for SnosBatchDetailsResponse {
+    fn from(batch: &SnosBatch) -> Self {
+        Self {
+            batch: batch.into(),
+            metrics: SnosBatchMetricsResponse {
+                state_diff_size: batch.builtin_weights.state_diff_size,
+                sierra_gas: batch.builtin_weights.sierra_gas.0,
+                proving_gas: batch.builtin_weights.proving_gas.0,
+            },
+        }
+    }
+}
+
+impl From<&AggregatorBatch> for AggregatorBatchDetailsResponse {
+    fn from(batch: &AggregatorBatch) -> Self {
+        Self { batch: batch.into(), blob_len: batch.blob_len }
+    }
 }

--- a/orchestrator/src/server/types.rs
+++ b/orchestrator/src/server/types.rs
@@ -225,28 +225,15 @@ pub struct SnosBatchMetricsResponse {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SnosBatchDetailsResponse {
-    pub index: u64,
-    pub aggregator_batch_index: Option<u64>,
-    pub start_block: u64,
-    pub end_block: u64,
-    pub status: SnosBatchStatus,
-    #[serde(with = "chrono::serde::ts_seconds")]
-    pub created_at: DateTime<Utc>,
-    #[serde(with = "chrono::serde::ts_seconds")]
-    pub updated_at: DateTime<Utc>,
+    #[serde(flatten)]
+    pub batch: SettlementSnosBatchResponse,
     pub metrics: SnosBatchMetricsResponse,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AggregatorBatchDetailsResponse {
-    pub index: u64,
-    pub start_block: u64,
-    pub end_block: u64,
-    pub status: AggregatorBatchStatus,
-    #[serde(with = "chrono::serde::ts_seconds")]
-    pub created_at: DateTime<Utc>,
-    #[serde(with = "chrono::serde::ts_seconds")]
-    pub updated_at: DateTime<Utc>,
+    #[serde(flatten)]
+    pub batch: SettlementAggregatorBatchResponse,
     pub blob_len: usize,
 }
 

--- a/orchestrator/src/server/types.rs
+++ b/orchestrator/src/server/types.rs
@@ -215,3 +215,44 @@ pub struct BlockSettlementStatusResponse {
     pub block_jobs: Vec<SettlementJobResponseItem>,
     pub aggregator_proof_jobs: Vec<SettlementJobResponseItem>,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SnosBatchMetricsResponse {
+    pub state_diff_size: usize,
+    pub sierra_gas: u64,
+    pub proving_gas: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SnosBatchDetailsResponse {
+    pub index: u64,
+    pub aggregator_batch_index: Option<u64>,
+    pub start_block: u64,
+    pub end_block: u64,
+    pub status: SnosBatchStatus,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub updated_at: DateTime<Utc>,
+    pub metrics: SnosBatchMetricsResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AggregatorBatchDetailsResponse {
+    pub index: u64,
+    pub start_block: u64,
+    pub end_block: u64,
+    pub status: AggregatorBatchStatus,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub updated_at: DateTime<Utc>,
+    pub blob_len: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BatchDetailsResponse {
+    pub snos_batch: SnosBatchDetailsResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aggregator_batch: Option<AggregatorBatchDetailsResponse>,
+}

--- a/orchestrator/src/server/types.rs
+++ b/orchestrator/src/server/types.rs
@@ -29,6 +29,32 @@ pub struct JobStatusQuery {
     pub status: JobStatus,
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum BatchSortOrder {
+    #[default]
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SnosBatchQuery {
+    pub index: Option<u64>,
+    pub status: Option<String>,
+    pub limit: Option<i64>,
+    #[serde(default)]
+    pub sort: BatchSortOrder,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AggregatorBatchQuery {
+    pub index: Option<u64>,
+    pub status: Option<String>,
+    pub limit: Option<i64>,
+    #[serde(default)]
+    pub sort: BatchSortOrder,
+}
+
 /// Represents query parameters for priority queue selection.
 #[derive(Deserialize)]
 pub struct PriorityQuery {
@@ -155,6 +181,18 @@ pub struct BlockStatusResponse {
     pub batch_number: u64,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockSnosBatchResponse {
+    pub block_number: u64,
+    pub batch: SettlementSnosBatchResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BlockAggregatorBatchResponse {
+    pub block_number: u64,
+    pub batch: SettlementAggregatorBatchResponse,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SettlementJobTimestampsResponse {
     #[serde(default, with = "chrono::serde::ts_seconds_option")]
@@ -242,4 +280,14 @@ pub struct BatchDetailsResponse {
     pub snos_batch: SnosBatchDetailsResponse,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregator_batch: Option<AggregatorBatchDetailsResponse>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SnosBatchListResponse {
+    pub batches: Vec<SnosBatchDetailsResponse>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AggregatorBatchListResponse {
+    pub batches: Vec<AggregatorBatchDetailsResponse>,
 }

--- a/orchestrator/src/tests/database/mod.rs
+++ b/orchestrator/src/tests/database/mod.rs
@@ -704,21 +704,24 @@ async fn test_get_snos_batches_by_status() {
     database_client.create_snos_batch(batch3.clone()).await.unwrap();
 
     // Test without version filter - should return all closed batches
-    let closed_batches = database_client.get_snos_batches_by_status(SnosBatchStatus::Closed, None, None).await.unwrap();
+    let closed_batches =
+        database_client.get_snos_batches_by_status(SnosBatchStatus::Closed, None, None, false).await.unwrap();
     assert_eq!(closed_batches.len(), 2);
     assert!(closed_batches.iter().any(|b| b.index == 1));
     assert!(closed_batches.iter().any(|b| b.index == 3));
 
     // Test with current version filter - should only return batch 1
     let current_version = crate::types::constant::ORCHESTRATOR_VERSION.to_string();
-    let current_version_batches =
-        database_client.get_snos_batches_by_status(SnosBatchStatus::Closed, None, Some(current_version)).await.unwrap();
+    let current_version_batches = database_client
+        .get_snos_batches_by_status(SnosBatchStatus::Closed, None, Some(current_version), false)
+        .await
+        .unwrap();
     assert_eq!(current_version_batches.len(), 1);
     assert_eq!(current_version_batches[0].index, 1);
 
     // Test with old version filter - should only return batch 3
     let old_version_batches = database_client
-        .get_snos_batches_by_status(SnosBatchStatus::Closed, None, Some("old-version".to_string()))
+        .get_snos_batches_by_status(SnosBatchStatus::Closed, None, Some("old-version".to_string()), false)
         .await
         .unwrap();
     assert_eq!(old_version_batches.len(), 1);
@@ -726,7 +729,7 @@ async fn test_get_snos_batches_by_status() {
 
     // Test with limit
     let limited_batches =
-        database_client.get_snos_batches_by_status(SnosBatchStatus::Closed, Some(1), None).await.unwrap();
+        database_client.get_snos_batches_by_status(SnosBatchStatus::Closed, Some(1), None, false).await.unwrap();
     assert_eq!(limited_batches.len(), 1);
 }
 
@@ -985,15 +988,17 @@ async fn test_get_aggregator_batches_by_status() {
     database_client.create_aggregator_batch(batch3.clone()).await.unwrap();
 
     // Test without version filter - should return all closed batches
-    let closed_batches =
-        database_client.get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, None).await.unwrap();
+    let closed_batches = database_client
+        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, None, false)
+        .await
+        .unwrap();
     assert_eq!(closed_batches.len(), 2);
     assert!(closed_batches.iter().any(|b| b.index == 1));
     assert!(closed_batches.iter().any(|b| b.index == 3));
 
     // Test with current version filter - should only return batch 1
     let current_version_batches = database_client
-        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, Some(current_version))
+        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, Some(current_version), false)
         .await
         .unwrap();
     assert_eq!(current_version_batches.len(), 1);
@@ -1001,15 +1006,17 @@ async fn test_get_aggregator_batches_by_status() {
 
     // Test with old version filter - should only return batch 3
     let old_version_batches = database_client
-        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, Some("old-version".to_string()))
+        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, Some("old-version".to_string()), false)
         .await
         .unwrap();
     assert_eq!(old_version_batches.len(), 1);
     assert_eq!(old_version_batches[0].index, 3);
 
     // Test with limit
-    let limited_batches =
-        database_client.get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, Some(1), None).await.unwrap();
+    let limited_batches = database_client
+        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, Some(1), None, false)
+        .await
+        .unwrap();
     assert_eq!(limited_batches.len(), 1);
 }
 

--- a/orchestrator/src/tests/database/mod.rs
+++ b/orchestrator/src/tests/database/mod.rs
@@ -1,4 +1,4 @@
-use crate::core::client::database::DatabaseError;
+use crate::core::client::database::{AggregatorBatchDbQuery, BatchIndexSort, DatabaseError, SnosBatchDbQuery};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::{
     build_aggregator_batch_with_version, build_batch, build_job_item, build_job_item_with_version, build_snos_batch,
@@ -640,11 +640,11 @@ async fn test_get_jobs_by_block_number() {
     assert!(retrieved_jobs.contains(&jobs[1]));
 }
 
-/// Test for `get_snos_batches_by_indices` operation in database trait.
+/// Test for indexed `get_snos_batches` filtering in database trait.
 /// Creates multiple SNOS batches and retrieves by their indices.
 #[rstest]
 #[tokio::test]
-async fn test_get_snos_batches_by_indices() {
+async fn test_get_snos_batches_by_indices_filter() {
     let services = TestConfigBuilder::new().configure_database(ConfigType::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
@@ -656,9 +656,10 @@ async fn test_get_snos_batches_by_indices() {
         database_client.create_snos_batch(batch.clone()).await.unwrap();
     }
 
-    let retrieved_batches = database_client.get_snos_batches_by_indices(vec![1, 3]).await.unwrap();
-
-    println!("{:?}", retrieved_batches);
+    let retrieved_batches = database_client
+        .get_snos_batches(SnosBatchDbQuery { indexes: Some(vec![1, 3]), ..Default::default() })
+        .await
+        .unwrap();
 
     assert_eq!(retrieved_batches.len(), 2);
     assert_eq!(retrieved_batches[0].index, 1);
@@ -683,11 +684,11 @@ async fn test_update_snos_batch_status_by_index() {
     assert_eq!(updated_batch.index, 1);
 }
 
-/// Test for `get_snos_batches_by_status` operation in database trait.
+/// Test for status `get_snos_batches` filtering in database trait.
 /// Creates SNOS batches with different statuses and versions, tests filtering.
 #[rstest]
 #[tokio::test]
-async fn test_get_snos_batches_by_status() {
+async fn test_get_snos_batches_by_status_filter() {
     let services = TestConfigBuilder::new().configure_database(ConfigType::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
@@ -704,8 +705,10 @@ async fn test_get_snos_batches_by_status() {
     database_client.create_snos_batch(batch3.clone()).await.unwrap();
 
     // Test without version filter - should return all closed batches
-    let closed_batches =
-        database_client.get_snos_batches_by_status(SnosBatchStatus::Closed, None, None, false).await.unwrap();
+    let closed_batches = database_client
+        .get_snos_batches(SnosBatchDbQuery { statuses: Some(vec![SnosBatchStatus::Closed]), ..Default::default() })
+        .await
+        .unwrap();
     assert_eq!(closed_batches.len(), 2);
     assert!(closed_batches.iter().any(|b| b.index == 1));
     assert!(closed_batches.iter().any(|b| b.index == 3));
@@ -713,7 +716,11 @@ async fn test_get_snos_batches_by_status() {
     // Test with current version filter - should only return batch 1
     let current_version = crate::types::constant::ORCHESTRATOR_VERSION.to_string();
     let current_version_batches = database_client
-        .get_snos_batches_by_status(SnosBatchStatus::Closed, None, Some(current_version), false)
+        .get_snos_batches(SnosBatchDbQuery {
+            statuses: Some(vec![SnosBatchStatus::Closed]),
+            orchestrator_version: Some(current_version),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(current_version_batches.len(), 1);
@@ -721,16 +728,36 @@ async fn test_get_snos_batches_by_status() {
 
     // Test with old version filter - should only return batch 3
     let old_version_batches = database_client
-        .get_snos_batches_by_status(SnosBatchStatus::Closed, None, Some("old-version".to_string()), false)
+        .get_snos_batches(SnosBatchDbQuery {
+            statuses: Some(vec![SnosBatchStatus::Closed]),
+            orchestrator_version: Some("old-version".to_string()),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(old_version_batches.len(), 1);
     assert_eq!(old_version_batches[0].index, 3);
 
     // Test with limit
-    let limited_batches =
-        database_client.get_snos_batches_by_status(SnosBatchStatus::Closed, Some(1), None, false).await.unwrap();
+    let limited_batches = database_client
+        .get_snos_batches(SnosBatchDbQuery {
+            statuses: Some(vec![SnosBatchStatus::Closed]),
+            limit: Some(1),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
     assert_eq!(limited_batches.len(), 1);
+
+    let descending_batches = database_client
+        .get_snos_batches(SnosBatchDbQuery {
+            statuses: Some(vec![SnosBatchStatus::Closed]),
+            sort: BatchIndexSort::Desc,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(descending_batches.iter().map(|batch| batch.index).collect::<Vec<_>>(), vec![3, 1]);
 }
 
 /// Test for `get_snos_batches_without_jobs` operation in database trait.
@@ -811,11 +838,11 @@ async fn test_get_snos_batches_without_jobs_returns_oldest_missing_across_large_
     assert_eq!(first_two_missing_batches.iter().map(|batch| batch.index).collect::<Vec<_>>(), vec![1, backlog_size]);
 }
 
-/// Test for `get_aggregator_batches_by_indexes` operation in database trait.
+/// Test for indexed `get_aggregator_batches` filtering in database trait.
 /// Creates multiple aggregator batches and retrieves by their indexes.
 #[rstest]
 #[tokio::test]
-async fn test_get_aggregator_batches_by_indexes(
+async fn test_get_aggregator_batches_by_indexes_filter(
     #[from(build_batch)]
     #[with(1, 100, 200)]
     batch1: AggregatorBatch,
@@ -834,7 +861,10 @@ async fn test_get_aggregator_batches_by_indexes(
     database_client.create_aggregator_batch(batch2.clone()).await.unwrap();
     database_client.create_aggregator_batch(batch3.clone()).await.unwrap();
 
-    let retrieved_batches = database_client.get_aggregator_batches_by_indexes(vec![1, 3]).await.unwrap();
+    let retrieved_batches = database_client
+        .get_aggregator_batches(AggregatorBatchDbQuery { indexes: Some(vec![1, 3]), ..Default::default() })
+        .await
+        .unwrap();
 
     assert_eq!(retrieved_batches.len(), 2);
     assert_eq!(retrieved_batches[0].index, 1);
@@ -966,11 +996,11 @@ async fn test_get_block_batch_lookup_after_batch_updates() {
     assert!(lookup.created_at.is_some());
 }
 
-/// Test for `get_aggregator_batches_by_status` operation in database trait.
+/// Test for status `get_aggregator_batches` filtering in database trait.
 /// Creates aggregator batches with different statuses and versions, tests filtering.
 #[rstest]
 #[tokio::test]
-async fn test_get_aggregator_batches_by_status() {
+async fn test_get_aggregator_batches_by_status_filter() {
     let services = TestConfigBuilder::new().configure_database(ConfigType::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
@@ -989,7 +1019,10 @@ async fn test_get_aggregator_batches_by_status() {
 
     // Test without version filter - should return all closed batches
     let closed_batches = database_client
-        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, None, false)
+        .get_aggregator_batches(AggregatorBatchDbQuery {
+            statuses: Some(vec![AggregatorBatchStatus::Closed]),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(closed_batches.len(), 2);
@@ -998,7 +1031,11 @@ async fn test_get_aggregator_batches_by_status() {
 
     // Test with current version filter - should only return batch 1
     let current_version_batches = database_client
-        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, Some(current_version), false)
+        .get_aggregator_batches(AggregatorBatchDbQuery {
+            statuses: Some(vec![AggregatorBatchStatus::Closed]),
+            orchestrator_version: Some(current_version),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(current_version_batches.len(), 1);
@@ -1006,7 +1043,11 @@ async fn test_get_aggregator_batches_by_status() {
 
     // Test with old version filter - should only return batch 3
     let old_version_batches = database_client
-        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, None, Some("old-version".to_string()), false)
+        .get_aggregator_batches(AggregatorBatchDbQuery {
+            statuses: Some(vec![AggregatorBatchStatus::Closed]),
+            orchestrator_version: Some("old-version".to_string()),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(old_version_batches.len(), 1);
@@ -1014,10 +1055,24 @@ async fn test_get_aggregator_batches_by_status() {
 
     // Test with limit
     let limited_batches = database_client
-        .get_aggregator_batches_by_status(AggregatorBatchStatus::Closed, Some(1), None, false)
+        .get_aggregator_batches(AggregatorBatchDbQuery {
+            statuses: Some(vec![AggregatorBatchStatus::Closed]),
+            limit: Some(1),
+            ..Default::default()
+        })
         .await
         .unwrap();
     assert_eq!(limited_batches.len(), 1);
+
+    let descending_batches = database_client
+        .get_aggregator_batches(AggregatorBatchDbQuery {
+            statuses: Some(vec![AggregatorBatchStatus::Closed]),
+            sort: BatchIndexSort::Desc,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(descending_batches.iter().map(|batch| batch.index).collect::<Vec<_>>(), vec![3, 1]);
 }
 
 /// Test for `get_snos_batches_by_aggregator_index` operation in database trait.

--- a/orchestrator/src/tests/jobs/state_update_job/mod.rs
+++ b/orchestrator/src/tests/jobs/state_update_job/mod.rs
@@ -1,7 +1,7 @@
 use std::fs::read_to_string;
 use std::path::PathBuf;
 
-use crate::core::client::database::MockDatabaseClient;
+use crate::core::client::database::{AggregatorBatchDbQuery, MockDatabaseClient};
 use crate::core::client::storage::MockStorageClient;
 use crate::core::config::StarknetVersion;
 use crate::error::job::state_update::StateUpdateError;
@@ -166,7 +166,8 @@ async fn test_process_job_l2_with_da_segment(
     let mut database_client = MockDatabaseClient::new();
 
     // Mock database batch lookup
-    database_client.expect_get_aggregator_batches_by_indexes().returning(move |_| {
+    database_client.expect_get_aggregator_batches().returning(move |query: AggregatorBatchDbQuery| {
+        assert_eq!(query.indexes, Some(vec![batch_index]));
         Ok(vec![AggregatorBatch::new(
             batch_index,
             end_block + 1,

--- a/orchestrator/src/tests/server/batch_routes.rs
+++ b/orchestrator/src/tests/server/batch_routes.rs
@@ -9,7 +9,7 @@ use rstest::*;
 use starknet_api::execution_resources::GasAmount;
 
 use crate::core::config::Config;
-use crate::server::types::{ApiResponse, BatchDetailsResponse};
+use crate::server::types::{AggregatorBatchListResponse, ApiResponse, SnosBatchListResponse};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::{build_batch, build_snos_batch};
 use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
@@ -17,6 +17,9 @@ use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
 #[fixture]
 async fn setup_batches_server() -> (SocketAddr, Arc<Config>) {
     dotenvy::from_filename_override("../.env.test").expect("Failed to load the .env.test file");
+    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
+        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
+    }
 
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
@@ -31,13 +34,12 @@ async fn setup_batches_server() -> (SocketAddr, Arc<Config>) {
 
 #[rstest]
 #[tokio::test]
-async fn test_get_snos_batch_details_with_parent_aggregator(#[future] setup_batches_server: (SocketAddr, Arc<Config>)) {
+async fn test_query_snos_batches_by_index(#[future] setup_batches_server: (SocketAddr, Arc<Config>)) {
     let (addr, config) = setup_batches_server.await;
     let now = Utc::now().round_subsecs(0);
 
     let mut aggregator_batch = build_batch(11, 100, 119);
     aggregator_batch.status = AggregatorBatchStatus::ReadyForStateUpdate;
-    aggregator_batch.blob_len = 777;
     aggregator_batch.created_at = now - Duration::minutes(12);
     aggregator_batch.updated_at = now - Duration::minutes(2);
 
@@ -58,7 +60,7 @@ async fn test_get_snos_batch_details_with_parent_aggregator(#[future] setup_batc
     let response = client
         .request(
             Request::builder()
-                .uri(format!("http://{}/batches/snos/{}/details", addr, snos_batch.index))
+                .uri(format!("http://{}/batches/snos?index={}", addr, snos_batch.index))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -67,58 +69,51 @@ async fn test_get_snos_batch_details_with_parent_aggregator(#[future] setup_batc
 
     assert_eq!(response.status(), 200);
     let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BatchDetailsResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<SnosBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
 
     assert!(response_body.success);
-    assert_eq!(
-        response_body.message,
-        Some(format!("Successfully fetched details for SNOS batch {}", snos_batch.index))
-    );
+    let batches = response_body.data.expect("missing snos batches payload").batches;
+    assert_eq!(batches.len(), 1);
 
-    let data = response_body.data.expect("missing batch details payload");
-    assert_eq!(data.snos_batch.batch.index, snos_batch.index);
-    assert_eq!(data.snos_batch.batch.aggregator_batch_index, Some(aggregator_batch.index));
-    assert_eq!(data.snos_batch.batch.start_block, snos_batch.start_block);
-    assert_eq!(data.snos_batch.batch.end_block, snos_batch.end_block);
-    assert_eq!(data.snos_batch.batch.status, snos_batch.status);
-    assert_eq!(data.snos_batch.batch.created_at, snos_batch.created_at);
-    assert_eq!(data.snos_batch.batch.updated_at, snos_batch.updated_at);
-    assert_eq!(data.snos_batch.metrics.state_diff_size, 333);
-    assert_eq!(data.snos_batch.metrics.sierra_gas, 444);
-    assert_eq!(data.snos_batch.metrics.proving_gas, 555);
-
-    let aggregator = data.aggregator_batch.expect("missing aggregator batch");
-    assert_eq!(aggregator.batch.index, aggregator_batch.index);
-    assert_eq!(aggregator.batch.start_block, aggregator_batch.start_block);
-    assert_eq!(aggregator.batch.end_block, aggregator_batch.end_block);
-    assert_eq!(aggregator.batch.status, aggregator_batch.status);
-    assert_eq!(aggregator.batch.created_at, aggregator_batch.created_at);
-    assert_eq!(aggregator.batch.updated_at, aggregator_batch.updated_at);
-    assert_eq!(aggregator.blob_len, aggregator_batch.blob_len);
+    let batch = &batches[0];
+    assert_eq!(batch.batch.index, snos_batch.index);
+    assert_eq!(batch.batch.aggregator_batch_index, Some(aggregator_batch.index));
+    assert_eq!(batch.batch.start_block, snos_batch.start_block);
+    assert_eq!(batch.batch.end_block, snos_batch.end_block);
+    assert_eq!(batch.batch.status, snos_batch.status);
+    assert_eq!(batch.metrics.state_diff_size, 333);
+    assert_eq!(batch.metrics.sierra_gas, 444);
+    assert_eq!(batch.metrics.proving_gas, 555);
 }
 
 #[rstest]
 #[tokio::test]
-async fn test_get_snos_batch_details_without_parent_aggregator(
+async fn test_query_aggregator_batches_closed_filter_returns_latest_closed(
     #[future] setup_batches_server: (SocketAddr, Arc<Config>),
 ) {
     let (addr, config) = setup_batches_server.await;
 
-    let mut snos_batch = build_snos_batch(52, None, 300);
-    snos_batch.end_block = 309;
-    snos_batch.num_blocks = 10;
-    snos_batch.status = SnosBatchStatus::Closed;
-    snos_batch.builtin_weights.state_diff_size = 901;
-    snos_batch.builtin_weights.sierra_gas = GasAmount(902);
-    snos_batch.builtin_weights.proving_gas = GasAmount(903);
+    let mut older_closed_batch = build_batch(11, 100, 119);
+    older_closed_batch.status = AggregatorBatchStatus::Closed;
+    older_closed_batch.blob_len = 777;
 
-    config.database().create_snos_batch(snos_batch.clone()).await.unwrap();
+    let mut latest_closed_batch = build_batch(12, 120, 139);
+    latest_closed_batch.status = AggregatorBatchStatus::ReadyForStateUpdate;
+    latest_closed_batch.blob_len = 888;
+
+    let mut open_batch = build_batch(13, 140, 149);
+    open_batch.status = AggregatorBatchStatus::Open;
+    open_batch.blob_len = 999;
+
+    config.database().create_aggregator_batch(older_closed_batch.clone()).await.unwrap();
+    config.database().create_aggregator_batch(latest_closed_batch.clone()).await.unwrap();
+    config.database().create_aggregator_batch(open_batch.clone()).await.unwrap();
 
     let client = hyper::Client::new();
     let response = client
         .request(
             Request::builder()
-                .uri(format!("http://{}/batches/snos/{}/details", addr, snos_batch.index))
+                .uri(format!("http://{}/batches/aggregator?status=closed&limit=1&sort=desc", addr))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -127,12 +122,16 @@ async fn test_get_snos_batch_details_without_parent_aggregator(
 
     assert_eq!(response.status(), 200);
     let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BatchDetailsResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<AggregatorBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
 
-    let data = response_body.data.expect("missing batch details payload");
-    assert_eq!(data.snos_batch.batch.index, snos_batch.index);
-    assert_eq!(data.snos_batch.metrics.state_diff_size, 901);
-    assert_eq!(data.snos_batch.metrics.sierra_gas, 902);
-    assert_eq!(data.snos_batch.metrics.proving_gas, 903);
-    assert!(data.aggregator_batch.is_none());
+    assert!(response_body.success);
+    let batches = response_body.data.expect("missing aggregator batches payload").batches;
+    assert_eq!(batches.len(), 1);
+
+    let batch = &batches[0];
+    assert_eq!(batch.batch.index, latest_closed_batch.index);
+    assert_eq!(batch.batch.start_block, latest_closed_batch.start_block);
+    assert_eq!(batch.batch.end_block, latest_closed_batch.end_block);
+    assert_eq!(batch.batch.status, latest_closed_batch.status);
+    assert_eq!(batch.blob_len, latest_closed_batch.blob_len);
 }

--- a/orchestrator/src/tests/server/batch_routes.rs
+++ b/orchestrator/src/tests/server/batch_routes.rs
@@ -76,24 +76,24 @@ async fn test_get_snos_batch_details_with_parent_aggregator(#[future] setup_batc
     );
 
     let data = response_body.data.expect("missing batch details payload");
-    assert_eq!(data.snos_batch.index, snos_batch.index);
-    assert_eq!(data.snos_batch.aggregator_batch_index, Some(aggregator_batch.index));
-    assert_eq!(data.snos_batch.start_block, snos_batch.start_block);
-    assert_eq!(data.snos_batch.end_block, snos_batch.end_block);
-    assert_eq!(data.snos_batch.status, snos_batch.status);
-    assert_eq!(data.snos_batch.created_at, snos_batch.created_at);
-    assert_eq!(data.snos_batch.updated_at, snos_batch.updated_at);
+    assert_eq!(data.snos_batch.batch.index, snos_batch.index);
+    assert_eq!(data.snos_batch.batch.aggregator_batch_index, Some(aggregator_batch.index));
+    assert_eq!(data.snos_batch.batch.start_block, snos_batch.start_block);
+    assert_eq!(data.snos_batch.batch.end_block, snos_batch.end_block);
+    assert_eq!(data.snos_batch.batch.status, snos_batch.status);
+    assert_eq!(data.snos_batch.batch.created_at, snos_batch.created_at);
+    assert_eq!(data.snos_batch.batch.updated_at, snos_batch.updated_at);
     assert_eq!(data.snos_batch.metrics.state_diff_size, 333);
     assert_eq!(data.snos_batch.metrics.sierra_gas, 444);
     assert_eq!(data.snos_batch.metrics.proving_gas, 555);
 
     let aggregator = data.aggregator_batch.expect("missing aggregator batch");
-    assert_eq!(aggregator.index, aggregator_batch.index);
-    assert_eq!(aggregator.start_block, aggregator_batch.start_block);
-    assert_eq!(aggregator.end_block, aggregator_batch.end_block);
-    assert_eq!(aggregator.status, aggregator_batch.status);
-    assert_eq!(aggregator.created_at, aggregator_batch.created_at);
-    assert_eq!(aggregator.updated_at, aggregator_batch.updated_at);
+    assert_eq!(aggregator.batch.index, aggregator_batch.index);
+    assert_eq!(aggregator.batch.start_block, aggregator_batch.start_block);
+    assert_eq!(aggregator.batch.end_block, aggregator_batch.end_block);
+    assert_eq!(aggregator.batch.status, aggregator_batch.status);
+    assert_eq!(aggregator.batch.created_at, aggregator_batch.created_at);
+    assert_eq!(aggregator.batch.updated_at, aggregator_batch.updated_at);
     assert_eq!(aggregator.blob_len, aggregator_batch.blob_len);
 }
 
@@ -130,7 +130,7 @@ async fn test_get_snos_batch_details_without_parent_aggregator(
     let response_body: ApiResponse<BatchDetailsResponse> = serde_json::from_slice(&body_bytes).unwrap();
 
     let data = response_body.data.expect("missing batch details payload");
-    assert_eq!(data.snos_batch.index, snos_batch.index);
+    assert_eq!(data.snos_batch.batch.index, snos_batch.index);
     assert_eq!(data.snos_batch.metrics.state_diff_size, 901);
     assert_eq!(data.snos_batch.metrics.sierra_gas, 902);
     assert_eq!(data.snos_batch.metrics.proving_gas, 903);

--- a/orchestrator/src/tests/server/batch_routes.rs
+++ b/orchestrator/src/tests/server/batch_routes.rs
@@ -1,0 +1,138 @@
+#![allow(clippy::await_holding_lock)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use chrono::{Duration, SubsecRound, Utc};
+use hyper::{Body, Request};
+use rstest::*;
+use starknet_api::execution_resources::GasAmount;
+
+use crate::core::config::Config;
+use crate::server::types::{ApiResponse, BatchDetailsResponse};
+use crate::tests::config::{ConfigType, TestConfigBuilder};
+use crate::tests::utils::{build_batch, build_snos_batch};
+use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
+
+#[fixture]
+async fn setup_batches_server() -> (SocketAddr, Arc<Config>) {
+    dotenvy::from_filename_override("../.env.test").expect("Failed to load the .env.test file");
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_api_server(ConfigType::Actual)
+        .build()
+        .await;
+
+    let addr = services.api_server_address.unwrap();
+    let config = services.config;
+    (addr, config)
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_snos_batch_details_with_parent_aggregator(#[future] setup_batches_server: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_batches_server.await;
+    let now = Utc::now().round_subsecs(0);
+
+    let mut aggregator_batch = build_batch(11, 100, 119);
+    aggregator_batch.status = AggregatorBatchStatus::ReadyForStateUpdate;
+    aggregator_batch.blob_len = 777;
+    aggregator_batch.created_at = now - Duration::minutes(12);
+    aggregator_batch.updated_at = now - Duration::minutes(2);
+
+    let mut snos_batch = build_snos_batch(21, Some(aggregator_batch.index), 100);
+    snos_batch.end_block = 109;
+    snos_batch.num_blocks = 10;
+    snos_batch.status = SnosBatchStatus::Completed;
+    snos_batch.created_at = now - Duration::minutes(11);
+    snos_batch.updated_at = now - Duration::minutes(3);
+    snos_batch.builtin_weights.state_diff_size = 333;
+    snos_batch.builtin_weights.sierra_gas = GasAmount(444);
+    snos_batch.builtin_weights.proving_gas = GasAmount(555);
+
+    config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
+    config.database().create_snos_batch(snos_batch.clone()).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/batches/snos/{}/details", addr, snos_batch.index))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<BatchDetailsResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(response_body.success);
+    assert_eq!(
+        response_body.message,
+        Some(format!("Successfully fetched details for SNOS batch {}", snos_batch.index))
+    );
+
+    let data = response_body.data.expect("missing batch details payload");
+    assert_eq!(data.snos_batch.index, snos_batch.index);
+    assert_eq!(data.snos_batch.aggregator_batch_index, Some(aggregator_batch.index));
+    assert_eq!(data.snos_batch.start_block, snos_batch.start_block);
+    assert_eq!(data.snos_batch.end_block, snos_batch.end_block);
+    assert_eq!(data.snos_batch.status, snos_batch.status);
+    assert_eq!(data.snos_batch.created_at, snos_batch.created_at);
+    assert_eq!(data.snos_batch.updated_at, snos_batch.updated_at);
+    assert_eq!(data.snos_batch.metrics.state_diff_size, 333);
+    assert_eq!(data.snos_batch.metrics.sierra_gas, 444);
+    assert_eq!(data.snos_batch.metrics.proving_gas, 555);
+
+    let aggregator = data.aggregator_batch.expect("missing aggregator batch");
+    assert_eq!(aggregator.index, aggregator_batch.index);
+    assert_eq!(aggregator.start_block, aggregator_batch.start_block);
+    assert_eq!(aggregator.end_block, aggregator_batch.end_block);
+    assert_eq!(aggregator.status, aggregator_batch.status);
+    assert_eq!(aggregator.created_at, aggregator_batch.created_at);
+    assert_eq!(aggregator.updated_at, aggregator_batch.updated_at);
+    assert_eq!(aggregator.blob_len, aggregator_batch.blob_len);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_snos_batch_details_without_parent_aggregator(
+    #[future] setup_batches_server: (SocketAddr, Arc<Config>),
+) {
+    let (addr, config) = setup_batches_server.await;
+
+    let mut snos_batch = build_snos_batch(52, None, 300);
+    snos_batch.end_block = 309;
+    snos_batch.num_blocks = 10;
+    snos_batch.status = SnosBatchStatus::Closed;
+    snos_batch.builtin_weights.state_diff_size = 901;
+    snos_batch.builtin_weights.sierra_gas = GasAmount(902);
+    snos_batch.builtin_weights.proving_gas = GasAmount(903);
+
+    config.database().create_snos_batch(snos_batch.clone()).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/batches/snos/{}/details", addr, snos_batch.index))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<BatchDetailsResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    let data = response_body.data.expect("missing batch details payload");
+    assert_eq!(data.snos_batch.index, snos_batch.index);
+    assert_eq!(data.snos_batch.metrics.state_diff_size, 901);
+    assert_eq!(data.snos_batch.metrics.sierra_gas, 902);
+    assert_eq!(data.snos_batch.metrics.proving_gas, 903);
+    assert!(data.aggregator_batch.is_none());
+}

--- a/orchestrator/src/tests/server/batch_routes.rs
+++ b/orchestrator/src/tests/server/batch_routes.rs
@@ -40,6 +40,7 @@ async fn test_query_snos_batches_by_index(#[future] setup_batches_server: (Socke
 
     let mut aggregator_batch = build_batch(11, 100, 119);
     aggregator_batch.status = AggregatorBatchStatus::ReadyForStateUpdate;
+    aggregator_batch.blob_len = 777;
     aggregator_batch.created_at = now - Duration::minutes(12);
     aggregator_batch.updated_at = now - Duration::minutes(2);
 
@@ -84,6 +85,47 @@ async fn test_query_snos_batches_by_index(#[future] setup_batches_server: (Socke
     assert_eq!(batch.metrics.state_diff_size, 333);
     assert_eq!(batch.metrics.sierra_gas, 444);
     assert_eq!(batch.metrics.proving_gas, 555);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_snos_batches_closed_filter_includes_closed_batches(
+    #[future] setup_batches_server: (SocketAddr, Arc<Config>),
+) {
+    let (addr, config) = setup_batches_server.await;
+
+    let mut closed_batch = build_snos_batch(31, None, 200);
+    closed_batch.status = SnosBatchStatus::Closed;
+
+    let mut snos_job_created_batch = build_snos_batch(33, None, 220);
+    snos_job_created_batch.status = SnosBatchStatus::SnosJobCreated;
+
+    let mut completed_batch = build_snos_batch(34, None, 230);
+    completed_batch.status = SnosBatchStatus::Completed;
+
+    let mut open_batch = build_snos_batch(32, None, 210);
+    open_batch.status = SnosBatchStatus::Open;
+
+    config.database().create_snos_batch(closed_batch.clone()).await.unwrap();
+    config.database().create_snos_batch(snos_job_created_batch.clone()).await.unwrap();
+    config.database().create_snos_batch(completed_batch.clone()).await.unwrap();
+    config.database().create_snos_batch(open_batch).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder().uri(format!("http://{}/batches/snos?status=closed", addr)).body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<SnosBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    let batches = response_body.data.expect("missing snos batches payload").batches;
+    assert_eq!(batches.iter().map(|batch| batch.batch.index).collect::<Vec<_>>(), vec![31, 33, 34]);
+    assert!(batches.iter().all(|batch| batch.batch.status != SnosBatchStatus::Open));
 }
 
 #[rstest]
@@ -134,4 +176,107 @@ async fn test_query_aggregator_batches_closed_filter_returns_latest_closed(
     assert_eq!(batch.batch.end_block, latest_closed_batch.end_block);
     assert_eq!(batch.batch.status, latest_closed_batch.status);
     assert_eq!(batch.blob_len, latest_closed_batch.blob_len);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_snos_batches_sort_order(#[future] setup_batches_server: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_batches_server.await;
+
+    config.database().create_snos_batch(build_snos_batch(41, None, 400)).await.unwrap();
+    config.database().create_snos_batch(build_snos_batch(42, None, 410)).await.unwrap();
+    config.database().create_snos_batch(build_snos_batch(43, None, 420)).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/batches/snos?limit=2&sort=desc", addr))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<SnosBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    let batches = response_body.data.expect("missing snos batches payload").batches;
+    assert_eq!(batches.iter().map(|batch| batch.batch.index).collect::<Vec<_>>(), vec![43, 42]);
+}
+
+#[rstest]
+#[case("/batches/snos?status=unknown")]
+#[case("/batches/aggregator?status=unknown")]
+#[tokio::test]
+async fn test_query_batches_rejects_invalid_status(
+    #[future] setup_batches_server: (SocketAddr, Arc<Config>),
+    #[case] path: &str,
+) {
+    let (addr, _config) = setup_batches_server.await;
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(Request::builder().uri(format!("http://{}{}", addr, path)).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 400);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(!response_body.success);
+    assert!(response_body.message.expect("missing error message").contains("unsupported"));
+}
+
+#[rstest]
+#[case("/batches/snos?limit=0", "positive integer")]
+#[case("/batches/aggregator?limit=501", "less than or equal to 500")]
+#[tokio::test]
+async fn test_query_batches_rejects_invalid_limit(
+    #[future] setup_batches_server: (SocketAddr, Arc<Config>),
+    #[case] path: &str,
+    #[case] expected_message: &str,
+) {
+    let (addr, _config) = setup_batches_server.await;
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(Request::builder().uri(format!("http://{}{}", addr, path)).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 400);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(!response_body.success);
+    assert!(response_body.message.expect("missing error message").contains(expected_message));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_aggregator_batches_accepts_max_limit(#[future] setup_batches_server: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_batches_server.await;
+
+    config.database().create_aggregator_batch(build_batch(51, 500, 509)).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/batches/aggregator?limit=500", addr))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<AggregatorBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(response_body.success);
+    assert_eq!(response_body.data.expect("missing aggregator batches payload").batches.len(), 1);
 }

--- a/orchestrator/src/tests/server/block_routes.rs
+++ b/orchestrator/src/tests/server/block_routes.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use crate::core::config::Config;
 use crate::server::types::{
     ApiResponse, BlockAggregatorBatchResponse, BlockSettlementStatusResponse, BlockSnosBatchResponse,
+    BlockStatusResponse,
 };
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::{build_batch, build_job_item, build_snos_batch};
@@ -275,6 +276,41 @@ async fn test_get_block_aggregator_batch_mapping(#[future] setup_blocks_server: 
     assert_eq!(data.batch.start_block, aggregator_batch.start_block);
     assert_eq!(data.batch.end_block, aggregator_batch.end_block);
     assert_eq!(data.batch.status, aggregator_batch.status);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_block_batch_mapping_legacy_route(#[future] setup_blocks_server: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_blocks_server.await;
+    let block_number = 115;
+
+    let mut aggregator_batch = build_batch(11, 100, 119);
+    aggregator_batch.status = AggregatorBatchStatus::ReadyForStateUpdate;
+
+    let mut snos_batch = build_snos_batch(21, Some(aggregator_batch.index), 100);
+    snos_batch.end_block = 119;
+    snos_batch.num_blocks = 20;
+    snos_batch.status = SnosBatchStatus::Completed;
+
+    config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
+    config.database().create_snos_batch(snos_batch).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/blocks/batch-for-block/{}", addr, block_number))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<BlockStatusResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(response_body.data.expect("missing legacy batch mapping payload").batch_number, aggregator_batch.index);
 }
 
 #[rstest]

--- a/orchestrator/src/tests/server/block_routes.rs
+++ b/orchestrator/src/tests/server/block_routes.rs
@@ -9,7 +9,9 @@ use rstest::*;
 use uuid::Uuid;
 
 use crate::core::config::Config;
-use crate::server::types::{ApiResponse, BlockSettlementStatusResponse};
+use crate::server::types::{
+    ApiResponse, BlockAggregatorBatchResponse, BlockSettlementStatusResponse, BlockSnosBatchResponse,
+};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::{build_batch, build_job_item, build_snos_batch};
 use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
@@ -24,6 +26,9 @@ use crate::types::jobs::types::{JobStatus, JobType};
 #[fixture]
 async fn setup_blocks_server() -> (SocketAddr, Arc<Config>) {
     dotenvy::from_filename_override("../.env.test").expect("Failed to load the .env.test file");
+    if std::env::var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL").is_err() {
+        std::env::set_var("MADARA_ORCHESTRATOR_ETHEREUM_SETTLEMENT_RPC_URL", "http://localhost:8545");
+    }
 
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
@@ -192,6 +197,84 @@ async fn test_get_block_settlement_status_for_batched_block(#[future] setup_bloc
     assert_eq!(data.aggregator_proof_jobs.len(), 2);
     assert!(data.aggregator_proof_jobs.iter().any(|job| job.id == proof_job_for_block.id));
     assert!(data.aggregator_proof_jobs.iter().any(|job| job.id == proof_job_for_other_batch.id));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_block_snos_batch_mapping(#[future] setup_blocks_server: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_blocks_server.await;
+    let block_number = 105;
+
+    let aggregator_batch = build_batch(11, 100, 119);
+    let mut snos_batch = build_snos_batch(21, Some(aggregator_batch.index), 100);
+    snos_batch.end_block = 109;
+    snos_batch.num_blocks = 10;
+    snos_batch.status = SnosBatchStatus::Completed;
+
+    config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
+    config.database().create_snos_batch(snos_batch.clone()).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/blocks/{}/snos-batch", addr, block_number))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<BlockSnosBatchResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    let data = response_body.data.expect("missing snos batch mapping payload");
+    assert_eq!(data.block_number, block_number);
+    assert_eq!(data.batch.index, snos_batch.index);
+    assert_eq!(data.batch.start_block, snos_batch.start_block);
+    assert_eq!(data.batch.end_block, snos_batch.end_block);
+    assert_eq!(data.batch.aggregator_batch_index, Some(aggregator_batch.index));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_block_aggregator_batch_mapping(#[future] setup_blocks_server: (SocketAddr, Arc<Config>)) {
+    let (addr, config) = setup_blocks_server.await;
+    let block_number = 115;
+
+    let mut aggregator_batch = build_batch(11, 100, 119);
+    aggregator_batch.status = AggregatorBatchStatus::ReadyForStateUpdate;
+
+    let mut snos_batch = build_snos_batch(21, Some(aggregator_batch.index), 100);
+    snos_batch.end_block = 119;
+    snos_batch.num_blocks = 20;
+    snos_batch.status = SnosBatchStatus::Completed;
+
+    config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
+    config.database().create_snos_batch(snos_batch).await.unwrap();
+
+    let client = hyper::Client::new();
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{}/blocks/{}/aggregator-batch", addr, block_number))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let response_body: ApiResponse<BlockAggregatorBatchResponse> = serde_json::from_slice(&body_bytes).unwrap();
+
+    let data = response_body.data.expect("missing aggregator batch mapping payload");
+    assert_eq!(data.block_number, block_number);
+    assert_eq!(data.batch.index, aggregator_batch.index);
+    assert_eq!(data.batch.start_block, aggregator_batch.start_block);
+    assert_eq!(data.batch.end_block, aggregator_batch.end_block);
+    assert_eq!(data.batch.status, aggregator_batch.status);
 }
 
 #[rstest]

--- a/orchestrator/src/tests/server/block_routes.rs
+++ b/orchestrator/src/tests/server/block_routes.rs
@@ -9,10 +9,7 @@ use rstest::*;
 use uuid::Uuid;
 
 use crate::core::config::Config;
-use crate::server::types::{
-    ApiResponse, BlockAggregatorBatchResponse, BlockSettlementStatusResponse, BlockSnosBatchResponse,
-    BlockStatusResponse,
-};
+use crate::server::types::{ApiResponse, BlockSettlementStatusResponse, BlockStatusResponse};
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::tests::utils::{build_batch, build_job_item, build_snos_batch};
 use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
@@ -198,84 +195,6 @@ async fn test_get_block_settlement_status_for_batched_block(#[future] setup_bloc
     assert_eq!(data.aggregator_proof_jobs.len(), 2);
     assert!(data.aggregator_proof_jobs.iter().any(|job| job.id == proof_job_for_block.id));
     assert!(data.aggregator_proof_jobs.iter().any(|job| job.id == proof_job_for_other_batch.id));
-}
-
-#[rstest]
-#[tokio::test]
-async fn test_get_block_snos_batch_mapping(#[future] setup_blocks_server: (SocketAddr, Arc<Config>)) {
-    let (addr, config) = setup_blocks_server.await;
-    let block_number = 105;
-
-    let aggregator_batch = build_batch(11, 100, 119);
-    let mut snos_batch = build_snos_batch(21, Some(aggregator_batch.index), 100);
-    snos_batch.end_block = 109;
-    snos_batch.num_blocks = 10;
-    snos_batch.status = SnosBatchStatus::Completed;
-
-    config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
-    config.database().create_snos_batch(snos_batch.clone()).await.unwrap();
-
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/blocks/{}/snos-batch", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BlockSnosBatchResponse> = serde_json::from_slice(&body_bytes).unwrap();
-
-    let data = response_body.data.expect("missing snos batch mapping payload");
-    assert_eq!(data.block_number, block_number);
-    assert_eq!(data.batch.index, snos_batch.index);
-    assert_eq!(data.batch.start_block, snos_batch.start_block);
-    assert_eq!(data.batch.end_block, snos_batch.end_block);
-    assert_eq!(data.batch.aggregator_batch_index, Some(aggregator_batch.index));
-}
-
-#[rstest]
-#[tokio::test]
-async fn test_get_block_aggregator_batch_mapping(#[future] setup_blocks_server: (SocketAddr, Arc<Config>)) {
-    let (addr, config) = setup_blocks_server.await;
-    let block_number = 115;
-
-    let mut aggregator_batch = build_batch(11, 100, 119);
-    aggregator_batch.status = AggregatorBatchStatus::ReadyForStateUpdate;
-
-    let mut snos_batch = build_snos_batch(21, Some(aggregator_batch.index), 100);
-    snos_batch.end_block = 119;
-    snos_batch.num_blocks = 20;
-    snos_batch.status = SnosBatchStatus::Completed;
-
-    config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
-    config.database().create_snos_batch(snos_batch).await.unwrap();
-
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/blocks/{}/aggregator-batch", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BlockAggregatorBatchResponse> = serde_json::from_slice(&body_bytes).unwrap();
-
-    let data = response_body.data.expect("missing aggregator batch mapping payload");
-    assert_eq!(data.block_number, block_number);
-    assert_eq!(data.batch.index, aggregator_batch.index);
-    assert_eq!(data.batch.start_block, aggregator_batch.start_block);
-    assert_eq!(data.batch.end_block, aggregator_batch.end_block);
-    assert_eq!(data.batch.status, aggregator_batch.status);
 }
 
 #[rstest]

--- a/orchestrator/src/tests/server/mod.rs
+++ b/orchestrator/src/tests/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_routes;
+pub mod batch_routes;
 pub mod block_routes;
 pub mod job_routes;
 pub mod jobs_by_status;

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use crate::core::client::database::MockDatabaseClient;
+use crate::core::client::database::{MockDatabaseClient, SnosBatchDbQuery};
 use crate::core::client::queue::MockQueueClient;
 use crate::tests::common::test_utils::{acquire_test_lock, get_job_handler_context_safe};
 use crate::tests::config::TestConfigBuilder;
@@ -92,12 +92,13 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
         .returning(move |_, _, _, _| Ok(snos_jobs.clone()));
 
     let expected_proving_jobs = if incomplete_runs { 4 } else { 5 };
-    db.expect_get_snos_batches_by_indices().times(expected_proving_jobs).withf(|indices| indices.len() == 1).returning(
-        |indices| {
-            let index = indices[0];
+    db.expect_get_snos_batches()
+        .times(expected_proving_jobs)
+        .withf(|query: &SnosBatchDbQuery| query.indexes.as_ref().is_some_and(|indices| indices.len() == 1))
+        .returning(|query: SnosBatchDbQuery| {
+            let index = query.indexes.and_then(|indices| indices.first().copied()).expect("missing SNOS batch index");
             Ok(vec![SnosBatch { index, start_block: index, end_block: index, num_blocks: 1, ..Default::default() }])
-        },
-    );
+        });
 
     // Set up expectations for each job
     for i in 1..=num_jobs {

--- a/orchestrator/src/tests/workers/snos/mod.rs
+++ b/orchestrator/src/tests/workers/snos/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::await_holding_lock)]
 
-use crate::core::client::database::MockDatabaseClient;
+use crate::core::client::database::{MockDatabaseClient, SnosBatchDbQuery};
 use crate::core::client::queue::MockQueueClient;
 use crate::core::config::StarknetVersion;
 use crate::tests::common::test_utils::{acquire_test_lock, get_job_handler_context_safe};
@@ -75,10 +75,10 @@ async fn test_snos_worker(#[case] completed_snos_batches: Vec<u64>) -> Result<()
         let job_item = get_job_item_mock_by_id(block_num, uuid);
         let job_item_clone = job_item.clone();
 
-        db.expect_get_snos_batches_by_indices()
+        db.expect_get_snos_batches()
             .withf({
                 let snos_batch_num = block_num;
-                move |i| *i == vec![snos_batch_num]
+                move |query: &SnosBatchDbQuery| query.indexes.as_ref().is_some_and(|i| *i == vec![snos_batch_num])
             })
             .times(1)
             .returning(|_| Ok(Vec::new()));
@@ -193,8 +193,8 @@ async fn test_create_snos_job_for_existing_batch(
         let job_item = get_job_item_mock_by_id(snos_batch_num, uuid);
         let job_item_clone = job_item.clone();
 
-        db.expect_get_snos_batches_by_indices()
-            .withf(move |i| *i == vec![snos_batch_num])
+        db.expect_get_snos_batches()
+            .withf(move |query: &SnosBatchDbQuery| query.indexes.as_ref().is_some_and(|i| *i == vec![snos_batch_num]))
             .times(1)
             .returning(|_| Ok(Vec::new()));
 

--- a/orchestrator/src/types/batch.rs
+++ b/orchestrator/src/types/batch.rs
@@ -7,6 +7,7 @@ use mongodb::bson::serde_helpers::{
     chrono_datetime_as_bson_datetime, chrono_datetime_as_bson_datetime_optional, uuid_1_as_binary,
 };
 use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumString};
 use uuid::Uuid;
 
 /// Status enum for Aggregator batches
@@ -17,7 +18,8 @@ use uuid::Uuid;
 ///
 /// Error states can occur at any point and include: BatchCreationFailed, AggregationFailed,
 /// VerificationFailed, StateUpdateFailed
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd, strum_macros::Display, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd, Display, EnumString, Eq, Default)]
+#[strum(serialize_all = "lowercase")]
 pub enum AggregatorBatchStatus {
     /// Batch is open and new blocks can be added to it
     #[default]
@@ -259,7 +261,8 @@ impl AggregatorBatch {
 ///
 /// Represents the lifecycle states of a SNOS batch. SNOS batches have a simpler
 /// lifecycle compared to aggregator batches.
-#[derive(Serialize, Deserialize, Eq, PartialEq, strum_macros::Display, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Display, EnumString, Debug, Clone, Default)]
+#[strum(serialize_all = "lowercase")]
 pub enum SnosBatchStatus {
     /// Batch is open and new blocks can be added to it
     #[default]

--- a/orchestrator/src/types/batch.rs
+++ b/orchestrator/src/types/batch.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 /// Error states can occur at any point and include: BatchCreationFailed, AggregationFailed,
 /// VerificationFailed, StateUpdateFailed
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd, Display, EnumString, Eq, Default)]
-#[strum(serialize_all = "lowercase")]
+#[strum(ascii_case_insensitive)]
 pub enum AggregatorBatchStatus {
     /// Batch is open and new blocks can be added to it
     #[default]
@@ -262,7 +262,7 @@ impl AggregatorBatch {
 /// Represents the lifecycle states of a SNOS batch. SNOS batches have a simpler
 /// lifecycle compared to aggregator batches.
 #[derive(Serialize, Deserialize, Eq, PartialEq, Display, EnumString, Debug, Clone, Default)]
-#[strum(serialize_all = "lowercase")]
+#[strum(ascii_case_insensitive)]
 pub enum SnosBatchStatus {
     /// Batch is open and new blocks can be added to it
     #[default]

--- a/orchestrator/src/worker/event_handler/jobs/state_update.rs
+++ b/orchestrator/src/worker/event_handler/jobs/state_update.rs
@@ -1,3 +1,4 @@
+use crate::core::client::database::{AggregatorBatchDbQuery, SnosBatchDbQuery};
 use crate::core::config::Config;
 use crate::error::job::state_update::StateUpdateError;
 use crate::error::job::JobError;
@@ -218,7 +219,13 @@ impl StateUpdateJobHandler {
         let (expected_last_block_number, batch_index) = match config.layer() {
             Layer::L2 => {
                 // Get the batch details for the settled batch
-                let batches = config.database().get_aggregator_batches_by_indexes(vec![num_settled]).await?;
+                let batches = config
+                    .database()
+                    .get_aggregator_batches(AggregatorBatchDbQuery {
+                        indexes: Some(vec![num_settled]),
+                        ..Default::default()
+                    })
+                    .await?;
                 if let Some(batch) = batches.first() {
                     // Return the end block of the batch
                     Ok((batch.end_block, batch.index))
@@ -228,7 +235,10 @@ impl StateUpdateJobHandler {
             }
             Layer::L3 => {
                 // Get the batch details for the settled batch
-                let batches = config.database().get_snos_batches_by_indices(vec![num_settled]).await?;
+                let batches = config
+                    .database()
+                    .get_snos_batches(SnosBatchDbQuery { indexes: Some(vec![num_settled]), ..Default::default() })
+                    .await?;
                 if let Some(batch) = batches.first() {
                     // Return the end block of the batch
                     Ok((batch.end_block, batch.index))
@@ -286,7 +296,13 @@ impl StateUpdateJobHandler {
         // Get the batch details for the batch to settle
         let to_block_num = match config.layer() {
             Layer::L2 => {
-                let batches = config.database().get_aggregator_batches_by_indexes(vec![to_batch_num]).await?;
+                let batches = config
+                    .database()
+                    .get_aggregator_batches(AggregatorBatchDbQuery {
+                        indexes: Some(vec![to_batch_num]),
+                        ..Default::default()
+                    })
+                    .await?;
                 batches
                     .first()
                     .ok_or_else(|| {
@@ -298,7 +314,10 @@ impl StateUpdateJobHandler {
                     .end_block
             }
             Layer::L3 => {
-                let batches = config.database().get_snos_batches_by_indices(vec![to_batch_num]).await?;
+                let batches = config
+                    .database()
+                    .get_snos_batches(SnosBatchDbQuery { indexes: Some(vec![to_batch_num]), ..Default::default() })
+                    .await?;
                 batches
                     .first()
                     .ok_or_else(|| {

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
+use crate::core::client::database::{AggregatorBatchDbQuery, SnosBatchDbQuery};
 use crate::core::config::Config;
 use crate::error::job::JobError;
 use crate::types::jobs::external_id::ExternalId;
@@ -844,7 +845,11 @@ impl JobHandlerService {
     }
 
     async fn resolve_aggregator_end_block(job_type: &JobType, internal_id: u64, config: &Arc<Config>) -> f64 {
-        match config.database().get_aggregator_batches_by_indexes(vec![internal_id]).await {
+        match config
+            .database()
+            .get_aggregator_batches(AggregatorBatchDbQuery { indexes: Some(vec![internal_id]), ..Default::default() })
+            .await
+        {
             Ok(batches) if !batches.is_empty() => batches[0].end_block as f64,
             Ok(_) => {
                 warn!(
@@ -867,7 +872,11 @@ impl JobHandlerService {
     }
 
     async fn resolve_snos_end_block(job_type: &JobType, internal_id: u64, config: &Arc<Config>) -> f64 {
-        match config.database().get_snos_batches_by_indices(vec![internal_id]).await {
+        match config
+            .database()
+            .get_snos_batches(SnosBatchDbQuery { indexes: Some(vec![internal_id]), ..Default::default() })
+            .await
+        {
             Ok(batches) if !batches.is_empty() => batches[0].end_block as f64,
             Ok(_) => {
                 warn!(

--- a/orchestrator/src/worker/event_handler/triggers/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/aggregator.rs
@@ -1,3 +1,4 @@
+use crate::core::client::database::{AggregatorBatchDbQuery, BatchIndexSort};
 use crate::core::config::Config;
 use crate::types::batch::{AggregatorBatch, AggregatorBatchStatus};
 use crate::types::constant::{
@@ -52,12 +53,13 @@ impl JobTrigger for AggregatorJobTrigger {
         // more than we can legitimately turn into jobs this tick.
         let closed_batches = config
             .database()
-            .get_aggregator_batches_by_status(
-                AggregatorBatchStatus::Closed,
-                Some(batch_fetch_limit),
-                Some(ORCHESTRATOR_VERSION.to_string()),
-                false,
-            )
+            .get_aggregator_batches(AggregatorBatchDbQuery {
+                statuses: Some(vec![AggregatorBatchStatus::Closed]),
+                limit: Some(batch_fetch_limit),
+                orchestrator_version: Some(ORCHESTRATOR_VERSION.to_string()),
+                sort: BatchIndexSort::Asc,
+                ..Default::default()
+            })
             .await?;
 
         debug!("Found {} closed batches", closed_batches.len());

--- a/orchestrator/src/worker/event_handler/triggers/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/aggregator.rs
@@ -56,6 +56,7 @@ impl JobTrigger for AggregatorJobTrigger {
                 AggregatorBatchStatus::Closed,
                 Some(batch_fetch_limit),
                 Some(ORCHESTRATOR_VERSION.to_string()),
+                false,
             )
             .await?;
 


### PR DESCRIPTION
## Summary
- add a dedicated SNOS batch details endpoint that returns SNOS batch gas metrics and the parent aggregator batch blob length
- expose the endpoint through the orchestrator router so external alert consumers can read stable batch metadata without recomputing batch math
- add server coverage for parented and standalone SNOS batches

## Notes
- This PR is intended to support a companion alerting-service change that consumes the new endpoint.
- Local Rust verification was environment-blocked in this worktree because the Cairo 0 toolchain on PATH is `0.14.0.1` while the build expects `0.14.1a0`.