### PR TITLE
fix(grafana): stabilize Madara Loki dashboard queries

### DIFF
--- a/observability/grafana/dashboards/Madara/madara-fullnode.json
+++ b/observability/grafana/dashboards/Madara/madara-fullnode.json
@@ -40,7 +40,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(2 * l2_block_number_sum{namespace=~\"$namespace\", pod=~\"$node\"} / l2_block_number_count{namespace=~\"$namespace\", pod=~\"$node\"} - 1)", "legendFormat": "L2 Block", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "max(2 * l2_block_number_sum{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"} / l2_block_number_count{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"} - 1)", "legendFormat": "L2 Block", "refId": "A" }],
       "title": "L2 Block",
       "type": "stat"
     },
@@ -68,7 +68,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "transaction_count_total{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "Txns Synced", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "transaction_count_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "Txns Synced", "refId": "A" }],
       "title": "Txns Synced",
       "type": "stat"
     },
@@ -96,7 +96,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "event_count_total{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "Events Synced", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "event_count_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "Events Synced", "refId": "A" }],
       "title": "Events Synced",
       "type": "stat"
     },
@@ -124,7 +124,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_block_number{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "L1 Block", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_block_number{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "L1 Block", "refId": "A" }],
       "title": "L1 Block",
       "type": "stat"
     },
@@ -148,8 +148,8 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.5, rate(l2_latest_sync_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))", "legendFormat": "{{pod}} - Latest Block Sync", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.5, rate(l2_avg_sync_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))", "legendFormat": "{{pod}} - Avg Sync Time", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.5, rate(l2_latest_sync_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m]))", "legendFormat": "{{pod}} - Latest Block Sync", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.5, rate(l2_avg_sync_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m]))", "legendFormat": "{{pod}} - Avg Sync Time", "refId": "B" }
       ],
       "title": "Block Sync Time",
       "type": "timeseries"
@@ -174,8 +174,8 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(transaction_count_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])", "legendFormat": "{{pod}} - Transactions/s", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(event_count_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])", "legendFormat": "{{pod}} - Events/s", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(transaction_count_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])", "legendFormat": "{{pod}} - Transactions/s", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "rate(event_count_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])", "legendFormat": "{{pod}} - Events/s", "refId": "B" }
       ],
       "title": "Sync Throughput",
       "type": "timeseries"
@@ -200,8 +200,8 @@
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_gas_price_wei{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "{{pod}} - L1 Gas (Wei)", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_gas_price_strk{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "{{pod}} - L1 Gas (STRK)", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_gas_price_wei{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "{{pod}} - L1 Gas (Wei)", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_gas_price_strk{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "{{pod}} - L1 Gas (STRK)", "refId": "B" }
       ],
       "title": "L1 Gas Prices",
       "type": "timeseries"
@@ -230,7 +230,7 @@
       "id": 10,
       "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "2 * l2_block_number_sum{namespace=~\"$namespace\", pod=~\"$node\"} / l2_block_number_count{namespace=~\"$namespace\", pod=~\"$node\"} - 1", "legendFormat": "{{pod}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "2 * l2_block_number_sum{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"} / l2_block_number_count{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"} - 1", "legendFormat": "{{pod}}", "refId": "A" }],
       "title": "L2 Block Height by Node",
       "type": "timeseries"
     },
@@ -250,7 +250,7 @@
       "id": 11,
       "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_block_number{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "{{pod}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "l1_block_number{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "{{pod}}", "refId": "A" }],
       "title": "L1 Block Height by Node",
       "type": "timeseries"
     },
@@ -270,7 +270,7 @@
       "id": 12,
       "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "transaction_count_total{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "{{pod}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "transaction_count_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "{{pod}}", "refId": "A" }],
       "title": "Total Transactions Synced by Node",
       "type": "timeseries"
     },
@@ -290,7 +290,7 @@
       "id": 13,
       "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "event_count_total{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "{{pod}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "event_count_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}", "legendFormat": "{{pod}}", "refId": "A" }],
       "title": "Total Events Synced by Node",
       "type": "timeseries"
     },
