### PR TITLE
ci: add Socket.dev supply chain security scanning

### DIFF
--- a/.github/workflows/socket-security.yml
+++ b/.github/workflows/socket-security.yml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Workflow - Socket Security
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  socket-scan:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    name: Socket Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: SocketDev/socket-basics@v2.0.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          socket_security_api_key: ${{ secrets.SOCKET_SECURITY_API_KEY }}

--- a/.github/workflows/socket-security.yml
+++ b/.github/workflows/socket-security.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: SocketDev/socket-basics@v2.0.3
+      - uses: SocketDev/socket-basics@aa80fcef76614b40e24e8194490bb5fc89b8edc2 # v2.0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           socket_security_api_key: ${{ secrets.SOCKET_SECURITY_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs Socket.dev dependency scanning on every PR
- Scans both `Cargo.lock` (Rust) and `package-lock.json` (npm) for supply chain risks
- Modeled after the existing setup in arcx-v2

## Setup required
- Add `SOCKET_SECURITY_API_KEY` to repo secrets (from Socket.dev dashboard)

## Test plan
- [ ] Verify `SOCKET_SECURITY_API_KEY` secret is added to the repo
- [ ] Open a test PR and confirm the Socket Security Scan job runs
- [ ] Verify scan results appear as PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)