### PR TITLE
build(orchestrator): surface SNOS logs in tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496#69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3#b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12754,7 +12754,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496#69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3#b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14139,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496#69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3#b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=fc13f62c272aea91378bab448421b9e4a41cc626#fc13f62c272aea91378bab448421b9e4a41cc626"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=68da24d7e7fc7d374ad280c11675691382a5e139#68da24d7e7fc7d374ad280c11675691382a5e139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12754,7 +12754,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=fc13f62c272aea91378bab448421b9e4a41cc626#fc13f62c272aea91378bab448421b9e4a41cc626"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=68da24d7e7fc7d374ad280c11675691382a5e139#68da24d7e7fc7d374ad280c11675691382a5e139"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14139,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=fc13f62c272aea91378bab448421b9e4a41cc626#fc13f62c272aea91378bab448421b9e4a41cc626"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=68da24d7e7fc7d374ad280c11675691382a5e139#68da24d7e7fc7d374ad280c11675691382a5e139"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=68da24d7e7fc7d374ad280c11675691382a5e139#68da24d7e7fc7d374ad280c11675691382a5e139"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=d313670437bd70be24480e8feb15fd12711558d9#d313670437bd70be24480e8feb15fd12711558d9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12754,7 +12754,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=68da24d7e7fc7d374ad280c11675691382a5e139#68da24d7e7fc7d374ad280c11675691382a5e139"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=d313670437bd70be24480e8feb15fd12711558d9#d313670437bd70be24480e8feb15fd12711558d9"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14139,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=68da24d7e7fc7d374ad280c11675691382a5e139#68da24d7e7fc7d374ad280c11675691382a5e139"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=d313670437bd70be24480e8feb15fd12711558d9#d313670437bd70be24480e8feb15fd12711558d9"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3#b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=a3ec60b50afc1bcad1c7f828bb68e97d1e29020b#a3ec60b50afc1bcad1c7f828bb68e97d1e29020b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12754,7 +12754,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3#b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=a3ec60b50afc1bcad1c7f828bb68e97d1e29020b#a3ec60b50afc1bcad1c7f828bb68e97d1e29020b"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14139,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3#b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=a3ec60b50afc1bcad1c7f828bb68e97d1e29020b#a3ec60b50afc1bcad1c7f828bb68e97d1e29020b"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,7 +2826,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2846,7 +2846,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2866,7 +2866,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=33846d17e4030e72abba774168e58885119d339a#33846d17e4030e72abba774168e58885119d339a"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77#6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11074,6 +11074,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-error",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
@@ -12198,7 +12199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -12211,7 +12212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -12753,7 +12754,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=33846d17e4030e72abba774168e58885119d339a#33846d17e4030e72abba774168e58885119d339a"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77#6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14138,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=33846d17e4030e72abba774168e58885119d339a#33846d17e4030e72abba774168e58885119d339a"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77#6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77#6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=fc13f62c272aea91378bab448421b9e4a41cc626#fc13f62c272aea91378bab448421b9e4a41cc626"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12754,7 +12754,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77#6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=fc13f62c272aea91378bab448421b9e4a41cc626#fc13f62c272aea91378bab448421b9e4a41cc626"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14139,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77#6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=fc13f62c272aea91378bab448421b9e4a41cc626#fc13f62c272aea91378bab448421b9e4a41cc626"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=d313670437bd70be24480e8feb15fd12711558d9#d313670437bd70be24480e8feb15fd12711558d9"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496#69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12754,7 +12754,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=d313670437bd70be24480e8feb15fd12711558d9#d313670437bd70be24480e8feb15fd12711558d9"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496#69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14139,7 +14139,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=d313670437bd70be24480e8feb15fd12711558d9#d313670437bd70be24480e8feb15fd12711558d9"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496#69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "d313670437bd70be24480e8feb15fd12711558d9", features = [
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496", features = [
   "cairo_native",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 tracing-test = "0.2.5"
 tracing-opentelemetry = "0.31.0"
