### PR TITLE
fix(rpc): align v0.10.2 gateway errors

### DIFF
--- a/madara/crates/client/db/src/view/state.rs
+++ b/madara/crates/client/db/src/view/state.rs
@@ -134,7 +134,7 @@ impl<D: MadaraStorageRead> MadaraStateView<D> {
     /// Get a confirmed block by hash.
     pub fn find_block_by_hash(&self, block_hash: &Felt) -> Result<Option<u64>> {
         let Some(latest_confirmed) = self.latest_confirmed_block_n() else { return Ok(None) };
-        Ok(self.backend().db.find_block_hash(block_hash)?.filter(|found_block_n| found_block_n >= &latest_confirmed))
+        Ok(self.backend().db.find_block_hash(block_hash)?.filter(|found_block_n| found_block_n <= &latest_confirmed))
     }
 
     fn lookup_preconfirmed_state<V>(

--- a/madara/crates/client/exec/src/lib.rs
+++ b/madara/crates/client/exec/src/lib.rs
@@ -227,8 +227,12 @@ fn transaction_error_is_entrypoint_not_found(error: &TransactionExecutionError) 
 }
 
 impl Error {
-    pub fn is_entrypoint_not_found(&self) -> bool {
+    pub fn is_call_contract_entrypoint_not_found(&self) -> bool {
         matches!(self, Self::CallContract(error) if transaction_error_is_entrypoint_not_found(&error.err))
+    }
+
+    pub fn is_message_fee_execution_error(&self) -> bool {
+        matches!(self, Self::MessageFeeEstimation(_))
     }
 }
 

--- a/madara/crates/client/exec/src/lib.rs
+++ b/madara/crates/client/exec/src/lib.rs
@@ -150,6 +150,7 @@
 #![allow(clippy::result_large_err)]
 
 use blockifier::{
+    execution::errors::{ConstructorEntryPointExecutionError, EntryPointExecutionError, PreExecutionError},
     state::cached_state::{CommitmentStateDiff, StateMaps},
     transaction::{errors::TransactionExecutionError, objects::TransactionExecutionInfo},
 };
@@ -203,6 +204,32 @@ pub enum Error {
     },
     #[error("Invalid sequencer address: {0:#x}")]
     InvalidSequencerAddress(Felt),
+}
+
+fn is_entrypoint_not_found(error: &EntryPointExecutionError) -> bool {
+    matches!(
+        error,
+        EntryPointExecutionError::PreExecutionError(
+            PreExecutionError::EntryPointNotFound(_) | PreExecutionError::NoEntryPointOfTypeFound(_)
+        )
+    )
+}
+
+fn transaction_error_is_entrypoint_not_found(error: &TransactionExecutionError) -> bool {
+    match error {
+        TransactionExecutionError::ExecutionError { error, .. }
+        | TransactionExecutionError::ValidateTransactionError { error, .. } => is_entrypoint_not_found(error),
+        TransactionExecutionError::ContractConstructorExecutionFailed(
+            ConstructorEntryPointExecutionError::ExecutionError { error, .. },
+        ) => is_entrypoint_not_found(error),
+        _ => false,
+    }
+}
+
+impl Error {
+    pub fn is_entrypoint_not_found(&self) -> bool {
+        matches!(self, Self::CallContract(error) if transaction_error_is_entrypoint_not_found(&error.err))
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/madara/crates/client/gateway/client/src/submit_tx.rs
+++ b/madara/crates/client/gateway/client/src/submit_tx.rs
@@ -48,6 +48,7 @@ fn map_gateway_error(err: SequencerError) -> SubmitTransactionError {
             GWErrCode::InsufficientAccountBalance => rejected(InsufficientAccountBalance, e.message),
             GWErrCode::InsufficientMaxFee => rejected(InsufficientMaxFee, e.message),
             GWErrCode::ValidateFailure => rejected(ValidateFailure, e.message),
+            GWErrCode::InvalidProof => rejected(InvalidProof, e.message),
             GWErrCode::ContractBytecodeSizeTooLarge => rejected(ContractBytecodeSizeTooLarge, e.message),
             GWErrCode::ContractClassObjectSizeTooLarge => rejected(ContractClassObjectSizeTooLarge, e.message),
             GWErrCode::DuplicatedTransaction => rejected(DuplicatedTransaction, e.message),

--- a/madara/crates/client/gateway/server/src/error.rs
+++ b/madara/crates/client/gateway/server/src/error.rs
@@ -64,6 +64,7 @@ fn map_rejected_tx_error(value: RejectedTransactionError) -> StarknetError {
         E::InsufficientAccountBalance => InsufficientAccountBalance,
         E::InsufficientMaxFee => InsufficientMaxFee,
         E::ValidateFailure => ValidateFailure,
+        E::InvalidProof => InvalidProof,
         E::ContractBytecodeSizeTooLarge => ContractBytecodeSizeTooLarge,
         E::ContractClassObjectSizeTooLarge => ContractClassObjectSizeTooLarge,
         E::DuplicatedTransaction => DuplicatedTransaction,
@@ -118,6 +119,13 @@ impl From<StarknetRpcApiError> for GatewayError {
             StarknetRpcApiError::ValidationFailure { error } => {
                 GatewayError::StarknetError(StarknetError::new(StarknetErrorCode::ValidateFailure, error.into()))
             }
+            StarknetRpcApiError::InvalidProof => {
+                GatewayError::StarknetError(StarknetError::new(StarknetErrorCode::InvalidProof, String::new()))
+            }
+            StarknetRpcApiError::EntrypointNotFound => GatewayError::StarknetError(StarknetError::new(
+                StarknetErrorCode::EntryPointNotFound,
+                "Requested entrypoint does not exist in the contract".into(),
+            )),
             StarknetRpcApiError::CompilationFailed { error } => GatewayError::StarknetError(StarknetError::new(
                 StarknetErrorCode::CompilationFailed,
                 err_message(error, "Compilation failed"),

--- a/madara/crates/client/gateway/server/src/router.rs
+++ b/madara/crates/client/gateway/server/src/router.rs
@@ -22,7 +22,7 @@ pub(crate) async fn main_router(
 ) -> Result<Response<String>, Infallible> {
     match (path, config.feeder_gateway_enable, config.gateway_enable) {
         ("health", _, _) => Ok(Response::new("OK".to_string())),
-        (path, true, _) if path.starts_with("gateway/") => {
+        (path, _, true) if path.starts_with("gateway/") => {
             Ok(gateway_router(req, path, add_transaction_provider).await?)
         }
         (path, true, _) if path.starts_with("feeder_gateway/") => Ok(feeder_gateway_router(req, path, backend).await?),
@@ -33,7 +33,7 @@ pub(crate) async fn main_router(
             Ok(handle_add_validated_transaction(req, submit_validated).await.unwrap_or_else(Into::into))
         }
         (path, false, _) if path.starts_with("feeder_gateway/") => Ok(service_unavailable_response("Feeder Gateway")),
-        (path, _, false) if path.starts_with("gateway/") => Ok(service_unavailable_response("Feeder")),
+        (path, _, false) if path.starts_with("gateway/") => Ok(service_unavailable_response("Gateway")),
         _ => {
             tracing::debug!(target: "feeder_gateway", "Main router received invalid request: {path}");
             Ok(not_found_response())

--- a/madara/crates/client/rpc/src/errors.rs
+++ b/madara/crates/client/rpc/src/errors.rs
@@ -43,13 +43,17 @@ pub enum StorageProofTrie {
 pub enum StarknetRpcApiError {
     #[error("Failed to write transaction")]
     FailedToReceiveTxn { err: Option<Cow<'static, str>> },
+    #[error("No trace available")]
+    NoTraceAvailable { error: Cow<'static, str> },
     #[error("Contract not found")]
     ContractNotFound { error: Cow<'static, str> },
+    #[error("Requested entrypoint does not exist in the contract")]
+    EntrypointNotFound,
     #[error("Block not found")]
     BlockNotFound,
     #[error("Invalid transaction hash")]
     InvalidTxnHash,
-    #[error("Invalid tblock hash")]
+    #[error("Invalid block hash")]
     InvalidBlockHash,
     #[error("Invalid transaction index in a block")]
     InvalidTxnIndex,
@@ -111,8 +115,10 @@ pub enum StarknetRpcApiError {
     UnimplementedMethod,
     #[error("Proof limit exceeded")]
     ProofLimitExceeded { kind: StorageProofLimit, limit: usize, got: usize },
-    #[error("Cannot create a storage proof for a block that old")]
-    CannotMakeProofOnOldBlock,
+    #[error("The node doesn't support storage proofs for blocks that are too far in the past")]
+    StorageProofNotSupported,
+    #[error("The proof field in the invoke v3 transaction is invalid")]
+    InvalidProof,
 }
 
 impl StarknetRpcApiError {
@@ -155,7 +161,9 @@ impl From<&StarknetRpcApiError> for i32 {
     fn from(err: &StarknetRpcApiError) -> Self {
         match err {
             StarknetRpcApiError::FailedToReceiveTxn { .. } => 1,
+            StarknetRpcApiError::NoTraceAvailable { .. } => 10,
             StarknetRpcApiError::ContractNotFound { .. } => 20,
+            StarknetRpcApiError::EntrypointNotFound => 21,
             StarknetRpcApiError::BlockNotFound => 24,
             StarknetRpcApiError::InvalidTxnHash => 25,
             StarknetRpcApiError::InvalidBlockHash => 26,
@@ -169,6 +177,7 @@ impl From<&StarknetRpcApiError> for i32 {
             StarknetRpcApiError::FailedToFetchPendingTransactions => 38,
             StarknetRpcApiError::ContractError => 40,
             StarknetRpcApiError::TxnExecutionError { .. } => 41,
+            StarknetRpcApiError::StorageProofNotSupported => 42,
             StarknetRpcApiError::InvalidContractClass { .. } => 50,
             StarknetRpcApiError::ClassAlreadyDeclared { .. } => 51,
             StarknetRpcApiError::InvalidTxnNonce { .. } => 52,
@@ -186,10 +195,10 @@ impl From<&StarknetRpcApiError> for i32 {
             StarknetRpcApiError::ErrUnexpectedError { .. } => 63,
             StarknetRpcApiError::ReplacementTxnUnderpriced => 64,
             StarknetRpcApiError::FeeBelowMinimum => 65,
+            StarknetRpcApiError::InvalidProof => 69,
             StarknetRpcApiError::InternalServerError => 500,
             StarknetRpcApiError::UnimplementedMethod => 501,
             StarknetRpcApiError::ProofLimitExceeded { .. } => 10000,
-            StarknetRpcApiError::CannotMakeProofOnOldBlock => 10001,
         }
     }
 }
@@ -206,6 +215,7 @@ impl StarknetRpcApiError {
                 Some(json!({ "kind": kind, "limit": limit, "got": got }))
             }
             StarknetRpcApiError::ErrUnexpectedError { error }
+            | StarknetRpcApiError::NoTraceAvailable { error }
             | StarknetRpcApiError::ValidationFailure { error }
             | StarknetRpcApiError::ContractNotFound { error }
             | StarknetRpcApiError::ClassHashNotFound { error }
@@ -232,6 +242,7 @@ impl StarknetRpcApiError {
             | StarknetRpcApiError::InvalidBlockHash
             | StarknetRpcApiError::InvalidTxnIndex
             | StarknetRpcApiError::InvalidSubscriptionId
+            | StarknetRpcApiError::EntrypointNotFound
             | StarknetRpcApiError::TxnHashNotFound
             | StarknetRpcApiError::PageSizeTooBig
             | StarknetRpcApiError::NoBlocks
@@ -239,17 +250,21 @@ impl StarknetRpcApiError {
             | StarknetRpcApiError::TooManyKeysInFilter
             | StarknetRpcApiError::FailedToFetchPendingTransactions
             | StarknetRpcApiError::ContractError
+            | StarknetRpcApiError::StorageProofNotSupported
             | StarknetRpcApiError::ReplacementTxnUnderpriced
             | StarknetRpcApiError::FeeBelowMinimum
+            | StarknetRpcApiError::InvalidProof
             | StarknetRpcApiError::InternalServerError
-            | StarknetRpcApiError::UnimplementedMethod
-            | StarknetRpcApiError::CannotMakeProofOnOldBlock => None,
+            | StarknetRpcApiError::UnimplementedMethod => None,
         }
     }
 }
 
 impl From<mc_exec::Error> for StarknetRpcApiError {
     fn from(err: mc_exec::Error) -> Self {
+        if err.is_entrypoint_not_found() {
+            return Self::EntrypointNotFound;
+        }
         Self::TxnExecutionError { tx_index: 0, error: format!("{:#}", err) }
     }
 }
@@ -279,6 +294,7 @@ impl From<StarknetError> for StarknetRpcApiError {
             StarknetErrorCode::TransactionFailed => {
                 StarknetRpcApiError::FailedToReceiveTxn { err: Some(err.message.into()) }
             }
+            StarknetErrorCode::EntryPointNotFound => StarknetRpcApiError::EntrypointNotFound,
             StarknetErrorCode::ValidateFailure => StarknetRpcApiError::ValidationFailure { error: err.message.into() },
             StarknetErrorCode::UninitializedContract => StarknetRpcApiError::contract_not_found(),
             StarknetErrorCode::UndeclaredClass => StarknetRpcApiError::class_hash_not_found(),
@@ -294,6 +310,7 @@ impl From<StarknetError> for StarknetRpcApiError {
             StarknetErrorCode::OutOfRangeBlockHash => StarknetRpcApiError::InvalidBlockHash,
             StarknetErrorCode::OutOfRangeTransactionHash => StarknetRpcApiError::InvalidTxnHash,
             StarknetErrorCode::InvalidTransactionVersion => StarknetRpcApiError::unsupported_txn_version(),
+            StarknetErrorCode::InvalidProof => StarknetRpcApiError::InvalidProof,
             _ => StarknetRpcApiError::ErrUnexpectedError { error: err.message.into() },
         }
     }
@@ -338,8 +355,9 @@ impl From<RejectedTransactionError> for StarknetRpcApiError {
             | E::InvalidContractClass
             => InvalidContractClass { error },
 
-            E::EntryPointNotFound
-            | E::TransactionFailed
+            E::EntryPointNotFound => EntrypointNotFound,
+
+            E::TransactionFailed
             | E::OutOfRangeTransactionHash
             | E::UnsupportedSelectorForFee
             | E::TransactionLimitExceeded
@@ -355,6 +373,7 @@ impl From<RejectedTransactionError> for StarknetRpcApiError {
             E::InvalidTransactionNonce => InvalidTxnNonce { error },
             E::ReplacementTransactionUnderpriced => ReplacementTxnUnderpriced,
             E::FeeBelowMinimum => FeeBelowMinimum,
+            E::InvalidProof => InvalidProof,
             E::UninitializedContract => ContractNotFound { error },
             E::UndeclaredClass => ClassHashNotFound { error },
             E::InvalidTransactionVersion
@@ -389,6 +408,33 @@ impl From<SubmitTransactionError> for StarknetRpcApiError {
                 StarknetRpcApiError::InternalServerError
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v0_10_2_specific_error_codes_match_spec() {
+        assert_eq!(i32::from(&StarknetRpcApiError::NoTraceAvailable { error: "".into() }), 10);
+        assert_eq!(i32::from(&StarknetRpcApiError::EntrypointNotFound), 21);
+        assert_eq!(i32::from(&StarknetRpcApiError::StorageProofNotSupported), 42);
+        assert_eq!(i32::from(&StarknetRpcApiError::InvalidProof), 69);
+    }
+
+    #[test]
+    fn invalid_proof_rejection_maps_to_invalid_proof_rpc_error() {
+        let err: RejectedTransactionError = RejectedTransactionErrorKind::InvalidProof.into();
+
+        assert_eq!(StarknetRpcApiError::from(err), StarknetRpcApiError::InvalidProof);
+    }
+
+    #[test]
+    fn gateway_invalid_proof_maps_to_invalid_proof_rpc_error() {
+        let err = StarknetError::new(StarknetErrorCode::InvalidProof, String::new());
+
+        assert_eq!(StarknetRpcApiError::from(err), StarknetRpcApiError::InvalidProof);
     }
 }
 

--- a/madara/crates/client/rpc/src/errors.rs
+++ b/madara/crates/client/rpc/src/errors.rs
@@ -119,6 +119,8 @@ pub enum StarknetRpcApiError {
     StorageProofNotSupported,
     #[error("The proof field in the invoke v3 transaction is invalid")]
     InvalidProof,
+    #[error("This method does not support being called on the pre_confirmed block")]
+    CallOnPreConfirmed,
 }
 
 impl StarknetRpcApiError {
@@ -196,6 +198,7 @@ impl From<&StarknetRpcApiError> for i32 {
             StarknetRpcApiError::ReplacementTxnUnderpriced => 64,
             StarknetRpcApiError::FeeBelowMinimum => 65,
             StarknetRpcApiError::InvalidProof => 69,
+            StarknetRpcApiError::CallOnPreConfirmed => 70,
             StarknetRpcApiError::InternalServerError => 500,
             StarknetRpcApiError::UnimplementedMethod => 501,
             StarknetRpcApiError::ProofLimitExceeded { .. } => 10000,
@@ -254,6 +257,7 @@ impl StarknetRpcApiError {
             | StarknetRpcApiError::ReplacementTxnUnderpriced
             | StarknetRpcApiError::FeeBelowMinimum
             | StarknetRpcApiError::InvalidProof
+            | StarknetRpcApiError::CallOnPreConfirmed
             | StarknetRpcApiError::InternalServerError
             | StarknetRpcApiError::UnimplementedMethod => None,
         }
@@ -421,6 +425,7 @@ mod tests {
         assert_eq!(i32::from(&StarknetRpcApiError::EntrypointNotFound), 21);
         assert_eq!(i32::from(&StarknetRpcApiError::StorageProofNotSupported), 42);
         assert_eq!(i32::from(&StarknetRpcApiError::InvalidProof), 69);
+        assert_eq!(i32::from(&StarknetRpcApiError::CallOnPreConfirmed), 70);
     }
 
     #[test]

--- a/madara/crates/client/rpc/src/errors.rs
+++ b/madara/crates/client/rpc/src/errors.rs
@@ -119,8 +119,6 @@ pub enum StarknetRpcApiError {
     StorageProofNotSupported,
     #[error("The proof field in the invoke v3 transaction is invalid")]
     InvalidProof,
-    #[error("This method does not support being called on the pre_confirmed block")]
-    CallOnPreConfirmed,
 }
 
 impl StarknetRpcApiError {
@@ -198,7 +196,6 @@ impl From<&StarknetRpcApiError> for i32 {
             StarknetRpcApiError::ReplacementTxnUnderpriced => 64,
             StarknetRpcApiError::FeeBelowMinimum => 65,
             StarknetRpcApiError::InvalidProof => 69,
-            StarknetRpcApiError::CallOnPreConfirmed => 70,
             StarknetRpcApiError::InternalServerError => 500,
             StarknetRpcApiError::UnimplementedMethod => 501,
             StarknetRpcApiError::ProofLimitExceeded { .. } => 10000,
@@ -257,7 +254,6 @@ impl StarknetRpcApiError {
             | StarknetRpcApiError::ReplacementTxnUnderpriced
             | StarknetRpcApiError::FeeBelowMinimum
             | StarknetRpcApiError::InvalidProof
-            | StarknetRpcApiError::CallOnPreConfirmed
             | StarknetRpcApiError::InternalServerError
             | StarknetRpcApiError::UnimplementedMethod => None,
         }
@@ -266,9 +262,14 @@ impl StarknetRpcApiError {
 
 impl From<mc_exec::Error> for StarknetRpcApiError {
     fn from(err: mc_exec::Error) -> Self {
-        if err.is_entrypoint_not_found() {
+        if err.is_call_contract_entrypoint_not_found() {
             return Self::EntrypointNotFound;
         }
+
+        if err.is_message_fee_execution_error() {
+            return Self::ContractError;
+        }
+
         Self::TxnExecutionError { tx_index: 0, error: format!("{:#}", err) }
     }
 }
@@ -425,7 +426,6 @@ mod tests {
         assert_eq!(i32::from(&StarknetRpcApiError::EntrypointNotFound), 21);
         assert_eq!(i32::from(&StarknetRpcApiError::StorageProofNotSupported), 42);
         assert_eq!(i32::from(&StarknetRpcApiError::InvalidProof), 69);
-        assert_eq!(i32::from(&StarknetRpcApiError::CallOnPreConfirmed), 70);
     }
 
     #[test]

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/trace/mod.rs
@@ -3,10 +3,8 @@ use crate::versions::user::v0_9_0::methods::trace::{
     trace_block_transactions::trace_block_transactions as trace_block_transactions_v0_9,
     trace_transaction::trace_transaction as trace_transaction_v0_9,
 };
-use crate::{versions::user::v0_10_0::StarknetTraceRpcApiV0_10_0Server, Starknet};
+use crate::{errors::StarknetRpcApiError, versions::user::v0_10_0::StarknetTraceRpcApiV0_10_0Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
-use jsonrpsee::types::error::INVALID_PARAMS_CODE;
-use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_10_0::{
     BlockId, BlockTag, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
     TraceTransactionResult,
@@ -15,7 +13,7 @@ use starknet_types_core::felt::Felt;
 
 fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
     if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
-        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
+        return Err(StarknetRpcApiError::CallOnPreConfirmed.into());
     }
     Ok(())
 }
@@ -41,5 +39,23 @@ impl StarknetTraceRpcApiV0_10_0Server for Starknet {
     async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceTransactionResult> {
         let v0_9_result = trace_transaction_v0_9(self, transaction_hash).await?;
         Ok(v0_9_result.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_block_transactions_rejects_pre_confirmed_tag_with_spec_error() {
+        let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
+            .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
+        assert_eq!(err.code(), 70);
+        assert_eq!(err.message(), "This method does not support being called on the pre_confirmed block");
+    }
+
+    #[test]
+    fn trace_block_transactions_accepts_latest_tag() {
+        assert!(validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::Latest)).is_ok());
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/trace/mod.rs
@@ -3,8 +3,10 @@ use crate::versions::user::v0_9_0::methods::trace::{
     trace_block_transactions::trace_block_transactions as trace_block_transactions_v0_9,
     trace_transaction::trace_transaction as trace_transaction_v0_9,
 };
-use crate::{errors::StarknetRpcApiError, versions::user::v0_10_0::StarknetTraceRpcApiV0_10_0Server, Starknet};
+use crate::{versions::user::v0_10_0::StarknetTraceRpcApiV0_10_0Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_10_0::{
     BlockId, BlockTag, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
     TraceTransactionResult,
@@ -13,7 +15,7 @@ use starknet_types_core::felt::Felt;
 
 fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
     if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
-        return Err(StarknetRpcApiError::CallOnPreConfirmed.into());
+        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
     }
     Ok(())
 }
@@ -47,11 +49,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn trace_block_transactions_rejects_pre_confirmed_tag_with_spec_error() {
+    fn trace_block_transactions_rejects_pre_confirmed_tag() {
         let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
             .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
-        assert_eq!(err.code(), 70);
-        assert_eq!(err.message(), "This method does not support being called on the pre_confirmed block");
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        assert_eq!(err.message(), "Invalid params");
     }
 
     #[test]

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/get_storage_at.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/get_storage_at.rs
@@ -87,10 +87,14 @@ mod tests {
 
     #[rstest]
     fn test_get_storage_at_value(sample_chain_for_state_updates: (SampleChainForStateUpdates, Starknet)) {
-        let (SampleChainForStateUpdates { contracts, keys, values, .. }, rpc) = sample_chain_for_state_updates;
+        let (SampleChainForStateUpdates { block_hashes, contracts, keys, values, .. }, rpc) =
+            sample_chain_for_state_updates;
 
         let result = get_storage_at(&rpc, contracts[0], keys[0], BlockId::Number(2), None).unwrap();
         assert_eq!(result, GetStorageAtResult::Value(values[1]));
+
+        let result = get_storage_at(&rpc, contracts[0], keys[0], BlockId::Hash(block_hashes[0]), None).unwrap();
+        assert_eq!(result, GetStorageAtResult::Value(values[0]));
     }
 
     #[rstest]

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/mod.rs
@@ -3,10 +3,8 @@ mod trace_block_transactions;
 mod trace_transaction;
 
 use crate::versions::user::v0_10_2::StarknetTraceRpcApiV0_10_2Server;
-use crate::Starknet;
+use crate::{errors::StarknetRpcApiError, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
-use jsonrpsee::types::error::INVALID_PARAMS_CODE;
-use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_10_0::{BlockId, BlockTag};
 use mp_rpc::v0_10_2::{
     BroadcastedTxn, SimulateTransactionsResponse, SimulationFlag, TraceBlockTransactionsResponse, TraceFlag,
@@ -22,7 +20,7 @@ use starknet_types_core::felt::Felt;
 
 fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
     if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
-        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
+        return Err(StarknetRpcApiError::CallOnPreConfirmed.into());
     }
     Ok(())
 }
@@ -60,8 +58,8 @@ mod tests {
     fn trace_block_transactions_rejects_pre_confirmed_tag() {
         let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
             .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
-        assert_eq!(err.code(), INVALID_PARAMS_CODE);
-        assert_eq!(err.message(), "Invalid params");
+        assert_eq!(err.code(), 70);
+        assert_eq!(err.message(), "This method does not support being called on the pre_confirmed block");
     }
 
     #[test]

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/mod.rs
@@ -3,8 +3,10 @@ mod trace_block_transactions;
 mod trace_transaction;
 
 use crate::versions::user::v0_10_2::StarknetTraceRpcApiV0_10_2Server;
-use crate::{errors::StarknetRpcApiError, Starknet};
+use crate::Starknet;
 use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_10_0::{BlockId, BlockTag};
 use mp_rpc::v0_10_2::{
     BroadcastedTxn, SimulateTransactionsResponse, SimulationFlag, TraceBlockTransactionsResponse, TraceFlag,
@@ -20,7 +22,7 @@ use starknet_types_core::felt::Felt;
 
 fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
     if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
-        return Err(StarknetRpcApiError::CallOnPreConfirmed.into());
+        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
     }
     Ok(())
 }
@@ -58,8 +60,8 @@ mod tests {
     fn trace_block_transactions_rejects_pre_confirmed_tag() {
         let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
             .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
-        assert_eq!(err.code(), 70);
-        assert_eq!(err.message(), "This method does not support being called on the pre_confirmed block");
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        assert_eq!(err.message(), "Invalid params");
     }
 
     #[test]

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/mod.rs
@@ -1,11 +1,13 @@
 mod simulate_transactions;
 mod trace_block_transactions;
+mod trace_transaction;
 
 use crate::versions::user::v0_10_2::StarknetTraceRpcApiV0_10_2Server;
-use crate::versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server as V0_9_0Impl;
 use crate::Starknet;
 use jsonrpsee::core::{async_trait, RpcResult};
-use mp_rpc::v0_10_0::BlockId;
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
+use mp_rpc::v0_10_0::{BlockId, BlockTag};
 use mp_rpc::v0_10_2::{
     BroadcastedTxn, SimulateTransactionsResponse, SimulationFlag, TraceBlockTransactionsResponse, TraceFlag,
     TraceTransactionResult,
@@ -17,6 +19,13 @@ use starknet_types_core::felt::Felt;
 // - SimulationFlag now includes RETURN_INITIAL_READS
 // - traceBlockTransactions now accepts optional trace_flags parameter
 // - Results can include initial_reads when RETURN_INITIAL_READS flag is set
+
+fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
+    if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
+        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
+    }
+    Ok(())
+}
 
 #[async_trait]
 impl StarknetTraceRpcApiV0_10_2Server for Starknet {
@@ -34,10 +43,29 @@ impl StarknetTraceRpcApiV0_10_2Server for Starknet {
         block_id: BlockId,
         trace_flags: Option<Vec<TraceFlag>>,
     ) -> RpcResult<TraceBlockTransactionsResponse> {
+        validate_trace_block_transactions_block_id(&block_id)?;
         Ok(trace_block_transactions::trace_block_transactions(self, block_id, trace_flags).await?)
     }
 
     async fn trace_transaction(&self, transaction_hash: Felt) -> RpcResult<TraceTransactionResult> {
-        V0_9_0Impl::trace_transaction(self, transaction_hash).await.map(Into::into)
+        Ok(trace_transaction::trace_transaction(self, transaction_hash).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_block_transactions_rejects_pre_confirmed_tag() {
+        let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
+            .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        assert_eq!(err.message(), "Invalid params");
+    }
+
+    #[test]
+    fn trace_block_transactions_accepts_latest_tag() {
+        assert!(validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::Latest)).is_ok());
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/trace_block_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/trace_block_transactions.rs
@@ -11,7 +11,7 @@ use mp_rpc::v0_10_0::BlockId;
 use mp_rpc::v0_10_2::{TraceBlockTransactionsResponse, TraceBlockTransactionsResult, TraceFlag};
 use mp_transactions::TransactionWithHash;
 
-fn prepare_tx_for_reexecution(
+pub(super) fn prepare_tx_for_reexecution(
     view: &MadaraStateView,
     tx: TransactionWithReceipt,
 ) -> anyhow::Result<blockifier::transaction::transaction_execution::Transaction> {

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/trace_transaction.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/trace_transaction.rs
@@ -1,0 +1,57 @@
+use super::trace_block_transactions::prepare_tx_for_reexecution;
+use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
+use crate::Starknet;
+use anyhow::Context;
+use mc_exec::trace::execution_result_to_tx_trace_v0_9;
+use mc_exec::{MadaraBlockViewExecutionExt, EXECUTION_UNSUPPORTED_BELOW_VERSION};
+use mp_rpc::v0_10_2::TraceTransactionResult;
+use starknet_types_core::felt::Felt;
+use std::borrow::Cow;
+
+fn no_trace_available(error: impl std::fmt::Display) -> StarknetRpcApiError {
+    StarknetRpcApiError::NoTraceAvailable { error: Cow::Owned(error.to_string()) }
+}
+
+pub async fn trace_transaction(
+    starknet: &Starknet,
+    transaction_hash: Felt,
+) -> StarknetRpcResult<TraceTransactionResult> {
+    let view = starknet.backend.view_on_latest();
+    let res = view.find_transaction_by_hash(&transaction_hash)?.ok_or(StarknetRpcApiError::TxnHashNotFound)?;
+    let mut exec_context = res.block.new_execution_context_at_block_start()?;
+
+    if exec_context.protocol_version < EXECUTION_UNSUPPORTED_BELOW_VERSION {
+        return Err(StarknetRpcApiError::unsupported_txn_version());
+    }
+
+    let state_view = res.block.state_view();
+    let previous_transactions: Vec<_> = res
+        .block
+        .get_executed_transactions(..res.transaction_index)?
+        .into_iter()
+        .map(|tx| prepare_tx_for_reexecution(&state_view, tx))
+        .collect::<Result<_, _>>()
+        .map_err(no_trace_available)?;
+
+    let transaction_to_trace =
+        prepare_tx_for_reexecution(&state_view, res.get_transaction()?).map_err(no_trace_available)?;
+
+    let (mut executions_results, exec_context) = mp_utils::spawn_blocking(move || {
+        Ok::<_, mc_exec::Error>((
+            exec_context.execute_transactions(previous_transactions, [transaction_to_trace])?,
+            exec_context,
+        ))
+    })
+    .await
+    .map_err(no_trace_available)?;
+
+    let execution_result =
+        executions_results.pop().context("No execution info returned").map_err(no_trace_available)?;
+
+    let trace = execution_result_to_tx_trace_v0_9(&execution_result, exec_context.block_context.versioned_constants())
+        .context("Converting execution infos to tx trace")
+        .map_err(no_trace_available)?
+        .into();
+
+    Ok(TraceTransactionResult { trace })
+}

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/mod.rs
@@ -167,7 +167,7 @@ pub trait StarknetReadRpcApi {
         contracts_storage_keys: Option<Vec<ContractStorageKeysItem>>,
     ) -> RpcResult<GetStorageProofResult>;
 
-    /// Non-spec in v0.10.2; kept for backward compatibility.
+    /// Get the compiled CASM for the given Sierra class hash.
     #[method(name = "getCompiledCasm")]
     fn get_compiled_casm(&self, class_hash: Felt) -> RpcResult<serde_json::Value>;
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_compiled_casm.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_compiled_casm.rs
@@ -9,12 +9,10 @@ pub fn get_compiled_casm(starknet: &Starknet, class_hash: Felt) -> StarknetRpcRe
 
     let sierra = class.as_sierra().ok_or(StarknetRpcApiError::class_hash_not_found())?;
 
-    // Using `Value::from_str` to deserialize `compiled_class` from a JSON string stored in the database.
-    // Since `compiled_class` is stored as a raw JSON string in the DB, we need to parse it into a
-    // `serde_json::Value` to work with it as a structured JSON object for serialization.
+    // `compiled_class` is stored as raw JSON in the DB, so parse it back into a structured JSON value.
     let res = serde_json::Value::from_str(sierra.compiled.0.as_str()).map_err(|error| {
         StarknetRpcApiError::CompilationFailed {
-            error: format!("Error serializing compiled contract class: {error:#}").into(),
+            error: format!("Error deserializing compiled contract class from database: {error:#}").into(),
         }
     })?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_compiled_casm.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_compiled_casm.rs
@@ -1,6 +1,5 @@
 use crate::errors::{StarknetRpcApiError, StarknetRpcResult};
 use crate::Starknet;
-use anyhow::Context;
 use starknet_types_core::felt::Felt;
 use std::str::FromStr;
 
@@ -8,13 +7,16 @@ pub fn get_compiled_casm(starknet: &Starknet, class_hash: Felt) -> StarknetRpcRe
     let view = starknet.backend.view_on_latest();
     let class = view.get_class_info_and_compiled(&class_hash)?.ok_or(StarknetRpcApiError::class_hash_not_found())?;
 
-    let sierra = class.as_sierra().ok_or(StarknetRpcApiError::unsupported_contract_class_version())?;
+    let sierra = class.as_sierra().ok_or(StarknetRpcApiError::class_hash_not_found())?;
 
     // Using `Value::from_str` to deserialize `compiled_class` from a JSON string stored in the database.
     // Since `compiled_class` is stored as a raw JSON string in the DB, we need to parse it into a
     // `serde_json::Value` to work with it as a structured JSON object for serialization.
-    let res =
-        serde_json::Value::from_str(sierra.compiled.0.as_str()).context("Error serializing compiled contract class")?;
+    let res = serde_json::Value::from_str(sierra.compiled.0.as_str()).map_err(|error| {
+        StarknetRpcApiError::CompilationFailed {
+            error: format!("Error serializing compiled contract class: {error:#}").into(),
+        }
+    })?;
 
     Ok(res)
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_storage_proof.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_storage_proof.rs
@@ -45,7 +45,7 @@ fn make_trie_proof<H: StarkHash + Send + Sync>(
         .get_transactional_state(BasicId::new(block_n), trie.get_config())
         .map_err(|err| anyhow::anyhow!("{err:#}"))
         .context("Getting transactional state")?
-        .ok_or(StarknetRpcApiError::CannotMakeProofOnOldBlock)?;
+        .ok_or(StarknetRpcApiError::StorageProofNotSupported)?;
 
     let root_hash =
         storage.root_hash(identifier).map_err(|err| anyhow::anyhow!("{err:#}")).context("Getting root hash of trie")?;
@@ -94,7 +94,7 @@ pub fn get_storage_proof(
     };
 
     if latest.saturating_sub(block_view.block_number()) > starknet.storage_proof_config.max_distance {
-        return Err(StarknetRpcApiError::CannotMakeProofOnOldBlock);
+        return Err(StarknetRpcApiError::StorageProofNotSupported);
     }
 
     let block_hash = block_view.get_block_info()?.block_hash;

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/get_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/get_transaction_status.rs
@@ -38,8 +38,7 @@ pub async fn get_transaction_status(
         } else if res.block.is_confirmed() {
             TxnStatus::AcceptedOnL2
         } else {
-            // FIXME: rpc v0.9 TxnStatus::Preconfirmed
-            TxnStatus::AcceptedOnL2
+            TxnStatus::PreConfirmed
         };
 
         Ok(TxnFinalityAndExecutionStatus { finality_status, execution_status })
@@ -165,6 +164,38 @@ mod tests {
             status,
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL2,
+                execution_status: Some(mp_rpc::v0_9_0::TxnExecutionStatus::Succeeded)
+            }
+        );
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_transaction_status_pre_confirmed(
+        _logs: (),
+        starknet: Starknet,
+        tx_with_receipt: mp_block::TransactionWithReceipt,
+    ) {
+        let backend = std::sync::Arc::clone(&starknet.backend);
+        let preconfirmed = mc_db::preconfirmed::PreconfirmedBlock::new_with_content(
+            mp_block::header::PreconfirmedHeader { block_number: 0, ..Default::default() },
+            [mc_db::preconfirmed::PreconfirmedExecutedTransaction {
+                transaction: tx_with_receipt,
+                state_diff: Default::default(),
+                declared_class: None,
+                arrived_at: Default::default(),
+                paid_fee_on_l1: None,
+            }],
+            std::iter::empty(),
+        );
+        backend.write_access().new_preconfirmed(preconfirmed).expect("Failed to store pre-confirmed block");
+
+        let status = get_transaction_status(&starknet, TX_HASH).await.expect("Failed to retrieve transaction status");
+
+        assert_eq!(
+            status,
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::PreConfirmed,
                 execution_status: Some(mp_rpc::v0_9_0::TxnExecutionStatus::Succeeded)
             }
         );

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
@@ -1,5 +1,7 @@
-use crate::{errors::StarknetRpcApiError, versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server, Starknet};
+use crate::{versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_9_0::{
     BlockId, BlockTag, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
     TraceTransactionResult,
@@ -15,7 +17,7 @@ pub(crate) mod trace_transaction;
 
 fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
     if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
-        return Err(StarknetRpcApiError::CallOnPreConfirmed.into());
+        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
     }
     Ok(())
 }
@@ -49,8 +51,8 @@ mod tests {
     fn trace_block_transactions_rejects_pre_confirmed_tag() {
         let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
             .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
-        assert_eq!(err.code(), 70);
-        assert_eq!(err.message(), "This method does not support being called on the pre_confirmed block");
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+        assert_eq!(err.message(), "Invalid params");
     }
 
     #[test]

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/mod.rs
@@ -1,7 +1,5 @@
-use crate::{versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server, Starknet};
+use crate::{errors::StarknetRpcApiError, versions::user::v0_9_0::StarknetTraceRpcApiV0_9_0Server, Starknet};
 use jsonrpsee::core::{async_trait, RpcResult};
-use jsonrpsee::types::error::INVALID_PARAMS_CODE;
-use jsonrpsee::types::ErrorObjectOwned;
 use mp_rpc::v0_9_0::{
     BlockId, BlockTag, BroadcastedTxn, SimulateTransactionsResult, SimulationFlag, TraceBlockTransactionsResult,
     TraceTransactionResult,
@@ -17,7 +15,7 @@ pub(crate) mod trace_transaction;
 
 fn validate_trace_block_transactions_block_id(block_id: &BlockId) -> RpcResult<()> {
     if matches!(block_id, BlockId::Tag(BlockTag::PreConfirmed)) {
-        return Err(ErrorObjectOwned::owned(INVALID_PARAMS_CODE, "Invalid params", None::<()>));
+        return Err(StarknetRpcApiError::CallOnPreConfirmed.into());
     }
     Ok(())
 }
@@ -51,8 +49,8 @@ mod tests {
     fn trace_block_transactions_rejects_pre_confirmed_tag() {
         let err = validate_trace_block_transactions_block_id(&BlockId::Tag(BlockTag::PreConfirmed))
             .expect_err("pre_confirmed should be rejected for traceBlockTransactions");
-        assert_eq!(err.code(), INVALID_PARAMS_CODE);
-        assert_eq!(err.message(), "Invalid params");
+        assert_eq!(err.code(), 70);
+        assert_eq!(err.message(), "This method does not support being called on the pre_confirmed block");
     }
 
     #[test]

--- a/madara/crates/client/submit_tx/src/error.rs
+++ b/madara/crates/client/submit_tx/src/error.rs
@@ -97,6 +97,8 @@ pub enum RejectedTransactionErrorKind {
     InsufficientMaxFee,
     #[error("ValidateFailure")]
     ValidateFailure,
+    #[error("InvalidProof")]
+    InvalidProof,
     #[error("ContractBytecodeSizeTooLarge")]
     ContractBytecodeSizeTooLarge,
     #[error("ContractClassObjectSizeTooLarge")]

--- a/madara/crates/client/submit_tx/src/validation.rs
+++ b/madara/crates/client/submit_tx/src/validation.rs
@@ -64,7 +64,7 @@ impl From<TransactionPreValidationError> for SubmitTransactionError {
         match err {
             E::InvalidNonce { .. } => rejected(InvalidTransactionNonce, format!("{err:#}")),
             E::StateError(err) => err.into(),
-            err @ E::InvalidProofFacts(_) => rejected(ValidateFailure, format!("{err:#}")),
+            err @ E::InvalidProofFacts(_) => rejected(InvalidProof, format!("{err:#}")),
             err @ E::TransactionFeeError(_) => rejected(ValidateFailure, format!("{err:#}")),
         }
     }

--- a/madara/crates/primitives/gateway/src/error.rs
+++ b/madara/crates/primitives/gateway/src/error.rs
@@ -171,6 +171,8 @@ pub enum StarknetErrorCode {
     InsufficientMaxFee,
     #[serde(rename = "StarknetErrorCode.VALIDATE_FAILURE")]
     ValidateFailure,
+    #[serde(rename = "StarknetErrorCode.INVALID_PROOF")]
+    InvalidProof,
     #[serde(rename = "StarknetErrorCode.CONTRACT_BYTECODE_SIZE_TOO_LARGE")]
     ContractBytecodeSizeTooLarge,
     #[serde(rename = "StarknetErrorCode.CONTRACT_CLASS_OBJECT_SIZE_TOO_LARGE")]

--- a/madara/crates/primitives/gateway/src/user_transaction.rs
+++ b/madara/crates/primitives/gateway/src/user_transaction.rs
@@ -449,6 +449,8 @@ pub struct UserInvokeFunctionV3Transaction {
     pub account_deployment_data: Vec<Felt>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proof: Option<Vec<u64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_facts: Option<Vec<Felt>>,
 }
 
 impl From<UserInvokeFunctionV3Transaction> for InvokeTxnV3 {
@@ -482,6 +484,7 @@ impl From<InvokeTxnV3> for UserInvokeFunctionV3Transaction {
             paymaster_data: transaction.paymaster_data,
             account_deployment_data: transaction.account_deployment_data,
             proof: None,
+            proof_facts: None,
         }
     }
 }
@@ -489,7 +492,8 @@ impl From<InvokeTxnV3> for UserInvokeFunctionV3Transaction {
 impl From<UserInvokeFunctionV3Transaction> for BroadcastedInvokeTxnV3V0_10_2 {
     fn from(transaction: UserInvokeFunctionV3Transaction) -> Self {
         let proof = transaction.proof.clone();
-        Self { inner: transaction.into(), proof, proof_facts: None }
+        let proof_facts = transaction.proof_facts.clone();
+        Self { inner: transaction.into(), proof, proof_facts }
     }
 }
 
@@ -497,6 +501,7 @@ impl From<BroadcastedInvokeTxnV3V0_10_2> for UserInvokeFunctionV3Transaction {
     fn from(transaction: BroadcastedInvokeTxnV3V0_10_2) -> Self {
         let mut user_transaction: UserInvokeFunctionV3Transaction = transaction.inner.into();
         user_transaction.proof = transaction.proof;
+        user_transaction.proof_facts = transaction.proof_facts;
         user_transaction
     }
 }
@@ -624,7 +629,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn sample_user_invoke_v3(proof: Option<Vec<u64>>) -> UserInvokeFunctionTransaction {
+    fn sample_user_invoke_v3(proof: Option<Vec<u64>>, proof_facts: Option<Vec<Felt>>) -> UserInvokeFunctionTransaction {
         let resource_bounds = ResourceBoundsMapping { l1_data_gas: Some(Default::default()), ..Default::default() };
 
         UserInvokeFunctionTransaction::V3(UserInvokeFunctionV3Transaction {
@@ -639,21 +644,49 @@ mod tests {
             paymaster_data: vec![Felt::from_hex_unchecked("0xdef")],
             account_deployment_data: vec![Felt::from_hex_unchecked("0x987")],
             proof,
+            proof_facts,
         })
     }
 
     #[rstest]
-    #[case(None)]
-    #[case(Some(vec![1, 2, 3]))]
-    fn invoke_v3_roundtrip_preserves_optional_proof(#[case] proof: Option<Vec<u64>>) {
-        let transaction = sample_user_invoke_v3(proof.clone());
+    #[case(None, None)]
+    #[case(Some(vec![1, 2, 3]), None)]
+    #[case(None, Some(vec![Felt::from_hex_unchecked("0x100"), Felt::from_hex_unchecked("0x200")]))]
+    #[case(
+        Some(vec![1, 2, 3]),
+        Some(vec![Felt::from_hex_unchecked("0x100"), Felt::from_hex_unchecked("0x200")])
+    )]
+    fn invoke_v3_roundtrip_preserves_optional_proof_fields(
+        #[case] proof: Option<Vec<u64>>,
+        #[case] proof_facts: Option<Vec<Felt>>,
+    ) {
+        let transaction = sample_user_invoke_v3(proof.clone(), proof_facts.clone());
         let broadcasted: BroadcastedInvokeTxnV0_10_2 = transaction.clone().into();
         let roundtrip = UserInvokeFunctionTransaction::try_from(broadcasted).unwrap();
 
         assert_eq!(roundtrip, transaction);
         match roundtrip {
-            UserInvokeFunctionTransaction::V3(tx) => assert_eq!(tx.proof, proof),
+            UserInvokeFunctionTransaction::V3(tx) => {
+                assert_eq!(tx.proof, proof);
+                assert_eq!(tx.proof_facts, proof_facts);
+            }
             _ => unreachable!("expected v3 invoke transaction"),
         }
+    }
+
+    #[test]
+    fn invoke_v3_deserializes_gateway_proof_facts() {
+        let transaction = sample_user_invoke_v3(
+            None,
+            Some(vec![Felt::from_hex_unchecked("0x100"), Felt::from_hex_unchecked("0x200")]),
+        );
+        let json = serde_json::to_string(&transaction).expect("transaction should serialize");
+
+        assert!(json.contains("proof_facts"));
+
+        let deserialized: UserInvokeFunctionTransaction =
+            serde_json::from_str(&json).expect("transaction should deserialize");
+
+        assert_eq!(deserialized, transaction);
     }
 }

--- a/tests/js_tests/src/assertion-runner.ts
+++ b/tests/js_tests/src/assertion-runner.ts
@@ -15,6 +15,7 @@ logger.setLogLevel("ERROR");
 import { RpcCaller } from "./rpc-caller";
 import { resolveValue } from "./ref-resolver";
 import { loadContractSierra, loadContractCasm } from "./contract-loader";
+import { waitForPreConfirmedTransaction } from "./transaction-waiter";
 import {
   DEFAULT_ACCOUNT_ADDRESS,
   DEFAULT_PRIVATE_KEY,
@@ -275,7 +276,10 @@ async function buildDeployAccountV3Params(
       amount: cairo.uint256("0x2386f26fc10000"),
     }),
   });
-  await provider.waitForTransaction(fundResponse.transaction_hash);
+  await waitForPreConfirmedTransaction(
+    ctx.rpcUrl,
+    fundResponse.transaction_hash,
+  );
 
   // Deploy the account
   const newAccount = new Account({

--- a/tests/js_tests/src/state-executor.ts
+++ b/tests/js_tests/src/state-executor.ts
@@ -16,6 +16,7 @@ logger.setLogLevel("ERROR");
 import { AdminClient } from "./admin-client";
 import { BlockTracker } from "./block-tracker";
 import { loadContractSierra, loadContractCasm } from "./contract-loader";
+import { waitForPreConfirmedTransaction } from "./transaction-waiter";
 import { resolveValue } from "./ref-resolver";
 import {
   DEFAULT_ACCOUNT_ADDRESS,
@@ -162,7 +163,7 @@ async function executeDeclare(
   );
 
   incrementNonce(ctx, DEFAULT_ACCOUNT_ADDRESS, nonce);
-  await provider.waitForTransaction(response.transaction_hash);
+  await waitForPreConfirmedTransaction(ctx.rpcUrl, response.transaction_hash);
 
   return {
     transaction_hash: response.transaction_hash,
@@ -195,7 +196,7 @@ async function executeDeploy(
   );
 
   incrementNonce(ctx, DEFAULT_ACCOUNT_ADDRESS, nonce);
-  await provider.waitForTransaction(response.transaction_hash);
+  await waitForPreConfirmedTransaction(ctx.rpcUrl, response.transaction_hash);
 
   return {
     transaction_hash: response.transaction_hash,
@@ -240,7 +241,7 @@ async function executeInvoke(
   );
 
   incrementNonce(ctx, DEFAULT_ACCOUNT_ADDRESS, nonce);
-  await provider.waitForTransaction(response.transaction_hash);
+  await waitForPreConfirmedTransaction(ctx.rpcUrl, response.transaction_hash);
 
   return {
     transaction_hash: response.transaction_hash,
@@ -290,7 +291,10 @@ async function executeDeployAccount(
       { nonce: fundNonce },
     );
     incrementNonce(ctx, DEFAULT_ACCOUNT_ADDRESS, fundNonce);
-    await provider.waitForTransaction(fundResponse.transaction_hash);
+    await waitForPreConfirmedTransaction(
+      ctx.rpcUrl,
+      fundResponse.transaction_hash,
+    );
   }
 
   // Create account instance and deploy
@@ -308,7 +312,7 @@ async function executeDeployAccount(
     addressSalt: publicKey,
   });
 
-  await provider.waitForTransaction(response.transaction_hash);
+  await waitForPreConfirmedTransaction(ctx.rpcUrl, response.transaction_hash);
 
   return {
     transaction_hash: response.transaction_hash,

--- a/tests/js_tests/src/transaction-waiter.ts
+++ b/tests/js_tests/src/transaction-waiter.ts
@@ -1,0 +1,48 @@
+import { BLOCK_POLL_INTERVAL_MS, BLOCK_POLL_TIMEOUT_MS } from "./config";
+import { RpcCaller } from "./rpc-caller";
+
+const INCLUDED_FINALITY_STATUSES = new Set([
+  "PRE_CONFIRMED",
+  "ACCEPTED_ON_L2",
+  "ACCEPTED_ON_L1",
+]);
+
+export async function waitForPreConfirmedTransaction(
+  rpcUrl: string,
+  transactionHash: string,
+): Promise<void> {
+  const rpcCaller = new RpcCaller(rpcUrl);
+  const deadline = Date.now() + BLOCK_POLL_TIMEOUT_MS;
+  let lastObserved = "<none>";
+
+  while (Date.now() < deadline) {
+    const envelope = await rpcCaller.rawCall("starknet_getTransactionStatus", {
+      transaction_hash: transactionHash,
+    });
+
+    if (envelope.error) {
+      lastObserved = `error ${envelope.error.code}: ${envelope.error.message}`;
+    } else {
+      const status = envelope.result;
+      lastObserved = JSON.stringify(status);
+
+      if (status?.execution_status === "REVERTED") {
+        throw new Error(`Transaction ${transactionHash} reverted`);
+      }
+
+      if (INCLUDED_FINALITY_STATUSES.has(status?.finality_status)) {
+        return;
+      }
+    }
+
+    await sleep(BLOCK_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `Timed out waiting for transaction ${transactionHash} to be pre-confirmed; last observed ${lastObserved}`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- Align JSON-RPC v0.10.2 HTTP behavior with Starknet v0.14.2 for pre-confirmed transaction status, trace errors, storage proof errors, compiled CASM errors, and invalid invoke proof handling.
- Preserve invoke v3 proof_facts through gateway conversion and map invalid proof_facts to INVALID_PROOF.
- Fix gateway enablement and historical hash lookup edge cases used by the RPC/gateway flows.

## Validation
- Formatting check passed.
- RPC unit tests passed.
- Gateway client/server compile check passed.