@@ -325,7 +325,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"})", "legendFormat": "Total Calls", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"})", "legendFormat": "Total Calls", "refId": "A" }],
       "title": "Total Calls",
       "type": "stat"
     },
@@ -352,7 +352,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))", "legendFormat": "RPS (5m)", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m]))", "legendFormat": "RPS (5m)", "refId": "A" }],
       "title": "RPS (5m)",
       "type": "stat"
     },
@@ -379,7 +379,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"true\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])), 1e-9)", "legendFormat": "Success Rate", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", success=\"true\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])), 1e-9)", "legendFormat": "Success Rate", "refId": "A" }],
       "title": "Success Rate",
       "type": "stat"
     },
@@ -413,7 +413,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "Latency p90", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])))", "legendFormat": "Latency p90", "refId": "A" }],
       "title": "Latency p90",
       "type": "stat"
     },
@@ -447,7 +447,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "Latency p99", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])))", "legendFormat": "Latency p99", "refId": "A" }],
       "title": "Latency p99",
       "type": "stat"
     },
@@ -474,7 +474,7 @@
         "textMode": "value_and_name"
       },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_started_total{namespace=~\"$namespace\", pod=~\"$node\"}) - sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"})", "legendFormat": "In-Flight", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_started_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}) - sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"})", "legendFormat": "In-Flight", "refId": "A" }],
       "title": "In-Flight",
       "type": "stat"
     },
@@ -494,7 +494,7 @@
       "id": 107,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))", "legendFormat": "Requests/s", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m]))", "legendFormat": "Requests/s", "refId": "A" }],
       "title": "RPC Request Rate",
       "type": "timeseries"
     },
@@ -519,9 +519,9 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "p50", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "p90", "refId": "B" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "p99", "refId": "C" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])))", "legendFormat": "p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])))", "legendFormat": "p90", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])))", "legendFormat": "p99", "refId": "C" }
       ],
       "title": "RPC Latency Percentiles",
       "type": "timeseries"
@@ -546,8 +546,8 @@
       "options": { "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"true\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])), 1e-9)", "legendFormat": "Success Rate", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"false\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])), 1e-9)", "legendFormat": "Error Rate", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", success=\"true\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])), 1e-9)", "legendFormat": "Success Rate", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", success=\"false\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\"}[5m])), 1e-9)", "legendFormat": "Error Rate", "refId": "B" }
       ],
       "title": "RPC Success/Error Rate",
       "type": "timeseries"
@@ -568,7 +568,7 @@
       "id": 110,
       "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"starknet_.*\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
       "title": "Top Starknet RPC Methods",
       "type": "timeseries"
     },
@@ -588,7 +588,7 @@
       "id": 111,
       "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\", success=\"false\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"starknet_.*\", success=\"false\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
       "title": "Top Starknet RPC Methods Failure",
       "type": "timeseries"
     },
@@ -612,8 +612,8 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"starknet_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"starknet_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
       ],
       "title": "Top Starknet RPC Method Latency",
       "type": "timeseries"
@@ -634,7 +634,7 @@
       "id": 113,
       "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"madara_.*\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
       "title": "Top Madara Admin Methods",
       "type": "timeseries"
     },
@@ -654,7 +654,7 @@
       "id": 114,
       "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\", success=\"false\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"madara_.*\", success=\"false\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
       "title": "Top Madara Admin Methods Failure",
       "type": "timeseries"
     },
@@ -678,8 +678,8 @@
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"madara_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", pod=~\".*fullnode.*\", method=~\"madara_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
       ],
       "title": "Top Madara Admin Method Latency",
       "type": "timeseries"
