### PR TITLE
fix(db): use leveled compaction for bonsai *_log CFs

### DIFF
--- a/madara/crates/client/db/src/rocksdb/column.rs
+++ b/madara/crates/client/db/src/rocksdb/column.rs
@@ -12,6 +12,11 @@ pub struct Column {
     pub prefix_extractor_len: Option<usize>,
     pub budget_tier: ColumnMemoryBudget,
     pub point_lookup: bool,
+    /// Use Leveled compaction (instead of Universal) for this CF.
+    /// Set on write-heavy, append-only log CFs (Bonsai TrieLog) where Universal
+    /// compaction accumulates L0 files faster than it can drain them, leading
+    /// to write stalls. Leveled drains L0 -> L1 continuously instead.
+    pub log_cf: bool,
 }
 
 pub const ALL_COLUMNS: &[Column] = &[
@@ -54,6 +59,7 @@ impl Column {
             prefix_extractor_len: None,
             budget_tier: ColumnMemoryBudget::Other,
             point_lookup: false,
+            log_cf: false,
         }
     }
     pub const fn with_prefix_extractor_len(mut self, prefix_extractor_len: usize) -> Self {
@@ -71,6 +77,10 @@ impl Column {
     }
     pub const fn set_point_lookup(mut self) -> Self {
         self.point_lookup = true;
+        self
+    }
+    pub const fn as_log_cf(mut self) -> Self {
+        self.log_cf = true;
         self
     }
 }

--- a/madara/crates/client/db/src/rocksdb/column.rs
+++ b/madara/crates/client/db/src/rocksdb/column.rs
@@ -79,7 +79,7 @@ impl Column {
         self.point_lookup = true;
         self
     }