+tracing-log = "0.2.0"
 
 # Networking
 jsonrpsee = { version = "0.22", default-features = false, features = [
@@ -312,7 +313,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "33846d17e4030e72abba774168e58885119d339a", features = [
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77", features = [
   "cairo_native",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "68da24d7e7fc7d374ad280c11675691382a5e139", features = [
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "d313670437bd70be24480e8feb15fd12711558d9", features = [
   "cairo_native",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "fc13f62c272aea91378bab448421b9e4a41cc626", features = [
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "68da24d7e7fc7d374ad280c11675691382a5e139", features = [
   "cairo_native",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "69b6fe98195fc85ce5fd6dc57ca0fbe5718f1496", features = [
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3", features = [
   "cairo_native",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "6752d108ceb4f8adca60ad0dcd71ba49ca5a1c77", features = [
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "fc13f62c272aea91378bab448421b9e4a41cc626", features = [
   "cairo_native",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "b0a1234b0e991316bb6ef07b2e785b8d2c9dfdb3", features = [
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos", rev = "a3ec60b50afc1bcad1c7f828bb68e97d1e29020b", features = [
   "cairo_native",
 ] }
 

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -108,6 +108,7 @@ opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "logs"] }
 tracing = { workspace = true }
 tracing-error = "0.2.1"
+tracing-log = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -400,6 +400,9 @@ pub fn init_logging() {
         .install()
         .expect("Unable to install color_eyre");
 
+    // Bridge log-based SNOS crates into the orchestrator tracing subscriber.
+    tracing_log::LogTracer::init().expect("Failed to install log to tracing bridge");
+
     // Read from `RUST_LOG` environment variable, with fallback to default
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         // Fallback if RUST_LOG is not set or invalid
@@ -457,6 +460,7 @@ pub fn init_logging() {
 ///
 /// - **Orchestrator crates** → Specific service names (ATLANTIC, UTILS, GPS_FACT_CHK, etc.)
 /// - **Generic orchestrator** → "-" (no specific service, core orchestrator code)
+/// - **SNOS crates** → "SNOS" (generate-pie / rpc_client logs bridged through log)
 /// - **Third-party dependencies** → "EXTERNAL" (logs from Rust ecosystem crates)
 ///
 /// Note: "EXTERNAL" refers to third-party Rust crates (tokio, hyper, reqwest, etc.),
@@ -467,6 +471,8 @@ pub fn init_logging() {
 /// ```ignore
 /// extract_service_name("orchestrator_atlantic_service::client") → "ATLANTIC"
 /// extract_service_name("orchestrator_utils::logging")           → "UTILS"
+/// extract_service_name("generate_pie::state_update")            → "SNOS"
+/// extract_service_name("rpc_client::client")                    → "SNOS"
 /// extract_service_name("orchestrator::core::config")            → "-"
 /// extract_service_name("tokio::runtime")                        → "EXTERNAL"
 /// extract_service_name("hyper::client")                         → "EXTERNAL"
@@ -480,10 +486,23 @@ fn extract_service_name(target: &str) -> &'static str {
         "PROVER_IFACE"
     } else if target.starts_with("orchestrator_utils") {
         "UTILS"
+    } else if target.starts_with("generate_pie") || target.starts_with("rpc_client") {
+        "SNOS"
     } else if target.starts_with("orchestrator") {
         "-"
     } else {
         "EXTERNAL"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_service_name;
+
+    #[test]
+    fn classify_snos_targets() {
+        assert_eq!(extract_service_name("generate_pie::state_update"), "SNOS");
+        assert_eq!(extract_service_name("rpc_client::client"), "SNOS");
     }
 }
 

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -8,6 +8,7 @@ use tracing::{
     Event, Level, Subscriber,
 };
 use tracing_error::ErrorLayer;
+use tracing_log::NormalizeEvent;
 use tracing_subscriber::field::{MakeVisitor, VisitFmt, VisitOutput};
 use tracing_subscriber::fmt::FmtContext;
 use tracing_subscriber::fmt::{format::Writer, FormatEvent, FormatFields};
@@ -115,7 +116,8 @@ where
     N: for<'a> FormatFields<'a> + 'static,
 {
     fn format_event(&self, ctx: &FmtContext<'_, S, N>, mut writer: Writer<'_>, event: &Event<'_>) -> std::fmt::Result {
-        let meta = event.metadata();
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
         let now = Utc::now().format("%y-%m-%d %H:%M:%S").to_string();
 
         // Extract queue from span fields
@@ -257,7 +259,8 @@ where
     N: for<'a> FormatFields<'a> + 'static,
 {
     fn format_event(&self, ctx: &FmtContext<'_, S, N>, mut writer: Writer<'_>, event: &Event<'_>) -> std::fmt::Result {
-        let meta = event.metadata();
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
         let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
         // Extract event message and fields

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -404,13 +404,7 @@ pub fn init_logging() {
     tracing_log::LogTracer::init().expect("Failed to install log to tracing bridge");
 
     // Read from `RUST_LOG` environment variable, with fallback to default
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        // Fallback if RUST_LOG is not set or invalid
-        EnvFilter::builder()
-            .with_default_directive(Level::INFO.into())
-            .parse("orchestrator=info")
-            .expect("Invalid filter directive and Logger control")
-    });
+    let env_filter = build_env_filter();
 
     // Check LOG_FORMAT environment variable
     let log_format = std::env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string());
@@ -450,6 +444,16 @@ pub fn init_logging() {
             .with(ErrorLayer::new(PlainFields::new()));
         tracing::subscriber::set_global_default(subscriber).expect("Failed to set global default subscriber");
     }
+}
+
+fn build_env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| fallback_env_filter())
+}
+
+fn fallback_env_filter() -> EnvFilter {
+    // Keep orchestrator INFO logs by default, but require explicit target
+    // opt-in for bridged SNOS logs and other third-party crates.
+    EnvFilter::builder().parse("error,orchestrator=info").expect("Invalid filter directive and Logger control")
 }
 
 /// Extract service/package name from the tracing target


### PR DESCRIPTION
## Summary
- bridge SNOS log records into the orchestrator tracing subscriber with `tracing-log`
- label `generate_pie` and `rpc_client` targets as `SNOS` in orchestrator logs
- bump the SNOS dependency to the instrumentation commit from keep-starknet-strange/snos#513

## Testing
- not run (`cargo check` intentionally skipped locally)