@@ -692,7 +692,7 @@
     "list": [
       { "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" }, "hide": 0, "includeAll": false, "multi": false, "name": "DS_PROMETHEUS", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource" },
       { "allValue": ".*", "current": { "selected": true, "text": "All", "value": "$__all" }, "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "definition": "label_values(l2_block_number_sum, namespace)", "hide": 0, "includeAll": true, "label": "Namespace", "multi": true, "name": "namespace", "options": [], "query": { "query": "label_values(l2_block_number_sum, namespace)", "refId": "StandardVariableQuery" }, "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query" },
-      { "allValue": ".*", "current": { "selected": true, "text": "All", "value": "$__all" }, "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "definition": "label_values(l2_block_number_sum{namespace=~\"$namespace\"}, pod)", "hide": 0, "includeAll": true, "label": "Node", "multi": true, "name": "node", "options": [], "query": { "query": "label_values(l2_block_number_sum{namespace=~\"$namespace\"}, pod)", "refId": "StandardVariableQuery" }, "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query" }
+      { "allValue": ".*fullnode.*", "current": { "selected": true, "text": "All", "value": "$__all" }, "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "definition": "label_values(l2_block_number_sum{namespace=~\"$namespace\", pod=~\".*fullnode.*\"}, pod)", "hide": 0, "includeAll": true, "label": "Node", "multi": true, "name": "node", "options": [], "query": { "query": "label_values(l2_block_number_sum{namespace=~\"$namespace\", pod=~\".*fullnode.*\"}, pod)", "refId": "StandardVariableQuery" }, "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query" }
     ]
   },
   "time": { "from": "now-15m", "to": "now" },

--- a/observability/grafana/dashboards/Madara/madara-fullnode.json
+++ b/observability/grafana/dashboards/Madara/madara-fullnode.json
@@ -541,7 +541,7 @@
           { "matcher": { "id": "byName", "options": "Error Rate" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 43 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 43 },
       "id": 109,
       "options": { "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
@@ -564,12 +564,12 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 43 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
       "id": 110,
       "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
-      "title": "Top RPC Methods",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "title": "Top Starknet RPC Methods",
       "type": "timeseries"
     },
     {
@@ -577,25 +577,19 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "custom": { "axisBorderShow": false, "axisCenteredZero": true, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
           "mappings": [],
           "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
           "unit": "reqps"
         },
-        "overrides": [
-          { "matcher": { "id": "byRegexp", "options": ".* success$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] },
-          { "matcher": { "id": "byRegexp", "options": ".* failure$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
-        ]
+        "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
       "id": 111,
       "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"true\"}[5m])))", "legendFormat": "{{method}} success", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"false\"}[5m])))", "legendFormat": "{{method}} failure", "refId": "B" }
-      ],
-      "title": "Per-Method Success/Failure Rate",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\", success=\"false\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "title": "Top Starknet RPC Methods Failure",
       "type": "timeseries"
     },
     {
@@ -613,15 +607,81 @@
           { "matcher": { "id": "byRegexp", "options": ".* p99$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 59 },
       "id": 112,
       "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "pluginVersion": "11.4.0",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"starknet_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
       ],
-      "title": "Per-Method Request Latency",
+      "title": "Top Starknet RPC Method Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 59 },
+      "id": 113,
+      "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "title": "Top Madara Admin Methods",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 67 },
+      "id": 114,
+      "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\", success=\"false\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "title": "Top Madara Admin Methods Failure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ms"
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": ".* p90$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": ".* p99$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
+      "id": 115,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\", method=~\"madara_.*\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
+      ],
+      "title": "Top Madara Admin Method Latency",
       "type": "timeseries"
     }
   ],

--- a/observability/grafana/dashboards/Madara/madara-fullnode.json
+++ b/observability/grafana/dashboards/Madara/madara-fullnode.json
@@ -571,6 +571,58 @@
       "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
       "title": "Top RPC Methods",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": true, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": ".* success$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": ".* failure$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
+      "id": 111,
+      "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"true\"}[5m])))", "legendFormat": "{{method}} success", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"false\"}[5m])))", "legendFormat": "{{method}} failure", "refId": "B" }
+      ],
+      "title": "Per-Method Success/Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ms"
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": ".* p90$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": ".* p99$" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
+      "id": 112,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))) >= 0)", "legendFormat": "{{method}} p90", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, histogram_quantile(0.99, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))) >= 0)", "legendFormat": "{{method}} p99", "refId": "B" }
+      ],
+      "title": "Per-Method Request Latency",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-fullnode.json
+++ b/observability/grafana/dashboards/Madara/madara-fullnode.json
@@ -293,6 +293,284 @@
       "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "event_count_total{namespace=~\"$namespace\", pod=~\"$node\"}", "legendFormat": "{{pod}}", "refId": "A" }],
       "title": "Total Events Synced by Node",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "id": 100,
