### PR TITLE
feat(metrics): expose closed-block tx count and empty-block streak

### DIFF
--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -304,6 +304,14 @@ pub(crate) enum TaskState {
     Executing(CurrentBlockState),
 }
 
+fn next_empty_block_streak(current_streak: u64, tx_count: usize) -> u64 {
+    if tx_count == 0 {
+        current_streak.saturating_add(1)
+    } else {
+        0
+    }
+}
+
 /// The block production task consumes transactions from the mempool in batches.
 ///
 /// This is to allow optimistic concurrency. However, the block may get full during batch execution,
@@ -315,6 +323,7 @@ pub struct BlockProductionTask {
     backend: Arc<MadaraBackend>,
     mempool: Arc<Mempool>,
     current_state: Option<TaskState>,
+    empty_block_streak: u64,
     metrics: Arc<BlockProductionMetrics>,
     state_notifications: Option<mpsc::UnboundedSender<BlockProductionStateNotification>>,
     handle: BlockProductionHandle,
@@ -349,6 +358,7 @@ impl BlockProductionTask {
             backend: backend.clone(),
             mempool,
             current_state: None,
+            empty_block_streak: 0,
             metrics,
             handle: BlockProductionHandle::new(backend, sender, bypass_input_sender, no_charge_fee),
             state_notifications: None,
@@ -938,6 +948,7 @@ impl BlockProductionTask {
 
         let time_to_close = start_time.elapsed();
         let block_production_time = state.block_start_time.elapsed();
+        self.empty_block_streak = next_empty_block_streak(self.empty_block_streak, n_txs);
 
         // Emit structured log event for Loki querying (close_block_complete)
         // All timing values converted to milliseconds for human-readability
@@ -947,6 +958,7 @@ impl BlockProductionTask {
             target: "close_block",
             block_number = state.block_number,
             tx_count = n_txs,
+            empty_block_streak = self.empty_block_streak,
             event_count = event_count,
             // High-level timing
             close_block_total_ms = time_to_close.as_secs_f64() * 1000.0,
@@ -998,6 +1010,8 @@ impl BlockProductionTask {
         self.metrics.block_counter.add(1, &[]);
         self.metrics.block_gauge.record(state.block_number, &[]);
         self.metrics.transaction_counter.add(n_txs as u64, &[]);
+        self.metrics.block_transaction_count.record(n_txs as u64, &[]);
+        self.metrics.block_empty_streak.record(self.empty_block_streak, &[]);
         self.metrics.block_production_time.record(block_production_time.as_secs_f64(), &[]);
         self.metrics.block_production_time_last.record(block_production_time.as_secs_f64(), &[]);
         self.metrics.block_close_time.record(time_to_close.as_secs_f64(), &[]);
@@ -1524,6 +1538,15 @@ pub(crate) mod tests {
     // - State diffs are sorted before comparison to handle ordering differences
     // - The test verifies that `paid_fee_on_l1` is preserved for L1 handler transactions
     // - The test ensures that re-execution produces deterministic results
+    #[rstest::rstest]
+    #[case(0, 0, 1)]
+    #[case(1, 0, 2)]
+    #[case(u64::MAX, 0, u64::MAX)]
+    #[case(4, 3, 0)]
+    fn test_next_empty_block_streak(#[case] current_streak: u64, #[case] tx_count: usize, #[case] expected: u64) {
+        assert_eq!(super::next_empty_block_streak(current_streak, tx_count), expected);
+    }
+
     #[rstest::rstest]
     #[timeout(Duration::from_secs(100))]
     #[tokio::test]

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -323,6 +323,7 @@ pub struct BlockProductionTask {
     backend: Arc<MadaraBackend>,
     mempool: Arc<Mempool>,
     current_state: Option<TaskState>,
+    // This is process-local state used only for metrics emission, so it resets on node restart.
     empty_block_streak: u64,
     metrics: Arc<BlockProductionMetrics>,
     state_notifications: Option<mpsc::UnboundedSender<BlockProductionStateNotification>>,

--- a/madara/crates/client/block_production/src/metrics.rs
+++ b/madara/crates/client/block_production/src/metrics.rs
@@ -194,7 +194,7 @@ impl BlockProductionMetrics {
         let block_empty_streak = register_gauge_metric_instrument(
             &meter,
             "block_empty_streak".to_string(),
-            "Current count of consecutive closed blocks with zero transactions".to_string(),
+            "Current count of consecutive closed blocks with zero transactions; resets on node restart".to_string(),
             "block".to_string(),
         );
         let block_event_count = register_gauge_metric_instrument(

--- a/madara/crates/client/block_production/src/metrics.rs
+++ b/madara/crates/client/block_production/src/metrics.rs
@@ -32,6 +32,8 @@ pub struct BlockProductionMetrics {
     pub executor_finalize_last: Gauge<f64>,
 
     // Block data gauges
+    pub block_transaction_count: Gauge<u64>,
+    pub block_empty_streak: Gauge<u64>,
     pub block_event_count: Gauge<u64>,
     pub block_state_diff_length: Gauge<u64>,
     pub block_declared_classes_count: Gauge<u64>,
@@ -183,6 +185,18 @@ impl BlockProductionMetrics {
         );
 
         // Block data gauges
+        let block_transaction_count = register_gauge_metric_instrument(
+            &meter,
+            "block_transaction_count".to_string(),
+            "Number of executed transactions in the closed block".to_string(),
+            "tx".to_string(),
+        );
+        let block_empty_streak = register_gauge_metric_instrument(
+            &meter,
+            "block_empty_streak".to_string(),
+            "Current count of consecutive closed blocks with zero transactions".to_string(),
+            "block".to_string(),
+        );
         let block_event_count = register_gauge_metric_instrument(
             &meter,
             "block_event_count".to_string(),
@@ -279,6 +293,8 @@ impl BlockProductionMetrics {
             close_preconfirmed_last,
             executor_finalize_duration,
             executor_finalize_last,
+            block_transaction_count,
+            block_empty_streak,
             block_event_count,
             block_state_diff_length,
             block_declared_classes_count,

--- a/observability/README.md
+++ b/observability/README.md
@@ -222,8 +222,8 @@ observability/
 | `block_produced_no`          | Gauge   | Current block number  |
 | `block_produced_count`       | Counter | Total blocks produced |
 | `transaction_counter`        | Counter | Total transactions    |
-| `block_transaction_count`    | Gauge   | Transactions in the last closed block |
-| `block_empty_streak`         | Gauge   | Consecutive closed blocks with 0 transactions since the last non-empty block or node restart |
+| `block_transaction_count`    | Gauge   | Tx count in the last closed block |
+| `block_empty_streak`         | Gauge   | Empty closed-block streak since last non-empty block or restart |
 | `accepted_transaction_count` | Counter | Mempool transactions  |
 
 ### Sync Service

--- a/observability/README.md
+++ b/observability/README.md
@@ -222,6 +222,8 @@ observability/
 | `block_produced_no`          | Gauge   | Current block number  |
 | `block_produced_count`       | Counter | Total blocks produced |
 | `transaction_counter`        | Counter | Total transactions    |
+| `block_transaction_count`    | Gauge   | Transactions in the last closed block |
+| `block_empty_streak`         | Gauge   | Consecutive closed blocks with 0 transactions |
 | `accepted_transaction_count` | Counter | Mempool transactions  |
 
 ### Sync Service

--- a/observability/README.md
+++ b/observability/README.md
@@ -223,7 +223,7 @@ observability/
 | `block_produced_count`       | Counter | Total blocks produced |
 | `transaction_counter`        | Counter | Total transactions    |
 | `block_transaction_count`    | Gauge   | Transactions in the last closed block |
-| `block_empty_streak`         | Gauge   | Consecutive closed blocks with 0 transactions |
+| `block_empty_streak`         | Gauge   | Consecutive closed blocks with 0 transactions since the last non-empty block or node restart |
 | `accepted_transaction_count` | Counter | Mempool transactions  |
 
 ### Sync Service


### PR DESCRIPTION
## Summary
- add `block_transaction_count` gauge for the number of transactions in the last closed block
- add `block_empty_streak` gauge so Grafana/Prometheus can alert on consecutive empty blocks exactly
- document both metrics in `observability/README.md`

## Why
Prometheus already has cumulative block and transaction counters, but it does not expose the last closed block's tx count as a direct series, and expressing "5 consecutive empty blocks" from time-windowed counters is awkward. This adds a direct block-close signal plus a streak gauge that can drive a simple alert.

## Suggested Grafana PromQL
Last closed block tx count:
```promql
block_transaction_count{namespace=~"$namespace", pod=~"$pod"}
```

Alert when the last 5 closed blocks were empty:
```promql
block_empty_streak{namespace=~"$namespace", pod=~"$pod"} >= 5
```

## Verification
- `cargo fmt --all`
- attempted focused `cargo test -p mc-block-production ...`, but local `mc-devnet` test builds require Docker/artifact fetching and failed before reaching this change
- attempted `cargo check -p mc-block-production --lib`, but local verification was blocked by the transitive `apollo_compile_to_native` native tool install/build path rather than by the metric patch itself
