### PR TITLE
fix(settlement-client): restart L1 message sync on stream error

### DIFF
--- a/madara/crates/client/settlement_client/src/messaging.rs
+++ b/madara/crates/client/settlement_client/src/messaging.rs
@@ -188,7 +188,7 @@ async fn run_message_sync(
                         pending_events.push_back(msg);
                     }
                     Some(Err(e)) => {
-                        tracing::warn!("L1 event stream error: {e:#}");
+                        return Err(e);
                     }
                     None => {
                         // Stream ended - return error to trigger reconnection


### PR DESCRIPTION
## Summary

Make L1 -> L2 message sync exit the current sync session when the live event stream yields an error.

The outer sync loop already backs off and recreates `messages_to_l2_stream`, so returning the stream error lets Madara create a fresh L1 filter instead of continuing with a broken live stream.

## Context

Alchemy returned `eth_getFilterChanges` errors for a dropped filter:

```json
{
  "jsonrpc": "2.0",
  "id": 1766,
  "error": {
    "code": -32000,
    "message": "filter not found"
  }
}
```

Once this error is surfaced by the underlying Alloy stream, Madara should leave the current message-sync session and let the existing reconnect/backfill flow recreate the watcher.

## Validation

Focused settlement-client checks passed before the final amend. A later rerun was blocked by a local Cargo git-cache symlink pointing to an unmounted external SSD path.