### PR TITLE
fix(external-db): persist retention cursor safely

### DIFF
--- a/.db-versions.yml
+++ b/.db-versions.yml
@@ -18,7 +18,7 @@
 # Current database schema version.
 # This is the version that new databases will be created with,
 # and the version that existing databases will be migrated to.
-current_version: 13
+current_version: 14
 
 # Minimum version that can be migrated from.
 # Databases older than this must be deleted and re-synced from scratch.
@@ -31,6 +31,8 @@ base_version: 8
 #   - pr: The PR number that introduced this version
 #   - description: (optional) Brief description of changes
 versions:
+  - version: 14
+    description: "Seed external DB retention cursor from latest L1-confirmed block for existing databases"
   - version: 13
     description: "Clear legacy Cairo Native disk cache so artifacts are rebuilt with host metadata sidecars"
   - version: 12

--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -1086,6 +1086,9 @@ impl<D: MadaraStorageRead> MadaraBackend<D> {
     pub fn get_l1_messaging_sync_tip(&self) -> Result<Option<u64>> {
         self.db.get_l1_messaging_sync_tip()
     }
+    pub fn get_external_db_retention_cursor(&self) -> Result<Option<u64>> {
+        self.db.get_external_db_retention_cursor()
+    }
     pub fn get_pending_message_to_l2(&self, core_contract_nonce: u64) -> Result<Option<L1HandlerTransactionWithFee>> {
         self.db.get_pending_message_to_l2(core_contract_nonce)
     }
@@ -1146,6 +1149,9 @@ impl<D: MadaraStorageRead> MadaraBackend<D> {
 impl<D: MadaraStorageWrite> MadaraBackend<D> {
     pub fn write_l1_messaging_sync_tip(&self, l1_block_n: Option<u64>) -> Result<()> {
         self.db.write_l1_messaging_sync_tip(l1_block_n)
+    }
+    pub fn write_external_db_retention_cursor(&self, block_n: u64) -> Result<()> {
+        self.db.write_external_db_retention_cursor(block_n)
     }
     pub fn write_l1_handler_txn_hash_by_nonce(&self, core_contract_nonce: u64, txn_hash: &Felt) -> Result<()> {
         self.db.write_l1_handler_txn_hash_by_nonce(core_contract_nonce, txn_hash)

--- a/madara/crates/client/db/src/migration/registry.rs
+++ b/madara/crates/client/db/src/migration/registry.rs
@@ -74,6 +74,12 @@ pub fn get_migrations() -> &'static [Migration] {
             name: "v12→v13: clear Cairo Native disk cache for metadata sidecars",
             migrate: super::revisions::revision_0013::migrate,
         },
+        Migration {
+            from_version: 13,
+            to_version: 14,
+            name: "v13→v14: seed external DB retention cursor from L1 tip",
+            migrate: super::revisions::revision_0014::migrate,
+        },
     ]
 }
 

--- a/madara/crates/client/db/src/migration/revisions/mod.rs
+++ b/madara/crates/client/db/src/migration/revisions/mod.rs
@@ -13,3 +13,4 @@ pub mod revision_0010;
 pub mod revision_0011;
 pub mod revision_0012;
 pub mod revision_0013;
+pub mod revision_0014;

--- a/madara/crates/client/db/src/migration/revisions/revision_0014.rs
+++ b/madara/crates/client/db/src/migration/revisions/revision_0014.rs
@@ -1,0 +1,89 @@
+//! Migration from v13 to v14: seed the external DB retention cursor.
+
+use crate::migration::{MigrationContext, MigrationError, MigrationProgress};
+use rocksdb::FlushOptions;
+
+const META_COLUMN: &str = "meta";
+const META_CONFIRMED_ON_L1_TIP_KEY: &[u8] = b"CONFIRMED_ON_L1_TIP";
+const META_EXTERNAL_DB_RETENTION_CURSOR_KEY: &[u8] = b"EXTERNAL_DB_RETENTION_CURSOR";
+
+const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+const RETENTION_DAYS: u64 = 3;
+const ASSUMED_BLOCK_TIME_SECONDS: u64 = 15;
+const RETENTION_BLOCKS: u64 = (SECONDS_PER_DAY * RETENTION_DAYS) / ASSUMED_BLOCK_TIME_SECONDS;
+
+pub fn migrate(ctx: &MigrationContext<'_>) -> Result<(), MigrationError> {
+    tracing::info!("Starting v13→v14 migration: seeding external DB retention cursor");
+    ctx.report_progress(MigrationProgress::new(0, 3, "Inspecting retention cursor state"));
+
+    let db = ctx.db();
+    let meta_cf =
+        db.cf_handle(META_COLUMN).ok_or_else(|| MigrationError::RocksDb(format!("{META_COLUMN} not found")))?;
+
+    if ctx.should_abort() {
+        return Err(MigrationError::Aborted);
+    }
+
+    if db.get_pinned_cf(&meta_cf, META_EXTERNAL_DB_RETENTION_CURSOR_KEY)?.is_some() {
+        tracing::info!(
+            target: "madara_db_migration",
+            "external_db_retention_cursor_already_present"
+        );
+        ctx.report_progress(MigrationProgress::new(3, 3, "Retention cursor already present"));
+        return Ok(());
+    }
+
+    ctx.report_progress(MigrationProgress::new(1, 3, "Loading latest L1-confirmed block"));
+    let Some(latest_confirmed_on_l1) = read_optional_u64(db.get_pinned_cf(&meta_cf, META_CONFIRMED_ON_L1_TIP_KEY)?)?
+    else {
+        tracing::info!(
+            target: "madara_db_migration",
+            "external_db_retention_cursor_not_seeded_no_l1_tip"
+        );
+        ctx.report_progress(MigrationProgress::new(3, 3, "No L1-confirmed block recorded yet"));
+        return Ok(());
+    };
+
+    if ctx.should_abort() {
+        return Err(MigrationError::Aborted);
+    }
+
+    let seeded_cursor = latest_confirmed_on_l1.saturating_sub(RETENTION_BLOCKS);
+    db.put_cf(&meta_cf, META_EXTERNAL_DB_RETENTION_CURSOR_KEY, seeded_cursor.to_be_bytes())?;
+
+    let mut flush_opts = FlushOptions::default();
+    flush_opts.set_wait(true);
+    db.flush_cf_opt(&meta_cf, &flush_opts)?;
+
+    tracing::info!(
+        target: "madara_db_migration",
+        latest_confirmed_on_l1,
+        seeded_cursor,
+        retention_blocks = RETENTION_BLOCKS,
+        "seeded_external_db_retention_cursor"
+    );
+    ctx.report_progress(MigrationProgress::new(3, 3, "Seeded external DB retention cursor"));
+    Ok(())
+}
+
+fn read_optional_u64(value: Option<impl AsRef<[u8]>>) -> Result<Option<u64>, MigrationError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let bytes = value.as_ref();
+    let array: [u8; 8] =
+        bytes.try_into().map_err(|_| MigrationError::Serialization("Malformed u64 metadata value".to_string()))?;
+    Ok(Some(u64::from_be_bytes(array)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_cursor_uses_three_day_fifteen_second_window() {
+        assert_eq!(RETENTION_BLOCKS, 17_280);
+        assert_eq!(20_000u64.saturating_sub(RETENTION_BLOCKS), 2_720);
+        assert_eq!(100u64.saturating_sub(RETENTION_BLOCKS), 0);
+    }
+}

--- a/madara/crates/client/db/src/rocksdb/meta.rs
+++ b/madara/crates/client/db/src/rocksdb/meta.rs
@@ -14,6 +14,7 @@ pub const PRECONFIRMED_COLUMN: Column = Column::new("preconfirmed");
 const META_DEVNET_KEYS_KEY: &[u8] = b"DEVNET_KEYS";
 const META_LAST_SYNCED_L1_EVENT_BLOCK_KEY: &[u8] = b"LAST_SYNCED_L1_EVENT_BLOCK";
 const META_CONFIRMED_ON_L1_TIP_KEY: &[u8] = b"CONFIRMED_ON_L1_TIP";
+const META_EXTERNAL_DB_RETENTION_CURSOR_KEY: &[u8] = b"EXTERNAL_DB_RETENTION_CURSOR";
 const META_CHAIN_TIP_KEY: &[u8] = b"CHAIN_TIP";
 const META_CHAIN_INFO_KEY: &[u8] = b"CHAIN_INFO";
 const META_LATEST_APPLIED_TRIE_UPDATE: &[u8] = b"LATEST_APPLIED_TRIE_UPDATE";
@@ -75,6 +76,26 @@ impl RocksDBStorageInner {
     #[tracing::instrument(skip(self))]
     pub(super) fn get_confirmed_on_l1_tip(&self) -> Result<Option<u64>> {
         let Some(data) = self.db.get_pinned_cf(&self.get_column(META_COLUMN), META_CONFIRMED_ON_L1_TIP_KEY)? else {
+            return Ok(None);
+        };
+        Ok(Some(u64::from_be_bytes(data[..].try_into().context("Malformated block_n in DB")?)))
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub(super) fn write_external_db_retention_cursor(&self, block_n: u64) -> Result<()> {
+        self.db.put_cf_opt(
+            &self.get_column(META_COLUMN),
+            META_EXTERNAL_DB_RETENTION_CURSOR_KEY,
+            block_n.to_be_bytes(),
+            &self.writeopts,
+        )?;
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub(super) fn get_external_db_retention_cursor(&self) -> Result<Option<u64>> {
+        let Some(data) = self.db.get_pinned_cf(&self.get_column(META_COLUMN), META_EXTERNAL_DB_RETENTION_CURSOR_KEY)?
+        else {
             return Ok(None);
         };
         Ok(Some(u64::from_be_bytes(data[..].try_into().context("Malformated block_n in DB")?)))

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -327,6 +327,9 @@ impl MadaraStorageRead for RocksDBStorage {
     fn get_l1_messaging_sync_tip(&self) -> Result<Option<u64>> {
         self.inner.get_l1_messaging_sync_tip().context("Getting l1 messaging sync tip")
     }
+    fn get_external_db_retention_cursor(&self) -> Result<Option<u64>> {
+        self.inner.get_external_db_retention_cursor().context("Getting external db retention cursor")
+    }
     fn get_stored_chain_info(&self) -> Result<Option<StoredChainInfo>> {
         self.inner.get_stored_chain_info().context("Getting stored chain info from db")
     }
@@ -494,6 +497,10 @@ impl MadaraStorageWrite for RocksDBStorage {
     fn write_l1_messaging_sync_tip(&self, block_n: Option<u64>) -> Result<()> {
         tracing::debug!("Write l1 messaging tip block_n={block_n:?}");
         self.inner.write_l1_messaging_sync_tip(block_n).context("Writing l1 messaging sync tip")
+    }
+    fn write_external_db_retention_cursor(&self, block_n: u64) -> Result<()> {
+        tracing::debug!("Write external db retention cursor block_n={block_n:?}");
+        self.inner.write_external_db_retention_cursor(block_n).context("Writing external db retention cursor")
     }
     fn write_l1_handler_txn_hash_by_nonce(&self, core_contract_nonce: u64, txn_hash: &Felt) -> Result<()> {
         tracing::debug!(

--- a/madara/crates/client/db/src/storage.rs
+++ b/madara/crates/client/db/src/storage.rs
@@ -142,6 +142,7 @@ pub trait MadaraStorageRead: Send + Sync + 'static {
     fn get_chain_tip(&self) -> Result<StorageChainTip>;
     fn get_confirmed_on_l1_tip(&self) -> Result<Option<u64>>;
     fn get_l1_messaging_sync_tip(&self) -> Result<Option<u64>>;
+    fn get_external_db_retention_cursor(&self) -> Result<Option<u64>>;
     fn get_stored_chain_info(&self) -> Result<Option<StoredChainInfo>>;
     fn get_latest_applied_trie_update(&self) -> Result<Option<u64>>;
     fn get_runtime_exec_config(
@@ -195,6 +196,8 @@ pub trait MadaraStorageWrite: Send + Sync + 'static {
     fn write_confirmed_on_l1_tip(&self, block_n: Option<u64>) -> Result<()>;
     /// Write the latest l1_block synced for the messaging worker.
     fn write_l1_messaging_sync_tip(&self, l1_block_n: Option<u64>) -> Result<()>;
+    /// Write the highest block fully processed by external DB retention.
+    fn write_external_db_retention_cursor(&self, block_n: u64) -> Result<()>;
 
     fn write_l1_handler_txn_hash_by_nonce(&self, core_contract_nonce: u64, txn_hash: &Felt) -> Result<()>;
     fn write_l1_handler_l1_block_by_nonce(&self, core_contract_nonce: u64, l1_block_n: u64) -> Result<()>;

--- a/madara/crates/client/db/src/tests/test_external_outbox.rs
+++ b/madara/crates/client/db/src/tests/test_external_outbox.rs
@@ -7,6 +7,7 @@ use mp_convert::Felt;
 use mp_transactions::{
     validated::TxTimestamp, DeclareTransaction, DeployAccountTransaction, InvokeTransaction, Transaction,
 };
+use rstest::rstest;
 
 #[tokio::test]
 async fn outbox_write_read_roundtrip() {
@@ -131,15 +132,16 @@ async fn outbox_duplicate_write_appends_entry() {
     assert!(outbox.iter().any(|entry| entry.tx == updated));
 }
 
-#[test]
-fn external_db_retention_cursor_roundtrip() {
+#[rstest]
+#[case(vec![7])]
+#[case(vec![7, 12])]
+fn external_db_retention_cursor_roundtrip(#[case] cursors: Vec<u64>) {
     let backend = MadaraBackend::open_for_testing(ChainConfig::madara_test().into());
 
     assert_eq!(backend.get_external_db_retention_cursor().unwrap(), None);
 
-    backend.write_external_db_retention_cursor(7).unwrap();
-    assert_eq!(backend.get_external_db_retention_cursor().unwrap(), Some(7));
-
-    backend.write_external_db_retention_cursor(12).unwrap();
-    assert_eq!(backend.get_external_db_retention_cursor().unwrap(), Some(12));
+    for cursor in cursors {
+        backend.write_external_db_retention_cursor(cursor).unwrap();
+        assert_eq!(backend.get_external_db_retention_cursor().unwrap(), Some(cursor));
+    }
 }

--- a/madara/crates/client/db/src/tests/test_external_outbox.rs
+++ b/madara/crates/client/db/src/tests/test_external_outbox.rs
@@ -130,3 +130,16 @@ async fn outbox_duplicate_write_appends_entry() {
     assert!(outbox.iter().any(|entry| entry.tx == tx));
     assert!(outbox.iter().any(|entry| entry.tx == updated));
 }
+
+#[test]
+fn external_db_retention_cursor_roundtrip() {
+    let backend = MadaraBackend::open_for_testing(ChainConfig::madara_test().into());
+
+    assert_eq!(backend.get_external_db_retention_cursor().unwrap(), None);
+
+    backend.write_external_db_retention_cursor(7).unwrap();
+    assert_eq!(backend.get_external_db_retention_cursor().unwrap(), Some(7));
+
+    backend.write_external_db_retention_cursor(12).unwrap();
+    assert_eq!(backend.get_external_db_retention_cursor().unwrap(), Some(12));
+}

--- a/madara/crates/client/db/src/tests/test_migration.rs
+++ b/madara/crates/client/db/src/tests/test_migration.rs
@@ -143,6 +143,43 @@ async fn test_migration_from_v12_clears_native_cache_directory() {
     drop(backend);
 }
 
+#[tokio::test]
+async fn test_migration_from_v13_seeds_external_db_retention_cursor() {
+    let (temp_dir, chain_config, native_config) = setup_test_env();
+
+    let backend = MadaraBackend::open_rocksdb(
+        temp_dir.path(),
+        chain_config.clone(),
+        Default::default(),
+        RocksDBConfig::default(),
+        native_config.clone(),
+    )
+    .expect("fresh database should open");
+    backend.set_latest_l1_confirmed(Some(20_000)).unwrap();
+    assert_eq!(backend.get_external_db_retention_cursor().unwrap(), None);
+    drop(backend);
+
+    fs::write(temp_dir.path().join(DB_VERSION_FILE), "13").unwrap();
+
+    let migrated = MadaraBackend::open_rocksdb(
+        temp_dir.path(),
+        chain_config,
+        Default::default(),
+        RocksDBConfig::default(),
+        native_config,
+    )
+    .expect("v13 database should migrate");
+
+    assert_eq!(migrated.get_external_db_retention_cursor().unwrap(), Some(2_720));
+
+    let expected_db_version = expected_db_version();
+    let runner = MigrationRunner::new(temp_dir.path(), expected_db_version, expected_db_version);
+    let version = runner.read_version_file().unwrap();
+    assert_eq!(version, expected_db_version);
+
+    drop(migrated);
+}
+
 // =============================================================================
 // Version Mismatch Tests (parameterized)
 // =============================================================================

--- a/madara/crates/client/external_db/src/writer.rs
+++ b/madara/crates/client/external_db/src/writer.rs
@@ -256,11 +256,11 @@ impl<S: L1ConfirmationSource> RetentionScheduler<S> {
                 confirmation.tx_hashes.iter().map(|felt| format!("{}", felt.hex_display())).collect::<Vec<_>>();
             match sink.delete_by_hashes(&self.chain_id, hashes).await {
                 Ok(deleted) => {
-                    self.metrics.mongodb_up.record(1, &[]);
-                    self.metrics.transactions_deleted.add(deleted, &[]);
                     self.source.mark_processed(confirmation.block_number).await.with_context(|| {
                         format!("Marking retention block {} as processed", confirmation.block_number)
                     })?;
+                    self.metrics.mongodb_up.record(1, &[]);
+                    self.metrics.transactions_deleted.add(deleted, &[]);
                 }
                 Err(err) => {
                     // This is a Mongo operation; mark Mongo as down and count it as a Mongo error for alerting.
@@ -954,7 +954,7 @@ mod tests {
     /// Backend confirmation source should fail loudly if L1-confirmed blocks are missing from local DB.
     #[tokio::test]
     async fn backend_source_errors_when_confirmed_block_missing() {
-        let backend = Arc::new(MadaraBackend::open_for_testing(ChainConfig::madara_test().into()));
+        let backend = MadaraBackend::open_for_testing(ChainConfig::madara_test().into());
         backend.set_latest_l1_confirmed(Some(0)).unwrap();
 
         let metrics = Arc::new(ExternalDbMetrics::register());

--- a/madara/crates/client/external_db/src/writer.rs
+++ b/madara/crates/client/external_db/src/writer.rs
@@ -140,6 +140,7 @@ struct L1Confirmation {
 #[async_trait::async_trait]
 trait L1ConfirmationSource: Send + Sync {
     async fn poll_confirmations(&mut self) -> anyhow::Result<Vec<L1Confirmation>>;
+    async fn mark_processed(&mut self, block_number: u64) -> anyhow::Result<()>;
 }
 
 /// L1 confirmation source backed by the local database.
@@ -153,9 +154,14 @@ struct BackendL1ConfirmationSource {
 
 impl BackendL1ConfirmationSource {
     /// Create a confirmation source for the given backend.
-    fn new(backend: Arc<MadaraBackend>, retention_delay: Duration, metrics: Arc<ExternalDbMetrics>) -> Self {
+    fn new(
+        backend: Arc<MadaraBackend>,
+        retention_delay: Duration,
+        metrics: Arc<ExternalDbMetrics>,
+    ) -> anyhow::Result<Self> {
         let block_time = backend.chain_config().block_time;
-        Self { backend, last_deleted: None, retention_delay, block_time, metrics }
+        let last_deleted = backend.get_external_db_retention_cursor().context("Loading external DB retention cursor")?;
+        Ok(Self { backend, last_deleted, retention_delay, block_time, metrics })
     }
 }
 
@@ -199,14 +205,21 @@ impl L1ConfirmationSource for BackendL1ConfirmationSource {
         let mut confirmations = Vec::new();
         for block_number in start..=eligible_latest {
             let Some(view) = self.backend.block_view_on_confirmed(block_number) else {
-                continue;
+                anyhow::bail!("Confirmed block {block_number} is missing from local DB state");
             };
             let info = view.get_block_info().with_context(|| format!("Block info missing for block {block_number}"))?;
             confirmations.push(L1Confirmation { block_number, tx_hashes: info.tx_hashes });
         }
 
-        self.last_deleted = Some(eligible_latest);
         Ok(confirmations)
+    }
+
+    async fn mark_processed(&mut self, block_number: u64) -> anyhow::Result<()> {
+        self.backend
+            .write_external_db_retention_cursor(block_number)
+            .with_context(|| format!("Persisting external DB retention cursor for block {block_number}"))?;
+        self.last_deleted = Some(block_number);
+        Ok(())
     }
 }
 
@@ -228,6 +241,10 @@ impl<S: L1ConfirmationSource> RetentionScheduler<S> {
         let confirmations = self.source.poll_confirmations().await?;
         for confirmation in confirmations {
             if confirmation.tx_hashes.is_empty() {
+                self.source
+                    .mark_processed(confirmation.block_number)
+                    .await
+                    .with_context(|| format!("Marking empty retention block {} as processed", confirmation.block_number))?;
                 continue;
             }
             tracing::debug!(
@@ -241,6 +258,9 @@ impl<S: L1ConfirmationSource> RetentionScheduler<S> {
                 Ok(deleted) => {
                     self.metrics.mongodb_up.record(1, &[]);
                     self.metrics.transactions_deleted.add(deleted, &[]);
+                    self.source.mark_processed(confirmation.block_number).await.with_context(|| {
+                        format!("Marking retention block {} as processed", confirmation.block_number)
+                    })?;
                 }
                 Err(err) => {
                     // This is a Mongo operation; mark Mongo as down and count it as a Mongo error for alerting.
@@ -311,7 +331,8 @@ impl ExternalDbWorker {
                 self.backend.clone(),
                 Duration::from_secs(self.config.retention_delay_secs),
                 self.metrics.clone(),
-            ),
+            )
+            .context("Initializing external DB retention source")?,
             self.metrics.clone(),
             self.chain_id.clone(),
         );
@@ -657,14 +678,23 @@ mod tests {
 
     struct FakeSink {
         responses: Mutex<Vec<anyhow::Result<InsertManySummary>>>,
+        delete_responses: Mutex<Vec<anyhow::Result<u64>>>,
         calls: Mutex<Vec<Vec<MempoolTransactionDocument>>>,
         delete_calls: Mutex<Vec<(String, Vec<String>)>>,
     }
 
     impl FakeSink {
         fn new(responses: Vec<anyhow::Result<InsertManySummary>>) -> Self {
+            Self::with_delete_responses(responses, Vec::new())
+        }
+
+        fn with_delete_responses(
+            responses: Vec<anyhow::Result<InsertManySummary>>,
+            delete_responses: Vec<anyhow::Result<u64>>,
+        ) -> Self {
             Self {
                 responses: Mutex::new(responses),
+                delete_responses: Mutex::new(delete_responses),
                 calls: Mutex::new(Vec::new()),
                 delete_calls: Mutex::new(Vec::new()),
             }
@@ -685,7 +715,12 @@ mod tests {
         async fn delete_by_hashes(&self, chain_id: &str, hashes: Vec<String>) -> anyhow::Result<u64> {
             let deleted = hashes.len() as u64;
             self.delete_calls.lock().unwrap().push((chain_id.to_string(), hashes));
-            Ok(deleted)
+            let mut delete_responses = self.delete_responses.lock().unwrap();
+            if delete_responses.is_empty() {
+                Ok(deleted)
+            } else {
+                delete_responses.remove(0)
+            }
         }
     }
 
@@ -825,11 +860,12 @@ mod tests {
 
     struct FakeL1Source {
         batches: Mutex<Vec<Vec<L1Confirmation>>>,
+        processed: Mutex<Vec<u64>>,
     }
 
     impl FakeL1Source {
         fn new(batches: Vec<Vec<L1Confirmation>>) -> Self {
-            Self { batches: Mutex::new(batches) }
+            Self { batches: Mutex::new(batches), processed: Mutex::new(Vec::new()) }
         }
     }
 
@@ -837,6 +873,11 @@ mod tests {
     impl L1ConfirmationSource for FakeL1Source {
         async fn poll_confirmations(&mut self) -> anyhow::Result<Vec<L1Confirmation>> {
             Ok(self.batches.lock().unwrap().remove(0))
+        }
+
+        async fn mark_processed(&mut self, block_number: u64) -> anyhow::Result<()> {
+            self.processed.lock().unwrap().push(block_number);
+            Ok(())
         }
     }
 
@@ -857,6 +898,7 @@ mod tests {
 
         scheduler.tick(&sink).await.unwrap();
         assert_eq!(sink.delete_calls.lock().unwrap().len(), 1);
+        assert_eq!(scheduler.source.processed.lock().unwrap().as_slice(), &[1]);
     }
 
     /// Retention should be a no-op when there are no confirmations.
@@ -869,6 +911,60 @@ mod tests {
 
         scheduler.tick(&sink).await.unwrap();
         assert!(sink.delete_calls.lock().unwrap().is_empty());
+        assert!(scheduler.source.processed.lock().unwrap().is_empty());
+    }
+
+    /// Empty confirmed blocks still advance the processed cursor without issuing Mongo deletes.
+    #[tokio::test]
+    async fn retention_marks_empty_blocks_processed() {
+        let metrics = Arc::new(ExternalDbMetrics::register());
+        let sink = FakeSink::new(Vec::new());
+        let confirmations = vec![L1Confirmation { block_number: 3, tx_hashes: Vec::new() }];
+        let mut scheduler =
+            RetentionScheduler::new(FakeL1Source::new(vec![confirmations]), metrics, "MADARA_TEST".to_string());
+
+        scheduler.tick(&sink).await.unwrap();
+
+        assert!(sink.delete_calls.lock().unwrap().is_empty());
+        assert_eq!(scheduler.source.processed.lock().unwrap().as_slice(), &[3]);
+    }
+
+    /// Failed retention deletes must not advance the failed block or later blocks.
+    #[tokio::test]
+    async fn retention_retries_failed_block_without_advancing_cursor() {
+        let metrics = Arc::new(ExternalDbMetrics::register());
+        let sink = FakeSink::with_delete_responses(
+            Vec::new(),
+            vec![Ok(1), Err(anyhow::anyhow!("mongo down")), Ok(1)],
+        );
+        let block_1 = L1Confirmation { block_number: 1, tx_hashes: vec![Felt::from_hex_unchecked("0x1")] };
+        let block_2 = L1Confirmation { block_number: 2, tx_hashes: vec![Felt::from_hex_unchecked("0x2")] };
+        let mut scheduler = RetentionScheduler::new(
+            FakeL1Source::new(vec![vec![block_1.clone(), block_2.clone()], vec![block_2]]),
+            metrics,
+            "MADARA_TEST".to_string(),
+        );
+
+        let err = scheduler.tick(&sink).await.unwrap_err();
+        assert!(format!("{err:#}").contains("Mongo delete_many"));
+        assert_eq!(scheduler.source.processed.lock().unwrap().as_slice(), &[1]);
+
+        scheduler.tick(&sink).await.unwrap();
+        assert_eq!(scheduler.source.processed.lock().unwrap().as_slice(), &[1, 2]);
+        assert_eq!(sink.delete_calls.lock().unwrap().len(), 3);
+    }
+
+    /// Backend confirmation source should fail loudly if L1-confirmed blocks are missing from local DB.
+    #[tokio::test]
+    async fn backend_source_errors_when_confirmed_block_missing() {
+        let backend = Arc::new(MadaraBackend::open_for_testing(ChainConfig::madara_test().into()));
+        backend.set_latest_l1_confirmed(Some(0)).unwrap();
+
+        let metrics = Arc::new(ExternalDbMetrics::register());
+        let mut source = BackendL1ConfirmationSource::new(backend, Duration::ZERO, metrics).unwrap();
+
+        let err = source.poll_confirmations().await.unwrap_err();
+        assert!(format!("{err:#}").contains("Confirmed block 0 is missing from local DB state"));
     }
 
     /// Document conversion should recognize all transaction types.

--- a/madara/crates/client/external_db/src/writer.rs
+++ b/madara/crates/client/external_db/src/writer.rs
@@ -160,7 +160,8 @@ impl BackendL1ConfirmationSource {
         metrics: Arc<ExternalDbMetrics>,
     ) -> anyhow::Result<Self> {
         let block_time = backend.chain_config().block_time;
-        let last_deleted = backend.get_external_db_retention_cursor().context("Loading external DB retention cursor")?;
+        let last_deleted =
+            backend.get_external_db_retention_cursor().context("Loading external DB retention cursor")?;
         Ok(Self { backend, last_deleted, retention_delay, block_time, metrics })
     }
 }
@@ -241,10 +242,9 @@ impl<S: L1ConfirmationSource> RetentionScheduler<S> {
         let confirmations = self.source.poll_confirmations().await?;
         for confirmation in confirmations {
             if confirmation.tx_hashes.is_empty() {
-                self.source
-                    .mark_processed(confirmation.block_number)
-                    .await
-                    .with_context(|| format!("Marking empty retention block {} as processed", confirmation.block_number))?;
+                self.source.mark_processed(confirmation.block_number).await.with_context(|| {
+                    format!("Marking empty retention block {} as processed", confirmation.block_number)
+                })?;
                 continue;
             }
             tracing::debug!(
@@ -933,10 +933,7 @@ mod tests {
     #[tokio::test]
     async fn retention_retries_failed_block_without_advancing_cursor() {
         let metrics = Arc::new(ExternalDbMetrics::register());
-        let sink = FakeSink::with_delete_responses(
-            Vec::new(),
-            vec![Ok(1), Err(anyhow::anyhow!("mongo down")), Ok(1)],
-        );
+        let sink = FakeSink::with_delete_responses(Vec::new(), vec![Ok(1), Err(anyhow::anyhow!("mongo down")), Ok(1)]);
         let block_1 = L1Confirmation { block_number: 1, tx_hashes: vec![Felt::from_hex_unchecked("0x1")] };
         let block_2 = L1Confirmation { block_number: 2, tx_hashes: vec![Felt::from_hex_unchecked("0x2")] };
         let mut scheduler = RetentionScheduler::new(

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -344,6 +344,10 @@ impl RunCmd {
         self.is_sequencer()
     }
 
+    pub fn should_run_external_db(&self) -> bool {
+        self.should_run_mempool() && self.external_db_params.is_enabled()
+    }
+
     pub fn should_save_mempool_to_db(&self) -> bool {
         self.should_run_mempool() && !self.validator_params.no_mempool_saving
     }
@@ -359,6 +363,7 @@ mod tests {
         let run_cmd = RunCmd::parse_from(["madara", "--full", "--network", "sepolia"]);
 
         assert!(!run_cmd.should_run_mempool());
+        assert!(!run_cmd.should_run_external_db());
         assert!(!run_cmd.should_save_mempool_to_db());
     }
 
@@ -367,6 +372,7 @@ mod tests {
         let run_cmd = RunCmd::parse_from(["madara", "--sequencer", "--preset", "devnet"]);
 
         assert!(run_cmd.should_run_mempool());
+        assert!(!run_cmd.should_run_external_db());
         assert!(run_cmd.should_save_mempool_to_db());
     }
 
@@ -376,6 +382,23 @@ mod tests {
 
         assert!(run_cmd.should_run_mempool());
         assert!(!run_cmd.should_save_mempool_to_db());
+    }
+
+    #[test]
+    fn sequencer_runs_external_db_only_when_enabled() {
+        let disabled = RunCmd::parse_from(["madara", "--sequencer", "--preset", "devnet"]);
+        assert!(!disabled.should_run_external_db());
+
+        let enabled = RunCmd::parse_from([
+            "madara",
+            "--sequencer",
+            "--preset",
+            "devnet",
+            "--external-db-enabled",
+            "--external-db-mongodb-uri",
+            "mongodb://localhost:27017",
+        ]);
+        assert!(enabled.should_run_external_db());
     }
 }
 

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -218,6 +218,14 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("🌐 Network: {} (chain id `{}`)", chain_config.chain_name, chain_config.chain_id);
     run_cmd.args_preset.greet();
 
+    let external_db_requested = run_cmd.external_db_params.is_enabled();
+    if external_db_requested && !run_cmd.should_run_mempool() {
+        tracing::warn!(
+            "External DB was configured, but this node is running in full-node mode. \
+             External DB is only enabled on sequencer/devnet nodes, so it will be skipped."
+        );
+    }
+
     let sys_info = SysInfo::probe();
     sys_info.show();
 
@@ -356,11 +364,15 @@ async fn main() -> anyhow::Result<()> {
         run_cmd.validator_params.no_charge_fee,
     )?;
 
-    let service_external_db = run_cmd
-        .external_db_params
-        .to_config()
-        .map(|config| ExternalDbService::new(config, chain_config.chain_id.to_string(), backend.clone()))
-        .transpose()?;
+    let service_external_db = if run_cmd.should_run_external_db() {
+        run_cmd
+            .external_db_params
+            .to_config()
+            .map(|config| ExternalDbService::new(config, chain_config.chain_id.to_string(), backend.clone()))
+            .transpose()?
+    } else {
+        None
+    };
     let external_db_configured = service_external_db.is_some();
 
     // Add transaction provider

--- a/madara/node/src/service/mempool.rs
+++ b/madara/node/src/service/mempool.rs
@@ -10,7 +10,7 @@ pub struct MempoolService {
 
 impl MempoolService {
     pub fn new(run_cmd: &RunCmd, backend: Arc<MadaraBackend>) -> Self {
-        let external_outbox = if run_cmd.external_db_params.is_enabled() {
+        let external_outbox = if run_cmd.should_run_external_db() {
             ExternalOutboxConfig::enabled(run_cmd.external_db_params.external_db_strict_outbox)
         } else {
             ExternalOutboxConfig::default()


### PR DESCRIPTION
## Summary
- persist the external-db retention cursor in RocksDB metadata
- advance the cursor only after successful Mongo retention deletes
- fail loudly when a confirmed block expected by retention is missing from local DB state
- use rstest for the retention cursor roundtrip coverage

## Notes
- retention cleanup deletes Mongo documents by confirmed block tx hashes and chain id
- local focused test verification is still pending because Cargo lock contention blocked completion in this workspace