+      "panels": [],
+      "title": "RPC Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#37872D", "value": null }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 31 },
+      "id": 101,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"})", "legendFormat": "Total Calls", "refId": "A" }],
+      "title": "Total Calls",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#FF9830", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 31 },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))", "legendFormat": "RPS (5m)", "refId": "A" }],
+      "title": "RPS (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#3274D9", "value": null }] },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 31 },
+      "id": 103,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"true\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])), 1e-9)", "legendFormat": "Success Rate", "refId": "A" }],
+      "title": "Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 200 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 31 },
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "Latency p90", "refId": "A" }],
+      "title": "Latency p90",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 31 },
+      "id": 105,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "Latency p99", "refId": "A" }],
+      "title": "Latency p99",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "#8F3BB8", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 31 },
+      "id": 106,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(calls_started_total{namespace=~\"$namespace\", pod=~\"$node\"}) - sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"})", "legendFormat": "In-Flight", "refId": "A" }],
+      "title": "In-Flight",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 107,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m]))", "legendFormat": "Requests/s", "refId": "A" }],
+      "title": "RPC Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ms"
+        },
+        "overrides": [
+          { "matcher": { "id": "byRegexp", "options": ".*p50.*" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": ".*p90.*" }, "properties": [{ "id": "color", "value": { "fixedColor": "#FF9830", "mode": "fixed" } }] },
+          { "matcher": { "id": "byRegexp", "options": ".*p99.*" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "id": 108,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "p90", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "p99", "refId": "C" }
+      ],
+      "title": "RPC Latency Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Success Rate" }, "properties": [{ "id": "color", "value": { "fixedColor": "#37872D", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Error Rate" }, "properties": [{ "id": "color", "value": { "fixedColor": "#C4162A", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 43 },
+      "id": 109,
+      "options": { "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"true\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])), 1e-9)", "legendFormat": "Success Rate", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\", success=\"false\"}[5m])) / clamp_min(sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])), 1e-9)", "legendFormat": "Error Rate", "refId": "B" }
+      ],
+      "title": "RPC Success/Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 43 },
+      "id": 110,
+      "options": { "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "pluginVersion": "11.4.0",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$node\"}[5m])))", "legendFormat": "{{method}}", "refId": "A" }],
+      "title": "Top RPC Methods",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5609,84 +5609,84 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_block_total_ms=\"close_block_total_ms\" | unwrap close_block_total_ms [$__interval])",
           "legendFormat": "Total Close Block",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap merklization_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json merklization_ms=\"merklization_ms\" | unwrap merklization_ms [$__interval])",
           "legendFormat": "Merklization",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap commitments_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json commitments_ms=\"commitments_ms\" | unwrap commitments_ms [$__interval])",
           "legendFormat": "Commitments",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap db_write_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json db_write_ms=\"db_write_ms\" | unwrap db_write_ms [$__interval])",
           "legendFormat": "DB Write",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json block_hash_ms=\"block_hash_ms\" | unwrap block_hash_ms [$__interval])",
           "legendFormat": "Block Hash",
           "refId": "E"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_preconfirmed_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_preconfirmed_ms=\"close_preconfirmed_ms\" | unwrap close_preconfirmed_ms [$__interval])",
           "legendFormat": "Close Preconfirmed",
           "refId": "F"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap get_full_block_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json get_full_block_ms=\"get_full_block_ms\" | unwrap get_full_block_ms [$__interval])",
           "legendFormat": "Get Full Block",
           "refId": "G"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_trie_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_trie_ms=\"contract_trie_ms\" | unwrap contract_trie_ms [$__interval])",
           "legendFormat": "Contract Trie",
           "refId": "H"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap class_trie_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json class_trie_ms=\"class_trie_ms\" | unwrap class_trie_ms [$__interval])",
           "legendFormat": "Class Trie",
           "refId": "I"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_storage_trie_commit_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_storage_trie_commit_ms=\"contract_storage_trie_commit_ms\" | unwrap contract_storage_trie_commit_ms [$__interval])",
           "legendFormat": "Contract Storage Trie Commit",
           "refId": "J"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_trie_commit_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_trie_commit_ms=\"contract_trie_commit_ms\" | unwrap contract_trie_commit_ms [$__interval])",
           "legendFormat": "Contract Trie Commit",
           "refId": "K"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap class_trie_commit_ms [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json class_trie_commit_ms=\"class_trie_commit_ms\" | unwrap class_trie_commit_ms [$__interval])",
           "legendFormat": "Class Trie Commit",
           "refId": "L"
         }
