### PR TITLE
fix: reconstruct historical storage proofs

### DIFF
--- a/e2e/src/setup/config.rs
+++ b/e2e/src/setup/config.rs
@@ -128,6 +128,7 @@ pub struct SetupConfig {
     // General Configurations
     pub layer: Layer,
     pub timeouts: Timeouts,
+    pub enable_orchestrator: bool,
 
     // Individual Component Configurations
     pub anvil_config: AnvilConfig,
@@ -148,6 +149,7 @@ impl Default for SetupConfig {
         Self {
             layer: Layer::L2,
             timeouts: Timeouts::default(),
+            enable_orchestrator: true,
             anvil_config: AnvilConfig::default(),
             localstack_config: LocalstackConfig::default(),
             mongo_config: MongoConfig::default(),
@@ -177,6 +179,11 @@ impl SetupConfig {
     /// Get Timeout Config
     pub fn get_timeouts(&self) -> &Timeouts {
         &self.timeouts
+    }
+
+    /// Whether orchestration should be part of the setup/runtime flow.
+    pub fn enable_orchestrator(&self) -> bool {
+        self.enable_orchestrator
     }
 
     /// Get Localstack Config
@@ -258,6 +265,12 @@ impl SetupConfigBuilder {
     /// Set Timeouts
     pub fn timeouts(mut self, timeouts: Timeouts) -> Self {
         self.config.timeouts = timeouts;
+        self
+    }
+
+    /// Enable or disable orchestrator setup/runtime steps.
+    pub fn enable_orchestrator(mut self, enable_orchestrator: bool) -> Self {
+        self.config.enable_orchestrator = enable_orchestrator;
         self
     }
 

--- a/e2e/src/setup/database_management.rs
+++ b/e2e/src/setup/database_management.rs
@@ -28,9 +28,10 @@ impl DatabaseManager {
 
     pub async fn create_data_directory(&self, dir_name: &str) -> Result<(), SetupError> {
         let data_dump_dir = REPO_ROOT.join(dir_name);
-        if !data_dump_dir.exists() {
-            fs::create_dir_all(data_dump_dir).await.map_err(|e| SetupError::OtherError(e.to_string()))?;
+        if data_dump_dir.exists() {
+            fs::remove_dir_all(&data_dump_dir).await.map_err(|e| SetupError::OtherError(e.to_string()))?;
         }
+        fs::create_dir_all(data_dump_dir).await.map_err(|e| SetupError::OtherError(e.to_string()))?;
         Ok(())
     }
 
@@ -42,7 +43,7 @@ impl DatabaseManager {
         Ok(())
     }
 
-    pub async fn check_existing_state(&self) -> Result<DBState, SetupError> {
+    pub async fn check_existing_state(&self, enable_orchestrator: bool) -> Result<DBState, SetupError> {
         // check if the folder exists or not
         if self.check_data_directory(DATA_DIR).is_err() {
             return Ok(DBState::NotReady);
@@ -61,7 +62,7 @@ impl DatabaseManager {
         println!("🔔 Pre Existing DB Status: {:?}", status);
 
         if status == DBState::ReadyToUse {
-            self.validate_required_files(&data_dir)?;
+            self.validate_required_files(&data_dir, enable_orchestrator)?;
         }
 
         Ok(status)
@@ -99,13 +100,18 @@ impl DatabaseManager {
         Ok(())
     }
 
-    fn validate_required_files(&self, data_dir: &Path) -> Result<(), SetupError> {
+    fn validate_required_files(&self, data_dir: &Path, enable_orchestrator: bool) -> Result<(), SetupError> {
         let anvil_json_exists = data_dir.join(ANVIL_DATABASE_FILE).exists();
         let madara_db_exists = data_dir.join(MADARA_DATABASE_DIR).exists();
         let mock_verifier_exists = data_dir.join(MOCK_VERIFIER_ADDRESS_FILE).exists();
         let orchestrator_dir_exists = data_dir.join(ORCHESTRATOR_DATABASE_NAME).exists();
 
-        if anvil_json_exists && madara_db_exists && mock_verifier_exists && orchestrator_dir_exists {
+        let has_required_files = anvil_json_exists
+            && madara_db_exists
+            && mock_verifier_exists
+            && (!enable_orchestrator || orchestrator_dir_exists);
+
+        if has_required_files {
             Ok(())
         } else {
             let mut missing = Vec::new();
@@ -118,7 +124,7 @@ impl DatabaseManager {
             if !mock_verifier_exists {
                 missing.push(MOCK_VERIFIER_ADDRESS_FILE);
             }
-            if !orchestrator_dir_exists {
+            if enable_orchestrator && !orchestrator_dir_exists {
                 missing.push(ORCHESTRATOR_DATABASE_NAME);
             }
             Err(SetupError::OtherError(format!("Database files missing despite ReadyToUse status: {:?}", missing)))

--- a/e2e/src/setup/mod.rs
+++ b/e2e/src/setup/mod.rs
@@ -43,7 +43,7 @@ impl ChainSetup {
     pub async fn setup(&mut self, test_name: &str) -> Result<(), SetupError> {
         println!("🚀 Starting Chain Setup for {:?} layer...", self.config.layer);
 
-        let db_status = self.database_manager.check_existing_state().await?;
+        let db_status = self.database_manager.check_existing_state(self.config.enable_orchestrator()).await?;
 
         match db_status {
             DBState::ReadyToUse => {
@@ -58,7 +58,10 @@ impl ChainSetup {
             DBState::NotReady => {
                 println!("❌ Chain state does not exist, setting up new chain...");
                 let test_config = self.config.to_owned();
-                let setup_config = SetupConfigBuilder::new(None).build_l2_config().await?;
+                let mut setup_config = SetupConfigBuilder::new(None).build_l2_config().await?;
+                setup_config.enable_orchestrator = test_config.enable_orchestrator();
+                setup_config.madara_config =
+                    apply_madara_runtime_overrides(setup_config.madara_config, test_config.get_madara_config());
                 self.config = Arc::new(setup_config);
                 self.service_manager = ServiceManager::new(self.config.clone());
                 self.setup_new_chain().await?;
@@ -120,6 +123,23 @@ impl ChainSetup {
     pub fn config(&self) -> &SetupConfig {
         &self.config
     }
+}
+
+fn apply_madara_runtime_overrides(
+    base: crate::services::madara::MadaraConfig,
+    overrides: &crate::services::madara::MadaraConfig,
+) -> crate::services::madara::MadaraConfig {
+    let mut builder = base.builder();
+
+    for arg in overrides.additional_args() {
+        builder = builder.arg(arg);
+    }
+
+    for (key, value) in overrides.environment_vars() {
+        builder = builder.env_var(key, value);
+    }
+
+    builder.build()
 }
 
 impl Drop for ChainSetup {

--- a/e2e/src/setup/service_management.rs
+++ b/e2e/src/setup/service_management.rs
@@ -67,7 +67,11 @@ impl ServiceManager {
         // self.setup_mock_prover(&mut services).await?;
 
         // Orchestration
-        self.setup_orchestration(&mut services).await?;
+        if self.config.enable_orchestrator() {
+            self.setup_orchestration(&mut services).await?;
+        } else {
+            println!("⏭️ Skipping orchestrator setup for this E2E flow");
+        }
 
         println!("✅ Setup completed successfully in {:?}", start.elapsed());
         Ok(())
@@ -79,14 +83,20 @@ impl ServiceManager {
         // Start infrastructure
         self.start_infrastructure(&mut services).await?;
         self.setup_localstack_infrastructure().await?;
-        self.restore_mongodb_database(&services).await?;
+        if self.config.enable_orchestrator() {
+            self.restore_mongodb_database(&services).await?;
+        }
 
         // // Start runtime services
         self.start_anvil(&mut services).await?;
         self.start_madara(&mut services).await?;
         self.start_pathfinder(&mut services).await?;
         // self.start_mock_prover(&mut services).await?;
-        self.start_orchestrator(&mut services).await?;
+        if self.config.enable_orchestrator() {
+            self.start_orchestrator(&mut services).await?;
+        } else {
+            println!("⏭️ Skipping orchestrator runtime startup for this E2E flow");
+        }
 
         Ok(services)
     }

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod deposit_withdraw;
 pub mod setup;
+pub mod storage_proof;

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod deposit_withdraw;
 pub mod setup;
+#[cfg(test)]
 pub mod storage_proof;

--- a/e2e/src/tests/storage_proof/mod.rs
+++ b/e2e/src/tests/storage_proof/mod.rs
@@ -1,0 +1,268 @@
+use crate::services::helpers::NodeRpcMethods;
+use crate::setup::{ChainSetup, SetupConfigBuilder};
+use crate::tests::deposit_withdraw::utils::cleanup_test_directory;
+use reqwest::Url;
+use rstest::*;
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone)]
+struct ContractKeys {
+    contract_address: String,
+    storage_keys: Vec<String>,
+}
+
+#[fixture]
+pub async fn setup_chain_with_storage_proof(#[default("")] test_name: &str) -> ChainSetup {
+    dotenvy::from_filename(".env.e2e").expect("Failed to load the .env file");
+
+    let mut setup_config = SetupConfigBuilder::new(None).test_config_l2(test_name).await.unwrap();
+    setup_config = setup_config.builder().enable_orchestrator(false).build();
+    setup_config.madara_config = setup_config
+        .madara_config
+        .builder()
+        .env_var("MADARA_RPC_STORAGE_PROOF_MAX_DISTANCE", "10000")
+        .env_var("MADARA_DB_MAX_SAVED_TRIE_LOGS", "10000")
+        .env_var("MADARA_DB_MAX_SNAPSHOTS", "1000")
+        .env_var("MADARA_DB_SNAPSHOT_INTERVAL", "1")
+        .build();
+
+    let mut setup = ChainSetup::new(setup_config).unwrap();
+    match setup.setup(test_name).await {
+        Ok(()) => println!("✅ Storage proof setup completed successfully"),
+        Err(e) => {
+            println!("❌ Storage proof setup failed: {}", e);
+            panic!("Setup failed: {}", e);
+        }
+    }
+
+    setup
+}
+
+#[rstest]
+#[case("storage_proof")]
+#[tokio::test]
+async fn test_storage_proof_matches_pathfinder_for_changed_keys(
+    #[case] test_name: &str,
+    #[future]
+    #[with(test_name)]
+    setup_chain_with_storage_proof: ChainSetup,
+) {
+    let result = run_storage_proof_comparison(setup_chain_with_storage_proof.await).await;
+
+    cleanup_test_directory(test_name);
+
+    match result {
+        Ok(_) => println!("✅ Storage proof comparison completed successfully"),
+        Err(e) => {
+            eprintln!("❌ Storage proof comparison failed: {}", e);
+            panic!("Test failed: {}", e);
+        }
+    }
+}
+
+async fn run_storage_proof_comparison(setup: ChainSetup) -> Result<(), String> {
+    let services =
+        setup.lifecycle_manager.services.as_ref().ok_or_else(|| "Runtime services are not available".to_string())?;
+
+    let madara = services.madara_service.as_ref().ok_or_else(|| "Madara service is not available".to_string())?;
+    let pathfinder =
+        services.pathfinder_service.as_ref().ok_or_else(|| "Pathfinder service is not available".to_string())?;
+
+    let latest_block = pathfinder
+        .get_latest_block_number()
+        .await
+        .map_err(|err| format!("Failed to get latest block from Pathfinder: {err}"))?
+        .ok_or_else(|| "No blocks available on Pathfinder".to_string())?;
+
+    let mut compared_contracts = 0usize;
+    let mut compared_blocks = 0usize;
+
+    for block_number in 0..=latest_block {
+        let state_update =
+            rpc_call(pathfinder.endpoint(), "starknet_getStateUpdate", json!([{ "block_number": block_number }]))
+                .await?;
+
+        let changed_contracts = extract_changed_contracts(&state_update)?;
+        if changed_contracts.is_empty() {
+            continue;
+        }
+        compared_blocks += 1;
+
+        for contract in changed_contracts {
+            let contract_address = contract.contract_address.clone();
+            let storage_keys = contract.storage_keys.clone();
+            let madara_proof = rpc_call(
+                madara.rpc_endpoint(),
+                "starknet_getStorageProof",
+                json!({
+                    "block_id": { "block_number": block_number },
+                    "contract_addresses": [contract_address.clone()],
+                    "contracts_storage_keys": [{
+                        "contract_address": contract_address.clone(),
+                        "storage_keys": storage_keys.clone(),
+                    }]
+                }),
+            )
+            .await?;
+
+            let pathfinder_proof = rpc_call(
+                pathfinder.endpoint(),
+                "starknet_getStorageProof",
+                json!({
+                    "block_id": { "block_number": block_number },
+                    "contract_addresses": [contract_address.clone()],
+                    "contracts_storage_keys": [{
+                        "contract_address": contract_address.clone(),
+                        "storage_keys": storage_keys.clone(),
+                    }]
+                }),
+            )
+            .await?;
+
+            assert_json_eq(
+                &madara_proof["global_roots"],
+                &pathfinder_proof["global_roots"],
+                block_number,
+                &contract_address,
+                "global_roots",
+            )?;
+
+            let madara_leaf = single_contract_leaf(&madara_proof)?;
+            let pathfinder_leaf = single_contract_leaf(&pathfinder_proof)?;
+            assert_json_eq(&madara_leaf, &pathfinder_leaf, block_number, &contract_address, "contract_leaf")?;
+
+            for key in &storage_keys {
+                let madara_value = rpc_call(
+                    madara.rpc_endpoint(),
+                    "starknet_getStorageAt",
+                    json!([contract_address.clone(), key, { "block_number": block_number }]),
+                )
+                .await?;
+                let pathfinder_value = rpc_call(
+                    pathfinder.endpoint(),
+                    "starknet_getStorageAt",
+                    json!([contract_address.clone(), key, { "block_number": block_number }]),
+                )
+                .await?;
+
+                assert_json_eq(
+                    &madara_value,
+                    &pathfinder_value,
+                    block_number,
+                    &contract_address,
+                    &format!("storage_value[{key}]"),
+                )?;
+            }
+
+            compared_contracts += 1;
+        }
+    }
+
+    if compared_contracts == 0 {
+        return Err("No changed contracts were compared in the E2E storage proof test".to_string());
+    }
+
+    println!("Compared storage proofs for {} contracts across {} blocks", compared_contracts, compared_blocks);
+
+    Ok(())
+}
+
+async fn rpc_call(endpoint: Url, method: &str, params: Value) -> Result<Value, String> {
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .header("accept", "application/json")
+        .header("content-type", "application/json")
+        .json(&json!({
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }))
+        .send()
+        .await
+        .map_err(|err| format!("RPC call to {method} failed: {err}"))?;
+
+    let body: Value = response.json().await.map_err(|err| format!("Invalid JSON response for {method}: {err}"))?;
+    if let Some(error) = body.get("error") {
+        return Err(format!("RPC {method} returned error: {error}"));
+    }
+
+    body.get("result").cloned().ok_or_else(|| format!("RPC {method} response is missing a result field"))
+}
+
+fn extract_changed_contracts(state_update: &Value) -> Result<Vec<ContractKeys>, String> {
+    let storage_diffs = state_update
+        .get("state_diff")
+        .and_then(|value| value.get("storage_diffs"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| "state_update is missing state_diff.storage_diffs".to_string())?;
+
+    let mut contracts = Vec::new();
+    for diff in storage_diffs {
+        let contract_address = diff
+            .get("address")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "storage diff is missing address".to_string())?
+            .to_string();
+
+        let storage_keys = diff
+            .get("storage_entries")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "storage diff is missing storage_entries".to_string())?
+            .iter()
+            .map(|entry| {
+                entry
+                    .get("key")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .ok_or_else(|| "storage entry is missing key".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if !storage_keys.is_empty() {
+            contracts.push(ContractKeys { contract_address, storage_keys });
+        }
+    }
+
+    Ok(contracts)
+}
+
+fn single_contract_leaf(proof: &Value) -> Result<Value, String> {
+    let leaf = proof
+        .get("contracts_proof")
+        .and_then(|value| value.get("contract_leaves_data"))
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .ok_or_else(|| "storage proof is missing contract_leaves_data[0]".to_string())?;
+
+    Ok(json!({
+        "class_hash": leaf
+            .get("class_hash")
+            .cloned()
+            .ok_or_else(|| "contract leaf is missing class_hash".to_string())?,
+        "nonce": leaf
+            .get("nonce")
+            .cloned()
+            .ok_or_else(|| "contract leaf is missing nonce".to_string())?,
+        "storage_root": leaf
+            .get("storage_root")
+            .cloned()
+            .ok_or_else(|| "contract leaf is missing storage_root".to_string())?,
+    }))
+}
+
+fn assert_json_eq(
+    left: &Value,
+    right: &Value,
+    block_number: u64,
+    contract_address: &str,
+    field: &str,
+) -> Result<(), String> {
+    if left == right {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Mismatch for {field} at block {block_number} contract {contract_address}\nleft: {left}\nright: {right}"
+    ))
+}

--- a/madara/crates/client/db/src/rocksdb/trie.rs
+++ b/madara/crates/client/db/src/rocksdb/trie.rs
@@ -226,6 +226,26 @@ fn to_changed_key(k: &DatabaseKey) -> (u8, ByteVec) {
     )
 }
 
+const TRIE_KEY_KIND: u8 = 0;
+const FLAT_KEY_KIND: u8 = 1;
+const TRIE_LOG_KEY_SEPARATOR: u8 = 0x00;
+const TRIE_LOG_NEW_VALUE: u8 = 0x00;
+const TRIE_LOG_OLD_VALUE: u8 = 0x01;
+
+#[derive(Default)]
+struct TrieLogChange {
+    old_value: Option<ByteVec>,
+    new_value: Option<ByteVec>,
+}
+
+fn database_key_from_parts<'a>(key_kind: u8, key: &'a [u8]) -> DatabaseKey<'a> {
+    match key_kind {
+        TRIE_KEY_KIND => DatabaseKey::Trie(key),
+        FLAT_KEY_KIND => DatabaseKey::Flat(key),
+        _ => panic!("invalid trie-log key kind {key_kind}"),
+    }
+}
+
 /// The backing database for a bonsai storage view. This is used
 /// to implement historical access (for storage proofs), by applying
 /// changes from the trie-log without modifying the real database.
@@ -250,6 +270,21 @@ impl fmt::Debug for BonsaiTransaction {
     }
 }
 
+impl BonsaiTransaction {
+    fn apply_change(&mut self, key_kind: u8, key: &[u8], value: Option<&[u8]>) -> Result<(), TrieError> {
+        let key = database_key_from_parts(key_kind, key);
+        match value {
+            Some(value) => {
+                self.insert(&key, value, None)?;
+            }
+            None => {
+                self.remove(&key, None)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 // TODO: a lot of this is not really used yet, this whole abstraction does not really make sense anyway, this needs to be modified
 // upstream in bonsai-trie
 impl BonsaiDatabase for BonsaiTransaction {
@@ -267,7 +302,7 @@ impl BonsaiDatabase for BonsaiTransaction {
             return Ok(val.clone());
         }
         let handle = self.snapshot.db.get_column(self.column_mapping.map(key).clone());
-        Ok(self.snapshot.db.db.get_cf(&handle, key.as_slice())?.map(Into::into))
+        Ok(self.snapshot.get_cf(&handle, key.as_slice())?.map(Into::into))
     }
 
     fn get_by_prefix(&self, _prefix: &DatabaseKey) -> Result<Vec<(ByteVec, ByteVec)>, Self::DatabaseError> {
@@ -277,8 +312,11 @@ impl BonsaiDatabase for BonsaiTransaction {
     #[tracing::instrument(skip(self, key))]
     fn contains(&self, key: &DatabaseKey) -> Result<bool, Self::DatabaseError> {
         tracing::trace!("Checking if RocksDB contains: {:?}", key);
+        if let Some(val) = self.changed.get(&to_changed_key(key)) {
+            return Ok(val.is_some());
+        }
         let handle = self.snapshot.db.get_column(self.column_mapping.map(key).clone());
-        Ok(self.snapshot.db.db.get_cf(&handle, key.as_slice())?.is_some())
+        Ok(self.snapshot.get_cf(&handle, key.as_slice())?.is_some())
     }
 
     fn insert(
@@ -323,20 +361,26 @@ impl BonsaiPersistentDatabase<BasicId> for BonsaiDB {
     #[tracing::instrument(skip(self))]
     fn transaction(&self, requested_id: BasicId) -> Option<(BasicId, Self::Transaction<'_>)> {
         tracing::trace!("Generating RocksDB transaction");
-        let (id, snapshot) = self.snapshots.get_closest(requested_id.as_u64());
+        let requested_id_u64 = requested_id.as_u64();
+        let (snapshot_id, snapshot) = self.snapshots.get_closest(requested_id_u64);
 
-        tracing::debug!("Snapshot for requested block_id={requested_id:?} => got block_id={id:?}");
+        tracing::debug!("Snapshot for requested block_id={requested_id:?} => got block_id={snapshot_id:?}");
 
-        id.map(|id| {
-            (
-                BasicId::new(id),
-                BonsaiTransaction {
-                    snapshot,
-                    column_mapping: self.column_mapping.clone(),
-                    changed: Default::default(),
-                },
-            )
-        })
+        let snapshot_id = snapshot_id?;
+        let mut txn =
+            BonsaiTransaction { snapshot, column_mapping: self.column_mapping.clone(), changed: Default::default() };
+
+        if let Err(error) = self.replay_trie_logs_into_transaction(&mut txn, snapshot_id, requested_id_u64) {
+            tracing::error!(
+                ?error,
+                requested_id = requested_id_u64,
+                snapshot_id,
+                "failed to reconstruct historical trie state from trie logs"
+            );
+            return None;
+        }
+
+        Some((requested_id, txn))
     }
 
     fn merge<'a>(&mut self, _transaction: Self::Transaction<'a>) -> Result<(), Self::DatabaseError>
@@ -344,5 +388,198 @@ impl BonsaiPersistentDatabase<BasicId> for BonsaiDB {
         Self: 'a,
     {
         unreachable!("unused for now")
+    }
+}
+
+impl BonsaiDB {
+    fn replay_trie_logs_into_transaction(
+        &self,
+        txn: &mut BonsaiTransaction,
+        snapshot_id: u64,
+        requested_id: u64,
+    ) -> Result<(), TrieError> {
+        if snapshot_id == requested_id {
+            return Ok(());
+        }
+
+        if snapshot_id > requested_id {
+            for block_id in ((requested_id + 1)..=snapshot_id).rev() {
+                let changes = self.load_trie_log_changes(BasicId::new(block_id))?;
+                for ((key_kind, key), change) in changes {
+                    txn.apply_change(key_kind, &key, change.old_value.as_deref())?;
+                }
+            }
+            return Ok(());
+        }
+
+        for block_id in (snapshot_id + 1)..=requested_id {
+            let changes = self.load_trie_log_changes(BasicId::new(block_id))?;
+            for ((key_kind, key), change) in changes {
+                txn.apply_change(key_kind, &key, change.new_value.as_deref())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn load_trie_log_changes(&self, block_id: BasicId) -> Result<BTreeMap<(u8, ByteVec), TrieLogChange>, TrieError> {
+        let prefix = block_id.to_bytes();
+        let trie_log_entries = self.get_by_prefix(&DatabaseKey::TrieLog(&prefix))?;
+        let mut changes = BTreeMap::new();
+
+        for (encoded_key, value) in trie_log_entries {
+            let key_len = encoded_key.len();
+            if key_len < prefix.len() + 3 {
+                panic!("invalid trie-log key length {}", key_len);
+            }
+            if encoded_key[prefix.len()] != TRIE_LOG_KEY_SEPARATOR {
+                panic!("invalid trie-log key separator");
+            }
+
+            let change_type = encoded_key[key_len - 1];
+            let key_kind = encoded_key[key_len - 2];
+            let key_bytes = ByteVec::from(&encoded_key[prefix.len() + 1..key_len - 2]);
+            let change = changes.entry((key_kind, key_bytes)).or_insert_with(TrieLogChange::default);
+
+            match change_type {
+                TRIE_LOG_NEW_VALUE => change.new_value = Some(value),
+                TRIE_LOG_OLD_VALUE => change.old_value = Some(value),
+                _ => panic!("invalid trie-log change type {change_type}"),
+            }
+        }
+
+        Ok(changes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitvec::view::AsBits;
+    use starknet_types_core::felt::Felt;
+
+    fn create_test_storage(config: crate::rocksdb::RocksDBConfig) -> (tempfile::TempDir, RocksDBStorage) {
+        let temp_dir = tempfile::TempDir::with_prefix("bonsai-transaction-test").unwrap();
+        let storage = RocksDBStorage::open(temp_dir.path(), config).unwrap();
+        (temp_dir, storage)
+    }
+
+    #[test]
+    fn contract_storage_transactional_state_uses_historical_snapshot_for_exact_block() {
+        let (_temp_dir, storage) = create_test_storage(crate::rocksdb::RocksDBConfig {
+            max_saved_trie_logs: Some(16),
+            max_kept_snapshots: Some(16),
+            snapshot_interval: 1,
+            ..Default::default()
+        });
+
+        let contract = Felt::from_hex_unchecked("0x1234");
+        let key = Felt::from_hex_unchecked("0x5678");
+        let identifier = contract.to_bytes_be();
+        let key_bits = key.to_bytes_be();
+
+        let mut trie = storage.contract_storage_trie();
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::ONE).unwrap();
+        trie.commit(BasicId::new(0)).unwrap();
+        storage.snapshots.set_new_head(0);
+        let root_at_0 = trie.root_hash(&identifier).unwrap();
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::TWO).unwrap();
+        trie.commit(BasicId::new(1)).unwrap();
+        storage.snapshots.set_new_head(1);
+        let root_at_1 = trie.root_hash(&identifier).unwrap();
+
+        assert_ne!(root_at_0, root_at_1);
+
+        let historical = storage
+            .contract_storage_trie()
+            .get_transactional_state(BasicId::new(0), storage.contract_storage_trie().get_config())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(historical.root_hash(&identifier).unwrap(), root_at_0);
+        assert_eq!(historical.get(&identifier, &key_bits.as_bits()[5..]).unwrap(), Some(Felt::ONE));
+    }
+
+    #[test]
+    fn contract_storage_transactional_state_reconstructs_between_snapshots() {
+        let (_temp_dir, storage) = create_test_storage(crate::rocksdb::RocksDBConfig {
+            max_saved_trie_logs: Some(16),
+            max_kept_snapshots: Some(16),
+            snapshot_interval: 4,
+            ..Default::default()
+        });
+
+        let contract = Felt::from_hex_unchecked("0x4321");
+        let key = Felt::from_hex_unchecked("0x8765");
+        let identifier = contract.to_bytes_be();
+        let key_bits = key.to_bytes_be();
+
+        let mut trie = storage.contract_storage_trie();
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::ONE).unwrap();
+        trie.commit(BasicId::new(0)).unwrap();
+        storage.snapshots.set_new_head(0);
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::TWO).unwrap();
+        trie.commit(BasicId::new(1)).unwrap();
+        storage.snapshots.set_new_head(1);
+        let root_at_1 = trie.root_hash(&identifier).unwrap();
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::THREE).unwrap();
+        trie.commit(BasicId::new(2)).unwrap();
+        storage.snapshots.set_new_head(2);
+
+        let historical = storage
+            .contract_storage_trie()
+            .get_transactional_state(BasicId::new(1), storage.contract_storage_trie().get_config())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(historical.root_hash(&identifier).unwrap(), root_at_1);
+        assert_eq!(historical.get(&identifier, &key_bits.as_bits()[5..]).unwrap(), Some(Felt::TWO));
+    }
+
+    #[test]
+    fn contract_storage_transactional_state_reconstructs_multiple_reverse_steps() {
+        let (_temp_dir, storage) = create_test_storage(crate::rocksdb::RocksDBConfig {
+            max_saved_trie_logs: Some(16),
+            max_kept_snapshots: Some(16),
+            snapshot_interval: 5,
+            ..Default::default()
+        });
+
+        let contract = Felt::from_hex_unchecked("0xaaaa");
+        let key = Felt::from_hex_unchecked("0xbbbb");
+        let identifier = contract.to_bytes_be();
+        let key_bits = key.to_bytes_be();
+
+        let mut trie = storage.contract_storage_trie();
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::ONE).unwrap();
+        trie.commit(BasicId::new(0)).unwrap();
+        storage.snapshots.set_new_head(0);
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::TWO).unwrap();
+        trie.commit(BasicId::new(1)).unwrap();
+        storage.snapshots.set_new_head(1);
+        let root_at_1 = trie.root_hash(&identifier).unwrap();
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::THREE).unwrap();
+        trie.commit(BasicId::new(2)).unwrap();
+        storage.snapshots.set_new_head(2);
+
+        trie.insert(&identifier, &key_bits.as_bits()[5..], &Felt::from(4_u8)).unwrap();
+        trie.commit(BasicId::new(3)).unwrap();
+        storage.snapshots.set_new_head(3);
+
+        let historical = storage
+            .contract_storage_trie()
+            .get_transactional_state(BasicId::new(1), storage.contract_storage_trie().get_config())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(historical.root_hash(&identifier).unwrap(), root_at_1);
+        assert_eq!(historical.get(&identifier, &key_bits.as_bits()[5..]).unwrap(), Some(Felt::TWO));
     }
 }


### PR DESCRIPTION
## Summary
Reconstruct historical storage-proof state from trie logs before serving proofs, so Madara returns the requested block state instead of drifting to a newer snapshot.

## Why
Historical storage proofs were matching latest-state roots for changing contracts, which broke SNOS PIE generation against Madara RPC even when Pathfinder stayed correct.

## Validation
Validated the Madara -> bootstrapper-v2 -> Pathfinder flow and confirmed proof parity on recent changed contracts and keys in the storage-proof E2E path.