### PR TITLE
fix(grafana): use _total suffix for ticker-based RocksDB metrics

### DIFF
--- a/madara/crates/client/db/src/rocksdb/metrics.rs
+++ b/madara/crates/client/db/src/rocksdb/metrics.rs
@@ -2,12 +2,12 @@
 //!
 //! ## Capacity Planning Metrics (requires statistics enabled, which is the default)
 //!
-//! Key queries for Grafana:
-//! - Ingest rate: `rate(db_bytes_written[5m])`
-//! - Compaction throughput: `rate(db_compact_write_bytes[5m])`
-//! - Write amplification: `rate(db_compact_write_bytes[5m]) / rate(db_flush_write_bytes[5m])`
-//! - Stall fraction: `rate(db_stall_micros[5m]) / 1e6`
-//! - Cache hit rate: `rate(db_block_cache_hit[5m]) / (rate(db_block_cache_hit[5m]) + rate(db_block_cache_miss[5m]))`
+//! Key queries for Grafana (OTLP pipeline appends `_total` to cumulative gauges):
+//! - Ingest rate: `rate(db_bytes_written_total[5m])`
+//! - Compaction throughput: `rate(db_compact_write_bytes_total[5m])`
+//! - Write amplification: `rate(db_compact_write_bytes_total[5m]) / rate(db_flush_write_bytes_total[5m])`
+//! - Stall fraction: `rate(db_stall_micros_total[5m]) / 1e6`
+//! - Cache hit rate: `rate(db_block_cache_hit_total[5m]) / (rate(db_block_cache_hit_total[5m]) + rate(db_block_cache_miss_total[5m]))`
 //!
 //! ## Write Stall Detection
 //!

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -3237,7 +3237,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_flush_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_flush_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Flush Rate (ingest \u2192 L0)",
           "refId": "A"
         },
@@ -3246,7 +3246,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_compact_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_compact_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Compaction Write Rate",
           "refId": "B"
         },
@@ -3255,7 +3255,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_compact_read_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_compact_read_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Compaction Read Rate",
           "refId": "C"
         },
@@ -3264,7 +3264,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_bytes_written{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_bytes_written_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "App Write Rate",
           "refId": "D"
         }
@@ -3326,7 +3326,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_compact_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / rate(db_flush_write_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
+          "expr": "rate(db_compact_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / rate(db_flush_write_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m])",
           "legendFormat": "Write Amplification (compact/flush)",
           "refId": "A"
         }
@@ -3389,7 +3389,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_stall_micros{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / 1e6",
+          "expr": "rate(db_stall_micros_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / 1e6",
           "legendFormat": "Stall Fraction",
           "refId": "A"
         }
@@ -3452,7 +3452,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(db_block_cache_hit{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(db_block_cache_hit{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(db_block_cache_miss{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+          "expr": "rate(db_block_cache_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) / (rate(db_block_cache_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]) + rate(db_block_cache_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
           "legendFormat": "Cache Hit Rate",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary
- Fix Grafana dashboard queries for ticker-based RocksDB metrics (Ingest vs Compaction Throughput, Write Amplification, Write Stall Time Fraction, Block Cache Hit Rate)
- The OTLP-to-Prometheus pipeline appends `_total` to monotonically increasing gauge values — dashboard queries were missing this suffix, causing "No data"
- Update doc comments in `metrics.rs` to match the actual Prometheus metric names

## Test plan
- [x] Verified metrics exist in Prometheus with `_total` suffix (`db_bytes_written_total`, `db_compact_write_bytes_total`, etc.)
- [x] Confirmed Grafana panels now show data after updating queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)