@@ -5739,7 +5739,7 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
+          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_block_total_ms=\"close_block_total_ms\" | unwrap close_block_total_ms [$__interval])",
           "legendFormat": "Close Block Total (p50)",
           "refId": "A"
         }
@@ -5795,84 +5795,84 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap tx_count [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json tx_count=\"tx_count\" | unwrap tx_count [$__interval])",
           "legendFormat": "Tx Count",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap event_count [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json event_count=\"event_count\" | unwrap event_count [$__interval])",
           "legendFormat": "Event Count",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_executed [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_executed=\"txs_executed\" | unwrap txs_executed [$__interval])",
           "legendFormat": "Txs Executed",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_reverted [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_reverted=\"txs_reverted\" | unwrap txs_reverted [$__interval])",
           "legendFormat": "Txs Reverted",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json state_diff_len=\"state_diff_len\" | unwrap state_diff_len [$__interval])",
           "legendFormat": "State Diff Length",
           "refId": "E"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap batches_executed [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json batches_executed=\"batches_executed\" | unwrap batches_executed [$__interval])",
           "legendFormat": "Batches Executed",
           "refId": "F"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_added_to_block [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_added_to_block=\"txs_added_to_block\" | unwrap txs_added_to_block [$__interval])",
           "legendFormat": "Txs Added to Block",
           "refId": "G"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_rejected [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_rejected=\"txs_rejected\" | unwrap txs_rejected [$__interval])",
           "legendFormat": "Txs Rejected",
           "refId": "H"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap classes_declared [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json classes_declared=\"classes_declared\" | unwrap classes_declared [$__interval])",
           "legendFormat": "Classes Declared",
           "refId": "I"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap deployed_contracts [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json deployed_contracts=\"deployed_contracts\" | unwrap deployed_contracts [$__interval])",
           "legendFormat": "Deployed Contracts",
           "refId": "J"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap storage_diffs [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json storage_diffs=\"storage_diffs\" | unwrap storage_diffs [$__interval])",
           "legendFormat": "Storage Diffs",
           "refId": "K"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap nonce_updates [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json nonce_updates=\"nonce_updates\" | unwrap nonce_updates [$__interval])",
           "legendFormat": "Nonce Updates",
           "refId": "L"
         }
@@ -5925,42 +5925,42 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap l2_gas_consumed [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json l2_gas_consumed=\"l2_gas_consumed\" | unwrap l2_gas_consumed [$__interval])",
           "legendFormat": "L2 Gas Consumed",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_l1_gas [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_l1_gas=\"bouncer_l1_gas\" | unwrap bouncer_l1_gas [$__interval])",
           "legendFormat": "Bouncer L1 Gas",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_sierra_gas [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_sierra_gas=\"bouncer_sierra_gas\" | unwrap bouncer_sierra_gas [$__interval])",
           "legendFormat": "Bouncer Sierra Gas",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_n_events [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_n_events=\"bouncer_n_events\" | unwrap bouncer_n_events [$__interval])",
           "legendFormat": "Bouncer Events",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_message_segment_length [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_message_segment_length=\"bouncer_message_segment_length\" | unwrap bouncer_message_segment_length [$__interval])",
           "legendFormat": "Bouncer Msg Segment Len",
           "refId": "E"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_state_diff_size [$__interval]) by ()",
+          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_state_diff_size=\"bouncer_state_diff_size\" | unwrap bouncer_state_diff_size [$__interval])",
           "legendFormat": "Bouncer State Diff Size",
           "refId": "F"
         }

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -5609,84 +5609,84 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_block_total_ms=\"close_block_total_ms\" | unwrap close_block_total_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_block_total_ms=\"close_block_total_ms\" | unwrap close_block_total_ms [$__interval])",
           "legendFormat": "Total Close Block",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json merklization_ms=\"merklization_ms\" | unwrap merklization_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json merklization_ms=\"merklization_ms\" | unwrap merklization_ms [$__interval])",
           "legendFormat": "Merklization",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json commitments_ms=\"commitments_ms\" | unwrap commitments_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json commitments_ms=\"commitments_ms\" | unwrap commitments_ms [$__interval])",
           "legendFormat": "Commitments",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json db_write_ms=\"db_write_ms\" | unwrap db_write_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json db_write_ms=\"db_write_ms\" | unwrap db_write_ms [$__interval])",
           "legendFormat": "DB Write",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json block_hash_ms=\"block_hash_ms\" | unwrap block_hash_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json block_hash_ms=\"block_hash_ms\" | unwrap block_hash_ms [$__interval])",
           "legendFormat": "Block Hash",
           "refId": "E"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_preconfirmed_ms=\"close_preconfirmed_ms\" | unwrap close_preconfirmed_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_preconfirmed_ms=\"close_preconfirmed_ms\" | unwrap close_preconfirmed_ms [$__interval])",
           "legendFormat": "Close Preconfirmed",
           "refId": "F"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json get_full_block_ms=\"get_full_block_ms\" | unwrap get_full_block_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json get_full_block_ms=\"get_full_block_ms\" | unwrap get_full_block_ms [$__interval])",
           "legendFormat": "Get Full Block",
           "refId": "G"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_trie_ms=\"contract_trie_ms\" | unwrap contract_trie_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_trie_ms=\"contract_trie_ms\" | unwrap contract_trie_ms [$__interval])",
           "legendFormat": "Contract Trie",
           "refId": "H"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json class_trie_ms=\"class_trie_ms\" | unwrap class_trie_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json class_trie_ms=\"class_trie_ms\" | unwrap class_trie_ms [$__interval])",
           "legendFormat": "Class Trie",
           "refId": "I"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_storage_trie_commit_ms=\"contract_storage_trie_commit_ms\" | unwrap contract_storage_trie_commit_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_storage_trie_commit_ms=\"contract_storage_trie_commit_ms\" | unwrap contract_storage_trie_commit_ms [$__interval])",
           "legendFormat": "Contract Storage Trie Commit",
           "refId": "J"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_trie_commit_ms=\"contract_trie_commit_ms\" | unwrap contract_trie_commit_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json contract_trie_commit_ms=\"contract_trie_commit_ms\" | unwrap contract_trie_commit_ms [$__interval])",
           "legendFormat": "Contract Trie Commit",
           "refId": "K"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json class_trie_commit_ms=\"class_trie_commit_ms\" | unwrap class_trie_commit_ms [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json class_trie_commit_ms=\"class_trie_commit_ms\" | unwrap class_trie_commit_ms [$__interval])",
           "legendFormat": "Class Trie Commit",
           "refId": "L"
         }
@@ -5739,7 +5739,7 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_block_total_ms=\"close_block_total_ms\" | unwrap close_block_total_ms [$__interval])",
+          "expr": "quantile_over_time(0.50, {container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json close_block_total_ms=\"close_block_total_ms\" | unwrap close_block_total_ms [$__interval])",
           "legendFormat": "Close Block Total (p50)",
           "refId": "A"
         }
@@ -5795,84 +5795,84 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json tx_count=\"tx_count\" | unwrap tx_count [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json tx_count=\"tx_count\" | unwrap tx_count [$__interval])",
           "legendFormat": "Tx Count",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json event_count=\"event_count\" | unwrap event_count [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json event_count=\"event_count\" | unwrap event_count [$__interval])",
           "legendFormat": "Event Count",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_executed=\"txs_executed\" | unwrap txs_executed [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_executed=\"txs_executed\" | unwrap txs_executed [$__interval])",
           "legendFormat": "Txs Executed",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_reverted=\"txs_reverted\" | unwrap txs_reverted [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_reverted=\"txs_reverted\" | unwrap txs_reverted [$__interval])",
           "legendFormat": "Txs Reverted",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json state_diff_len=\"state_diff_len\" | unwrap state_diff_len [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json state_diff_len=\"state_diff_len\" | unwrap state_diff_len [$__interval])",
           "legendFormat": "State Diff Length",
           "refId": "E"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json batches_executed=\"batches_executed\" | unwrap batches_executed [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json batches_executed=\"batches_executed\" | unwrap batches_executed [$__interval])",
           "legendFormat": "Batches Executed",
           "refId": "F"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_added_to_block=\"txs_added_to_block\" | unwrap txs_added_to_block [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_added_to_block=\"txs_added_to_block\" | unwrap txs_added_to_block [$__interval])",
           "legendFormat": "Txs Added to Block",
           "refId": "G"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_rejected=\"txs_rejected\" | unwrap txs_rejected [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json txs_rejected=\"txs_rejected\" | unwrap txs_rejected [$__interval])",
           "legendFormat": "Txs Rejected",
           "refId": "H"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json classes_declared=\"classes_declared\" | unwrap classes_declared [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json classes_declared=\"classes_declared\" | unwrap classes_declared [$__interval])",
           "legendFormat": "Classes Declared",
           "refId": "I"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json deployed_contracts=\"deployed_contracts\" | unwrap deployed_contracts [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json deployed_contracts=\"deployed_contracts\" | unwrap deployed_contracts [$__interval])",
           "legendFormat": "Deployed Contracts",
           "refId": "J"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json storage_diffs=\"storage_diffs\" | unwrap storage_diffs [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json storage_diffs=\"storage_diffs\" | unwrap storage_diffs [$__interval])",
           "legendFormat": "Storage Diffs",
           "refId": "K"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json nonce_updates=\"nonce_updates\" | unwrap nonce_updates [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json nonce_updates=\"nonce_updates\" | unwrap nonce_updates [$__interval])",
           "legendFormat": "Nonce Updates",
           "refId": "L"
         }
@@ -5925,42 +5925,42 @@
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json l2_gas_consumed=\"l2_gas_consumed\" | unwrap l2_gas_consumed [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json l2_gas_consumed=\"l2_gas_consumed\" | unwrap l2_gas_consumed [$__interval])",
           "legendFormat": "L2 Gas Consumed",
           "refId": "A"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_l1_gas=\"bouncer_l1_gas\" | unwrap bouncer_l1_gas [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_l1_gas=\"bouncer_l1_gas\" | unwrap bouncer_l1_gas [$__interval])",
           "legendFormat": "Bouncer L1 Gas",
           "refId": "B"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_sierra_gas=\"bouncer_sierra_gas\" | unwrap bouncer_sierra_gas [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_sierra_gas=\"bouncer_sierra_gas\" | unwrap bouncer_sierra_gas [$__interval])",
           "legendFormat": "Bouncer Sierra Gas",
           "refId": "C"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_n_events=\"bouncer_n_events\" | unwrap bouncer_n_events [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_n_events=\"bouncer_n_events\" | unwrap bouncer_n_events [$__interval])",
           "legendFormat": "Bouncer Events",
           "refId": "D"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_message_segment_length=\"bouncer_message_segment_length\" | unwrap bouncer_message_segment_length [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_message_segment_length=\"bouncer_message_segment_length\" | unwrap bouncer_message_segment_length [$__interval])",
           "legendFormat": "Bouncer Msg Segment Len",
           "refId": "E"
         },
         {
           "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
           "editorMode": "code",
-          "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_state_diff_size=\"bouncer_state_diff_size\" | unwrap bouncer_state_diff_size [$__interval])",
+          "expr": "avg_over_time({container=\"madara\", namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json bouncer_state_diff_size=\"bouncer_state_diff_size\" | unwrap bouncer_state_diff_size [$__interval])",
           "legendFormat": "Bouncer State Diff Size",
           "refId": "F"
         }

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -849,7 +849,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "expr": "sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"})",
           "legendFormat": "Total Calls",
           "refId": "A"
         }
@@ -909,7 +909,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m]))",
           "legendFormat": "RPS (5m)",
           "refId": "A"
         }
@@ -969,7 +969,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}",
           "legendFormat": "WS Sessions",
           "refId": "A"
         }
