### PR TITLE
feat(orchestrator): add workload activity metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11175,6 +11175,7 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
+ "dashmap 6.1.0",
  "dotenvy",
  "futures",
  "generate-pie",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -40,6 +40,7 @@ cairo-vm = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }
+dashmap = { workspace = true }
 dotenvy = { workspace = true }
 futures = { workspace = true }
 generate-pie = { workspace = true }

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -922,6 +922,14 @@ async fn verify_job_with_pending_status_works() {
     assert_matches!(queue_error, QueueError::ErrorFromQueueError(_));
 }
 
+#[test]
+fn verification_workload_is_error_only_for_failure_statuses() {
+    assert!(!JobHandlerService::verification_workload_is_error(None));
+    assert!(!JobHandlerService::verification_workload_is_error(Some(&JobStatus::Completed)));
+    assert!(JobHandlerService::verification_workload_is_error(Some(&JobStatus::VerificationFailed)));
+    assert!(JobHandlerService::verification_workload_is_error(Some(&JobStatus::VerificationTimeout)));
+}
+
 #[rstest]
 #[case(JobType::DataSubmission, JobStatus::Completed)] // code should panic here, how can completed move to dl queue ?
 #[case(JobType::SnosRun, JobStatus::PendingVerification)]

--- a/orchestrator/src/utils/metrics.rs
+++ b/orchestrator/src/utils/metrics.rs
@@ -1,9 +1,10 @@
 use crate::core::client::database::constant::JOBS_COLLECTION;
 use crate::utils::job_status_metrics::JobStatusTracker;
+use crate::utils::metrics_recorder::register_workload_active_slots_observer;
 use once_cell;
 use once_cell::sync::Lazy;
 use opentelemetry::global;
-use opentelemetry::metrics::{Counter, Gauge, Histogram};
+use opentelemetry::metrics::{Counter, Gauge, Histogram, ObservableGauge};
 use orchestrator_utils::metrics::lib::{
     register_counter_metric_instrument, register_gauge_metric_instrument, register_histogram_metric_instrument, Metrics,
 };
