### PR TITLE
[codex] fix(ci): gate main PR jobs for drafts

### DIFF
--- a/.github/workflows/pull-request-main-ci.yml
+++ b/.github/workflows/pull-request-main-ci.yml
@@ -119,7 +119,6 @@ jobs:
 
   # Run integration tests
   test-madara:
-    if: github.event.pull_request.draft == false
     needs: [build-madara, build-madara-tests]
     uses: ./.github/workflows/task-test-madara.yml
     with:
@@ -129,7 +128,6 @@ jobs:
 
   # Run migration tests
   test-migration:
-    if: github.event.pull_request.draft == false
     needs: [build-madara, build-migration-tests]
     uses: ./.github/workflows/task-test-migration.yml
     with:
@@ -139,7 +137,6 @@ jobs:
 
   # Run JavaScript tests against the built binary
   test-js:
-    if: github.event.pull_request.draft == false
     needs: [build-madara, build-cairo-artifacts]
     uses: ./.github/workflows/task-test-js.yml
     with:
@@ -148,7 +145,6 @@ jobs:
 
   # Run CLI tests against the built binary
   test-cli:
-    if: github.event.pull_request.draft == false
     needs: build-madara
     uses: ./.github/workflows/task-test-cli.yml
     with:
@@ -196,7 +192,7 @@ jobs:
   # Check Orchestrator binary
   # (We don't re-use the Orchestrator binary in other tests)
   check-orchestrator:
-    if: github.event.pull_request.draft == false && needs.detect-orchestrator-runtime-changes.outputs.should-run == 'true'
+    if: needs.detect-orchestrator-runtime-changes.outputs.should-run == 'true'
     needs: [lint-code-style, detect-orchestrator-runtime-changes]
     uses: ./.github/workflows/task-check-orchestrator.yml
     secrets: inherit
@@ -209,7 +205,6 @@ jobs:
 
   # Run integration tests
   test-orchestrator:
-    if: github.event.pull_request.draft == false
     needs: [build-madara, build-cairo-artifacts, build-orchestrator-tests]
     uses: ./.github/workflows/task-test-orchestrator.yml
     with:
@@ -233,7 +228,6 @@ jobs:
 
   # Deprecating bootstrapper V1
   check-bootstrapper:
-    if: github.event.pull_request.draft == false
     needs: lint-code-style
     uses: ./.github/workflows/task-do-nothing-check-bootstrapper.yml
     secrets: inherit

--- a/.github/workflows/pull-request-main-ci.yml
+++ b/.github/workflows/pull-request-main-ci.yml
@@ -98,23 +98,28 @@ jobs:
   # still recompiles a large overlapping graph instead of cleanly reusing the
   # release build one-for-one.
   build-madara:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/task-build-madara.yml
     secrets: inherit
 
   build-cairo-artifacts:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/task-build-cairo-artifacts.yml
     secrets: inherit
 
   build-madara-tests:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/task-build-madara-tests.yml
     secrets: inherit
 
   build-migration-tests:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/task-build-migration-tests.yml
     secrets: inherit
 
   # Run integration tests
   test-madara:
+    if: github.event.pull_request.draft == false
     needs: [build-madara, build-madara-tests]
     uses: ./.github/workflows/task-test-madara.yml
     with:
@@ -124,6 +129,7 @@ jobs:
 
   # Run migration tests
   test-migration:
+    if: github.event.pull_request.draft == false
     needs: [build-madara, build-migration-tests]
     uses: ./.github/workflows/task-test-migration.yml
     with:
@@ -133,6 +139,7 @@ jobs:
 
   # Run JavaScript tests against the built binary
   test-js:
+    if: github.event.pull_request.draft == false
     needs: [build-madara, build-cairo-artifacts]
     uses: ./.github/workflows/task-test-js.yml
     with:
@@ -141,6 +148,7 @@ jobs:
 
   # Run CLI tests against the built binary
   test-cli:
+    if: github.event.pull_request.draft == false
     needs: build-madara
     uses: ./.github/workflows/task-test-cli.yml
     with:
@@ -152,6 +160,7 @@ jobs:
   # ========================================================================= #
 
   detect-orchestrator-runtime-changes:
+    if: github.event.pull_request.draft == false
     runs-on: blacksmith-4vcpu-ubuntu-2204
     outputs:
       should-run: ${{ steps.set-output.outputs.should-run }}
@@ -187,18 +196,20 @@ jobs:
   # Check Orchestrator binary
   # (We don't re-use the Orchestrator binary in other tests)
   check-orchestrator:
-    if: needs.detect-orchestrator-runtime-changes.outputs.should-run == 'true'
+    if: github.event.pull_request.draft == false && needs.detect-orchestrator-runtime-changes.outputs.should-run == 'true'
     needs: [lint-code-style, detect-orchestrator-runtime-changes]
     uses: ./.github/workflows/task-check-orchestrator.yml
     secrets: inherit
 
   # Build the archived orchestrator test binaries in parallel with Madara.
   build-orchestrator-tests:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/task-build-orchestrator-tests.yml
     secrets: inherit
 
   # Run integration tests
   test-orchestrator:
+    if: github.event.pull_request.draft == false
     needs: [build-madara, build-cairo-artifacts, build-orchestrator-tests]
     uses: ./.github/workflows/task-test-orchestrator.yml
     with:
@@ -222,6 +233,7 @@ jobs:
 
   # Deprecating bootstrapper V1
   check-bootstrapper:
+    if: github.event.pull_request.draft == false
     needs: lint-code-style
     uses: ./.github/workflows/task-do-nothing-check-bootstrapper.yml
     secrets: inherit


### PR DESCRIPTION
## What changed
Add explicit draft guards to the detached producer and test jobs in the main PR workflow.

## Why it changed
Commit `6a5337a3a` (`Optimize CI setup graph and LLVM provisioning`, May 14, 2026) split several build jobs out of the old dependency chain that had been implicitly gated by `update-version-db`.

## Root cause
Before that refactor, draft PRs skipped the expensive jobs because `build-madara` depended on `lint-code-style`, which depended on `update-version-db` guarded by `github.event.pull_request.draft == false`.
After the refactor, jobs like `build-madara`, `build-cairo-artifacts`, `build-madara-tests`, `build-migration-tests`, and `build-orchestrator-tests` no longer inherited that gate, so they started running on draft PRs.

## Impact
Draft PRs now skip those producer and downstream test jobs again instead of executing the main CI workload.

## Validation
- Parsed `.github/workflows/pull-request-main-ci.yml` successfully with Ruby YAML
- Checked the workflow diff
- Ran `git diff --check`

## Note
GitHub still creates a workflow run object for matching `pull_request` events; this change restores the intended behavior by skipping the jobs during draft PRs.