@@ -1037,7 +1037,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m])))",
           "legendFormat": "Latency p50",
           "refId": "A"
         }
@@ -1105,7 +1105,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m])))",
           "legendFormat": "Latency p99",
           "refId": "A"
         }
@@ -1165,7 +1165,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(calls_started_total{namespace=~\"$namespace\", pod=~\"$pod\"}) - sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"})",
+          "expr": "sum(calls_started_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}) - sum(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"})",
           "legendFormat": "In-Flight",
           "refId": "A"
         }
@@ -1258,7 +1258,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m]))",
           "legendFormat": "Requests/s",
           "refId": "A"
         }
@@ -1397,7 +1397,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m])))",
           "legendFormat": "p50 (all methods)",
           "refId": "A"
         },
@@ -1406,7 +1406,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m])))",
           "legendFormat": "p90 (all methods)",
           "refId": "B"
         },
@@ -1415,7 +1415,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m])))",
           "legendFormat": "p99 (all methods)",
           "refId": "C"
         }
@@ -1539,7 +1539,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", success=\"true\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\", success=\"true\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m]))",
           "legendFormat": "Success Rate",
           "refId": "A"
         },
@@ -1548,7 +1548,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", success=\"false\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "expr": "sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\", success=\"false\"}[5m])) / sum(rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m]))",
           "legendFormat": "Error Rate",
           "refId": "B"
         }