@@ -78,7 +79,7 @@ pub struct OrchestratorMetrics {
     pub cleanup_artifacts_tagged: Counter<f64>,
     pub cleanup_failures_total: Counter<f64>,
     // Workload metrics
-    pub workload_active_slots: Gauge<f64>,
+    pub workload_active_slots: ObservableGauge<u64>,
     pub workload_busy_seconds_total: Counter<f64>,
     pub workload_runs_total: Counter<f64>,
     pub workload_duration_seconds: Histogram<f64>,
@@ -443,12 +444,7 @@ impl Metrics for OrchestratorMetrics {
             "errors".to_string(),
         );
 
-        let workload_active_slots = register_gauge_metric_instrument(
-            &orchestrator_meter,
-            "workload_active_slots".to_string(),
-            "Current active workload slots by kind, phase, and class".to_string(),
-            "slots".to_string(),
-        );
+        let workload_active_slots = register_workload_active_slots_observer(&orchestrator_meter);
 
         let workload_busy_seconds_total = register_counter_metric_instrument(
             &orchestrator_meter,

--- a/orchestrator/src/utils/metrics.rs
+++ b/orchestrator/src/utils/metrics.rs
@@ -77,6 +77,13 @@ pub struct OrchestratorMetrics {
     pub cleanup_jobs_processed: Counter<f64>,
     pub cleanup_artifacts_tagged: Counter<f64>,
     pub cleanup_failures_total: Counter<f64>,
+    // Workload metrics
+    pub workload_active_slots: Gauge<f64>,
+    pub workload_busy_seconds_total: Counter<f64>,
+    pub workload_runs_total: Counter<f64>,
+    pub workload_duration_seconds: Histogram<f64>,
+    pub workload_capacity_slots: Gauge<f64>,
+    pub healed_jobs_total: Counter<f64>,
 }
 
 impl Metrics for OrchestratorMetrics {
@@ -436,6 +443,48 @@ impl Metrics for OrchestratorMetrics {
             "errors".to_string(),
         );
 
+        let workload_active_slots = register_gauge_metric_instrument(
+            &orchestrator_meter,
+            "workload_active_slots".to_string(),
+            "Current active workload slots by kind, phase, and class".to_string(),
+            "slots".to_string(),
+        );
+
+        let workload_busy_seconds_total = register_counter_metric_instrument(
+            &orchestrator_meter,
+            "workload_busy_seconds_total".to_string(),
+            "Cumulative busy time spent on orchestrator workloads".to_string(),
+            "s".to_string(),
+        );
+
+        let workload_runs_total = register_counter_metric_instrument(
+            &orchestrator_meter,
+            "workload_runs_total".to_string(),
+            "Total number of orchestrator workload runs".to_string(),
+            "runs".to_string(),
+        );
+
+        let workload_duration_seconds = register_histogram_metric_instrument(
+            &orchestrator_meter,
+            "workload_duration_seconds".to_string(),
+            "Duration of orchestrator workload runs".to_string(),
+            "s".to_string(),
+        );
+
+        let workload_capacity_slots = register_gauge_metric_instrument(
+            &orchestrator_meter,
+            "workload_capacity_slots".to_string(),
+            "Configured local worker slot capacity for queue-backed workloads".to_string(),
+            "slots".to_string(),
+        );
+
+        let healed_jobs_total = register_counter_metric_instrument(
+            &orchestrator_meter,
+            "healed_jobs_total".to_string(),
+            "Total number of stale jobs healed back to Created".to_string(),
+            "jobs".to_string(),
+        );
+
         Self {
             block_gauge,
             successful_job_operations,
@@ -482,6 +531,12 @@ impl Metrics for OrchestratorMetrics {
             cleanup_jobs_processed,
             cleanup_artifacts_tagged,
             cleanup_failures_total,
+            workload_active_slots,
+            workload_busy_seconds_total,
+            workload_runs_total,
+            workload_duration_seconds,
+            workload_capacity_slots,
+            healed_jobs_total,
         }
     }
 }

--- a/orchestrator/src/utils/metrics.rs
+++ b/orchestrator/src/utils/metrics.rs
@@ -78,7 +78,10 @@ pub struct OrchestratorMetrics {
     pub cleanup_jobs_processed: Counter<f64>,
     pub cleanup_artifacts_tagged: Counter<f64>,
     pub cleanup_failures_total: Counter<f64>,
-    // Workload metrics
+    // Workload metrics.
+    // `workload_active_slots` is an ObservableGauge because the source of truth is
+    // a shared in-memory slot map. Reading that map at scrape time avoids racy
+    // "mutate then record" snapshots that can under-report concurrent work.
     pub workload_active_slots: ObservableGauge<u64>,
     pub workload_busy_seconds_total: Counter<f64>,
     pub workload_capacity_slots: Gauge<f64>,

--- a/orchestrator/src/utils/metrics.rs
+++ b/orchestrator/src/utils/metrics.rs
@@ -81,8 +81,6 @@ pub struct OrchestratorMetrics {
     // Workload metrics
     pub workload_active_slots: ObservableGauge<u64>,
     pub workload_busy_seconds_total: Counter<f64>,
-    pub workload_runs_total: Counter<f64>,
-    pub workload_duration_seconds: Histogram<f64>,
     pub workload_capacity_slots: Gauge<f64>,
     pub healed_jobs_total: Counter<f64>,
 }
@@ -453,20 +451,6 @@ impl Metrics for OrchestratorMetrics {
             "s".to_string(),
         );
 
-        let workload_runs_total = register_counter_metric_instrument(
-            &orchestrator_meter,
-            "workload_runs_total".to_string(),
-            "Total number of orchestrator workload runs".to_string(),
-            "runs".to_string(),
-        );
-
-        let workload_duration_seconds = register_histogram_metric_instrument(
-            &orchestrator_meter,
-            "workload_duration_seconds".to_string(),
-            "Duration of orchestrator workload runs".to_string(),
-            "s".to_string(),
-        );
-
         let workload_capacity_slots = register_gauge_metric_instrument(
             &orchestrator_meter,
             "workload_capacity_slots".to_string(),
@@ -529,8 +513,6 @@ impl Metrics for OrchestratorMetrics {
             cleanup_failures_total,
             workload_active_slots,
             workload_busy_seconds_total,
-            workload_runs_total,
-            workload_duration_seconds,
             workload_capacity_slots,
             healed_jobs_total,
         }

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -58,6 +58,7 @@ impl WorkKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum WorkPhase {
+    // Concrete lifecycle stage shown on dashboards.
     Process,
     Verify,
     Trigger,
@@ -77,6 +78,8 @@ impl WorkPhase {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum WorkClass {
+    // Broader rollup bucket so related phases can still be grouped together even
+    // if we later add more specific phases under the same class.
     JobExecution,
     JobVerification,
     Trigger,

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -77,27 +77,6 @@ impl WorkPhase {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum WorkClass {
-    // Broader rollup bucket so related phases can still be grouped together even
-    // if we later add more specific phases under the same class.
-    JobExecution,
-    JobVerification,
-    Trigger,
-    Maintenance,
-}
-
-impl WorkClass {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::JobExecution => "job_execution",
-            Self::JobVerification => "job_verification",
-            Self::Trigger => "trigger",
-            Self::Maintenance => "maintenance",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum WorkloadOutcome {
     Success,
     Error,
@@ -116,34 +95,26 @@ impl WorkloadOutcome {
 struct WorkloadDescriptor {
     work_kind: WorkKind,
     work_phase: WorkPhase,
-    work_class: WorkClass,
     source_job_type: Option<WorkKind>,
 }
 
 impl WorkloadDescriptor {
-    fn new(
-        work_kind: WorkKind,
-        work_phase: WorkPhase,
-        work_class: WorkClass,
-        source_job_type: Option<WorkKind>,
-    ) -> Self {
-        Self { work_kind, work_phase, work_class, source_job_type }
+    fn new(work_kind: WorkKind, work_phase: WorkPhase, source_job_type: Option<WorkKind>) -> Self {
+        Self { work_kind, work_phase, source_job_type }
     }
 
-    fn active_attributes(self) -> [KeyValue; 4] {
+    fn active_attributes(self) -> [KeyValue; 3] {
         [
             KeyValue::new("work_kind", self.work_kind.as_str()),
             KeyValue::new("work_phase", self.work_phase.as_str()),
-            KeyValue::new("work_class", self.work_class.as_str()),
             KeyValue::new("source_job_type", self.source_job_type.map_or("none", WorkKind::as_str)),
         ]
     }
 
-    fn completed_attributes(self, outcome: WorkloadOutcome) -> [KeyValue; 5] {
+    fn completed_attributes(self, outcome: WorkloadOutcome) -> [KeyValue; 4] {
         [
             KeyValue::new("work_kind", self.work_kind.as_str()),
             KeyValue::new("work_phase", self.work_phase.as_str()),
-            KeyValue::new("work_class", self.work_class.as_str()),
             KeyValue::new("source_job_type", self.source_job_type.map_or("none", WorkKind::as_str)),
             KeyValue::new("outcome", outcome.as_str()),
         ]
@@ -231,41 +202,29 @@ pub fn register_workload_active_slots_observer(meter: &Meter) -> ObservableGauge
 fn workload_descriptor_for_job(job_type: &JobType, job_state: JobState) -> WorkloadDescriptor {
     let work_kind = WorkKind::from_job_type(job_type);
     match job_state {
-        JobState::Processing => WorkloadDescriptor::new(work_kind, WorkPhase::Process, WorkClass::JobExecution, None),
-        JobState::Verification => {
-            WorkloadDescriptor::new(work_kind, WorkPhase::Verify, WorkClass::JobVerification, None)
-        }
+        JobState::Processing => WorkloadDescriptor::new(work_kind, WorkPhase::Process, None),
+        JobState::Verification => WorkloadDescriptor::new(work_kind, WorkPhase::Verify, None),
     }
 }
 
 fn workload_descriptor_for_worker_trigger(worker_trigger_type: &WorkerTriggerType) -> WorkloadDescriptor {
     match worker_trigger_type {
-        WorkerTriggerType::Snos => {
-            WorkloadDescriptor::new(WorkKind::SnosRun, WorkPhase::Trigger, WorkClass::Trigger, None)
-        }
-        WorkerTriggerType::Proving => {
-            WorkloadDescriptor::new(WorkKind::ProofCreation, WorkPhase::Trigger, WorkClass::Trigger, None)
-        }
+        WorkerTriggerType::Snos => WorkloadDescriptor::new(WorkKind::SnosRun, WorkPhase::Trigger, None),
+        WorkerTriggerType::Proving => WorkloadDescriptor::new(WorkKind::ProofCreation, WorkPhase::Trigger, None),
         WorkerTriggerType::ProofRegistration => {
-            WorkloadDescriptor::new(WorkKind::ProofRegistration, WorkPhase::Trigger, WorkClass::Trigger, None)
+            WorkloadDescriptor::new(WorkKind::ProofRegistration, WorkPhase::Trigger, None)
         }
         WorkerTriggerType::DataSubmission => {
-            WorkloadDescriptor::new(WorkKind::DataSubmission, WorkPhase::Trigger, WorkClass::Trigger, None)
+            WorkloadDescriptor::new(WorkKind::DataSubmission, WorkPhase::Trigger, None)
         }
-        WorkerTriggerType::UpdateState => {
-            WorkloadDescriptor::new(WorkKind::StateTransition, WorkPhase::Trigger, WorkClass::Trigger, None)
-        }
-        WorkerTriggerType::Aggregator => {
-            WorkloadDescriptor::new(WorkKind::Aggregator, WorkPhase::Trigger, WorkClass::Trigger, None)
-        }
+        WorkerTriggerType::UpdateState => WorkloadDescriptor::new(WorkKind::StateTransition, WorkPhase::Trigger, None),
+        WorkerTriggerType::Aggregator => WorkloadDescriptor::new(WorkKind::Aggregator, WorkPhase::Trigger, None),
         WorkerTriggerType::AggregatorBatching => {
-            WorkloadDescriptor::new(WorkKind::AggregatorBatching, WorkPhase::Trigger, WorkClass::Trigger, None)
+            WorkloadDescriptor::new(WorkKind::AggregatorBatching, WorkPhase::Trigger, None)
         }
-        WorkerTriggerType::SnosBatching => {
-            WorkloadDescriptor::new(WorkKind::SnosBatching, WorkPhase::Trigger, WorkClass::Trigger, None)
-        }
+        WorkerTriggerType::SnosBatching => WorkloadDescriptor::new(WorkKind::SnosBatching, WorkPhase::Trigger, None),
         WorkerTriggerType::StorageCleanup => {
-            WorkloadDescriptor::new(WorkKind::StorageCleanup, WorkPhase::Maintenance, WorkClass::Maintenance, None)
+            WorkloadDescriptor::new(WorkKind::StorageCleanup, WorkPhase::Maintenance, None)
         }
     }
 }
@@ -312,12 +271,7 @@ fn workload_descriptor_for_queue(queue_type: &QueueType) -> Option<WorkloadDescr
 }
 
 fn healing_descriptor(source_job_type: &JobType) -> WorkloadDescriptor {
-    WorkloadDescriptor::new(
-        WorkKind::Healing,
-        WorkPhase::Maintenance,
-        WorkClass::Maintenance,
-        Some(WorkKind::from_job_type(source_job_type)),
-    )
+    WorkloadDescriptor::new(WorkKind::Healing, WorkPhase::Maintenance, Some(WorkKind::from_job_type(source_job_type)))
 }
 
 /// Helper functions to record metrics at various points in the job lifecycle
@@ -692,7 +646,6 @@ mod tests {
 
         assert_eq!(descriptor.work_kind, WorkKind::SnosRun);
         assert_eq!(descriptor.work_phase, WorkPhase::Process);
-        assert_eq!(descriptor.work_class, WorkClass::JobExecution);
         assert_eq!(descriptor.source_job_type, None);
     }
 
@@ -702,7 +655,6 @@ mod tests {
 
         assert_eq!(descriptor.work_kind, WorkKind::StorageCleanup);
         assert_eq!(descriptor.work_phase, WorkPhase::Maintenance);
-        assert_eq!(descriptor.work_class, WorkClass::Maintenance);
     }
 
     #[test]
@@ -731,7 +683,6 @@ mod tests {
 
         assert_eq!(descriptor.work_kind, WorkKind::Healing);
         assert_eq!(descriptor.work_phase, WorkPhase::Maintenance);
-        assert_eq!(descriptor.work_class, WorkClass::Maintenance);
         assert_eq!(descriptor.source_job_type, Some(WorkKind::StateTransition));
     }
 }

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -263,6 +263,10 @@ fn workload_descriptor_for_queue(queue_type: &QueueType) -> Option<WorkloadDescr
         QueueType::AggregatorJobVerification => {
             Some(workload_descriptor_for_job(&JobType::Aggregator, JobState::Verification))
         }
+        // Capacity is intentionally limited to queue-backed processing/verification work.
+        // Trigger, failure-handling, priority helper, and maintenance-style workloads still emit
+        // active/busy signals for observability, but they do not have a meaningful slot-capacity
+        // denominator for the sizing questions this PR is targeting today.
         QueueType::WorkerTrigger
         | QueueType::JobHandleFailure
         | QueueType::PriorityProcessingQueue

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -681,8 +681,8 @@ mod tests {
         ACTIVE_WORKLOAD_SLOTS.clear();
     }
 
-    fn active_slots_for(descriptor: WorkloadDescriptor) -> i64 {
-        ACTIVE_WORKLOAD_SLOTS.get(&descriptor.key()).map(|entry| *entry).unwrap_or(0)
+    fn active_slots_for(descriptor: WorkloadDescriptor) -> u64 {
+        ACTIVE_WORKLOAD_SLOTS.get(&descriptor).map(|entry| *entry).unwrap_or(0)
     }
 
     #[test]

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -189,7 +189,7 @@ fn decrement_active_slots(descriptor: WorkloadDescriptor) {
 pub fn register_workload_active_slots_observer(meter: &Meter) -> ObservableGauge<u64> {
     meter
         .u64_observable_gauge("workload_active_slots")
-        .with_description("Current active workload slots by kind, phase, and class")
+        .with_description("Current active workload slots by kind and phase")
         .with_unit("slots")
         .with_callback(|observer| {
             for active_slots in ACTIVE_WORKLOAD_SLOTS.iter() {

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -1,15 +1,373 @@
 use chrono::Utc;
+use dashmap::{mapref::entry::Entry, DashMap};
+use once_cell::sync::Lazy;
 use opentelemetry::KeyValue;
+use std::time::Instant;
 
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::types::{JobStatus, JobType};
+use crate::types::jobs::WorkerTriggerType;
+use crate::types::queue::{JobState, QueueType};
 use crate::utils::metrics::ORCHESTRATOR_METRICS;
+
+static ACTIVE_WORKLOAD_SLOTS: Lazy<DashMap<WorkloadKey, i64>> = Lazy::new(DashMap::new);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum WorkKind {
+    SnosRun,
+    ProofCreation,
+    ProofRegistration,
+    DataSubmission,
+    StateTransition,
+    Aggregator,
+    SnosBatching,
+    AggregatorBatching,
+    StorageCleanup,
+    Healing,
+}
+
+impl WorkKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SnosRun => "SnosRun",
+            Self::ProofCreation => "ProofCreation",
+            Self::ProofRegistration => "ProofRegistration",
+            Self::DataSubmission => "DataSubmission",
+            Self::StateTransition => "StateTransition",
+            Self::Aggregator => "Aggregator",
+            Self::SnosBatching => "SnosBatching",
+            Self::AggregatorBatching => "AggregatorBatching",
+            Self::StorageCleanup => "StorageCleanup",
+            Self::Healing => "Healing",
+        }
+    }
+
+    fn from_job_type(job_type: &JobType) -> Self {
+        match job_type {
+            JobType::SnosRun => Self::SnosRun,
+            JobType::ProofCreation => Self::ProofCreation,
+            JobType::ProofRegistration => Self::ProofRegistration,
+            JobType::DataSubmission => Self::DataSubmission,
+            JobType::StateTransition => Self::StateTransition,
+            JobType::Aggregator => Self::Aggregator,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum WorkPhase {
+    Process,
+    Verify,
+    Trigger,
+    Maintenance,
+}
+
+impl WorkPhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Process => "process",
+            Self::Verify => "verify",
+            Self::Trigger => "trigger",
+            Self::Maintenance => "maintenance",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum WorkClass {
+    JobExecution,
+    JobVerification,
+    Trigger,
+    Maintenance,
+}
+
+impl WorkClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::JobExecution => "job_execution",
+            Self::JobVerification => "job_verification",
+            Self::Trigger => "trigger",
+            Self::Maintenance => "maintenance",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum WorkloadOutcome {
+    Success,
+    Error,
+}
+
+impl WorkloadOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct WorkloadDescriptor {
+    work_kind: WorkKind,
+    work_phase: WorkPhase,
+    work_class: WorkClass,
+    source_job_type: Option<WorkKind>,
+}
+
+impl WorkloadDescriptor {
+    fn new(
+        work_kind: WorkKind,
+        work_phase: WorkPhase,
+        work_class: WorkClass,
+        source_job_type: Option<WorkKind>,
+    ) -> Self {
+        Self { work_kind, work_phase, work_class, source_job_type }
+    }
+
+    fn key(self) -> WorkloadKey {
+        WorkloadKey {
+            work_kind: self.work_kind,
+            work_phase: self.work_phase,
+            work_class: self.work_class,
+            source_job_type: self.source_job_type,
+        }
+    }
+
+    fn active_attributes(self) -> [KeyValue; 4] {
+        [
+            KeyValue::new("work_kind", self.work_kind.as_str()),
+            KeyValue::new("work_phase", self.work_phase.as_str()),
+            KeyValue::new("work_class", self.work_class.as_str()),
+            KeyValue::new("source_job_type", self.source_job_type.map_or("none", WorkKind::as_str)),
+        ]
+    }
+
+    fn completed_attributes(self, outcome: WorkloadOutcome) -> [KeyValue; 5] {
+        [
+            KeyValue::new("work_kind", self.work_kind.as_str()),
+            KeyValue::new("work_phase", self.work_phase.as_str()),
+            KeyValue::new("work_class", self.work_class.as_str()),
+            KeyValue::new("source_job_type", self.source_job_type.map_or("none", WorkKind::as_str)),
+            KeyValue::new("outcome", outcome.as_str()),
+        ]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct WorkloadKey {
+    work_kind: WorkKind,
+    work_phase: WorkPhase,
+    work_class: WorkClass,
+    source_job_type: Option<WorkKind>,
+}
+
+pub struct WorkloadTracker {
+    descriptor: WorkloadDescriptor,
+    started_at: Instant,
+    finished: bool,
+}
+
+impl WorkloadTracker {
+    fn start(descriptor: WorkloadDescriptor) -> Self {
+        let active_slots = increment_active_slots(descriptor);
+        ORCHESTRATOR_METRICS.workload_active_slots.record(active_slots as f64, &descriptor.active_attributes());
+
+        Self { descriptor, started_at: Instant::now(), finished: false }
+    }
+
+    pub fn finish_success(mut self) {
+        self.finish(WorkloadOutcome::Success);
+    }
+
+    pub fn finish_error(mut self) {
+        self.finish(WorkloadOutcome::Error);
+    }
+
+    fn finish(&mut self, outcome: WorkloadOutcome) {
+        if self.finished {
+            return;
+        }
+
+        self.finished = true;
+        let duration_seconds = self.started_at.elapsed().as_secs_f64();
+        let completed_attributes = self.descriptor.completed_attributes(outcome);
+        let active_attributes = self.descriptor.active_attributes();
+
+        ORCHESTRATOR_METRICS.workload_busy_seconds_total.add(duration_seconds, &completed_attributes);
+        ORCHESTRATOR_METRICS.workload_runs_total.add(1.0, &completed_attributes);
+        ORCHESTRATOR_METRICS.workload_duration_seconds.record(duration_seconds, &completed_attributes);
+
+        let active_slots = decrement_active_slots(self.descriptor);
+        ORCHESTRATOR_METRICS.workload_active_slots.record(active_slots as f64, &active_attributes);
+    }
+}
+
+impl Drop for WorkloadTracker {
+    fn drop(&mut self) {
+        self.finish(WorkloadOutcome::Error);
+    }
+}
+
+fn increment_active_slots(descriptor: WorkloadDescriptor) -> i64 {
+    let key = descriptor.key();
+    match ACTIVE_WORKLOAD_SLOTS.entry(key) {
+        Entry::Occupied(mut entry) => {
+            let value = entry.get_mut();
+            *value += 1;
+            *value
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(1);
+            1
+        }
+    }
+}
+
+fn decrement_active_slots(descriptor: WorkloadDescriptor) -> i64 {
+    let key = descriptor.key();
+    match ACTIVE_WORKLOAD_SLOTS.entry(key) {
+        Entry::Occupied(mut entry) => {
+            let updated = {
+                let value = entry.get_mut();
+                let updated = (*value - 1).max(0);
+                if updated > 0 {
+                    *value = updated;
+                }
+                updated
+            };
+            if updated == 0 {
+                entry.remove();
+                0
+            } else {
+                updated
+            }
+        }
+        Entry::Vacant(_) => 0,
+    }
+}
+
+fn workload_descriptor_for_job(job_type: &JobType, job_state: JobState) -> WorkloadDescriptor {
+    let work_kind = WorkKind::from_job_type(job_type);
+    match job_state {
+        JobState::Processing => WorkloadDescriptor::new(work_kind, WorkPhase::Process, WorkClass::JobExecution, None),
+        JobState::Verification => {
+            WorkloadDescriptor::new(work_kind, WorkPhase::Verify, WorkClass::JobVerification, None)
+        }
+    }
+}
+
+fn workload_descriptor_for_worker_trigger(worker_trigger_type: &WorkerTriggerType) -> WorkloadDescriptor {
+    match worker_trigger_type {
+        WorkerTriggerType::Snos => {
+            WorkloadDescriptor::new(WorkKind::SnosRun, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::Proving => {
+            WorkloadDescriptor::new(WorkKind::ProofCreation, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::ProofRegistration => {
+            WorkloadDescriptor::new(WorkKind::ProofRegistration, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::DataSubmission => {
+            WorkloadDescriptor::new(WorkKind::DataSubmission, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::UpdateState => {
+            WorkloadDescriptor::new(WorkKind::StateTransition, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::Aggregator => {
+            WorkloadDescriptor::new(WorkKind::Aggregator, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::AggregatorBatching => {
+            WorkloadDescriptor::new(WorkKind::AggregatorBatching, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::SnosBatching => {
+            WorkloadDescriptor::new(WorkKind::SnosBatching, WorkPhase::Trigger, WorkClass::Trigger, None)
+        }
+        WorkerTriggerType::StorageCleanup => {
+            WorkloadDescriptor::new(WorkKind::StorageCleanup, WorkPhase::Maintenance, WorkClass::Maintenance, None)
+        }
+    }
+}
+
+fn workload_descriptor_for_queue(queue_type: &QueueType) -> Option<WorkloadDescriptor> {
+    match queue_type {
+        QueueType::SnosJobProcessing => Some(workload_descriptor_for_job(&JobType::SnosRun, JobState::Processing)),
+        QueueType::SnosJobVerification => Some(workload_descriptor_for_job(&JobType::SnosRun, JobState::Verification)),
+        QueueType::ProvingJobProcessing => {
+            Some(workload_descriptor_for_job(&JobType::ProofCreation, JobState::Processing))
+        }
+        QueueType::ProvingJobVerification => {
+            Some(workload_descriptor_for_job(&JobType::ProofCreation, JobState::Verification))
+        }
+        QueueType::ProofRegistrationJobProcessing => {
+            Some(workload_descriptor_for_job(&JobType::ProofRegistration, JobState::Processing))
+        }
+        QueueType::ProofRegistrationJobVerification => {
+            Some(workload_descriptor_for_job(&JobType::ProofRegistration, JobState::Verification))
+        }
+        QueueType::DataSubmissionJobProcessing => {
+            Some(workload_descriptor_for_job(&JobType::DataSubmission, JobState::Processing))
+        }
+        QueueType::DataSubmissionJobVerification => {
+            Some(workload_descriptor_for_job(&JobType::DataSubmission, JobState::Verification))
+        }
+        QueueType::UpdateStateJobProcessing => {
+            Some(workload_descriptor_for_job(&JobType::StateTransition, JobState::Processing))
+        }
+        QueueType::UpdateStateJobVerification => {
+            Some(workload_descriptor_for_job(&JobType::StateTransition, JobState::Verification))
+        }
+        QueueType::AggregatorJobProcessing => {
+            Some(workload_descriptor_for_job(&JobType::Aggregator, JobState::Processing))
+        }
+        QueueType::AggregatorJobVerification => {
+            Some(workload_descriptor_for_job(&JobType::Aggregator, JobState::Verification))
+        }
+        QueueType::WorkerTrigger
+        | QueueType::JobHandleFailure
+        | QueueType::PriorityProcessingQueue
+        | QueueType::PriorityVerificationQueue => None,
+    }
+}
+
+fn healing_descriptor(source_job_type: &JobType) -> WorkloadDescriptor {
+    WorkloadDescriptor::new(
+        WorkKind::Healing,
+        WorkPhase::Maintenance,
+        WorkClass::Maintenance,
+        Some(WorkKind::from_job_type(source_job_type)),
+    )
+}
 
 /// Helper functions to record metrics at various points in the job lifecycle
 /// These should be called from the existing service handlers without modifying the DB model
 pub struct MetricsRecorder;
 
 impl MetricsRecorder {
+    pub fn start_job_workload(job_type: &JobType, job_state: JobState) -> WorkloadTracker {
+        WorkloadTracker::start(workload_descriptor_for_job(job_type, job_state))
+    }
+
+    pub fn start_worker_trigger_workload(worker_trigger_type: &WorkerTriggerType) -> WorkloadTracker {
+        WorkloadTracker::start(workload_descriptor_for_worker_trigger(worker_trigger_type))
+    }
+
+    pub fn start_healing_workload(job_type: &JobType) -> WorkloadTracker {
+        WorkloadTracker::start(healing_descriptor(job_type))
+    }
+
+    pub fn record_workload_capacity_for_queue(queue_type: &QueueType, max_slots: usize) {
+        if let Some(descriptor) = workload_descriptor_for_queue(queue_type) {
+            ORCHESTRATOR_METRICS.workload_capacity_slots.record(max_slots as f64, &descriptor.active_attributes());
+        }
+    }
+
+    pub fn record_healed_job(job_type: &JobType) {
+        ORCHESTRATOR_METRICS
+            .healed_jobs_total
+            .add(1.0, &[KeyValue::new("source_job_type", WorkKind::from_job_type(job_type).as_str())]);
+    }
+
     /// Record metrics when a job is created and enters the queue
     pub fn record_job_created(job: &JobItem) {
         let attributes = [
@@ -331,5 +689,67 @@ impl MetricsRecorder {
         ORCHESTRATOR_METRICS.aggregator_program_output_bytes.record(program_output_bytes as f64, &attrs);
         ORCHESTRATOR_METRICS.aggregator_da_segment_bytes.record(da_segment_bytes as f64, &attrs);
         ORCHESTRATOR_METRICS.aggregator_pie_zip_bytes.record(pie_zip_bytes as f64, &attrs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reset_active_workload_state() {
+        ACTIVE_WORKLOAD_SLOTS.clear();
+    }
+
+    fn active_slots_for(descriptor: WorkloadDescriptor) -> i64 {
+        ACTIVE_WORKLOAD_SLOTS.get(&descriptor.key()).map(|entry| *entry).unwrap_or(0)
+    }
+
+    #[test]
+    fn job_processing_descriptor_is_mapped_consistently() {
+        let descriptor = workload_descriptor_for_job(&JobType::SnosRun, JobState::Processing);
+
+        assert_eq!(descriptor.work_kind, WorkKind::SnosRun);
+        assert_eq!(descriptor.work_phase, WorkPhase::Process);
+        assert_eq!(descriptor.work_class, WorkClass::JobExecution);
+        assert_eq!(descriptor.source_job_type, None);
+    }
+
+    #[test]
+    fn worker_trigger_descriptor_maps_storage_cleanup_to_maintenance() {
+        let descriptor = workload_descriptor_for_worker_trigger(&WorkerTriggerType::StorageCleanup);
+
+        assert_eq!(descriptor.work_kind, WorkKind::StorageCleanup);
+        assert_eq!(descriptor.work_phase, WorkPhase::Maintenance);
+        assert_eq!(descriptor.work_class, WorkClass::Maintenance);
+    }
+
+    #[test]
+    fn capacity_descriptor_exists_only_for_queue_backed_workloads() {
+        assert!(workload_descriptor_for_queue(&QueueType::SnosJobProcessing).is_some());
+        assert!(workload_descriptor_for_queue(&QueueType::AggregatorJobVerification).is_some());
+        assert!(workload_descriptor_for_queue(&QueueType::WorkerTrigger).is_none());
+        assert!(workload_descriptor_for_queue(&QueueType::JobHandleFailure).is_none());
+    }
+
+    #[test]
+    fn workload_tracker_increments_and_clears_active_slots() {
+        reset_active_workload_state();
+        let descriptor = workload_descriptor_for_job(&JobType::ProofCreation, JobState::Verification);
+
+        let tracker = WorkloadTracker::start(descriptor);
+        assert_eq!(active_slots_for(descriptor), 1);
+
+        tracker.finish_success();
+        assert_eq!(active_slots_for(descriptor), 0);
+    }
+
+    #[test]
+    fn healing_descriptor_carries_source_job_type() {
+        let descriptor = healing_descriptor(&JobType::StateTransition);
+
+        assert_eq!(descriptor.work_kind, WorkKind::Healing);
+        assert_eq!(descriptor.work_phase, WorkPhase::Maintenance);
+        assert_eq!(descriptor.work_class, WorkClass::Maintenance);
+        assert_eq!(descriptor.source_job_type, Some(WorkKind::StateTransition));
     }
 }

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -177,8 +177,6 @@ impl WorkloadTracker {
         let completed_attributes = self.descriptor.completed_attributes(outcome);
 
         ORCHESTRATOR_METRICS.workload_busy_seconds_total.add(duration_seconds, &completed_attributes);
-        ORCHESTRATOR_METRICS.workload_runs_total.add(1.0, &completed_attributes);
-        ORCHESTRATOR_METRICS.workload_duration_seconds.record(duration_seconds, &completed_attributes);
 
         decrement_active_slots(self.descriptor);
     }

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use dashmap::{mapref::entry::Entry, DashMap};
 use once_cell::sync::Lazy;
+use opentelemetry::metrics::{Meter, ObservableGauge};
 use opentelemetry::KeyValue;
 use std::time::Instant;
 
@@ -10,7 +11,8 @@ use crate::types::jobs::WorkerTriggerType;
 use crate::types::queue::{JobState, QueueType};
 use crate::utils::metrics::ORCHESTRATOR_METRICS;
 
-static ACTIVE_WORKLOAD_SLOTS: Lazy<DashMap<WorkloadKey, i64>> = Lazy::new(DashMap::new);
+// Keep descriptors at zero so the async gauge can publish drained workloads as 0 on later scrapes.
+static ACTIVE_WORKLOAD_SLOTS: Lazy<DashMap<WorkloadDescriptor, u64>> = Lazy::new(DashMap::new);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum WorkKind {
@@ -125,15 +127,6 @@ impl WorkloadDescriptor {
         Self { work_kind, work_phase, work_class, source_job_type }
     }
 
-    fn key(self) -> WorkloadKey {
-        WorkloadKey {
-            work_kind: self.work_kind,
-            work_phase: self.work_phase,
-            work_class: self.work_class,
-            source_job_type: self.source_job_type,
-        }
-    }
-
     fn active_attributes(self) -> [KeyValue; 4] {
         [
             KeyValue::new("work_kind", self.work_kind.as_str()),
@@ -154,14 +147,6 @@ impl WorkloadDescriptor {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct WorkloadKey {
-    work_kind: WorkKind,
-    work_phase: WorkPhase,
-    work_class: WorkClass,
-    source_job_type: Option<WorkKind>,
-}
-
 pub struct WorkloadTracker {
     descriptor: WorkloadDescriptor,
     started_at: Instant,
@@ -170,9 +155,7 @@ pub struct WorkloadTracker {
 
 impl WorkloadTracker {
     fn start(descriptor: WorkloadDescriptor) -> Self {
-        let active_slots = increment_active_slots(descriptor);
-        ORCHESTRATOR_METRICS.workload_active_slots.record(active_slots as f64, &descriptor.active_attributes());
-
+        increment_active_slots(descriptor);
         Self { descriptor, started_at: Instant::now(), finished: false }
     }
 
@@ -192,14 +175,12 @@ impl WorkloadTracker {
         self.finished = true;
         let duration_seconds = self.started_at.elapsed().as_secs_f64();
         let completed_attributes = self.descriptor.completed_attributes(outcome);
-        let active_attributes = self.descriptor.active_attributes();
 
         ORCHESTRATOR_METRICS.workload_busy_seconds_total.add(duration_seconds, &completed_attributes);
         ORCHESTRATOR_METRICS.workload_runs_total.add(1.0, &completed_attributes);
         ORCHESTRATOR_METRICS.workload_duration_seconds.record(duration_seconds, &completed_attributes);
 
-        let active_slots = decrement_active_slots(self.descriptor);
-        ORCHESTRATOR_METRICS.workload_active_slots.record(active_slots as f64, &active_attributes);
+        decrement_active_slots(self.descriptor);
     }
 }
 
@@ -209,42 +190,41 @@ impl Drop for WorkloadTracker {
     }
 }
 
-fn increment_active_slots(descriptor: WorkloadDescriptor) -> i64 {
-    let key = descriptor.key();
-    match ACTIVE_WORKLOAD_SLOTS.entry(key) {
+fn increment_active_slots(descriptor: WorkloadDescriptor) {
+    match ACTIVE_WORKLOAD_SLOTS.entry(descriptor) {
         Entry::Occupied(mut entry) => {
             let value = entry.get_mut();
             *value += 1;
-            *value
         }
         Entry::Vacant(entry) => {
             entry.insert(1);
-            1
         }
     }
 }
 
-fn decrement_active_slots(descriptor: WorkloadDescriptor) -> i64 {
-    let key = descriptor.key();
-    match ACTIVE_WORKLOAD_SLOTS.entry(key) {
+fn decrement_active_slots(descriptor: WorkloadDescriptor) {
+    match ACTIVE_WORKLOAD_SLOTS.entry(descriptor) {
         Entry::Occupied(mut entry) => {
-            let updated = {
-                let value = entry.get_mut();
-                let updated = (*value - 1).max(0);
-                if updated > 0 {
-                    *value = updated;
-                }
-                updated
-            };
-            if updated == 0 {
-                entry.remove();
-                0
-            } else {
-                updated
-            }
+            let value = entry.get_mut();
+            *value = value.saturating_sub(1);
         }
-        Entry::Vacant(_) => 0,
+        Entry::Vacant(entry) => {
+            entry.insert(0);
+        }
     }
+}
+
+pub fn register_workload_active_slots_observer(meter: &Meter) -> ObservableGauge<u64> {
+    meter
+        .u64_observable_gauge("workload_active_slots")
+        .with_description("Current active workload slots by kind, phase, and class")
+        .with_unit("slots")
+        .with_callback(|observer| {
+            for active_slots in ACTIVE_WORKLOAD_SLOTS.iter() {
+                observer.observe(*active_slots.value(), &active_slots.key().active_attributes());
+            }
+        })
+        .build()
 }
 
 fn workload_descriptor_for_job(job_type: &JobType, job_state: JobState) -> WorkloadDescriptor {
@@ -358,6 +338,7 @@ impl MetricsRecorder {
 
     pub fn record_workload_capacity_for_queue(queue_type: &QueueType, max_slots: usize) {
         if let Some(descriptor) = workload_descriptor_for_queue(queue_type) {
+            ACTIVE_WORKLOAD_SLOTS.entry(descriptor).or_insert(0);
             ORCHESTRATOR_METRICS.workload_capacity_slots.record(max_slots as f64, &descriptor.active_attributes());
         }
     }

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -7,6 +7,7 @@ use crate::types::priority_slot::{
 use crate::types::queue::JobAction;
 use crate::types::queue::{JobState, QueueType};
 use crate::types::queue_control::{QueueControlConfig, QUEUES};
+use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
 use crate::worker::parser::{job_queue_message::JobQueueMessage, worker_trigger_message::WorkerTriggerMessage};
 use crate::worker::traits::message::{MessageParser, ParsedMessage};
@@ -174,10 +175,12 @@ impl EventWorker {
     async fn handle_worker_trigger(&self, worker_message: &WorkerTriggerMessage) -> EventSystemResult<()> {
         let worker_handler =
             JobHandlerService::get_worker_handler_from_worker_trigger_type(worker_message.worker.clone());
+        let workload = MetricsRecorder::start_worker_trigger_workload(&worker_message.worker);
         worker_handler
             .run_worker_if_enabled(self.config.clone())
             .await
             .map_err(|e| ConsumptionError::Other(OtherError::from(e.to_string())))?;
+        workload.finish_success();
         Ok(())
     }
 
@@ -350,6 +353,7 @@ impl EventWorker {
     pub async fn run(&self) -> EventSystemResult<()> {
         let mut tasks = JoinSet::new();
         let max_concurrent_tasks = self.queue_control.max_message_count;
+        MetricsRecorder::record_workload_capacity_for_queue(&self.queue_type, max_concurrent_tasks);
         info!("Starting {:?} worker (pool_size={})", self.queue_type, max_concurrent_tasks);
 
         loop {

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -662,10 +662,7 @@ impl JobHandlerService {
                         );
                     }
 
-                    attributes.push(KeyValue::new(
-                        "operation_job_status",
-                        JobStatus::VerificationTimeout.to_string(),
-                    ));
+                    attributes.push(KeyValue::new("operation_job_status", JobStatus::VerificationTimeout.to_string()));
 
                     debug!(log_type = "completed", category = "general", function_type = "verify_job", block_no = %internal_id, "General verify job completed for block");
                     let duration = start.elapsed();
@@ -709,7 +706,10 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
-        workload.finish_success();
+        match operation_job_status {
+            Some(JobStatus::VerificationFailed) => workload.finish_error(),
+            _ => workload.finish_success(),
+        }
         Ok(())
     }
 

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -37,6 +37,10 @@ use tracing::{debug, error, info, warn, Span};
 pub struct JobHandlerService;
 
 impl JobHandlerService {
+    pub(crate) fn verification_workload_is_error(operation_job_status: Option<&JobStatus>) -> bool {
+        matches!(operation_job_status, Some(JobStatus::VerificationFailed | JobStatus::VerificationTimeout))
+    }
+
     /// Creates the job in the DB in the created state and adds it to the process queue
     ///
     /// # Arguments
@@ -704,7 +708,7 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
-        if matches!(operation_job_status, Some(JobStatus::VerificationFailed | JobStatus::VerificationTimeout)) {
+        if Self::verification_workload_is_error(operation_job_status.as_ref()) {
             workload.finish_error();
         } else {
             workload.finish_success();

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -624,16 +624,8 @@ impl JobHandlerService {
                     )
                     .await;
 
-                    match move_result {
-                        Ok(()) => {
-                            workload.finish_error();
-                            return Ok(());
-                        }
-                        Err(e) => {
-                            workload.finish_error();
-                            return Err(e);
-                        }
-                    }
+                    workload.finish_error();
+                    return move_result;
                 }
             }
             JobVerificationStatus::Pending => {

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -696,7 +696,10 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
-        workload.finish_success();
+        match operation_job_status {
+            Some(JobStatus::VerificationTimeout) => workload.finish_error(),
+            _ => workload.finish_success(),
+        }
         Ok(())
     }
 

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -17,7 +17,7 @@ use crate::types::jobs::metadata::JobMetadata;
 use crate::types::jobs::status::JobVerificationStatus;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::types::jobs::WorkerTriggerType;
-use crate::types::queue::QueueNameForJobType;
+use crate::types::queue::{JobState, QueueNameForJobType};
 use crate::utils::metrics_recorder::MetricsRecorder;
 #[double]
 use crate::worker::event_handler::factory::factory;
@@ -211,6 +211,7 @@ impl JobHandlerService {
 
                     // Record orphaned job metric
                     MetricsRecorder::record_orphaned_job(&job);
+                    let healing_workload = MetricsRecorder::start_healing_workload(&job.job_type);
 
                     // Reset process_started_at to allow fresh processing
                     job.metadata.common.process_started_at = None;
@@ -229,6 +230,9 @@ impl JobHandlerService {
                         .inspect_err(|e| {
                             error!(job_id = ?id, error = ?e, "Failed to heal stale job");
                         })?;
+
+                    MetricsRecorder::record_healed_job(&job.job_type);
+                    healing_workload.finish_success();
 
                     info!(
                         job_id = ?id,
@@ -310,6 +314,7 @@ impl JobHandlerService {
         // Record queue wait time only after readiness succeeds and the job is locked for processing.
         let queue_wait_time = Utc::now().signed_duration_since(job.created_at).num_seconds() as f64;
         MetricsRecorder::record_job_processing_started(&job, queue_wait_time);
+        let workload = MetricsRecorder::start_job_workload(&job.job_type, JobState::Processing);
 
         // Increment process attempt counter
         job.metadata.common.process_attempt_no += 1;
@@ -409,6 +414,7 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
+        workload.finish_success();
 
         Ok(())
     }
@@ -480,6 +486,7 @@ impl JobHandlerService {
                 error!(job_id = ?id, error = ?e, "Failed to update job status");
                 e
             })?;
+        let workload = MetricsRecorder::start_job_workload(&job.job_type, JobState::Verification);
 
         let verification_status = job_handler.verify_job(config.clone(), &mut job).await?;
         Span::current().record("verification_status", format!("{:?}", &verification_status));
@@ -591,7 +598,7 @@ impl JobHandlerService {
                         JobStatus::Failed,
                         &job.job_type,
                     );
-                    return JobService::move_job_to_failed(
+                    let move_result = JobService::move_job_to_failed(
                         &job,
                         config.clone(),
                         format!(
@@ -600,6 +607,17 @@ impl JobHandlerService {
                         ),
                     )
                     .await;
+
+                    match move_result {
+                        Ok(()) => {
+                            workload.finish_success();
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            workload.finish_error();
+                            return Err(e);
+                        }
+                    }
                 }
             }
             JobVerificationStatus::Pending => {
@@ -678,6 +696,7 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
+        workload.finish_success();
         Ok(())
     }
 

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -610,7 +610,7 @@ impl JobHandlerService {
 
                     match move_result {
                         Ok(()) => {
-                            workload.finish_success();
+                            workload.finish_error();
                             return Ok(());
                         }
                         Err(e) => {

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -661,6 +661,19 @@ impl JobHandlerService {
                             "SNS alert sent successfully for verification timeout"
                         );
                     }
+
+                    attributes.push(KeyValue::new(
+                        "operation_job_status",
+                        JobStatus::VerificationTimeout.to_string(),
+                    ));
+
+                    debug!(log_type = "completed", category = "general", function_type = "verify_job", block_no = %internal_id, "General verify job completed for block");
+                    let duration = start.elapsed();
+                    MetricsRecorder::record_successful_job_operation(1.0, &attributes);
+                    MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
+                    Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
+                    workload.finish_error();
+                    return Ok(());
                 } else {
                     config
                         .database()
@@ -696,10 +709,7 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
-        match operation_job_status {
-            Some(JobStatus::VerificationTimeout) => workload.finish_error(),
-            _ => workload.finish_success(),
-        }
+        workload.finish_success();
         Ok(())
     }
 

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -37,10 +37,6 @@ use tracing::{debug, error, info, warn, Span};
 pub struct JobHandlerService;
 
 impl JobHandlerService {
-    pub(crate) fn verification_workload_is_error(operation_job_status: Option<&JobStatus>) -> bool {
-        matches!(operation_job_status, Some(JobStatus::VerificationFailed | JobStatus::VerificationTimeout))
-    }
-
     /// Creates the job in the DB in the created state and adds it to the process queue
     ///
     /// # Arguments
@@ -742,6 +738,10 @@ impl JobHandlerService {
             format!("Job moved to DLQ after exhausting retries (last status: {})", status),
         )
         .await
+    }
+
+    pub(crate) fn verification_workload_is_error(operation_job_status: Option<&JobStatus>) -> bool {
+        matches!(operation_job_status, Some(JobStatus::VerificationFailed | JobStatus::VerificationTimeout))
     }
 
     /// Retries a failed job by reprocessing it.

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -635,8 +635,6 @@ impl JobHandlerService {
                             error!(job_id = ?id, error = ?e, "Failed to update job status to VerificationTimeout");
                             JobError::from(e)
                         })?;
-                    operation_job_status = Some(JobStatus::VerificationTimeout);
-
                     MetricsRecorder::record_job_state_transition(
                         JobStatus::PendingVerification,
                         JobStatus::VerificationTimeout,
@@ -697,8 +695,8 @@ impl JobHandlerService {
             }
         };
 
-        if let Some(job_status) = operation_job_status {
-            attributes.push(KeyValue::new("operation_job_status", format!("{}", job_status)));
+        if let Some(job_status) = operation_job_status.as_ref() {
+            attributes.push(KeyValue::new("operation_job_status", job_status.to_string()));
         }
 
         debug!(log_type = "completed", category = "general", function_type = "verify_job", block_no = %internal_id, "General verify job completed for block");
@@ -706,9 +704,10 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
-        match operation_job_status {
-            Some(JobStatus::VerificationFailed) => workload.finish_error(),
-            _ => workload.finish_success(),
+        if operation_job_status == Some(JobStatus::VerificationFailed) {
+            workload.finish_error();
+        } else {
+            workload.finish_success();
         }
         Ok(())
     }

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -668,15 +668,7 @@ impl JobHandlerService {
                         );
                     }
 
-                    attributes.push(KeyValue::new("operation_job_status", JobStatus::VerificationTimeout.to_string()));
-
-                    debug!(log_type = "completed", category = "general", function_type = "verify_job", block_no = %internal_id, "General verify job completed for block");
-                    let duration = start.elapsed();
-                    MetricsRecorder::record_successful_job_operation(1.0, &attributes);
-                    MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
-                    Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
-                    workload.finish_error();
-                    return Ok(());
+                    operation_job_status = Some(JobStatus::VerificationTimeout);
                 } else {
                     config
                         .database()
@@ -712,7 +704,7 @@ impl JobHandlerService {
         MetricsRecorder::record_successful_job_operation(1.0, &attributes);
         MetricsRecorder::record_job_response_time(duration.as_secs_f64(), &attributes);
         Self::register_block_gauge(job.job_type, job.internal_id, &attributes, &config).await?;
-        if operation_job_status == Some(JobStatus::VerificationFailed) {
+        if matches!(operation_job_status, Some(JobStatus::VerificationFailed | JobStatus::VerificationTimeout)) {
             workload.finish_error();
         } else {
             workload.finish_success();


### PR DESCRIPTION
## Summary
- add a workload tracker and workload-specific OTEL metrics for orchestrator activity
- instrument queue-backed processing, verification, worker triggers, capacity slots, and stale-job healing
- add unit coverage for workload label mapping and active-slot tracking

## Metrics Added
- `workload_active_slots`
- `workload_busy_seconds_total`
- `workload_capacity_slots`
- `healed_jobs_total`

## Notes
- labels are bounded to `work_kind`, `work_phase`, `source_job_type`, and `outcome`
- queue-backed workers emit configured capacity slots so Grafana can compare busy time versus local capacity per pod
- healing is emitted as maintenance work under `work_kind="Healing"` with the original job type in `source_job_type`

## Testing
- `cargo fmt --manifest-path Cargo.toml -p orchestrator`
- `cargo test --manifest-path Cargo.toml -p orchestrator metrics_recorder -- --nocapture` *(blocked by existing upstream dependency failure in `size-of 0.1.5` on `aarch64-apple-darwin` due to unsupported ABIs)*
