### PR TITLE
Fix replayBlock L1 handler fee JSON encoding

### DIFF
--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -27,7 +27,7 @@ pub enum ServiceRequest {
     Restart,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReplayBlockRequest {
     pub custom_header: CustomHeader,
     pub transactions: Vec<ReplayBlockTransaction>,

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -27,6 +27,41 @@ pub enum ServiceRequest {
     Restart,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ReplayBlockRequest {
+    pub custom_header: CustomHeader,
+    pub transactions: Vec<ReplayBlockTransaction>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ReplayBlockResult {
+    pub block_number: u64,
+    pub block_hash: Felt,
+    pub transaction_hashes: Vec<Felt>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ReplayBlockTransaction {
+    Invoke { transaction_hash: Felt, invoke_transaction: BroadcastedInvokeTxn },
+    DeclareV0 { transaction_hash: Felt, declare_transaction: BroadcastedDeclareTxnV0 },
+    Declare { transaction_hash: Felt, declare_transaction: BroadcastedDeclareTxn },
+    DeployAccount { transaction_hash: Felt, deploy_account_transaction: BroadcastedDeployAccountTxn },
+    L1Handler { transaction_hash: Felt, l1_handler_message: L1HandlerTransactionWithFee },
+}
+
+impl ReplayBlockTransaction {
+    pub fn expected_tx_hash(&self) -> Felt {
+        match self {
+            Self::Invoke { transaction_hash, .. }
+            | Self::DeclareV0 { transaction_hash, .. }
+            | Self::Declare { transaction_hash, .. }
+            | Self::DeployAccount { transaction_hash, .. }
+            | Self::L1Handler { transaction_hash, .. } => *transaction_hash,
+        }
+    }
+}
+
 /// This is an admin method, so semver is different!
 #[versioned_rpc("V0_1_0", "madara")]
 pub trait MadaraWriteRpcApi {
@@ -87,6 +122,14 @@ pub trait MadaraWriteRpcApi {
     /// Sets custom headers to be used for the upcoming block
     #[method(name = "setCustomBlockHeader")]
     async fn set_block_header(&self, custom_block_headers: CustomHeader) -> RpcResult<()>;
+
+    /// Replays a full Starknet block inside Madara and only returns after the block is confirmed.
+    ///
+    /// The replay request stages the custom header, submits the ordered transactions, waits until all
+    /// expected transaction hashes are present in the current preconfirmed block, force-closes the block,
+    /// and then waits until the confirmed block is written to the database.
+    #[method(name = "replayBlock")]
+    async fn replay_block(&self, replay_block_request: ReplayBlockRequest) -> RpcResult<ReplayBlockResult>;
 }
 
 /// This is an admin method, so semver is different!

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -1,4 +1,9 @@
-use crate::{versions::admin::v0_1_0::MadaraWriteRpcApiV0_1_0Server, Starknet, StarknetRpcApiError};
+use crate::{
+    versions::admin::v0_1_0::{
+        MadaraWriteRpcApiV0_1_0Server, ReplayBlockRequest, ReplayBlockResult, ReplayBlockTransaction,
+    },
+    Starknet, StarknetRpcApiError,
+};
 use anyhow::Context;
 use jsonrpsee::core::{async_trait, RpcResult};
 use mc_db::MadaraStorageRead;
@@ -13,12 +18,14 @@ use mp_rpc::v0_9_0::{
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
 use mp_utils::service::{MadaraServiceId, MadaraServiceStatus, SERVICE_GRACE_PERIOD};
 use std::time::Duration;
-use tokio::time::Instant;
+use tokio::time::{timeout, Instant};
 
 const REVERT_STOP_WAIT_EXTRA: Duration = Duration::from_secs(5);
 const REVERT_STOP_LOG_INTERVAL: Duration = Duration::from_secs(1);
 const REVERT_STOP_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const REVERT_SHUTDOWN_DELAY: Duration = Duration::from_millis(100);
+const REPLAY_BLOCK_PRECONFIRMED_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const REPLAY_BLOCK_CONFIRM_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 
 fn schedule_global_cancel(ctx: mp_utils::service::ServiceContext) {
     tokio::spawn(async move {
@@ -37,6 +44,82 @@ fn services_to_stop_for_revert() -> [MadaraServiceId; 6] {
         MadaraServiceId::Gateway,
         MadaraServiceId::Mempool,
     ]
+}
+
+async fn wait_for_preconfirmed_alignment<D: MadaraStorageRead>(
+    backend: &std::sync::Arc<mc_db::MadaraBackend<D>>,
+    block_n: u64,
+    expected_tx_hashes: &[Felt],
+) -> anyhow::Result<()> {
+    if expected_tx_hashes.is_empty() {
+        return Ok(());
+    }
+
+    timeout(REPLAY_BLOCK_PRECONFIRMED_TIMEOUT, async {
+        let mut chain_tip = backend.watch_chain_tip();
+
+        loop {
+            if let Some(mut view) = backend.block_view_on_preconfirmed() {
+                if view.block_number() != block_n {
+                    chain_tip.recv().await;
+                    continue;
+                }
+
+                let actual_tx_hashes = view.get_block_info().tx_hashes;
+
+                if actual_tx_hashes.len() > expected_tx_hashes.len() {
+                    anyhow::bail!(
+                        "Preconfirmed block #{} already has {} transactions, expected at most {}",
+                        block_n,
+                        actual_tx_hashes.len(),
+                        expected_tx_hashes.len()
+                    );
+                }
+
+                for (idx, (actual, expected)) in actual_tx_hashes.iter().zip(expected_tx_hashes.iter()).enumerate() {
+                    if actual != expected {
+                        anyhow::bail!(
+                            "Preconfirmed block #{} diverged at tx index {}: expected {:#x}, found {:#x}",
+                            block_n,
+                            idx,
+                            expected,
+                            actual
+                        );
+                    }
+                }
+
+                if actual_tx_hashes.len() == expected_tx_hashes.len() {
+                    return Ok(());
+                }
+
+                view.wait_until_outdated().await;
+                continue;
+            }
+
+            chain_tip.recv().await;
+        }
+    })
+    .await
+    .context("Timed out waiting for replayed transactions to reach the preconfirmed block")?
+}
+
+async fn wait_for_confirmed_block<D: MadaraStorageRead>(
+    backend: &std::sync::Arc<mc_db::MadaraBackend<D>>,
+    block_n: u64,
+) -> anyhow::Result<Felt> {
+    timeout(REPLAY_BLOCK_CONFIRM_TIMEOUT, async {
+        let mut chain_tip = backend.watch_chain_tip();
+
+        loop {
+            if let Some(view) = backend.block_view_on_confirmed(block_n) {
+                return view.get_block_info().map(|info| info.block_hash);
+            }
+
+            chain_tip.recv().await;
+        }
+    })
+    .await
+    .context(format!("Timed out waiting for block #{} to be confirmed", block_n))?
 }
 
 #[async_trait]
@@ -275,6 +358,129 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
         self.backend.set_custom_header(custom_block_headers).map_err(StarknetRpcApiError::from)?;
 
         Ok(())
+    }
+
+    async fn replay_block(&self, replay_block_request: ReplayBlockRequest) -> RpcResult<ReplayBlockResult> {
+        if !self.rpc_unsafe_enabled {
+            return Err(StarknetRpcApiError::ErrUnexpectedError {
+                error: "This method requires the --rpc-unsafe flag to be enabled".to_string().into(),
+            }
+            .into());
+        }
+
+        let block_prod_handle = self.block_prod_handle.as_ref().ok_or(StarknetRpcApiError::UnimplementedMethod)?;
+
+        let block_n = replay_block_request.custom_header.block_n;
+        let expected_parent = block_n.checked_sub(1);
+        let latest_confirmed = self.backend.latest_confirmed_block_n();
+
+        if latest_confirmed >= Some(block_n) {
+            return Err(StarknetRpcApiError::ErrUnexpectedError {
+                error: format!(
+                    "Cannot replay block {} because latest confirmed block is already {:?}",
+                    block_n, latest_confirmed
+                )
+                .into(),
+            }
+            .into());
+        }
+
+        if latest_confirmed != expected_parent && !(block_n == 0 && latest_confirmed.is_none()) {
+            return Err(StarknetRpcApiError::ErrUnexpectedError {
+                error: format!(
+                    "Cannot replay block {} on top of latest confirmed block {:?}",
+                    block_n, latest_confirmed
+                )
+                .into(),
+            }
+            .into());
+        }
+
+        if let Some(preconfirmed) = self.backend.block_view_on_preconfirmed() {
+            if preconfirmed.block_number() == block_n && preconfirmed.num_executed_transactions() > 0 {
+                return Err(StarknetRpcApiError::ErrUnexpectedError {
+                    error: format!(
+                        "Cannot replay block {} because a preconfirmed block with {} executed transactions already exists",
+                        block_n,
+                        preconfirmed.num_executed_transactions()
+                    )
+                    .into(),
+                }
+                .into());
+            }
+        }
+
+        let expected_tx_hashes =
+            replay_block_request.transactions.iter().map(ReplayBlockTransaction::expected_tx_hash).collect::<Vec<_>>();
+
+        self.backend.set_custom_header(replay_block_request.custom_header).map_err(StarknetRpcApiError::from)?;
+
+        for tx in replay_block_request.transactions {
+            let expected_tx_hash = tx.expected_tx_hash();
+
+            let actual_tx_hash = match tx {
+                ReplayBlockTransaction::Invoke { invoke_transaction, .. } => {
+                    block_prod_handle
+                        .submit_invoke_transaction(invoke_transaction)
+                        .await
+                        .map_err(StarknetRpcApiError::from)?
+                        .transaction_hash
+                }
+                ReplayBlockTransaction::DeclareV0 { declare_transaction, .. } => {
+                    block_prod_handle
+                        .submit_declare_v0_transaction(declare_transaction)
+                        .await
+                        .map_err(StarknetRpcApiError::from)?
+                        .transaction_hash
+                }
+                ReplayBlockTransaction::Declare { declare_transaction, .. } => {
+                    block_prod_handle
+                        .submit_declare_transaction(declare_transaction)
+                        .await
+                        .map_err(StarknetRpcApiError::from)?
+                        .transaction_hash
+                }
+                ReplayBlockTransaction::DeployAccount { deploy_account_transaction, .. } => {
+                    block_prod_handle
+                        .submit_deploy_account_transaction(deploy_account_transaction)
+                        .await
+                        .map_err(StarknetRpcApiError::from)?
+                        .transaction_hash
+                }
+                ReplayBlockTransaction::L1Handler { l1_handler_message, .. } => {
+                    block_prod_handle
+                        .submit_l1_handler_transaction(l1_handler_message)
+                        .await
+                        .map_err(StarknetRpcApiError::from)?
+                        .transaction_hash
+                }
+            };
+
+            if actual_tx_hash != expected_tx_hash {
+                return Err(StarknetRpcApiError::ErrUnexpectedError {
+                    error: format!(
+                        "Replay transaction hash mismatch for block #{}: expected {:#x}, got {:#x}",
+                        block_n, expected_tx_hash, actual_tx_hash
+                    )
+                    .into(),
+                }
+                .into());
+            }
+        }
+
+        wait_for_preconfirmed_alignment(&self.backend, block_n, &expected_tx_hashes)
+            .await
+            .map_err(StarknetRpcApiError::from)?;
+
+        block_prod_handle
+            .close_block()
+            .await
+            .context("Force-closing replayed block")
+            .map_err(StarknetRpcApiError::from)?;
+
+        let block_hash = wait_for_confirmed_block(&self.backend, block_n).await.map_err(StarknetRpcApiError::from)?;
+
+        Ok(ReplayBlockResult { block_number: block_n, block_hash, transaction_hashes: expected_tx_hashes })
     }
 }
 

--- a/madara/crates/primitives/convert/src/hex_serde.rs
+++ b/madara/crates/primitives/convert/src/hex_serde.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+
+use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
@@ -51,6 +54,65 @@ impl<'de> DeserializeAs<'de, u128> for U128AsHex {
     }
 }
 
+pub struct U128AsHexOrNumber;
+
+impl SerializeAs<u128> for U128AsHexOrNumber {
+    fn serialize_as<S>(value: &u128, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        U128AsHex::serialize_as(value, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, u128> for U128AsHexOrNumber {
+    fn deserialize_as<D>(deserializer: D) -> Result<u128, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct U128HexOrNumberVisitor;
+
+        impl<'de> Visitor<'de> for U128HexOrNumberVisitor {
+            type Value = u128;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a u128 encoded as a hex string, decimal string, or JSON integer")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+                Ok(u128::from(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                u128::try_from(value).map_err(E::custom)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if value.starts_with("0x") || value.starts_with("0X") {
+                    u128::from_str_radix(value.trim_start_matches("0x").trim_start_matches("0X"), 16).map_err(E::custom)
+                } else {
+                    value.parse::<u128>().map_err(E::custom)
+                }
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_str(&value)
+            }
+        }
+
+        deserializer.deserialize_any(U128HexOrNumberVisitor)
+    }
+}
+
 pub fn hex_str_to_u128(s: &str) -> Result<u128, std::num::ParseIntError> {
     u128::from_str_radix(s.trim_start_matches("0x"), 16)
 }
@@ -62,6 +124,7 @@ pub fn u128_to_hex_string(n: u128) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_with::serde_as;
 
     #[test]
     fn test_u64_as_hex() {
@@ -79,5 +142,21 @@ mod tests {
         assert_eq!(s, "0x1234567890abcdef1234567890abcdef");
         let m = hex_str_to_u128(&s).unwrap();
         assert_eq!(m, n);
+    }
+
+    #[test]
+    fn test_u128_as_hex_or_number_deserializes_hex_and_number() {
+        #[serde_as]
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde_as(as = "U128AsHexOrNumber")]
+            value: u128,
+        }
+
+        let hex = serde_json::from_str::<Wrapper>(r#"{"value":"0x7530"}"#).unwrap();
+        assert_eq!(hex.value, 30_000);
+
+        let number = serde_json::from_str::<Wrapper>(r#"{"value":30000}"#).unwrap();
+        assert_eq!(number.value, 30_000);
     }
 }

--- a/madara/crates/primitives/transactions/src/lib.rs
+++ b/madara/crates/primitives/transactions/src/lib.rs
@@ -386,9 +386,11 @@ impl InvokeTransactionV3 {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct L1HandlerTransactionWithFee {
     pub tx: L1HandlerTransaction,
+    #[serde_as(as = "U128AsHex")]
     pub paid_fee_on_l1: u128,
 }
 
@@ -802,6 +804,7 @@ impl From<mp_rpc::v0_7_1::DaMode> for DataAvailabilityMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_tx_with_hash() {
@@ -1081,6 +1084,27 @@ mod tests {
         let da_mode_back: DataAvailabilityMode = starknet_da_mode.into();
 
         assert_eq!(da_mode, da_mode_back);
+    }
+
+    #[test]
+    fn test_l1_handler_transaction_with_fee_uses_hex_fee_in_json() {
+        let tx = L1HandlerTransactionWithFee::new(
+            L1HandlerTransaction {
+                version: Felt::ZERO,
+                nonce: 7,
+                contract_address: Felt::from_hex_unchecked("0x1234"),
+                entry_point_selector: Felt::from_hex_unchecked("0x5678"),
+                calldata: Arc::new(vec![Felt::from_hex_unchecked("0x9abc")]),
+            },
+            128_328,
+        );
+
+        let value = serde_json::to_value(&tx).expect("serialization should succeed");
+        assert_eq!(value["paid_fee_on_l1"], json!("0x1f548"));
+
+        let roundtrip: L1HandlerTransactionWithFee =
+            serde_json::from_value(value).expect("deserialization should succeed");
+        assert_eq!(roundtrip, tx);
     }
 
     pub(crate) fn dummy_tx_invoke_v0() -> InvokeTransactionV0 {

--- a/madara/crates/primitives/transactions/src/lib.rs
+++ b/madara/crates/primitives/transactions/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use mp_convert::hex_serde::{U128AsHex, U64AsHex};
+use mp_convert::hex_serde::{U128AsHex, U128AsHexOrNumber, U64AsHex};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet_api::{block::FeeType, transaction::TransactionVersion};
@@ -390,7 +390,7 @@ impl InvokeTransactionV3 {
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct L1HandlerTransactionWithFee {
     pub tx: L1HandlerTransaction,
-    #[serde_as(as = "U128AsHex")]
+    #[serde_as(as = "U128AsHexOrNumber")]
     pub paid_fee_on_l1: u128,
 }
 
@@ -1105,6 +1105,24 @@ mod tests {
         let roundtrip: L1HandlerTransactionWithFee =
             serde_json::from_value(value).expect("deserialization should succeed");
         assert_eq!(roundtrip, tx);
+    }
+
+    #[test]
+    fn test_l1_handler_transaction_with_fee_accepts_numeric_fee_in_json() {
+        let value = json!({
+            "tx": {
+                "version": "0x0",
+                "nonce": 7,
+                "contract_address": "0x1234",
+                "entry_point_selector": "0x5678",
+                "calldata": ["0x9abc"]
+            },
+            "paid_fee_on_l1": 30000
+        });
+
+        let parsed: L1HandlerTransactionWithFee =
+            serde_json::from_value(value).expect("numeric deserialization should succeed");
+        assert_eq!(parsed.paid_fee_on_l1, 30_000);
     }
 
     pub(crate) fn dummy_tx_invoke_v0() -> InvokeTransactionV0 {


### PR DESCRIPTION
## Summary
- encode `L1HandlerTransactionWithFee.paid_fee_on_l1` as hex in RPC JSON
- add a regression test covering serde roundtrip for the RPC-facing type

## Root cause
`replayBlock` failed on blocks containing `L1_HANDLER` because the admin RPC request decoded `paid_fee_on_l1: u128` directly from JSON. `serde_json` rejected that field with `u128 is not supported`, so Madara returned `-32602 Invalid params` before execution started.

## Validation
- `cargo check -p mc-rpc`
- targeted serde regression test added for `L1HandlerTransactionWithFee`