@@ -1640,7 +1640,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+          "expr": "topk(10, sum by (method) (rate(calls_finished_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m])))",
           "legendFormat": "{{method}}",
           "refId": "A"
         }
@@ -1733,7 +1733,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "expr": "ws_sessions_opened_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"} - ws_sessions_closed_total{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}",
           "legendFormat": "Active Sessions",
           "refId": "A"
         }
@@ -1826,7 +1826,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(5, histogram_quantile(0.50, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))))",
+          "expr": "topk(5, histogram_quantile(0.50, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m]))))",
           "legendFormat": "{{method}} p50",
           "refId": "A"
         },
@@ -1835,7 +1835,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(5, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))))",
+          "expr": "topk(5, histogram_quantile(0.90, sum by (le, method) (rate(calls_time_bucket{namespace=~\"$namespace\", pod=~\"$pod\", pod!~\".*fullnode.*\"}[5m]))))",
           "legendFormat": "{{method}} p90",
           "refId": "B"
         }
@@ -7396,7 +7396,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)",
+        "definition": "label_values(block_produced_no{namespace=~\"$namespace\", pod!~\".*fullnode.*\"}, pod)",
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
@@ -7404,7 +7404,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(block_produced_no{namespace=~\"$namespace\"}, pod)",
+          "query": "label_values(block_produced_no{namespace=~\"$namespace\", pod!~\".*fullnode.*\"}, pod)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## Summary
- narrow Loki JSON extraction in the Madara overview dashboard to only the field each panel needs
- remove the redundant `by ()` aggregation from Loki range functions
- keep the dashboard template aligned with the live Grafana fix that was validated against devnet, testnet, and mainnet

## Validation
- validated representative Loki queries for close block timing, close block p50, block execution stats, and bouncer weights against all three PC Loki datasources
- verified the dashboard JSON remains valid with `jq empty`
