### PR TITLE
test: harden flaky CI timeout and mongo startup tests

### DIFF
--- a/madara/crates/client/cairo_native/src/execution.rs
+++ b/madara/crates/client/cairo_native/src/execution.rs
@@ -888,27 +888,26 @@ mod tests {
 
         let class_hash = create_unique_test_class_hash();
 
-        // Create config with very short timeout to force compilation failure
+        // Simulate an already-running compilation so blocking mode exercises the
+        // timeout path without spawning a detached native compiler thread.
         let config = Arc::new(
             config::NativeConfig::builder()
                 .with_cache_dir(temp_dir.path().to_path_buf())
                 .with_compilation_mode(config::NativeCompilationMode::Blocking)
-                .with_compilation_timeout(Duration::from_millis(1)) // Very short timeout
+                .with_compilation_timeout(Duration::from_millis(1))
                 .build(),
         );
 
         // Verify caches don't have our unique class_hash
         assert!(!cache::cache_contains(&class_hash), "Class should not be in memory cache initially");
         assert!(
-            !compilation::is_compilation_in_progress(&class_hash),
-            "Class should not be in compilation_in_progress initially"
-        );
-        assert!(
             !compilation::has_failed_compilation(&class_hash),
             "Class should not be in failed_compilations initially"
         );
 
-        // Compilation timeout expected in blocking mode with very short timeout
+        compilation::insert_compilation_in_progress(class_hash);
+        assert!(compilation::is_compilation_in_progress(&class_hash), "Class should be in compilation_in_progress");
+
         let result = handle_sierra_class(
             &sierra_class,
             &class_hash.to_felt(),
@@ -916,42 +915,31 @@ mod tests {
             &sierra_class.info,
             config.clone(),
         );
+        compilation::remove_compilation_in_progress(&class_hash);
 
-        // In blocking mode, compilation failures/timeouts should return an error (not fall back to VM)
-        // This is the key difference from async mode - blocking mode waits and fails if compilation fails
         assert!(
             result.is_err(),
             "Blocking mode should return error on compilation timeout/failure, not fall back to VM"
         );
         let error = result.unwrap_err();
-        // Verify error message contains timeout or compilation failure indication
         let error_msg = format!("{:?}", error);
         assert!(
-            error_msg.contains("timeout") || error_msg.contains("Compilation") || error_msg.contains("failed"),
-            "Error message should indicate compilation timeout or failure: {}",
+            error_msg.contains("timeout") || error_msg.contains("Timeout"),
+            "Error message should indicate compilation timeout: {}",
             error_msg
         );
 
-        // Expected: compilation timeout/failure in blocking mode
-        // Verify class is not cached after failure
         assert!(!cache::cache_contains(&class_hash), "Class should not be in memory cache after compilation failure");
         assert!(
             !compilation::is_compilation_in_progress(&class_hash),
             "Class should not be in compilation_in_progress after failure"
         );
-        // In blocking mode, failures don't go to FAILED_COMPILATIONS (that's async mode only)
-
-        // Metrics assertions - compilation timeout/failure
         assert_counters!(
             CACHE_MEMORY_MISS: 1,
-            CACHE_DISK_MISS: 1,
-            COMPILATIONS_STARTED: 1,
-            VM_FALLBACKS: 0, // No VM fallback in blocking mode
+            COMPILATION_IN_PROGRESS_SKIP: 1,
+            COMPILATIONS_STARTED: 0,
+            VM_FALLBACKS: 0,
         );
-        use std::sync::atomic::Ordering;
-        let timeout_or_failed = test_counters::COMPILATIONS_TIMEOUT.load(Ordering::Relaxed)
-            + test_counters::COMPILATIONS_FAILED.load(Ordering::Relaxed);
-        assert_eq!(timeout_or_failed, 1, "Should have exactly one compilation timeout or failure");
     }
 
     /// Tests the memory cache timeout scenario.
@@ -1405,8 +1393,8 @@ mod tests {
             configured_timeout
         );
 
-        // Attempt compilation with very short timeout - should timeout
-        // In blocking mode, timeouts should return an error (not fall back to VM)
+        compilation::insert_compilation_in_progress(class_hash);
+        let start = Instant::now();
         let result = handle_sierra_class(
             &sierra_class,
             &class_hash.to_felt(),
@@ -1414,23 +1402,28 @@ mod tests {
             &sierra_class.info,
             config.clone(),
         );
+        let elapsed = start.elapsed();
+        compilation::remove_compilation_in_progress(&class_hash);
 
-        // In blocking mode, compilation timeouts should return an error (not fall back to VM)
-        // This is the key difference from async mode - blocking mode waits and fails if compilation times out
         assert!(result.is_err(), "Blocking mode should return error on compilation timeout, not fall back to VM");
         let error = result.unwrap_err();
-        // Verify error message contains timeout indication
         let error_msg = format!("{:?}", error);
         assert!(
             error_msg.contains("timeout") || error_msg.contains("Timeout"),
             "Error message should indicate compilation timeout: {}",
             error_msg
         );
+        assert!(
+            elapsed >= configured_timeout,
+            "Blocking mode should wait at least the configured timeout before failing"
+        );
+        assert!(elapsed < Duration::from_secs(1), "Blocking mode timeout should still fail promptly in tests");
 
-        // Verify timeout metrics were recorded (no VM fallback in blocking mode)
         assert_counters!(
-            COMPILATIONS_TIMEOUT: 1,
-            VM_FALLBACKS: 0, // No VM fallback in blocking mode
+            CACHE_MEMORY_MISS: 1,
+            COMPILATION_IN_PROGRESS_SKIP: 1,
+            COMPILATIONS_STARTED: 0,
+            VM_FALLBACKS: 0,
         );
     }
 

--- a/madara/crates/client/external_db/tests/e2e.rs
+++ b/madara/crates/client/external_db/tests/e2e.rs
@@ -138,9 +138,12 @@ async fn start_mongo_container() -> ContainerAsync<GenericImage> {
         match image.start().await {
             Ok(node) => return node,
             Err(err) if attempt < MAX_ATTEMPTS => {
-                eprintln!(
-                    "MongoDB testcontainer start attempt {attempt}/{MAX_ATTEMPTS} failed: {err:#}. Retrying in {:?}...",
-                    RETRY_DELAY
+                tracing::warn!(
+                    attempt,
+                    max_attempts = MAX_ATTEMPTS,
+                    retry_delay = ?RETRY_DELAY,
+                    error = %err,
+                    "mongo_testcontainer_start_failed_retrying"
                 );
                 tokio::time::sleep(RETRY_DELAY).await;
             }

--- a/madara/crates/client/external_db/tests/e2e.rs
+++ b/madara/crates/client/external_db/tests/e2e.rs
@@ -15,7 +15,7 @@ use starknet_signers::SigningKey;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
-use testcontainers::{ContainerAsync, GenericImage, core::IntoContainerPort, runners::AsyncRunner};
+use testcontainers::{core::IntoContainerPort, runners::AsyncRunner, ContainerAsync, GenericImage};
 use tokio::sync::OnceCell;
 
 const DEVNET_STRK_CONTRACT_ADDRESS: Felt =
@@ -91,7 +91,11 @@ async fn wait_for_tx_in_block<P: Provider + Sync>(provider: &P, tx_hash: Felt, t
     wait_for_cond(
         || async {
             let receipt = provider.get_transaction_receipt(tx_hash).await?;
-            if receipt.block.is_block() { Ok(()) } else { Err(anyhow::anyhow!("tx not in block yet")) }
+            if receipt.block.is_block() {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("tx not in block yet"))
+            }
         },
         Duration::from_millis(500),
         timeout_attempts,
@@ -323,7 +327,11 @@ async fn e2e_devnet_replay_from_mongo_matches_root() {
     wait_for_cond(
         || async {
             let block = rpc.block_hash_and_number().await?;
-            if block.block_number >= 11 { Ok(()) } else { Err(anyhow::anyhow!("chain not at 11 blocks yet")) }
+            if block.block_number >= 11 {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("chain not at 11 blocks yet"))
+            }
         },
         Duration::from_millis(500),
         60,
@@ -346,7 +354,11 @@ async fn e2e_devnet_replay_from_mongo_matches_root() {
     wait_for_cond(
         || async {
             let count = collection.count_documents(mongodb::bson::doc! { "tx_hash": { "$in": &tx_ids } }).await?;
-            if count >= tx_ids.len() as u64 { Ok(()) } else { Err(anyhow::anyhow!("mongo not updated yet")) }
+            if count >= tx_ids.len() as u64 {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("mongo not updated yet"))
+            }
         },
         Duration::from_millis(200),
         60,
@@ -422,7 +434,11 @@ async fn e2e_devnet_replay_from_mongo_matches_root() {
     wait_for_cond(
         || async {
             let block = rpc.block_hash_and_number().await?;
-            if block.block_number >= target_block { Ok(()) } else { Err(anyhow::anyhow!("chain not caught up yet")) }
+            if block.block_number >= target_block {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("chain not caught up yet"))
+            }
         },
         Duration::from_millis(500),
         80,

--- a/madara/crates/client/external_db/tests/e2e.rs
+++ b/madara/crates/client/external_db/tests/e2e.rs
@@ -15,7 +15,7 @@ use starknet_signers::SigningKey;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
-use testcontainers::{core::IntoContainerPort, runners::AsyncRunner, ContainerAsync, GenericImage};
+use testcontainers::{ContainerAsync, GenericImage, core::IntoContainerPort, runners::AsyncRunner};
 use tokio::sync::OnceCell;
 
 const DEVNET_STRK_CONTRACT_ADDRESS: Felt =
@@ -91,11 +91,7 @@ async fn wait_for_tx_in_block<P: Provider + Sync>(provider: &P, tx_hash: Felt, t
     wait_for_cond(
         || async {
             let receipt = provider.get_transaction_receipt(tx_hash).await?;
-            if receipt.block.is_block() {
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!("tx not in block yet"))
-            }
+            if receipt.block.is_block() { Ok(()) } else { Err(anyhow::anyhow!("tx not in block yet")) }
         },
         Duration::from_millis(500),
         timeout_attempts,
@@ -127,6 +123,28 @@ async fn wait_for_mongo_ready(uri: &str) {
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
+}
+
+async fn start_mongo_container() -> ContainerAsync<GenericImage> {
+    const MAX_ATTEMPTS: usize = 3;
+    const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let image = GenericImage::new("mongo", "7.0").with_exposed_port(27017.tcp());
+        match image.start().await {
+            Ok(node) => return node,
+            Err(err) if attempt < MAX_ATTEMPTS => {
+                eprintln!(
+                    "MongoDB testcontainer start attempt {attempt}/{MAX_ATTEMPTS} failed: {err:#}. Retrying in {:?}...",
+                    RETRY_DELAY
+                );
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+            Err(err) => panic!("failed to start MongoDB testcontainer after {MAX_ATTEMPTS} attempts: {err:#}"),
+        }
+    }
+
+    unreachable!("MongoDB testcontainer retry loop should have returned or panicked")
 }
 
 struct MongoFixture {
@@ -170,8 +188,7 @@ async fn mongo_fixture() -> &'static MongoFixture {
                 return MongoFixture { _node: None, uri };
             }
 
-            let image = GenericImage::new("mongo", "7.0").with_exposed_port(27017.tcp());
-            let node = image.start().await.unwrap();
+            let node = start_mongo_container().await;
             let port = node.get_host_port_ipv4(27017).await.unwrap();
             let uri = format!("mongodb://127.0.0.1:{port}");
             wait_for_mongo_ready(&uri).await;
@@ -306,11 +323,7 @@ async fn e2e_devnet_replay_from_mongo_matches_root() {
     wait_for_cond(
         || async {
             let block = rpc.block_hash_and_number().await?;
-            if block.block_number >= 11 {
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!("chain not at 11 blocks yet"))
-            }
+            if block.block_number >= 11 { Ok(()) } else { Err(anyhow::anyhow!("chain not at 11 blocks yet")) }
         },
         Duration::from_millis(500),
         60,
@@ -333,11 +346,7 @@ async fn e2e_devnet_replay_from_mongo_matches_root() {
     wait_for_cond(
         || async {
             let count = collection.count_documents(mongodb::bson::doc! { "tx_hash": { "$in": &tx_ids } }).await?;
-            if count >= tx_ids.len() as u64 {
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!("mongo not updated yet"))
-            }
+            if count >= tx_ids.len() as u64 { Ok(()) } else { Err(anyhow::anyhow!("mongo not updated yet")) }
         },
         Duration::from_millis(200),
         60,
@@ -413,11 +422,7 @@ async fn e2e_devnet_replay_from_mongo_matches_root() {
     wait_for_cond(
         || async {
             let block = rpc.block_hash_and_number().await?;
-            if block.block_number >= target_block {
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!("chain not caught up yet"))
-            }
+            if block.block_number >= target_block { Ok(()) } else { Err(anyhow::anyhow!("chain not caught up yet")) }
         },
         Duration::from_millis(500),
         80,


### PR DESCRIPTION
## Summary
- avoid spawning detached native compilation work in the blocking-timeout cairo native tests
- retry Mongo testcontainer startup in external DB e2e tests
- keep the retry logging lint-clean and apply rustfmt

## Why
These test stability fixes are unrelated to PR #1055's runtime-config feature work, so they are split into a separate PR.