-    pub const fn as_log_cf(mut self) -> Self {
+    pub const fn set_log_cf(mut self) -> Self {
         self.log_cf = true;
         self
     }

--- a/madara/crates/client/db/src/rocksdb/metrics.rs
+++ b/madara/crates/client/db/src/rocksdb/metrics.rs
@@ -3,11 +3,11 @@
 //! ## Capacity Planning Metrics (requires statistics enabled, which is the default)
 //!
 //! Key queries for Grafana:
-//! - Ingest rate: `rate(db_bytes_written_total[5m])`
-//! - Compaction throughput: `rate(db_compact_write_bytes_total[5m])`
-//! - Write amplification: `rate(db_compact_write_bytes_total[5m]) / rate(db_flush_write_bytes_total[5m])`
-//! - Stall fraction: `rate(db_stall_micros_total[5m]) / 1e6`
-//! - Cache hit rate: `rate(db_block_cache_hit_total[5m]) / (rate(db_block_cache_hit_total[5m]) + rate(db_block_cache_miss_total[5m]))`
+//! - Ingest rate: `rate(db_bytes_written[5m])`
+//! - Compaction throughput: `rate(db_compact_write_bytes[5m])`
+//! - Write amplification: `rate(db_compact_write_bytes[5m]) / rate(db_flush_write_bytes[5m])`
+//! - Stall fraction: `rate(db_stall_micros[5m]) / 1e6`
+//! - Cache hit rate: `rate(db_block_cache_hit[5m]) / (rate(db_block_cache_hit[5m]) + rate(db_block_cache_miss[5m]))`
 //!
 //! ## Write Stall Detection
 //!
@@ -16,7 +16,7 @@
 //! | `db_is_write_stopped` | - | = 1 |
 //! | `db_pending_compaction_bytes` | > 4 GiB | > 6 GiB |
 //! | `db_level_files_count` | L0: >= 15 | L0: >= 20 |
-//! | `db_stall_micros_total` rate > 0 | warning | - |
+//! | `db_stall_micros` rate > 0 | warning | - |
 //!
 //! ## Note on `pending_compaction_bytes`
 //!
@@ -27,14 +27,13 @@
 use crate::rocksdb::column::ALL_COLUMNS;
 use crate::rocksdb::RocksDBStorage;
 use anyhow::Context;
-use mc_telemetry::{register_counter_metric_instrument, register_gauge_metric_instrument};
-use opentelemetry::metrics::{Counter, Gauge};
+use mc_telemetry::register_gauge_metric_instrument;
+use opentelemetry::metrics::Gauge;
 use opentelemetry::{global, InstrumentationScope, KeyValue};
 use rocksdb::perf::MemoryUsageBuilder;
 use rocksdb::statistics::Ticker;
-use std::sync::atomic::{AtomicU64, Ordering};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DbMetrics {
     // Storage metrics
     pub db_size: Gauge<u64>,
@@ -55,23 +54,15 @@ pub struct DbMetrics {
     // LSM tree level metrics
     pub level_files_count: Gauge<u64>,
 
-    // Compaction & I/O throughput counters (from RocksDB Statistics tickers)
-    pub bytes_written: Counter<u64>,
-    pub flush_write_bytes: Counter<u64>,
-    pub compact_read_bytes: Counter<u64>,
-    pub compact_write_bytes: Counter<u64>,
-    pub stall_micros: Counter<u64>,
-    pub block_cache_hit: Counter<u64>,
-    pub block_cache_miss: Counter<u64>,
-
-    // Previous ticker values for delta computation (get_ticker_count returns cumulative values)
-    prev_bytes_written: AtomicU64,
-    prev_flush_write_bytes: AtomicU64,
-    prev_compact_read_bytes: AtomicU64,
-    prev_compact_write_bytes: AtomicU64,
-    prev_stall_micros: AtomicU64,
-    prev_block_cache_hit: AtomicU64,
-    prev_block_cache_miss: AtomicU64,
+    // Compaction & I/O throughput gauges (cumulative values from RocksDB Statistics tickers).
+    // These are monotonically increasing; use rate() in Grafana to get per-second throughput.
+    pub bytes_written: Gauge<u64>,
+    pub flush_write_bytes: Gauge<u64>,
+    pub compact_read_bytes: Gauge<u64>,
+    pub compact_write_bytes: Gauge<u64>,
+    pub stall_micros: Gauge<u64>,
+    pub block_cache_hit: Gauge<u64>,
+    pub block_cache_miss: Gauge<u64>,
 
     // Compaction activity gauges
     pub running_compactions: Gauge<u64>,
@@ -166,50 +157,50 @@ impl DbMetrics {
             "".to_string(),
         );
 
-        // Compaction & I/O throughput counters
-        let bytes_written = register_counter_metric_instrument(
+        // Compaction & I/O throughput gauges (cumulative ticker values)
+        let bytes_written = register_gauge_metric_instrument(
             &meter,
             "db_bytes_written".to_string(),
             "Cumulative bytes written by application (Put/Merge/Delete)".to_string(),
             "".to_string(),
         );
 
-        let flush_write_bytes = register_counter_metric_instrument(
+        let flush_write_bytes = register_gauge_metric_instrument(
             &meter,
             "db_flush_write_bytes".to_string(),
             "Cumulative bytes written by memtable flushes to L0".to_string(),
             "".to_string(),
         );
 
-        let compact_read_bytes = register_counter_metric_instrument(
+        let compact_read_bytes = register_gauge_metric_instrument(
             &meter,
             "db_compact_read_bytes".to_string(),
             "Cumulative bytes read during compaction".to_string(),
             "".to_string(),
         );
 
-        let compact_write_bytes = register_counter_metric_instrument(
+        let compact_write_bytes = register_gauge_metric_instrument(
             &meter,
             "db_compact_write_bytes".to_string(),
             "Cumulative bytes written during compaction".to_string(),
             "".to_string(),
         );
 
-        let stall_micros = register_counter_metric_instrument(
+        let stall_micros = register_gauge_metric_instrument(
             &meter,
             "db_stall_micros".to_string(),
             "Cumulative microseconds spent in write stalls".to_string(),
             "".to_string(),
         );
 
-        let block_cache_hit = register_counter_metric_instrument(
+        let block_cache_hit = register_gauge_metric_instrument(
             &meter,
             "db_block_cache_hit".to_string(),
             "Cumulative block cache hits".to_string(),
             "".to_string(),
         );
 
-        let block_cache_miss = register_counter_metric_instrument(
+        let block_cache_miss = register_gauge_metric_instrument(
             &meter,
             "db_block_cache_miss".to_string(),
             "Cumulative block cache misses (each miss = a disk read)".to_string(),
@@ -257,25 +248,10 @@ impl DbMetrics {
             stall_micros,
             block_cache_hit,
             block_cache_miss,
-            prev_bytes_written: AtomicU64::new(0),
-            prev_flush_write_bytes: AtomicU64::new(0),
-            prev_compact_read_bytes: AtomicU64::new(0),
-            prev_compact_write_bytes: AtomicU64::new(0),
-            prev_stall_micros: AtomicU64::new(0),
-            prev_block_cache_hit: AtomicU64::new(0),
-            prev_block_cache_miss: AtomicU64::new(0),
             running_compactions,
             running_flushes,
             actual_delayed_write_rate,
         })
-    }
-
-    fn add_ticker_delta(&self, counter: &Counter<u64>, prev: &AtomicU64, current: u64) {
-        let previous = prev.swap(current, Ordering::Relaxed);
-        let delta = current.saturating_sub(previous);
-        if delta > 0 {
-            counter.add(delta, &[]);
-        }
     }
 
     pub fn try_update(&self, db: &RocksDBStorage) -> anyhow::Result<u64> {
@@ -357,37 +333,13 @@ impl DbMetrics {
         // ═══════════════════════════════════════════════════════════════════════════
 
         let opts = &db.inner.global_opts;
-        self.add_ticker_delta(
-            &self.bytes_written,
-            &self.prev_bytes_written,
-            opts.get_ticker_count(Ticker::BytesWritten),
-        );
-        self.add_ticker_delta(
-            &self.flush_write_bytes,
-            &self.prev_flush_write_bytes,
-            opts.get_ticker_count(Ticker::FlushWriteBytes),
-        );
-        self.add_ticker_delta(
-            &self.compact_read_bytes,
-            &self.prev_compact_read_bytes,
-            opts.get_ticker_count(Ticker::CompactReadBytes),
-        );
-        self.add_ticker_delta(
-            &self.compact_write_bytes,
-            &self.prev_compact_write_bytes,
-            opts.get_ticker_count(Ticker::CompactWriteBytes),
-        );
-        self.add_ticker_delta(&self.stall_micros, &self.prev_stall_micros, opts.get_ticker_count(Ticker::StallMicros));
-        self.add_ticker_delta(
-            &self.block_cache_hit,
-            &self.prev_block_cache_hit,
-            opts.get_ticker_count(Ticker::BlockCacheHit),
-        );
-        self.add_ticker_delta(
-            &self.block_cache_miss,
-            &self.prev_block_cache_miss,
-            opts.get_ticker_count(Ticker::BlockCacheMiss),
-        );
+        self.bytes_written.record(opts.get_ticker_count(Ticker::BytesWritten), &[]);
+        self.flush_write_bytes.record(opts.get_ticker_count(Ticker::FlushWriteBytes), &[]);
+        self.compact_read_bytes.record(opts.get_ticker_count(Ticker::CompactReadBytes), &[]);
+        self.compact_write_bytes.record(opts.get_ticker_count(Ticker::CompactWriteBytes), &[]);
+        self.stall_micros.record(opts.get_ticker_count(Ticker::StallMicros), &[]);
+        self.block_cache_hit.record(opts.get_ticker_count(Ticker::BlockCacheHit), &[]);
+        self.block_cache_miss.record(opts.get_ticker_count(Ticker::BlockCacheMiss), &[]);
 
         // ═══════════════════════════════════════════════════════════════════════════
         // COMPACTION ACTIVITY (global properties)
@@ -412,5 +364,53 @@ impl DbMetrics {
             tracing::warn!("Error updating db metrics: {err:#}");
             0
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rocksdb::column::ALL_COLUMNS;
+    use crate::rocksdb::options::rocksdb_global_options;
+    use crate::rocksdb::RocksDBConfig;
+    use rocksdb::statistics::Ticker;
+    use rocksdb::{ColumnFamilyDescriptor, DBWithThreadMode, MultiThreaded, Options as RocksDBOptions};
+    use std::sync::Arc;
+
+    struct StoredOpts {
+        db: DBWithThreadMode<MultiThreaded>,
+        global_opts: RocksDBOptions,
+    }
+
+    #[test]
+    fn test_ticker_via_stored_opts_after_cf_descriptors_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = RocksDBConfig::default();
+        let opts = rocksdb_global_options(&config).unwrap();
+
+        let cfs: Vec<ColumnFamilyDescriptor> = ALL_COLUMNS
+            .iter()
+            .map(|col| ColumnFamilyDescriptor::new(col.rocksdb_name, col.rocksdb_options(&config)))
+            .collect();
+
+        let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(&opts, dir.path(), cfs).unwrap();
+
+        let stored = Arc::new(StoredOpts { db, global_opts: opts });
+
+        let writeopts = config.write_mode.to_write_options();
+        let cf = stored.db.cf_handle("block_info").unwrap();
+        for i in 0..1000u32 {
+            stored.db.put_cf_opt(&cf, i.to_be_bytes(), vec![0u8; 256], &writeopts).unwrap();
+        }
+
+        let bytes_written = stored.global_opts.get_ticker_count(Ticker::BytesWritten);
+        println!("BytesWritten:      {bytes_written}");
+        println!("FlushWriteBytes:   {}", stored.global_opts.get_ticker_count(Ticker::FlushWriteBytes));
+        println!("CompactReadBytes:  {}", stored.global_opts.get_ticker_count(Ticker::CompactReadBytes));
+        println!("CompactWriteBytes: {}", stored.global_opts.get_ticker_count(Ticker::CompactWriteBytes));
+        println!("BlockCacheHit:     {}", stored.global_opts.get_ticker_count(Ticker::BlockCacheHit));
+        println!("BlockCacheMiss:    {}", stored.global_opts.get_ticker_count(Ticker::BlockCacheMiss));
+        println!("StallMicros:       {}", stored.global_opts.get_ticker_count(Ticker::StallMicros));
+
+        assert!(bytes_written > 0, "BytesWritten should be > 0 after 1000 puts, got {bytes_written}");
     }
 }

--- a/madara/crates/client/db/src/rocksdb/metrics.rs
+++ b/madara/crates/client/db/src/rocksdb/metrics.rs
@@ -169,49 +169,49 @@ impl DbMetrics {
         // Compaction & I/O throughput counters
         let bytes_written = register_counter_metric_instrument(
             &meter,
-            "db_bytes_written_total".to_string(),
+            "db_bytes_written".to_string(),
             "Cumulative bytes written by application (Put/Merge/Delete)".to_string(),
             "".to_string(),
         );
 
         let flush_write_bytes = register_counter_metric_instrument(
             &meter,
-            "db_flush_write_bytes_total".to_string(),
+            "db_flush_write_bytes".to_string(),
             "Cumulative bytes written by memtable flushes to L0".to_string(),
             "".to_string(),
         );
 
         let compact_read_bytes = register_counter_metric_instrument(
             &meter,
-            "db_compact_read_bytes_total".to_string(),
+            "db_compact_read_bytes".to_string(),
             "Cumulative bytes read during compaction".to_string(),
             "".to_string(),
         );
 
         let compact_write_bytes = register_counter_metric_instrument(
             &meter,
-            "db_compact_write_bytes_total".to_string(),
+            "db_compact_write_bytes".to_string(),
             "Cumulative bytes written during compaction".to_string(),
             "".to_string(),
         );
 
         let stall_micros = register_counter_metric_instrument(
             &meter,
-            "db_stall_micros_total".to_string(),
+            "db_stall_micros".to_string(),
             "Cumulative microseconds spent in write stalls".to_string(),
             "".to_string(),
         );
 
         let block_cache_hit = register_counter_metric_instrument(
             &meter,
-            "db_block_cache_hit_total".to_string(),
+            "db_block_cache_hit".to_string(),
             "Cumulative block cache hits".to_string(),
             "".to_string(),
         );
 
         let block_cache_miss = register_counter_metric_instrument(
             &meter,
-            "db_block_cache_miss_total".to_string(),
+            "db_block_cache_miss".to_string(),
             "Cumulative block cache misses (each miss = a disk read)".to_string(),
             "".to_string(),
         );

--- a/madara/crates/client/db/src/rocksdb/metrics.rs
+++ b/madara/crates/client/db/src/rocksdb/metrics.rs
@@ -80,6 +80,10 @@ impl DbMetrics {
                 .build(),
         );
 
+        // ═══════════════════════════════════════════════════════════════════════════
+        // STORAGE METRICS
+        // ═══════════════════════════════════════════════════════════════════════════
+
         let db_size = register_gauge_metric_instrument(
             &meter,
             "db_size".to_string(),
@@ -93,6 +97,10 @@ impl DbMetrics {
             "Size of each RocksDB column family in bytes".to_string(),
             "".to_string(),
         );
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // MEMORY METRICS
+        // ═══════════════════════════════════════════════════════════════════════════
 
         let mem_table_total = register_gauge_metric_instrument(
             &meter,
@@ -122,6 +130,10 @@ impl DbMetrics {
             "".to_string(),
         );
 
+        // ═══════════════════════════════════════════════════════════════════════════
+        // LSM TREE & MEMTABLE METRICS
+        // ═══════════════════════════════════════════════════════════════════════════
+
         let level_files_count = register_gauge_metric_instrument(
             &meter,
             "db_level_files_count".to_string(),
@@ -132,7 +144,7 @@ impl DbMetrics {
         let num_immutable_memtables = register_gauge_metric_instrument(
             &meter,
             "db_num_immutable_memtables".to_string(),
-            "Number of immutable memtables waiting to be flushed".to_string(),
+            "Number of immutable memtables waiting to be flushed (stall when >= max_write_buffer_number)".to_string(),
             "".to_string(),
         );
 
@@ -142,6 +154,10 @@ impl DbMetrics {
             "Total size of all memtables in bytes".to_string(),
             "".to_string(),
         );
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // WRITE STALL DETECTION METRICS
+        // ═══════════════════════════════════════════════════════════════════════════
 
         let is_write_stopped = register_gauge_metric_instrument(
             &meter,
@@ -157,7 +173,10 @@ impl DbMetrics {
             "".to_string(),
         );
 
-        // Compaction & I/O throughput gauges (cumulative ticker values)
+        // ═══════════════════════════════════════════════════════════════════════════
+        // COMPACTION & I/O THROUGHPUT (cumulative ticker values, requires statistics)
+        // ═══════════════════════════════════════════════════════════════════════════
+
         let bytes_written = register_gauge_metric_instrument(
             &meter,
             "db_bytes_written".to_string(),
@@ -207,7 +226,10 @@ impl DbMetrics {
             "".to_string(),
         );
 
-        // Compaction activity gauges
+        // ═══════════════════════════════════════════════════════════════════════════
+        // COMPACTION ACTIVITY
+        // ═══════════════════════════════════════════════════════════════════════════
+
         let running_compactions = register_gauge_metric_instrument(
             &meter,
             "db_running_compactions".to_string(),
@@ -322,6 +344,7 @@ impl DbMetrics {
         // WRITE STALL DETECTION
         // ═══════════════════════════════════════════════════════════════════════════
 
+        // Global property (not per-CF): 1 if writes are completely blocked
         if let Ok(Some(val)) = db.inner.db.property_int_value("rocksdb.is-write-stopped") {
             self.is_write_stopped.record(val, &[]);
         }

--- a/madara/crates/client/db/src/rocksdb/metrics.rs
+++ b/madara/crates/client/db/src/rocksdb/metrics.rs
@@ -1,34 +1,40 @@
-//! RocksDB metrics for monitoring database health and detecting write stalls.
+//! RocksDB metrics for monitoring database health, compaction throughput, and write stalls.
 //!
-//! These metrics are exported via OpenTelemetry and can be scraped by Prometheus
-//! or pushed to an OTLP endpoint.
+//! ## Capacity Planning Metrics (requires statistics enabled, which is the default)
+//!
+//! Key queries for Grafana:
+//! - Ingest rate: `rate(db_bytes_written_total[5m])`
+//! - Compaction throughput: `rate(db_compact_write_bytes_total[5m])`
+//! - Write amplification: `rate(db_compact_write_bytes_total[5m]) / rate(db_flush_write_bytes_total[5m])`
+//! - Stall fraction: `rate(db_stall_micros_total[5m]) / 1e6`
+//! - Cache hit rate: `rate(db_block_cache_hit_total[5m]) / (rate(db_block_cache_hit_total[5m]) + rate(db_block_cache_miss_total[5m]))`
 //!
 //! ## Write Stall Detection
-//!
-//! Key metrics for detecting write stalls:
-//! - `db_is_write_stopped`: 1 if writes are completely blocked
-//! - `db_pending_compaction_bytes`: Backlog of data waiting to be compacted
-//! - `db_level_files_count`: Number of files at each LSM tree level
-//! - `db_num_immutable_memtables`: Memtables waiting to be flushed
-//!
-//! ## Alerting Thresholds
 //!
 //! | Metric | Warning | Critical |
 //! |--------|---------|----------|
 //! | `db_is_write_stopped` | - | = 1 |
 //! | `db_pending_compaction_bytes` | > 4 GiB | > 6 GiB |
 //! | `db_level_files_count` | L0: >= 15 | L0: >= 20 |
-//! | `db_num_immutable_memtables` | >= 3 | >= 4 |
+//! | `db_stall_micros_total` rate > 0 | warning | - |
+//!
+//! ## Note on `pending_compaction_bytes`
+//!
+//! `rocksdb.estimate-pending-compaction-bytes` always returns 0 for column families using
+//! universal compaction. Only leveled compaction CFs (the `bonsai_*_log` CFs) report
+//! meaningful values. The per-CF label lets you filter to leveled CFs only.
 
 use crate::rocksdb::column::ALL_COLUMNS;
 use crate::rocksdb::RocksDBStorage;
 use anyhow::Context;
-use mc_telemetry::register_gauge_metric_instrument;
-use opentelemetry::metrics::Gauge;
+use mc_telemetry::{register_counter_metric_instrument, register_gauge_metric_instrument};
+use opentelemetry::metrics::{Counter, Gauge};
 use opentelemetry::{global, InstrumentationScope, KeyValue};
 use rocksdb::perf::MemoryUsageBuilder;
+use rocksdb::statistics::Ticker;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct DbMetrics {
     // Storage metrics
     pub db_size: Gauge<u64>,
@@ -48,6 +54,29 @@ pub struct DbMetrics {
 
     // LSM tree level metrics
     pub level_files_count: Gauge<u64>,
+
+    // Compaction & I/O throughput counters (from RocksDB Statistics tickers)
+    pub bytes_written: Counter<u64>,
+    pub flush_write_bytes: Counter<u64>,
+    pub compact_read_bytes: Counter<u64>,
+    pub compact_write_bytes: Counter<u64>,
+    pub stall_micros: Counter<u64>,
+    pub block_cache_hit: Counter<u64>,
+    pub block_cache_miss: Counter<u64>,
+
+    // Previous ticker values for delta computation (get_ticker_count returns cumulative values)
+    prev_bytes_written: AtomicU64,
+    prev_flush_write_bytes: AtomicU64,
+    prev_compact_read_bytes: AtomicU64,
+    prev_compact_write_bytes: AtomicU64,
+    prev_stall_micros: AtomicU64,
+    prev_block_cache_hit: AtomicU64,
+    prev_block_cache_miss: AtomicU64,
+
+    // Compaction activity gauges
+    pub running_compactions: Gauge<u64>,
+    pub running_flushes: Gauge<u64>,
+    pub actual_delayed_write_rate: Gauge<u64>,
 }
 
 impl DbMetrics {
@@ -59,10 +88,6 @@ impl DbMetrics {
                 .with_attributes([KeyValue::new("crate", "db")])
                 .build(),
         );
-
-        // ═══════════════════════════════════════════════════════════════════════════
-        // STORAGE METRICS
-        // ═══════════════════════════════════════════════════════════════════════════
 
         let db_size = register_gauge_metric_instrument(
             &meter,
@@ -77,10 +102,6 @@ impl DbMetrics {
             "Size of each RocksDB column family in bytes".to_string(),
             "".to_string(),
         );
-
-        // ═══════════════════════════════════════════════════════════════════════════
-        // MEMORY METRICS
-        // ═══════════════════════════════════════════════════════════════════════════
 
         let mem_table_total = register_gauge_metric_instrument(
             &meter,
@@ -110,10 +131,6 @@ impl DbMetrics {
             "".to_string(),
         );
 
-        // ═══════════════════════════════════════════════════════════════════════════
-        // LSM TREE LEVEL METRICS
-        // ═══════════════════════════════════════════════════════════════════════════
-
         let level_files_count = register_gauge_metric_instrument(
             &meter,
             "db_level_files_count".to_string(),
@@ -121,14 +138,10 @@ impl DbMetrics {
             "".to_string(),
         );
 
-        // ═══════════════════════════════════════════════════════════════════════════
-        // MEMTABLE MONITORING
-        // ═══════════════════════════════════════════════════════════════════════════
-
         let num_immutable_memtables = register_gauge_metric_instrument(
             &meter,
             "db_num_immutable_memtables".to_string(),
-            "Number of immutable memtables waiting to be flushed (stall when >= max_write_buffer_number)".to_string(),
+            "Number of immutable memtables waiting to be flushed".to_string(),
             "".to_string(),
         );
 
@@ -138,10 +151,6 @@ impl DbMetrics {
             "Total size of all memtables in bytes".to_string(),
             "".to_string(),
         );
-
-        // ═══════════════════════════════════════════════════════════════════════════
-        // WRITE STALL DETECTION METRICS
-        // ═══════════════════════════════════════════════════════════════════════════
 
         let is_write_stopped = register_gauge_metric_instrument(
             &meter,
@@ -153,7 +162,79 @@ impl DbMetrics {
         let pending_compaction_bytes = register_gauge_metric_instrument(
             &meter,
             "db_pending_compaction_bytes".to_string(),
-            "Estimated bytes pending compaction".to_string(),
+            "Estimated bytes pending compaction (always 0 for universal compaction CFs)".to_string(),
+            "".to_string(),
+        );
+
+        // Compaction & I/O throughput counters
+        let bytes_written = register_counter_metric_instrument(
+            &meter,
+            "db_bytes_written_total".to_string(),
+            "Cumulative bytes written by application (Put/Merge/Delete)".to_string(),
+            "".to_string(),
+        );
+
+        let flush_write_bytes = register_counter_metric_instrument(
+            &meter,
+            "db_flush_write_bytes_total".to_string(),
+            "Cumulative bytes written by memtable flushes to L0".to_string(),
+            "".to_string(),
+        );
+
+        let compact_read_bytes = register_counter_metric_instrument(
+            &meter,
+            "db_compact_read_bytes_total".to_string(),
+            "Cumulative bytes read during compaction".to_string(),
+            "".to_string(),
+        );
+
+        let compact_write_bytes = register_counter_metric_instrument(
+            &meter,
+            "db_compact_write_bytes_total".to_string(),
+            "Cumulative bytes written during compaction".to_string(),
+            "".to_string(),
+        );
+
+        let stall_micros = register_counter_metric_instrument(
+            &meter,
+            "db_stall_micros_total".to_string(),
+            "Cumulative microseconds spent in write stalls".to_string(),
+            "".to_string(),
+        );
+
+        let block_cache_hit = register_counter_metric_instrument(
+            &meter,
+            "db_block_cache_hit_total".to_string(),
+            "Cumulative block cache hits".to_string(),
+            "".to_string(),
+        );
+
+        let block_cache_miss = register_counter_metric_instrument(
+            &meter,
+            "db_block_cache_miss_total".to_string(),
+            "Cumulative block cache misses (each miss = a disk read)".to_string(),
+            "".to_string(),
+        );
+
+        // Compaction activity gauges
+        let running_compactions = register_gauge_metric_instrument(
+            &meter,
+            "db_running_compactions".to_string(),
+            "Number of currently running compaction jobs".to_string(),
+            "".to_string(),
+        );
+
+        let running_flushes = register_gauge_metric_instrument(
+            &meter,
+            "db_running_flushes".to_string(),
+            "Number of currently running flush jobs".to_string(),
+            "".to_string(),
+        );
+
+        let actual_delayed_write_rate = register_gauge_metric_instrument(
+            &meter,
+            "db_actual_delayed_write_rate".to_string(),
+            "Current throttled write rate in bytes/sec when slowdown triggers fire".to_string(),
             "".to_string(),
         );
 
@@ -169,7 +250,32 @@ impl DbMetrics {
             level_files_count,
             num_immutable_memtables,
             memtable_size_bytes,
+            bytes_written,
+            flush_write_bytes,
+            compact_read_bytes,
+            compact_write_bytes,
+            stall_micros,
+            block_cache_hit,
+            block_cache_miss,
+            prev_bytes_written: AtomicU64::new(0),
+            prev_flush_write_bytes: AtomicU64::new(0),
+            prev_compact_read_bytes: AtomicU64::new(0),
+            prev_compact_write_bytes: AtomicU64::new(0),
+            prev_stall_micros: AtomicU64::new(0),
+            prev_block_cache_hit: AtomicU64::new(0),
+            prev_block_cache_miss: AtomicU64::new(0),
+            running_compactions,
+            running_flushes,
+            actual_delayed_write_rate,
         })
+    }
+
+    fn add_ticker_delta(&self, counter: &Counter<u64>, prev: &AtomicU64, current: u64) {
+        let previous = prev.swap(current, Ordering::Relaxed);
+        let delta = current.saturating_sub(previous);
+        if delta > 0 {
+            counter.add(delta, &[]);
+        }
     }
 
     pub fn try_update(&self, db: &RocksDBStorage) -> anyhow::Result<u64> {
@@ -180,36 +286,33 @@ impl DbMetrics {
         let mut total_files_at_level: [u64; 7] = [0; 7];
 
         // ═══════════════════════════════════════════════════════════════════════════
-        // PER-COLUMN-FAMILY METRICS (aggregated across all columns)
+        // PER-COLUMN-FAMILY METRICS
         // ═══════════════════════════════════════════════════════════════════════════
 
         for column in ALL_COLUMNS {
             let cf_handle = db.inner.get_column(column.clone());
 
-            // Storage size
             let cf_metadata = db.inner.db.get_column_family_metadata_cf(&cf_handle);
             let column_size = cf_metadata.size;
             storage_size += column_size;
             self.column_sizes.record(column_size, &[KeyValue::new("column", column.rocksdb_name)]);
 
-            // Immutable memtables waiting to be flushed
             if let Ok(Some(val)) = db.inner.db.property_int_value_cf(&cf_handle, "rocksdb.num-immutable-mem-table") {
                 total_immutable_memtables += val;
             }
 
-            // Memtable size
             if let Ok(Some(val)) = db.inner.db.property_int_value_cf(&cf_handle, "rocksdb.cur-size-all-mem-tables") {
                 total_memtable_size += val;
             }
 
-            // Pending compaction bytes
+            // pending_compaction_bytes: report per-CF (universal CFs always report 0)
             if let Ok(Some(val)) =
                 db.inner.db.property_int_value_cf(&cf_handle, "rocksdb.estimate-pending-compaction-bytes")
             {
                 total_pending_compaction += val;
+                self.pending_compaction_bytes.record(val, &[KeyValue::new("column", column.rocksdb_name)]);
             }
 
-            // Record file counts for levels 0-6 (RocksDB typically uses up to 7 levels)
             for (level, count) in total_files_at_level.iter_mut().enumerate() {
                 let property = format!("rocksdb.num-files-at-level{}", level);
                 if let Ok(Some(val)) = db.inner.db.property_int_value_cf(&cf_handle, &property) {
@@ -218,12 +321,10 @@ impl DbMetrics {
             }
         }
 
-        // Record file counts for levels 0-6
         for (level, count) in total_files_at_level.iter().enumerate() {
             self.level_files_count.record(*count, &[KeyValue::new("level", format!("L{}", level))]);
         }
 
-        // Record aggregated storage metrics
         self.db_size.record(storage_size, &[]);
 
         // ═══════════════════════════════════════════════════════════════════════════
@@ -238,21 +339,69 @@ impl DbMetrics {
         self.mem_table_readers_total.record(mem_usage.approximate_mem_table_readers_total(), &[]);
         self.cache_total.record(mem_usage.approximate_cache_total(), &[]);
 
-        // Record aggregated per-CF metrics
         self.num_immutable_memtables.record(total_immutable_memtables, &[]);
         self.memtable_size_bytes.record(total_memtable_size, &[]);
 
         // ═══════════════════════════════════════════════════════════════════════════
-        // WRITE STALL DETECTION METRICS
+        // WRITE STALL DETECTION
         // ═══════════════════════════════════════════════════════════════════════════
 
-        // Is write stopped? (global property, not per-CF)
         if let Ok(Some(val)) = db.inner.db.property_int_value("rocksdb.is-write-stopped") {
             self.is_write_stopped.record(val, &[]);
         }
 
-        // Record aggregated per-CF metrics
-        self.pending_compaction_bytes.record(total_pending_compaction, &[]);
+        self.pending_compaction_bytes.record(total_pending_compaction, &[KeyValue::new("column", "total")]);
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // COMPACTION & I/O THROUGHPUT (from Statistics tickers, DB-wide)
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        let opts = &db.inner.global_opts;
+        self.add_ticker_delta(
+            &self.bytes_written,
+            &self.prev_bytes_written,
+            opts.get_ticker_count(Ticker::BytesWritten),
+        );
+        self.add_ticker_delta(
+            &self.flush_write_bytes,
+            &self.prev_flush_write_bytes,
+            opts.get_ticker_count(Ticker::FlushWriteBytes),
+        );
+        self.add_ticker_delta(
+            &self.compact_read_bytes,
+            &self.prev_compact_read_bytes,
+            opts.get_ticker_count(Ticker::CompactReadBytes),
+        );
+        self.add_ticker_delta(
+            &self.compact_write_bytes,
+            &self.prev_compact_write_bytes,
+            opts.get_ticker_count(Ticker::CompactWriteBytes),
+        );
+        self.add_ticker_delta(&self.stall_micros, &self.prev_stall_micros, opts.get_ticker_count(Ticker::StallMicros));
+        self.add_ticker_delta(
+            &self.block_cache_hit,
+            &self.prev_block_cache_hit,
+            opts.get_ticker_count(Ticker::BlockCacheHit),
+        );
+        self.add_ticker_delta(
+            &self.block_cache_miss,
+            &self.prev_block_cache_miss,
+            opts.get_ticker_count(Ticker::BlockCacheMiss),
+        );
+
+        // ═══════════════════════════════════════════════════════════════════════════
+        // COMPACTION ACTIVITY (global properties)
+        // ═══════════════════════════════════════════════════════════════════════════
+
+        if let Ok(Some(val)) = db.inner.db.property_int_value("rocksdb.num-running-compactions") {
+            self.running_compactions.record(val, &[]);
+        }
+        if let Ok(Some(val)) = db.inner.db.property_int_value("rocksdb.num-running-flushes") {
+            self.running_flushes.record(val, &[]);
+        }
+        if let Ok(Some(val)) = db.inner.db.property_int_value("rocksdb.actual-delayed-write-rate") {
+            self.actual_delayed_write_rate.record(val, &[]);
+        }
 
         Ok(storage_size)
     }

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -181,7 +181,7 @@ pub struct RocksDBStorage {
     inner: Arc<RocksDBStorageInner>,
     backup: BackupManager,
     snapshots: Arc<Snapshots>,
-    metrics: Arc<DbMetrics>,
+    metrics: DbMetrics,
 }
 
 impl RocksDBStorage {
@@ -208,7 +208,7 @@ impl RocksDBStorage {
         Ok(Self {
             inner,
             snapshots: snapshot.into(),
-            metrics: Arc::new(DbMetrics::register().context("Registering database metrics")?),
+            metrics: DbMetrics::register().context("Registering database metrics")?,
             backup: BackupManager::start_if_enabled(path, &config).context("Startup backup manager")?,
         })
     }

--- a/madara/crates/client/db/src/rocksdb/mod.rs
+++ b/madara/crates/client/db/src/rocksdb/mod.rs
@@ -26,6 +26,7 @@ use mp_class::ConvertedClass;
 use mp_convert::Felt;
 use mp_state_update::StateDiff;
 use mp_transactions::{validated::ValidatedTransaction, L1HandlerTransactionWithFee};
+use rocksdb::Options as RocksDBOptions;
 use rocksdb::{BoundColumnFamily, ColumnFamilyDescriptor, DBWithThreadMode, FlushOptions, MultiThreaded, WriteOptions};
 use std::{fmt, path::Path, sync::Arc};
 
@@ -82,6 +83,7 @@ fn deserialize<T: serde::de::DeserializeOwned>(bytes: impl AsRef<[u8]>) -> Resul
 
 struct RocksDBStorageInner {
     db: DB,
+    global_opts: RocksDBOptions,
     writeopts: WriteOptions,
     config: RocksDBConfig,
 }
@@ -179,7 +181,7 @@ pub struct RocksDBStorage {
     inner: Arc<RocksDBStorageInner>,
     backup: BackupManager,
     snapshots: Arc<Snapshots>,
-    metrics: DbMetrics,
+    metrics: Arc<DbMetrics>,
 }
 
 impl RocksDBStorage {
@@ -194,7 +196,7 @@ impl RocksDBStorage {
 
         let writeopts = config.write_mode.to_write_options();
         tracing::info!("📝 Database write mode: {}", config.write_mode);
-        let inner = Arc::new(RocksDBStorageInner { writeopts, db, config: config.clone() });
+        let inner = Arc::new(RocksDBStorageInner { global_opts: opts, writeopts, db, config: config.clone() });
 
         let head_block_n = inner.get_chain_tip_without_content()?.and_then(|c| match c {
             StoredChainTipWithoutContent::Confirmed(block_n) => Some(block_n),
@@ -206,7 +208,7 @@ impl RocksDBStorage {
         Ok(Self {
             inner,
             snapshots: snapshot.into(),
-            metrics: DbMetrics::register().context("Registering database metrics")?,
+            metrics: Arc::new(DbMetrics::register().context("Registering database metrics")?),
             backup: BackupManager::start_if_enabled(path, &config).context("Startup backup manager")?,
         })
     }

--- a/madara/crates/client/db/src/rocksdb/options.rs
+++ b/madara/crates/client/db/src/rocksdb/options.rs
@@ -184,11 +184,13 @@ impl std::fmt::Display for DbWriteMode {
 
 #[derive(Debug, Clone)]
 pub struct RocksDBConfig {
-    /// Enable statistics. Statistics will be put in the `LOG` file in the db folder. This can have an effect on performance.
+    /// Enable statistics for compaction/stall monitoring. Uses ExceptDetailedTimers by default
+    /// which has minimal overhead but enables all counter-based metrics (write amplification,
+    /// compaction throughput, stall time). Disable only if profiling shows measurable impact.
     pub enable_statistics: bool,
     /// Dump statistics every `statistics_period_sec`.
     pub statistics_period_sec: u32,
-    /// Statistics level. This can have an effect on performance.
+    /// Statistics level. ExceptDetailedTimers is recommended for production.
     pub statistics_level: StatsLevel,
     /// Memory budget for blocks-related columns
     pub memtable_blocks_budget_bytes: usize,
@@ -242,9 +244,9 @@ pub struct RocksDBConfig {
 impl Default for RocksDBConfig {
     fn default() -> Self {
         Self {
-            enable_statistics: false,
+            enable_statistics: true,
             statistics_period_sec: 60,
-            statistics_level: StatsLevel::All,
+            statistics_level: StatsLevel::ExceptDetailedTimers,
             // TODO: these might not be the best defaults at all
             memtable_blocks_budget_bytes: 1 * GiB,
             memtable_contracts_budget_bytes: 128 * MiB,
@@ -440,8 +442,8 @@ pub fn rocksdb_global_options(config: &RocksDBConfig) -> Result<Options> {
     // ═══════════════════════════════════════════════════════════════════════════
     // STATISTICS (Optional, for debugging)
     // ═══════════════════════════════════════════════════════════════════════════
-    // Statistics add overhead but are invaluable for diagnosing performance issues.
-    // Enable temporarily with --db-enable-statistics to debug stalls.
+    // Statistics are enabled by default with ExceptDetailedTimers level for production
+    // monitoring of compaction throughput, write amplification, and stall detection.
     if config.enable_statistics {
         options.enable_statistics();
         options.set_statistics_level(config.statistics_level);

--- a/madara/crates/client/db/src/rocksdb/options.rs
+++ b/madara/crates/client/db/src/rocksdb/options.rs
@@ -75,7 +75,6 @@
 //! ### 1. MemTable Settings
 //! - `write_buffer_size`: Size of single memtable (larger = fewer flushes, more memory)
 //! - `max_write_buffer_number`: Max memtables before stall (higher = more buffer)
-//! - `min_write_buffer_number_to_merge`: Memtables to merge before flush (reduces L0 files)
 //!
 //! ### 2. L0 Thresholds
 //! - `level_zero_slowdown_writes_trigger`: Start throttling (gradual slowdown)
@@ -382,11 +381,6 @@ pub fn rocksdb_global_options(config: &RocksDBConfig) -> Result<Options> {
     // providing much more headroom during write bursts.
     options.set_max_write_buffer_number(config.max_write_buffer_number);
 
-    // Merge 2 memtables before flushing to L0.
-    // This reduces L0 file count (fewer files = less read amplification)
-    // and removes duplicate keys, reducing overall data size.
-    options.set_min_write_buffer_number_to_merge(2);
-
     // ═══════════════════════════════════════════════════════════════════════════
     // WRITE STALL PREVENTION - L0 THRESHOLDS
     // ═══════════════════════════════════════════════════════════════════════════
@@ -530,13 +524,9 @@ impl Column {
             options.set_compaction_style(DBCompactionStyle::Level);
             options.set_write_buffer_size(budget_bytes / 4);
             options.set_max_write_buffer_number(config.max_write_buffer_number);
-            options.set_min_write_buffer_number_to_merge(2);
-            options.set_level_zero_file_num_compaction_trigger(4);
+            // 2x default (256 MiB) so L1 absorbs more data before triggering L1->L2 compaction,
+            // reducing write amplification for these append-heavy log CFs.
             options.set_max_bytes_for_level_base(512 * MiB as u64);
-            options.set_max_bytes_for_level_multiplier(10.0);
-            options.set_target_file_size_base(64 * MiB as u64);
-            options.set_target_file_size_multiplier(1);
-            options.set_num_levels(7);
         } else {
             // Universal compaction for everything else (lower write amp, fine
             // for read-heavy or balanced CFs). Sets write_buffer_size, memtable
@@ -544,11 +534,8 @@ impl Column {
             options.optimize_universal_style_compaction(budget_bytes);
         }
 
-        // IMPORTANT: `optimize_universal_style_compaction` resets the L0 stall
-        // triggers to RocksDB's hardcoded defaults (slowdown=20, stop=36),
-        // ignoring whatever we set globally / via CLI / via env. Re-apply them
-        // here so our configured values actually take effect per-CF. Setting
-        // them on the leveled branch is harmless (matches the explicit values).
+        // L0 stall thresholds are CF-scoped in RocksDB, so the global-level
+        // values don't propagate to named CFs. Set them explicitly here.
         options.set_level_zero_slowdown_writes_trigger(config.level_zero_slowdown_writes_trigger);
         options.set_level_zero_stop_writes_trigger(config.level_zero_stop_writes_trigger);
 

--- a/madara/crates/client/db/src/rocksdb/options.rs
+++ b/madara/crates/client/db/src/rocksdb/options.rs
@@ -479,10 +479,16 @@ impl Column {
     ///
     /// ## Compaction Strategy
     ///
-    /// We use Universal Compaction which:
-    /// - Has lower write amplification than Level Compaction
-    /// - Better for write-heavy workloads (like blockchain sync)
-    /// - Trade-off: Higher space amplification
+    /// Two styles are used depending on the column's write pattern:
+    ///
+    /// - **Universal** (default for most CFs): lower write amplification, well-suited
+    ///   to random-write CFs where memtables dedup and SSTs have overlapping ranges.
+    ///   Trade-off: higher space amplification, deferred big merges.
+    /// - **Leveled** (CFs marked with `set_log_cf()`, i.e. `bonsai_*_log`): continuously
+    ///   drains L0 -> L1 as soon as `level0_file_num_compaction_trigger=4` is exceeded.
+    ///   Required for append-only log CFs where universal's size-ratio / size-amp
+    ///   heuristics fail to fire and L0 SSTs accumulate past the stop trigger,
+    ///   stalling the entire DB via `atomic_flush`.
     ///
     /// ## Compression
     ///

--- a/madara/crates/client/db/src/rocksdb/options.rs
+++ b/madara/crates/client/db/src/rocksdb/options.rs
@@ -98,7 +98,7 @@ use std::path::PathBuf;
 
 use crate::rocksdb::column::{Column, ColumnMemoryBudget};
 use anyhow::{Context, Result};
-use rocksdb::{DBCompressionType, Env, Options, SliceTransform, WriteOptions};
+use rocksdb::{DBCompactionStyle, DBCompressionType, Env, Options, SliceTransform, WriteOptions};
 use serde::{Deserialize, Serialize};
 
 const KiB: usize = 1024;
@@ -505,25 +505,44 @@ impl Column {
         // Zstd provides excellent compression with good read/write performance.
         options.set_compression_type(DBCompressionType::Zstd);
 
-        // Configure memory budget and compaction based on column tier.
-        // optimize_universal_style_compaction sets:
-        // - write_buffer_size (memtable size)
-        // - Universal compaction settings
-        // - Appropriate L0 thresholds for the budget
-        match self.budget_tier {
-            ColumnMemoryBudget::Blocks => {
-                options.set_memtable_prefix_bloom_ratio(config.memtable_prefix_bloom_filter_ratio);
-                options.optimize_universal_style_compaction(config.memtable_blocks_budget_bytes);
-            }
-            ColumnMemoryBudget::Contracts => {
-                options.set_memtable_prefix_bloom_ratio(config.memtable_prefix_bloom_filter_ratio);
-                options.optimize_universal_style_compaction(config.memtable_contracts_budget_bytes);
-            }
-            ColumnMemoryBudget::Other => {
-                options.set_memtable_prefix_bloom_ratio(config.memtable_prefix_bloom_filter_ratio);
-                options.optimize_universal_style_compaction(config.memtable_other_budget_bytes);
-            }
+        let budget_bytes = match self.budget_tier {
+            ColumnMemoryBudget::Blocks => config.memtable_blocks_budget_bytes,
+            ColumnMemoryBudget::Contracts => config.memtable_contracts_budget_bytes,
+            ColumnMemoryBudget::Other => config.memtable_other_budget_bytes,
+        };
+
+        options.set_memtable_prefix_bloom_ratio(config.memtable_prefix_bloom_filter_ratio);
+
+        if self.log_cf {
+            // Leveled compaction for write-heavy, append-only log CFs (Bonsai TrieLog).
+            // Universal compaction defers work and then does one giant merge, which
+            // falls behind on append-mostly workloads and accumulates L0 files until
+            // writes stall. Leveled drains L0 -> L1 continuously in many small,
+            // parallelisable jobs, keeping L0 file counts low at steady state.
+            options.set_compaction_style(DBCompactionStyle::Level);
+            options.set_write_buffer_size(budget_bytes / 4);
+            options.set_max_write_buffer_number(config.max_write_buffer_number);
+            options.set_min_write_buffer_number_to_merge(2);
+            options.set_level_zero_file_num_compaction_trigger(4);
+            options.set_max_bytes_for_level_base(512 * MiB as u64);
+            options.set_max_bytes_for_level_multiplier(10.0);
+            options.set_target_file_size_base(64 * MiB as u64);
+            options.set_target_file_size_multiplier(1);
+            options.set_num_levels(7);
+        } else {
+            // Universal compaction for everything else (lower write amp, fine
+            // for read-heavy or balanced CFs). Sets write_buffer_size, memtable
+            // counts, L0 thresholds, and num_levels for the given memory budget.
+            options.optimize_universal_style_compaction(budget_bytes);
         }
+
+        // IMPORTANT: `optimize_universal_style_compaction` resets the L0 stall
+        // triggers to RocksDB's hardcoded defaults (slowdown=20, stop=36),
+        // ignoring whatever we set globally / via CLI / via env. Re-apply them
+        // here so our configured values actually take effect per-CF. Setting
+        // them on the leveled branch is harmless (matches the explicit values).
+        options.set_level_zero_slowdown_writes_trigger(config.level_zero_slowdown_writes_trigger);
+        options.set_level_zero_stop_writes_trigger(config.level_zero_stop_writes_trigger);
 
         // Point lookup optimization for columns that primarily do single-key gets.
         // Adds a bloom filter in the block cache for faster negative lookups.

--- a/madara/crates/client/db/src/rocksdb/trie.rs
+++ b/madara/crates/client/db/src/rocksdb/trie.rs
@@ -13,13 +13,13 @@ use std::sync::Arc;
 
 pub const BONSAI_CONTRACT_FLAT_COLUMN: Column = Column::new("bonsai_contract_flat").set_point_lookup();
 pub const BONSAI_CONTRACT_TRIE_COLUMN: Column = Column::new("bonsai_contract_trie").set_point_lookup();
-pub const BONSAI_CONTRACT_LOG_COLUMN: Column = Column::new("bonsai_contract_log");
+pub const BONSAI_CONTRACT_LOG_COLUMN: Column = Column::new("bonsai_contract_log").as_log_cf();
 pub const BONSAI_CONTRACT_STORAGE_FLAT_COLUMN: Column = Column::new("bonsai_contract_storage_flat").set_point_lookup();
 pub const BONSAI_CONTRACT_STORAGE_TRIE_COLUMN: Column = Column::new("bonsai_contract_storage_trie").set_point_lookup();
-pub const BONSAI_CONTRACT_STORAGE_LOG_COLUMN: Column = Column::new("bonsai_contract_storage_log");
+pub const BONSAI_CONTRACT_STORAGE_LOG_COLUMN: Column = Column::new("bonsai_contract_storage_log").as_log_cf();
 pub const BONSAI_CLASS_FLAT_COLUMN: Column = Column::new("bonsai_class_flat").set_point_lookup();
 pub const BONSAI_CLASS_TRIE_COLUMN: Column = Column::new("bonsai_class_trie").set_point_lookup();
-pub const BONSAI_CLASS_LOG_COLUMN: Column = Column::new("bonsai_class_log");
+pub const BONSAI_CLASS_LOG_COLUMN: Column = Column::new("bonsai_class_log").as_log_cf();
 
 pub type GlobalTrie<H> = BonsaiStorage<BasicId, BonsaiDB, H>;
 

--- a/madara/crates/client/db/src/rocksdb/trie.rs
+++ b/madara/crates/client/db/src/rocksdb/trie.rs
@@ -13,13 +13,13 @@ use std::sync::Arc;
 
 pub const BONSAI_CONTRACT_FLAT_COLUMN: Column = Column::new("bonsai_contract_flat").set_point_lookup();
 pub const BONSAI_CONTRACT_TRIE_COLUMN: Column = Column::new("bonsai_contract_trie").set_point_lookup();
-pub const BONSAI_CONTRACT_LOG_COLUMN: Column = Column::new("bonsai_contract_log").as_log_cf();
+pub const BONSAI_CONTRACT_LOG_COLUMN: Column = Column::new("bonsai_contract_log").set_log_cf();
 pub const BONSAI_CONTRACT_STORAGE_FLAT_COLUMN: Column = Column::new("bonsai_contract_storage_flat").set_point_lookup();
 pub const BONSAI_CONTRACT_STORAGE_TRIE_COLUMN: Column = Column::new("bonsai_contract_storage_trie").set_point_lookup();
-pub const BONSAI_CONTRACT_STORAGE_LOG_COLUMN: Column = Column::new("bonsai_contract_storage_log").as_log_cf();
+pub const BONSAI_CONTRACT_STORAGE_LOG_COLUMN: Column = Column::new("bonsai_contract_storage_log").set_log_cf();
 pub const BONSAI_CLASS_FLAT_COLUMN: Column = Column::new("bonsai_class_flat").set_point_lookup();
 pub const BONSAI_CLASS_TRIE_COLUMN: Column = Column::new("bonsai_class_trie").set_point_lookup();
-pub const BONSAI_CLASS_LOG_COLUMN: Column = Column::new("bonsai_class_log").as_log_cf();
+pub const BONSAI_CLASS_LOG_COLUMN: Column = Column::new("bonsai_class_log").set_log_cf();
 
 pub type GlobalTrie<H> = BonsaiStorage<BasicId, BonsaiDB, H>;
 

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -3237,7 +3237,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_flush_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_flush_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Flush Rate (ingest \u2192 L0)",
           "refId": "A"
         },
@@ -3246,7 +3246,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_compact_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_compact_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Compaction Write Rate",
           "refId": "B"
         },
@@ -3255,7 +3255,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_compact_read_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_compact_read_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Compaction Read Rate",
           "refId": "C"
         },
@@ -3264,7 +3264,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_bytes_written_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_bytes_written{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "App Write Rate",
           "refId": "D"
         }
@@ -3326,7 +3326,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_compact_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / rate(db_flush_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_compact_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / rate(db_flush_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Write Amplification (compact/flush)",
           "refId": "A"
         }
@@ -3389,7 +3389,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_stall_micros_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / 1e6",
+          "expr": "rate(db_stall_micros{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / 1e6",
           "legendFormat": "Stall Fraction",
           "refId": "A"
         }
@@ -3452,7 +3452,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_block_cache_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(db_block_cache_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(db_block_cache_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "expr": "rate(db_block_cache_hit{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(db_block_cache_hit{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(db_block_cache_miss{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "Cache Hit Rate",
           "refId": "A"
         }

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -3180,6 +3180,452 @@
         "x": 0,
         "y": 84
       },
+      "id": 420,
+      "panels": [],
+      "title": "RocksDB Compaction & I/O Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "bytes/sec",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 85
+      },
+      "id": 421,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(db_flush_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Flush Rate (ingest \u2192 L0)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(db_compact_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Compaction Write Rate",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(db_compact_read_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Compaction Read Rate",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(db_bytes_written_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "App Write Rate",
+          "refId": "D"
+        }
+      ],
+      "title": "Ingest vs Compaction Throughput",
+      "description": "Compares application write rate against compaction throughput.\nIf flush rate sustained above compaction ceiling (disk_bw / WA), a stall is coming.\nCompaction read+write combined should stay below disk throughput (125 MB/s for gp3 default).",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "ratio",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "none",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "id": 422,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(db_compact_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / rate(db_flush_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "legendFormat": "Write Amplification (compact/flush)",
+          "refId": "A"
+        }
+      ],
+      "title": "Write Amplification",
+      "description": "Ratio of compaction output bytes to flush bytes.\nLeveled compaction: typically 10-25x. Universal: 5-10x.\nHigher WA = more disk bandwidth consumed by background work.",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "fillOpacity": 30,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 93
+      },
+      "id": 423,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(db_stall_micros_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / 1e6",
+          "legendFormat": "Stall Fraction",
+          "refId": "A"
+        }
+      ],
+      "title": "Write Stall Time Fraction",
+      "description": "Fraction of time spent in write stalls. Any non-zero value means RocksDB is throttling writes.\nThis is the earliest canary for compaction falling behind.",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 93
+      },
+      "id": 424,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(db_block_cache_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(db_block_cache_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(db_block_cache_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "Cache Hit Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Block Cache Hit Rate",
+      "description": "Fraction of block reads served from cache vs disk.\nLow hit rate = high read amplification hitting IOPS.",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "none",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Delayed Write Rate"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 93
+      },
+      "id": 425,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "db_running_compactions{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Running Compactions",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "db_running_flushes{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Running Flushes",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "db_actual_delayed_write_rate{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "legendFormat": "Delayed Write Rate",
+          "refId": "C"
+        }
+      ],
+      "title": "Compaction Activity & Write Throttle",
+      "description": "Running compaction/flush jobs and the throttled write rate.\n0 compactions when L0 is growing = compaction not triggering.\nDelayed write rate > 0 = RocksDB is actively throttling writes.",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 101
+      },
+      "id": 426,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "db_pending_compaction_bytes{namespace=~\"$namespace\", pod=~\"$pod\", column!=\"total\"} > 0",
+          "legendFormat": "{{column}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Compaction Bytes (per Column Family)",
+      "description": "Per-CF pending compaction bytes. Only leveled compaction CFs (bonsai_*_log) report meaningful values.\nUniversal compaction CFs always report 0 \u2014 this is a known RocksDB limitation, not a bug.",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 111
+      },
       "id": 200,
       "panels": [],
       "title": "Cairo Native Execution",
@@ -3213,7 +3659,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 85
+        "y": 112
       },
       "id": 201,
       "options": {
@@ -3272,7 +3718,7 @@
         "h": 4,
         "w": 3,
         "x": 3,
-        "y": 85
+        "y": 112
       },
       "id": 202,
       "options": {
@@ -3331,7 +3777,7 @@
         "h": 4,
         "w": 3,
         "x": 6,
-        "y": 85
+        "y": 112
       },
       "id": 203,
       "options": {
@@ -3390,7 +3836,7 @@
         "h": 4,
         "w": 3,
         "x": 9,
-        "y": 85
+        "y": 112
       },
       "id": 204,
       "options": {
@@ -3449,7 +3895,7 @@
         "h": 4,
         "w": 3,
         "x": 12,
-        "y": 85
+        "y": 112
       },
       "id": 205,
       "options": {
@@ -3508,7 +3954,7 @@
         "h": 4,
         "w": 3,
         "x": 15,
-        "y": 85
+        "y": 112
       },
       "id": 206,
       "options": {
@@ -3571,7 +4017,7 @@
         "h": 4,
         "w": 3,
         "x": 18,
-        "y": 85
+        "y": 112
       },
       "id": 212,
       "options": {
@@ -3634,7 +4080,7 @@
         "h": 4,
         "w": 3,
         "x": 21,
-        "y": 85
+        "y": 112
       },
       "id": 213,
       "options": {
@@ -3725,7 +4171,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 89
+        "y": 116
       },
       "id": 207,
       "options": {
@@ -3858,7 +4304,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 89
+        "y": 116
       },
       "id": 208,
       "options": {
@@ -3978,7 +4424,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 89
+        "y": 116
       },
       "id": 209,
       "options": {
@@ -4114,7 +4560,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 97
+        "y": 124
       },
       "id": 210,
       "options": {
@@ -4260,7 +4706,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 97
+        "y": 124
       },
       "id": 211,
       "options": {
@@ -4308,7 +4754,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 132
       },
       "id": 300,
       "panels": [],
@@ -4375,7 +4821,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 106
+        "y": 133
       },
       "id": 301,
       "options": {
@@ -4505,7 +4951,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 106
+        "y": 133
       },
       "id": 302,
       "options": {
@@ -4680,7 +5126,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 114
+        "y": 141
       },
       "id": 309,
       "options": {
@@ -4792,7 +5238,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 114
+        "y": 141
       },
       "id": 314,
       "options": {
@@ -4903,7 +5349,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 122
+        "y": 149
       },
       "id": 303,
       "options": {
@@ -5022,7 +5468,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 114
+        "y": 141
       },
       "id": 304,
       "options": {
@@ -5141,7 +5587,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 122
+        "y": 149
       },
       "id": 305,
       "options": {
@@ -5271,7 +5717,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 122
+        "y": 149
       },
       "id": 306,
       "options": {
@@ -5410,7 +5856,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 130
+        "y": 157
       },
       "id": 307,
       "options": {
@@ -5522,7 +5968,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 130
+        "y": 157
       },
       "id": 308,
       "options": {
@@ -5587,7 +6033,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 157
+        "y": 184
       },
       "options": {
         "legend": {
@@ -5607,84 +6053,120 @@
       },
       "targets": [
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Total Close Block",
           "refId": "A"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap merklization_ms [$__interval]) by ()",
           "legendFormat": "Merklization",
           "refId": "B"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap commitments_ms [$__interval]) by ()",
           "legendFormat": "Commitments",
           "refId": "C"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap db_write_ms [$__interval]) by ()",
           "legendFormat": "DB Write",
           "refId": "D"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap block_hash_ms [$__interval]) by ()",
           "legendFormat": "Block Hash",
           "refId": "E"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_preconfirmed_ms [$__interval]) by ()",
           "legendFormat": "Close Preconfirmed",
           "refId": "F"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap get_full_block_ms [$__interval]) by ()",
           "legendFormat": "Get Full Block",
           "refId": "G"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_trie_ms [$__interval]) by ()",
           "legendFormat": "Contract Trie",
           "refId": "H"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap class_trie_ms [$__interval]) by ()",
           "legendFormat": "Class Trie",
           "refId": "I"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_storage_trie_commit_ms [$__interval]) by ()",
           "legendFormat": "Contract Storage Trie Commit",
           "refId": "J"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap contract_trie_commit_ms [$__interval]) by ()",
           "legendFormat": "Contract Trie Commit",
           "refId": "K"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap class_trie_commit_ms [$__interval]) by ()",
           "legendFormat": "Class Trie Commit",
@@ -5721,14 +6203,18 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 167
+        "y": 194
       },
       "options": {
         "legend": {
           "showLegend": true,
           "displayMode": "table",
           "placement": "right",
-          "calcs": ["lastNotNull", "mean", "max"]
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
         },
         "tooltip": {
           "mode": "multi",
@@ -5737,7 +6223,10 @@
       },
       "targets": [
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "quantile_over_time(0.50, {namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap close_block_total_ms [$__interval]) by ()",
           "legendFormat": "Close Block Total (p50)",
@@ -5773,7 +6262,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 167
+        "y": 194
       },
       "options": {
         "legend": {
@@ -5793,84 +6282,120 @@
       },
       "targets": [
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap tx_count [$__interval]) by ()",
           "legendFormat": "Tx Count",
           "refId": "A"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap event_count [$__interval]) by ()",
           "legendFormat": "Event Count",
           "refId": "B"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_executed [$__interval]) by ()",
           "legendFormat": "Txs Executed",
           "refId": "C"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_reverted [$__interval]) by ()",
           "legendFormat": "Txs Reverted",
           "refId": "D"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap state_diff_len [$__interval]) by ()",
           "legendFormat": "State Diff Length",
           "refId": "E"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap batches_executed [$__interval]) by ()",
           "legendFormat": "Batches Executed",
           "refId": "F"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_added_to_block [$__interval]) by ()",
           "legendFormat": "Txs Added to Block",
           "refId": "G"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap txs_rejected [$__interval]) by ()",
           "legendFormat": "Txs Rejected",
           "refId": "H"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap classes_declared [$__interval]) by ()",
           "legendFormat": "Classes Declared",
           "refId": "I"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap deployed_contracts [$__interval]) by ()",
           "legendFormat": "Deployed Contracts",
           "refId": "J"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap storage_diffs [$__interval]) by ()",
           "legendFormat": "Storage Diffs",
           "refId": "K"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap nonce_updates [$__interval]) by ()",
           "legendFormat": "Nonce Updates",
@@ -5907,14 +6432,18 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 177
+        "y": 204
       },
       "options": {
         "legend": {
           "showLegend": true,
           "displayMode": "table",
           "placement": "right",
-          "calcs": ["lastNotNull", "mean", "max"]
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
         },
         "tooltip": {
           "mode": "multi",
@@ -5923,42 +6452,60 @@
       },
       "targets": [
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap l2_gas_consumed [$__interval]) by ()",
           "legendFormat": "L2 Gas Consumed",
           "refId": "A"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_l1_gas [$__interval]) by ()",
           "legendFormat": "Bouncer L1 Gas",
           "refId": "B"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_sierra_gas [$__interval]) by ()",
           "legendFormat": "Bouncer Sierra Gas",
           "refId": "C"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_n_events [$__interval]) by ()",
           "legendFormat": "Bouncer Events",
           "refId": "D"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_message_segment_length [$__interval]) by ()",
           "legendFormat": "Bouncer Msg Segment Len",
           "refId": "E"
         },
         {
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
           "editorMode": "code",
           "expr": "avg_over_time({namespace=~\"$namespace\", pod=~\"$pod\"} |= \"close_block_complete\" | json | unwrap bouncer_state_diff_size [$__interval]) by ()",
           "legendFormat": "Bouncer State Diff Size",
@@ -5991,7 +6538,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 187
+        "y": 214
       },
       "panelLinks": null,
       "targets": null,
@@ -6010,7 +6557,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 188
+        "y": 215
       },
       "fieldConfig": {
         "defaults": {
@@ -6071,7 +6618,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 188
+        "y": 215
       },
       "fieldConfig": {
         "defaults": {
@@ -6132,7 +6679,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 188
+        "y": 215
       },
       "fieldConfig": {
         "defaults": {
@@ -6193,7 +6740,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 188
+        "y": 215
       },
       "fieldConfig": {
         "defaults": {
@@ -6254,7 +6801,7 @@
         "h": 4,
         "w": 4,
         "x": 16,
-        "y": 188
+        "y": 215
       },
       "fieldConfig": {
         "defaults": {
@@ -6319,7 +6866,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 188
+        "y": 215
       },
       "fieldConfig": {
         "defaults": {
@@ -6380,7 +6927,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 192
+        "y": 219
       },
       "options": {
         "legend": {
@@ -6484,7 +7031,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 192
+        "y": 219
       },
       "options": {
         "legend": {
@@ -6620,7 +7167,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 200
+        "y": 227
       },
       "options": {
         "legend": {
@@ -6740,7 +7287,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 200
+        "y": 227
       },
       "options": {
         "legend": {
@@ -6844,7 +7391,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 208
+        "y": 235
       },
       "options": {
         "legend": {
@@ -6998,7 +7545,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 208
+        "y": 235
       },
       "options": {
         "legend": {
@@ -7095,7 +7642,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 216
+        "y": 243
       },
       "id": 413,
       "panels": [],
@@ -7130,7 +7677,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 217
+        "y": 244
       },
       "id": 414,
       "options": {
@@ -7188,7 +7735,7 @@
         "h": 6,
         "w": 12,
         "x": 6,
-        "y": 217
+        "y": 244
       },
       "id": 415,
       "options": {
@@ -7263,7 +7810,7 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 217
+        "y": 244
       },
       "id": 416,
       "options": {


### PR DESCRIPTION
Universal compaction defers L0->L1 work via size-ratio and size-amplification heuristics that do not fire on append-only `bonsai_*_log` CFs (Bonsai TrieLog: one large entry per block, monotonic keys, no dedup potential). L0 SST files accumulated past the per-CF stop trigger, and because `atomic_flush(true)` is enabled the stall on one CF blocked all writes DB-wide, hanging block production at the first put_cf_opt on the meta column.

Switch the three `bonsai_*_log` CFs (contract / contract-storage / class) to leveled compaction, which drains L0->L1 continuously as soon as L0 exceeds level0_file_num_compaction_trigger=4. Other CFs keep universal. Also re-apply the per-CF L0 slowdown/stop triggers after optimize_universal_style_compaction() since that call resets them to RocksDB's hardcoded defaults regardless of the global Options / CLI flags / env vars.

Verified on a real DB: bonsai_contract_storage_log L0 dropped from 33 to 0 within ~5 minutes of running the patched binary, with no stall and block production starting normally.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #NA

## What is the new behavior?

## Does this introduce a breaking change?

<!-- Yes or No -->
<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- If you modify database schema, ensure you:
     1. Add the 'db-migration label to the PR
     2. Document the schema changes
     3. Provide migration instructions if needed
-->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
