### PR TITLE
fix(orchestrator): use SNOS v0.14.2-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2#3af39ab119bd123ab998910b7e6b000bf154def6"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.1#aaffeb9d6e5fd01fd178bb4798e186e207e9126e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12998,7 +12998,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2#3af39ab119bd123ab998910b7e6b000bf154def6"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.1#aaffeb9d6e5fd01fd178bb4798e186e207e9126e"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14424,7 +14424,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2#3af39ab119bd123ab998910b7e6b000bf154def6"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.1#aaffeb9d6e5fd01fd178bb4798e186e207e9126e"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,8 +314,9 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-# SNOS 0.14.2 with Cairo 2.17 support needed for Sierra 1.8 declares during replay.
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2" }
+# Keep this on the requested SNOS 0.14.2 RC while replay validation targets
+# that artifact set; do not move to the stable tag without rerunning replay fixtures.
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.1" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }


### PR DESCRIPTION
## Summary
- Update the keep-starknet-strange SNOS dependency to v0.14.2-rc.1.
- Keep the lockfile change scoped to the SNOS git packages resolved from that tag.

## Notes
- The RC pin is intentional while replay validation targets this SNOS artifact set. The manifest now documents that this should not be moved to the stable tag without rerunning replay fixtures.
- The unrelated lockfile resolver churn flagged by Greptile, including windows-sys dependency-edge changes, has been removed.

## Validation
- cargo metadata --locked --no-deps --format-version 1
- git diff --check

The full pre-push gate was skipped per request after the branch push was explicitly requested without pre-push verification.