### PR TITLE
feat(mempool): add alert-friendly mempool metrics

### DIFF
--- a/madara/crates/client/mempool/src/chain_watcher_task.rs
+++ b/madara/crates/client/mempool/src/chain_watcher_task.rs
@@ -1,4 +1,5 @@
 use crate::{
+    metrics::{MempoolIngressSource, MempoolRemovalReason},
     transaction_status::{PreConfirmationStatus, TransactionStatus},
     Mempool,
 };
@@ -266,7 +267,10 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
                         &mut removed_txs,
                     );
                 }
-                self.metrics.record_mempool_state(&guard.summary());
+                self.metrics.record_mempool_state(&guard.summary(mp_transactions::validated::TxTimestamp::now()));
+            }
+            if !removed_txs.is_empty() {
+                self.metrics.record_removed(MempoolRemovalReason::NonceAdvanced, removed_txs.len() as u64);
             }
             self.on_txs_removed(&removed_txs);
 
@@ -274,7 +278,7 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
             for (tx_hash, tx) in removed {
                 if put_back_into_mempool {
                     // Try to add back to mempool.
-                    if let Err(err) = self.accept_tx((*tx).clone()).await {
+                    if let Err(err) = self.accept_tx_from_source((*tx).clone(), MempoolIngressSource::Reinsert).await {
                         // Re-insertion may fail for various valid reasons: the tx has reached its TTL, the tx is a L1HandlerTransaction..
                         // TODO: it may fail because of tip-bump / eviction score. Maybe we shouldn't drop the tx in these cases?
                         tracing::debug!("Could not add transaction {:#x} back into mempool: {err:#}", tx.hash);

--- a/madara/crates/client/mempool/src/inner/accounts.rs
+++ b/madara/crates/client/mempool/src/inner/accounts.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     tx::{Score, TxSummary},
 };
+use mp_transactions::validated::TxTimestamp;
 use starknet_api::core::{ContractAddress, Nonce};
 use std::{
     collections::{btree_map, hash_map, BTreeMap, HashMap},
@@ -99,6 +100,10 @@ impl AccountState {
 
     pub fn last_queued_tx(&self) -> Option<&'_ MempoolTransaction> {
         self.queued_txs.last_key_value().map(|kv| kv.1)
+    }
+
+    pub fn first_queued_tx(&self) -> Option<&'_ MempoolTransaction> {
+        self.queued_txs.first_key_value().map(|kv| kv.1)
     }
 
     /// The eviction score of an account is based on the last queued transaction. This value is per-account,
@@ -403,5 +408,13 @@ impl Accounts {
     }
     pub fn num_accounts(&self) -> usize {
         self.accounts.len()
+    }
+
+    pub fn oldest_ready_arrived_at(&self) -> Option<TxTimestamp> {
+        self.accounts
+            .values()
+            .filter(|account| matches!(account.status(), AccountStatus::Ready(_)))
+            .filter_map(|account| account.first_queued_tx().map(|tx| tx.arrived_at()))
+            .min()
     }
 }

--- a/madara/crates/client/mempool/src/inner/mod.rs
+++ b/madara/crates/client/mempool/src/inner/mod.rs
@@ -348,12 +348,20 @@ impl InnerMempool {
         self.accounts.num_accounts()
     }
 
-    pub fn summary(&self) -> MempoolStateSummary {
+    pub fn summary(&self, now: TxTimestamp) -> MempoolStateSummary {
+        let num_transactions = self.num_transactions();
+        let ready_transactions = self.ready_transactions();
         MempoolStateSummary {
-            num_transactions: self.num_transactions(),
-            ready_transactions: self.ready_transactions(),
+            num_transactions,
             transaction_capacity: self.config.max_transactions,
             num_accounts: self.num_accounts(),
+            ready_transactions,
+            queued_transactions: num_transactions.saturating_sub(ready_transactions),
+            oldest_transaction_age: self.timestamp_queue.oldest().and_then(|arrived_at| now.duration_since(arrived_at)),
+            oldest_ready_transaction_age: self
+                .accounts
+                .oldest_ready_arrived_at()
+                .and_then(|arrived_at| now.duration_since(arrived_at)),
         }
     }
 }
@@ -363,14 +371,21 @@ pub struct MempoolStateSummary {
     pub transaction_capacity: usize,
     pub num_accounts: usize,
     pub ready_transactions: usize,
+    pub queued_transactions: usize,
+    pub oldest_transaction_age: Option<Duration>,
+    pub oldest_ready_transaction_age: Option<Duration>,
 }
 
 impl fmt::Display for MempoolStateSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}/{} transaction(s), {} account(s), {} ready",
-            self.num_transactions, self.transaction_capacity, self.num_accounts, self.ready_transactions
+            "{}/{} transaction(s), {} account(s), {} ready, {} queued",
+            self.num_transactions,
+            self.transaction_capacity,
+            self.num_accounts,
+            self.ready_transactions,
+            self.queued_transactions
         )
     }
 }

--- a/madara/crates/client/mempool/src/inner/timestamp_queue.rs
+++ b/madara/crates/client/mempool/src/inner/timestamp_queue.rs
@@ -39,4 +39,8 @@ impl TimestampQueue {
         // Oldest is first (min `arrived_at`)
         self.0.first().filter(|tx| tx.0 < ts).map(|e| &e.1)
     }
+
+    pub fn oldest(&self) -> Option<TxTimestamp> {
+        self.0.first().map(|(ts, _)| *ts)
+    }
 }

--- a/madara/crates/client/mempool/src/lib.rs
+++ b/madara/crates/client/mempool/src/lib.rs
@@ -123,7 +123,9 @@
 use anyhow::Context;
 use dashmap::DashMap;
 use mc_db::{rocksdb::RocksDBStorage, MadaraBackend, MadaraStorageRead, MadaraStorageWrite};
-use metrics::{ExternalDbOutboxMetrics, MempoolMetrics};
+use metrics::{
+    ExternalDbOutboxMetrics, MempoolAddRejectReason, MempoolIngressSource, MempoolMetrics, MempoolRemovalReason,
+};
 use mp_transactions::validated::{TxTimestamp, ValidatedToBlockifierTxError, ValidatedTransaction};
 use mp_utils::service::ServiceContext;
 use notify::MempoolInnerWithNotify;
@@ -216,13 +218,24 @@ pub struct Mempool<D: MadaraStorageRead = RocksDBStorage> {
 
 impl<D: MadaraStorageRead> Mempool<D> {
     pub fn new(backend: Arc<MadaraBackend<D>>, config: MempoolConfig) -> Self {
+        let metrics = MempoolMetrics::register();
+        metrics.record_mempool_state(&MempoolStateSummary {
+            num_transactions: 0,
+            transaction_capacity: backend.chain_config().mempool_max_transactions,
+            num_accounts: 0,
+            ready_transactions: 0,
+            queued_transactions: 0,
+            oldest_transaction_age: None,
+            oldest_ready_transaction_age: None,
+        });
+
         Mempool {
             inner: MempoolInnerWithNotify::new(backend.chain_config()),
             ttl: backend.chain_config().mempool_ttl,
             backend,
             external_outbox: config.external_outbox,
             config,
-            metrics: MempoolMetrics::register(),
+            metrics,
             external_db_outbox_metrics: ExternalDbOutboxMetrics::register(),
             watch_transaction_status: Default::default(),
             preconfirmed_transactions_statuses: Default::default(),
@@ -246,7 +259,7 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
                 }
             };
             let is_new_tx = false; // do not trigger metrics update and db update.
-            if let Err(err) = self.add_tx(tx, is_new_tx).await {
+            if let Err(err) = self.add_tx(tx, is_new_tx, MempoolIngressSource::DbRestore).await {
                 match err {
                     MempoolInsertionError::InnerMempool(TxInsertionError::TooOld { .. }) => {} // do nothing
                     err => tracing::warn!("Could not re-add mempool transaction from db: {err:#}"),
@@ -258,12 +271,35 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
 
     /// Accept a new validated transaction.
     pub async fn accept_tx(&self, tx: ValidatedTransaction) -> Result<(), MempoolInsertionError> {
-        self.add_tx(tx, /* is_new_tx */ true).await
+        self.accept_tx_from_source(tx, MempoolIngressSource::Unknown).await
+    }
+
+    /// Accept a new validated transaction from a known ingress path.
+    pub async fn accept_tx_from_source(
+        &self,
+        tx: ValidatedTransaction,
+        source: MempoolIngressSource,
+    ) -> Result<(), MempoolInsertionError> {
+        self.add_tx(tx, /* is_new_tx */ true, source).await
     }
 
     /// Use `is_new_tx: false` when loading transactions from db, so that we skip saving in db and updating metrics.
-    async fn add_tx(&self, tx: ValidatedTransaction, is_new_tx: bool) -> Result<(), MempoolInsertionError> {
-        tracing::debug!("Accepting transaction tx_hash={:#x} is_new_tx={is_new_tx}", tx.hash);
+    async fn add_tx(
+        &self,
+        tx: ValidatedTransaction,
+        is_new_tx: bool,
+        source: MempoolIngressSource,
+    ) -> Result<(), MempoolInsertionError> {
+        tracing::debug!(
+            "Accepting transaction tx_hash={:#x} is_new_tx={is_new_tx} source={}",
+            tx.hash,
+            source.as_label()
+        );
+
+        let record_ingress_metrics = source.should_record_ingress_metrics();
+        if record_ingress_metrics {
+            self.metrics.record_add_attempt(source, &tx);
+        }
 
         let mut outbox_id = None;
         if is_new_tx && self.external_outbox.enabled {
@@ -277,6 +313,9 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
                     self.external_db_outbox_metrics.outbox_write_errors.add(1, &[]);
                     if self.external_outbox.strict {
                         self.external_db_outbox_metrics.outbox_strict_rejections.add(1, &[]);
+                        if record_ingress_metrics {
+                            self.metrics.record_add_rejected(source, &tx, MempoolAddRejectReason::Internal);
+                        }
                         return Err(MempoolInsertionError::Internal(anyhow::anyhow!("outbox write failed: {err:#}")));
                     }
                 }
@@ -291,7 +330,7 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
         let (ret, summary) = {
             let mut lock = self.inner.write().await;
             let ret = lock.insert_tx(now, tx.clone(), Nonce(account_nonce), &mut removed_txs);
-            (ret, lock.summary())
+            (ret, lock.summary(now))
         };
 
         if ret.is_err() {
@@ -304,6 +343,16 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
         }
 
         self.metrics.record_mempool_state(&summary);
+
+        if let Err(err) = &ret {
+            if record_ingress_metrics {
+                self.metrics.record_add_rejected(source, &tx, MempoolAddRejectReason::from_inner_error(err));
+            }
+        }
+
+        if !removed_txs.is_empty() {
+            self.metrics.record_removed(MempoolRemovalReason::DisplacedByInsert, removed_txs.len() as u64);
+        }
 
         self.on_txs_removed(&removed_txs);
         if ret.is_ok() {
@@ -318,6 +367,9 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
                 );
             }
             self.on_tx_added(&tx, is_new_tx);
+            if record_ingress_metrics {
+                self.metrics.record_add_success(source, &tx);
+            }
         }
         ret.map_err(Into::into)
     }
@@ -373,10 +425,13 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
         let summary = {
             let mut lock = self.inner.write().await;
             lock.remove_all_ttl_exceeded_txs(now, &mut removed_txs);
-            lock.summary()
+            lock.summary(now)
         };
 
         self.metrics.record_mempool_state(&summary);
+        if !removed_txs.is_empty() {
+            self.metrics.record_removed(MempoolRemovalReason::TtlExpired, removed_txs.len() as u64);
+        }
 
         self.on_txs_removed(&removed_txs);
         if !removed_txs.is_empty() {
@@ -432,7 +487,7 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
     /// If the mempool has no mempool that can be consumed, this function will wait until there is at least 1 transaction to consume.
     /// This holds the lock to the inner mempool - use with care.
     pub async fn get_consumer(&self) -> MempoolConsumer {
-        MempoolConsumer { lock: self.inner.get_write_access_wait_for_ready().await }
+        MempoolConsumer { lock: self.inner.get_write_access_wait_for_ready().await, metrics: self.metrics.clone() }
     }
 }
 
@@ -444,11 +499,17 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
 /// This holds the lock to the inner mempool - use with care.
 pub struct MempoolConsumer {
     lock: MempoolWriteAccess,
+    metrics: MempoolMetrics,
 }
 impl Iterator for MempoolConsumer {
     type Item = ValidatedTransaction;
     fn next(&mut self) -> Option<Self::Item> {
-        self.lock.pop_next_ready()
+        let next = self.lock.pop_next_ready();
+        if next.is_some() {
+            self.metrics.record_removed(MempoolRemovalReason::ConsumedForBlock, 1);
+            self.metrics.record_mempool_state(&self.lock.summary(TxTimestamp::now()));
+        }
+        next
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         let n_ready = self.lock.ready_transactions();
@@ -459,12 +520,18 @@ impl Iterator for MempoolConsumer {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use crate::metrics::{test_counters, MempoolAddRejectReason, MempoolIngressSource, MempoolRemovalReason};
     use starknet_api::{core::ContractAddress, transaction::TransactionHash};
     use std::time::Duration;
 
     #[rstest::fixture]
     async fn backend() -> Arc<mc_db::MadaraBackend> {
-        let backend = mc_db::MadaraBackend::open_for_testing(Arc::new(mp_chain_config::ChainConfig::madara_test()));
+        let backend = test_backend_with_chain_config(mp_chain_config::ChainConfig::madara_test()).await;
+        backend
+    }
+
+    async fn test_backend_with_chain_config(chain_config: mp_chain_config::ChainConfig) -> Arc<mc_db::MadaraBackend> {
+        let backend = mc_db::MadaraBackend::open_for_testing(Arc::new(chain_config));
         let mut genesis = mc_devnet::ChainGenesisDescription::base_config().unwrap();
         genesis.add_devnet_contracts(10).unwrap();
         genesis.build_and_store(&backend).await.unwrap();
@@ -531,6 +598,83 @@ pub(crate) mod tests {
     #[rstest::rstest]
     #[timeout(Duration::from_millis(1_000))]
     #[tokio::test]
+    async fn mempool_accept_tx_records_metrics(
+        #[future] backend: Arc<mc_db::MadaraBackend>,
+        tx_account: ValidatedTransaction,
+    ) {
+        test_counters::capture(async {
+            let backend = backend.await;
+            let mempool = Mempool::new(backend.clone(), MempoolConfig::default());
+
+            assert_matches::assert_matches!(
+                mempool.accept_tx_from_source(tx_account.clone(), MempoolIngressSource::Rpc).await,
+                Ok(())
+            );
+
+            assert_eq!(
+                test_counters::ADD_ATTEMPTS.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+                &[(MempoolIngressSource::Rpc, "invoke")]
+            );
+            assert_eq!(
+                test_counters::ADD_SUCCESSES.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+                &[(MempoolIngressSource::Rpc, "invoke")]
+            );
+            assert!(
+                test_counters::ADD_REJECTIONS.lock().unwrap_or_else(|e| e.into_inner()).is_empty(),
+                "successful add should not record rejections"
+            );
+            assert_eq!(test_counters::MEMPOOL_TRANSACTIONS_CURRENT_LAST.load(std::sync::atomic::Ordering::Relaxed), 1);
+            assert_eq!(
+                test_counters::MEMPOOL_READY_TRANSACTIONS_CURRENT_LAST.load(std::sync::atomic::Ordering::Relaxed),
+                1
+            );
+            assert_eq!(
+                test_counters::MEMPOOL_QUEUED_TRANSACTIONS_CURRENT_LAST.load(std::sync::atomic::Ordering::Relaxed),
+                0
+            );
+            assert_eq!(test_counters::MEMPOOL_ACCOUNTS_CURRENT_LAST.load(std::sync::atomic::Ordering::Relaxed), 1);
+            assert_eq!(
+                test_counters::MEMPOOL_CAPACITY_TRANSACTIONS_LAST.load(std::sync::atomic::Ordering::Relaxed),
+                backend.chain_config().mempool_max_transactions as u64
+            );
+        })
+        .await;
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_millis(1_000))]
+    #[tokio::test]
+    async fn mempool_duplicate_rejection_records_metrics(
+        #[future] backend: Arc<mc_db::MadaraBackend>,
+        tx_account: ValidatedTransaction,
+    ) {
+        test_counters::capture(async {
+            let backend = backend.await;
+            let mempool = Mempool::new(backend, MempoolConfig::default());
+
+            assert_matches::assert_matches!(
+                mempool.accept_tx_from_source(tx_account.clone(), MempoolIngressSource::Gateway).await,
+                Ok(())
+            );
+            assert_matches::assert_matches!(
+                mempool.accept_tx_from_source(tx_account, MempoolIngressSource::Gateway).await,
+                Err(MempoolInsertionError::InnerMempool(TxInsertionError::DuplicateTxn))
+            );
+
+            assert_eq!(test_counters::ADD_ATTEMPTS.lock().unwrap_or_else(|e| e.into_inner()).len(), 2);
+            assert_eq!(test_counters::ADD_SUCCESSES.lock().unwrap_or_else(|e| e.into_inner()).len(), 1);
+            assert_eq!(
+                test_counters::ADD_REJECTIONS.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+                &[(MempoolIngressSource::Gateway, "invoke", MempoolAddRejectReason::DuplicateTxn)]
+            );
+            assert_eq!(test_counters::MEMPOOL_TRANSACTIONS_CURRENT_LAST.load(std::sync::atomic::Ordering::Relaxed), 1);
+        })
+        .await;
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_millis(1_000))]
+    #[tokio::test]
     async fn mempool_accept_persists_and_remove_clears_saved_tx(
         #[future] backend: Arc<mc_db::MadaraBackend>,
         tx_account: ValidatedTransaction,
@@ -584,6 +728,32 @@ pub(crate) mod tests {
     #[rstest::rstest]
     #[timeout(Duration::from_millis(1_000))]
     #[tokio::test]
+    async fn mempool_take_tx_records_consumed_metric(
+        #[future] backend: Arc<mc_db::MadaraBackend>,
+        tx_account: ValidatedTransaction,
+    ) {
+        test_counters::capture(async {
+            let backend = backend.await;
+            let mempool = Mempool::new(backend, MempoolConfig::default());
+
+            assert_matches::assert_matches!(
+                mempool.accept_tx_from_source(tx_account, MempoolIngressSource::Rpc).await,
+                Ok(())
+            );
+            let _ = mempool.get_consumer().await.next().expect("Mempool should contain a transaction");
+
+            assert_eq!(
+                test_counters::REMOVALS.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+                &[(MempoolRemovalReason::ConsumedForBlock, 1)]
+            );
+            assert_eq!(test_counters::MEMPOOL_TRANSACTIONS_CURRENT_LAST.load(std::sync::atomic::Ordering::Relaxed), 0);
+        })
+        .await;
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_millis(1_000))]
+    #[tokio::test]
     async fn mempool_accept_writes_outbox(
         #[future] backend: Arc<mc_db::MadaraBackend>,
         tx_account: ValidatedTransaction,
@@ -627,14 +797,46 @@ pub(crate) mod tests {
         #[future] backend: Arc<mc_db::MadaraBackend>,
         tx_account: ValidatedTransaction,
     ) {
-        let backend = backend.await;
-        let config = MempoolConfig::default().with_external_outbox(ExternalOutboxConfig::enabled(true));
-        let mempool = Mempool::new(backend.clone(), config);
+        test_counters::capture(async {
+            let backend = backend.await;
+            let config = MempoolConfig::default().with_external_outbox(ExternalOutboxConfig::enabled(true));
+            let mempool = Mempool::new(backend.clone(), config);
 
-        mc_db::set_external_outbox_write_failpoint(true);
-        let result = mempool.accept_tx(tx_account).await;
-        mc_db::set_external_outbox_write_failpoint(false);
+            mc_db::set_external_outbox_write_failpoint(true);
+            let result = mempool.accept_tx_from_source(tx_account, MempoolIngressSource::Rpc).await;
+            mc_db::set_external_outbox_write_failpoint(false);
 
-        assert_matches::assert_matches!(result, Err(MempoolInsertionError::Internal(_)));
+            assert_matches::assert_matches!(result, Err(MempoolInsertionError::Internal(_)));
+            assert_eq!(
+                test_counters::ADD_REJECTIONS.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+                &[(MempoolIngressSource::Rpc, "invoke", MempoolAddRejectReason::Internal)]
+            );
+        })
+        .await;
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_millis(1_000))]
+    #[tokio::test]
+    async fn mempool_ttl_removal_records_metrics() {
+        test_counters::capture(async {
+            let mut chain_config = mp_chain_config::ChainConfig::madara_test();
+            chain_config.mempool_ttl = Some(Duration::from_millis(1));
+            let backend = test_backend_with_chain_config(chain_config).await;
+            let mempool = Mempool::new(backend, MempoolConfig::default());
+
+            let tx = tx_account(CONTRACT_ADDRESS);
+            assert_matches::assert_matches!(mempool.accept_tx_from_source(tx, MempoolIngressSource::Rpc).await, Ok(()));
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            assert_matches::assert_matches!(mempool.remove_ttl_exceeded_txs().await, Ok(()));
+
+            assert_eq!(
+                test_counters::REMOVALS.lock().unwrap_or_else(|e| e.into_inner()).as_slice(),
+                &[(MempoolRemovalReason::TtlExpired, 1)]
+            );
+            assert_eq!(test_counters::MEMPOOL_TRANSACTIONS_CURRENT_LAST.load(std::sync::atomic::Ordering::Relaxed), 0);
+        })
+        .await;
     }
 }

--- a/madara/crates/client/mempool/src/metrics.rs
+++ b/madara/crates/client/mempool/src/metrics.rs
@@ -1,12 +1,132 @@
-use crate::inner::MempoolStateSummary;
+use crate::inner::{limits::MempoolLimitReached, MempoolStateSummary, TxInsertionError};
 use mc_telemetry::{register_counter_metric_instrument, register_gauge_metric_instrument};
+use mp_transactions::{validated::ValidatedTransaction, Transaction};
 use opentelemetry::metrics::{Counter, Gauge};
 use opentelemetry::{global, InstrumentationScope, KeyValue};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MempoolIngressSource {
+    Unknown,
+    Rpc,
+    Gateway,
+    Reinsert,
+    DbRestore,
+}
+
+impl MempoolIngressSource {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Rpc => "rpc",
+            Self::Gateway => "gateway",
+            Self::Reinsert => "reinsert",
+            Self::DbRestore => "db_restore",
+        }
+    }
+
+    pub fn should_record_ingress_metrics(self) -> bool {
+        !matches!(self, Self::DbRestore)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MempoolAddRejectReason {
+    DuplicateTxn,
+    InvalidContractAddress,
+    InvalidNonce,
+    Internal,
+    MaxDeclareTransactions,
+    MaxTransactions,
+    MinTipBump,
+    NonceConflict,
+    NonceTooLow,
+    PendingDeclare,
+    TooOld,
+    ValidatedToBlockifier,
+}
+
+impl MempoolAddRejectReason {
+    pub fn from_inner_error(inner: &TxInsertionError) -> Self {
+        match inner {
+            TxInsertionError::NonceTooLow { .. } => Self::NonceTooLow,
+            TxInsertionError::NonceConflict => Self::NonceConflict,
+            TxInsertionError::DuplicateTxn => Self::DuplicateTxn,
+            TxInsertionError::MinTipBump { .. } => Self::MinTipBump,
+            TxInsertionError::TooOld { .. } => Self::TooOld,
+            TxInsertionError::PendingDeclare => Self::PendingDeclare,
+            TxInsertionError::InvalidContractAddress => Self::InvalidContractAddress,
+            TxInsertionError::Limit(limit) => match limit {
+                MempoolLimitReached::MaxTransactions { .. } => Self::MaxTransactions,
+                MempoolLimitReached::MaxDeclareTransactions { .. } => Self::MaxDeclareTransactions,
+            },
+        }
+    }
+
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::DuplicateTxn => "duplicate_txn",
+            Self::InvalidContractAddress => "invalid_contract_address",
+            Self::InvalidNonce => "invalid_nonce",
+            Self::Internal => "internal",
+            Self::MaxDeclareTransactions => "max_declare_transactions",
+            Self::MaxTransactions => "max_transactions",
+            Self::MinTipBump => "min_tip_bump",
+            Self::NonceConflict => "nonce_conflict",
+            Self::NonceTooLow => "nonce_too_low",
+            Self::PendingDeclare => "pending_declare",
+            Self::TooOld => "too_old",
+            Self::ValidatedToBlockifier => "validated_to_blockifier",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MempoolRemovalReason {
+    AdminFlush,
+    ConsumedForBlock,
+    DisplacedByInsert,
+    NonceAdvanced,
+    TtlExpired,
+}
+
+impl MempoolRemovalReason {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::AdminFlush => "admin_flush",
+            Self::ConsumedForBlock => "consumed_for_block",
+            Self::DisplacedByInsert => "displaced_by_insert",
+            Self::NonceAdvanced => "nonce_advanced",
+            Self::TtlExpired => "ttl_expired",
+        }
+    }
+}
+
+fn tx_type_label(tx: &ValidatedTransaction) -> &'static str {
+    match &tx.transaction {
+        Transaction::Invoke(_) => "invoke",
+        Transaction::L1Handler(_) => "l1_handler",
+        Transaction::Declare(_) => "declare",
+        Transaction::Deploy(_) => "deploy",
+        Transaction::DeployAccount(_) => "deploy_account",
+    }
+}
+
+#[derive(Clone)]
 pub struct MempoolMetrics {
     pub accepted_transaction_counter: Counter<u64>,
     pub mempool_current_size: Gauge<u64>,
     pub mempool_ready_transactions: Gauge<u64>,
+    pub mempool_transactions_current: Gauge<u64>,
+    pub mempool_capacity_transactions: Gauge<u64>,
+    pub mempool_accounts_current: Gauge<u64>,
+    pub mempool_ready_transactions_current: Gauge<u64>,
+    pub mempool_queued_transactions_current: Gauge<u64>,
+    pub mempool_oldest_transaction_age_seconds: Gauge<f64>,
+    pub mempool_oldest_ready_transaction_age_seconds: Gauge<f64>,
+    pub mempool_add_attempts_total: Counter<u64>,
+    pub mempool_add_success_total: Counter<u64>,
+    pub mempool_add_rejected_total: Counter<u64>,
+    pub mempool_removed_total: Counter<u64>,
 }
 
 impl MempoolMetrics {
@@ -39,12 +159,188 @@ impl MempoolMetrics {
             "transaction".to_string(),
         );
 
-        Self { accepted_transaction_counter, mempool_current_size, mempool_ready_transactions }
+        let mempool_transactions_current = register_gauge_metric_instrument(
+            &meter,
+            "mempool_transactions_current".to_string(),
+            "Current number of transactions in the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        let mempool_capacity_transactions = register_gauge_metric_instrument(
+            &meter,
+            "mempool_capacity_transactions".to_string(),
+            "Configured transaction capacity of the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        let mempool_accounts_current = register_gauge_metric_instrument(
+            &meter,
+            "mempool_accounts_current".to_string(),
+            "Current number of accounts represented in the mempool".to_string(),
+            "account".to_string(),
+        );
+
+        let mempool_ready_transactions_current = register_gauge_metric_instrument(
+            &meter,
+            "mempool_ready_transactions_current".to_string(),
+            "Current number of ready transactions in the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        let mempool_queued_transactions_current = register_gauge_metric_instrument(
+            &meter,
+            "mempool_queued_transactions_current".to_string(),
+            "Current number of queued non-ready transactions in the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        let mempool_oldest_transaction_age_seconds = register_gauge_metric_instrument(
+            &meter,
+            "mempool_oldest_transaction_age_seconds".to_string(),
+            "Age of the oldest transaction currently in the mempool".to_string(),
+            "s".to_string(),
+        );
+
+        let mempool_oldest_ready_transaction_age_seconds = register_gauge_metric_instrument(
+            &meter,
+            "mempool_oldest_ready_transaction_age_seconds".to_string(),
+            "Age of the oldest ready transaction currently in the mempool".to_string(),
+            "s".to_string(),
+        );
+
+        let mempool_add_attempts_total = register_counter_metric_instrument(
+            &meter,
+            "mempool_add_attempts_total".to_string(),
+            "Attempts to add validated transactions to the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        let mempool_add_success_total = register_counter_metric_instrument(
+            &meter,
+            "mempool_add_success_total".to_string(),
+            "Validated transactions successfully added to the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        let mempool_add_rejected_total = register_counter_metric_instrument(
+            &meter,
+            "mempool_add_rejected_total".to_string(),
+            "Validated transactions rejected by the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        let mempool_removed_total = register_counter_metric_instrument(
+            &meter,
+            "mempool_removed_total".to_string(),
+            "Transactions removed from the mempool".to_string(),
+            "transaction".to_string(),
+        );
+
+        Self {
+            accepted_transaction_counter,
+            mempool_current_size,
+            mempool_ready_transactions,
+            mempool_transactions_current,
+            mempool_capacity_transactions,
+            mempool_accounts_current,
+            mempool_ready_transactions_current,
+            mempool_queued_transactions_current,
+            mempool_oldest_transaction_age_seconds,
+            mempool_oldest_ready_transaction_age_seconds,
+            mempool_add_attempts_total,
+            mempool_add_success_total,
+            mempool_add_rejected_total,
+            mempool_removed_total,
+        }
     }
 
     pub fn record_mempool_state(&self, summary: &MempoolStateSummary) {
         self.mempool_current_size.record(summary.num_transactions as u64, &[]);
         self.mempool_ready_transactions.record(summary.ready_transactions as u64, &[]);
+        self.mempool_transactions_current.record(summary.num_transactions as u64, &[]);
+        self.mempool_capacity_transactions.record(summary.transaction_capacity as u64, &[]);
+        self.mempool_accounts_current.record(summary.num_accounts as u64, &[]);
+        self.mempool_ready_transactions_current.record(summary.ready_transactions as u64, &[]);
+        self.mempool_queued_transactions_current.record(summary.queued_transactions as u64, &[]);
+        self.mempool_oldest_transaction_age_seconds
+            .record(summary.oldest_transaction_age.map(|age| age.as_secs_f64()).unwrap_or_default(), &[]);
+        self.mempool_oldest_ready_transaction_age_seconds
+            .record(summary.oldest_ready_transaction_age.map(|age| age.as_secs_f64()).unwrap_or_default(), &[]);
+
+        #[cfg(test)]
+        if test_counters::metrics_enabled() {
+            test_counters::MEMPOOL_TRANSACTIONS_CURRENT_LAST
+                .store(summary.num_transactions as u64, std::sync::atomic::Ordering::Relaxed);
+            test_counters::MEMPOOL_CAPACITY_TRANSACTIONS_LAST
+                .store(summary.transaction_capacity as u64, std::sync::atomic::Ordering::Relaxed);
+            test_counters::MEMPOOL_ACCOUNTS_CURRENT_LAST
+                .store(summary.num_accounts as u64, std::sync::atomic::Ordering::Relaxed);
+            test_counters::MEMPOOL_READY_TRANSACTIONS_CURRENT_LAST
+                .store(summary.ready_transactions as u64, std::sync::atomic::Ordering::Relaxed);
+            test_counters::MEMPOOL_QUEUED_TRANSACTIONS_CURRENT_LAST
+                .store(summary.queued_transactions as u64, std::sync::atomic::Ordering::Relaxed);
+            test_counters::MEMPOOL_OLDEST_TRANSACTION_AGE_MS_LAST.store(
+                summary.oldest_transaction_age.map(|age| age.as_millis() as u64).unwrap_or_default(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            test_counters::MEMPOOL_OLDEST_READY_TRANSACTION_AGE_MS_LAST.store(
+                summary.oldest_ready_transaction_age.map(|age| age.as_millis() as u64).unwrap_or_default(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
+    }
+
+    pub fn record_add_attempt(&self, source: MempoolIngressSource, tx: &ValidatedTransaction) {
+        let tx_type = tx_type_label(tx);
+        self.mempool_add_attempts_total
+            .add(1, &[KeyValue::new("source", source.as_label()), KeyValue::new("tx_type", tx_type)]);
+
+        #[cfg(test)]
+        if test_counters::metrics_enabled() {
+            test_counters::ADD_ATTEMPTS.lock().unwrap_or_else(|e| e.into_inner()).push((source, tx_type));
+        }
+    }
+
+    pub fn record_add_success(&self, source: MempoolIngressSource, tx: &ValidatedTransaction) {
+        let tx_type = tx_type_label(tx);
+        self.mempool_add_success_total
+            .add(1, &[KeyValue::new("source", source.as_label()), KeyValue::new("tx_type", tx_type)]);
+
+        #[cfg(test)]
+        if test_counters::metrics_enabled() {
+            test_counters::ADD_SUCCESSES.lock().unwrap_or_else(|e| e.into_inner()).push((source, tx_type));
+        }
+    }
+
+    pub fn record_add_rejected(
+        &self,
+        source: MempoolIngressSource,
+        tx: &ValidatedTransaction,
+        reason: MempoolAddRejectReason,
+    ) {
+        let tx_type = tx_type_label(tx);
+        self.mempool_add_rejected_total.add(
+            1,
+            &[
+                KeyValue::new("source", source.as_label()),
+                KeyValue::new("tx_type", tx_type),
+                KeyValue::new("reason", reason.as_label()),
+            ],
+        );
+
+        #[cfg(test)]
+        if test_counters::metrics_enabled() {
+            test_counters::ADD_REJECTIONS.lock().unwrap_or_else(|e| e.into_inner()).push((source, tx_type, reason));
+        }
+    }
+
+    pub fn record_removed(&self, reason: MempoolRemovalReason, count: u64) {
+        self.mempool_removed_total.add(count, &[KeyValue::new("reason", reason.as_label())]);
+
+        #[cfg(test)]
+        if test_counters::metrics_enabled() {
+            test_counters::REMOVALS.lock().unwrap_or_else(|e| e.into_inner()).push((reason, count));
+        }
     }
 }
 
@@ -82,5 +378,60 @@ impl ExternalDbOutboxMetrics {
                 .with_description("Outbox rollback delete failures when mempool insertion fails")
                 .build(),
         }
+    }
+}
+
+#[cfg(test)]
+pub mod test_counters {
+    use super::{MempoolAddRejectReason, MempoolIngressSource, MempoolRemovalReason};
+    use std::future::Future;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{LazyLock, Mutex};
+    use tokio::sync::Mutex as AsyncMutex;
+
+    static TEST_MUTEX: AsyncMutex<()> = AsyncMutex::const_new(());
+    tokio::task_local! {
+        static METRICS_ENABLED: ();
+    }
+
+    pub static ADD_ATTEMPTS: LazyLock<Mutex<Vec<(MempoolIngressSource, &'static str)>>> =
+        LazyLock::new(|| Mutex::new(Vec::new()));
+    pub static ADD_SUCCESSES: LazyLock<Mutex<Vec<(MempoolIngressSource, &'static str)>>> =
+        LazyLock::new(|| Mutex::new(Vec::new()));
+    pub static ADD_REJECTIONS: LazyLock<Mutex<Vec<(MempoolIngressSource, &'static str, MempoolAddRejectReason)>>> =
+        LazyLock::new(|| Mutex::new(Vec::new()));
+    pub static REMOVALS: LazyLock<Mutex<Vec<(MempoolRemovalReason, u64)>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+    pub static MEMPOOL_TRANSACTIONS_CURRENT_LAST: AtomicU64 = AtomicU64::new(0);
+    pub static MEMPOOL_CAPACITY_TRANSACTIONS_LAST: AtomicU64 = AtomicU64::new(0);
+    pub static MEMPOOL_ACCOUNTS_CURRENT_LAST: AtomicU64 = AtomicU64::new(0);
+    pub static MEMPOOL_READY_TRANSACTIONS_CURRENT_LAST: AtomicU64 = AtomicU64::new(0);
+    pub static MEMPOOL_QUEUED_TRANSACTIONS_CURRENT_LAST: AtomicU64 = AtomicU64::new(0);
+    pub static MEMPOOL_OLDEST_TRANSACTION_AGE_MS_LAST: AtomicU64 = AtomicU64::new(0);
+    pub static MEMPOOL_OLDEST_READY_TRANSACTION_AGE_MS_LAST: AtomicU64 = AtomicU64::new(0);
+
+    pub async fn capture<T>(future: impl Future<Output = T>) -> T {
+        let _guard = TEST_MUTEX.lock().await;
+        reset_all();
+        METRICS_ENABLED.scope((), future).await
+    }
+
+    pub fn metrics_enabled() -> bool {
+        METRICS_ENABLED.try_with(|_| ()).is_ok()
+    }
+
+    pub fn reset_all() {
+        ADD_ATTEMPTS.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        ADD_SUCCESSES.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        ADD_REJECTIONS.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        REMOVALS.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+        MEMPOOL_TRANSACTIONS_CURRENT_LAST.store(0, Ordering::Relaxed);
+        MEMPOOL_CAPACITY_TRANSACTIONS_LAST.store(0, Ordering::Relaxed);
+        MEMPOOL_ACCOUNTS_CURRENT_LAST.store(0, Ordering::Relaxed);
+        MEMPOOL_READY_TRANSACTIONS_CURRENT_LAST.store(0, Ordering::Relaxed);
+        MEMPOOL_QUEUED_TRANSACTIONS_CURRENT_LAST.store(0, Ordering::Relaxed);
+        MEMPOOL_OLDEST_TRANSACTION_AGE_MS_LAST.store(0, Ordering::Relaxed);
+        MEMPOOL_OLDEST_READY_TRANSACTION_AGE_MS_LAST.store(0, Ordering::Relaxed);
     }
 }

--- a/madara/crates/client/submit_tx/src/lib.rs
+++ b/madara/crates/client/submit_tx/src/lib.rs
@@ -109,7 +109,7 @@
 //! [`StatefulValidator`]: blockifier::blockifier::stateful_validator::StatefulValidator
 use async_trait::async_trait;
 use mc_db::MadaraStorage;
-use mc_mempool::Mempool;
+use mc_mempool::{metrics::MempoolIngressSource, Mempool};
 use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::v0_10_2::BroadcastedInvokeTxn;
 use mp_rpc::v0_9_0::{
@@ -172,6 +172,14 @@ pub trait SubmitL1HandlerTransaction: Send + Sync {
 pub trait SubmitValidatedTransaction: Send + Sync {
     async fn submit_validated_transaction(&self, tx: ValidatedTransaction) -> Result<(), SubmitTransactionError>;
 
+    async fn submit_validated_transaction_with_source(
+        &self,
+        tx: ValidatedTransaction,
+        _source: MempoolIngressSource,
+    ) -> Result<(), SubmitTransactionError> {
+        self.submit_validated_transaction(tx).await
+    }
+
     async fn received_transaction(&self, hash: mp_convert::Felt) -> Option<bool>;
 
     async fn subscribe_new_transactions(&self) -> Option<tokio::sync::broadcast::Receiver<mp_convert::Felt>>;
@@ -182,6 +190,15 @@ impl<D: MadaraStorage> SubmitValidatedTransaction for Mempool<D> {
     async fn submit_validated_transaction(&self, tx: ValidatedTransaction) -> Result<(), SubmitTransactionError> {
         Ok(self.accept_tx(tx).await?)
     }
+
+    async fn submit_validated_transaction_with_source(
+        &self,
+        tx: ValidatedTransaction,
+        source: MempoolIngressSource,
+    ) -> Result<(), SubmitTransactionError> {
+        Ok(self.accept_tx_from_source(tx, source).await?)
+    }
+
     async fn received_transaction(&self, hash: mp_convert::Felt) -> Option<bool> {
         Some(self.is_transaction_in_mempool(&hash))
     }

--- a/madara/crates/client/submit_tx/src/validation.rs
+++ b/madara/crates/client/submit_tx/src/validation.rs
@@ -15,7 +15,7 @@ use blockifier::{
 use mc_db::{MadaraBackend, MadaraBlockView};
 use mc_exec::execution::TxInfo;
 use mc_exec::MadaraBlockViewExecutionExt;
-use mc_mempool::{MempoolInsertionError, TxInsertionError};
+use mc_mempool::{metrics::MempoolIngressSource, MempoolInsertionError, TxInsertionError};
 use mp_chain_config::StarknetVersion;
 use mp_class::ConvertedClass;
 use mp_convert::{Felt, ToFelt};
@@ -236,6 +236,7 @@ pub struct TransactionValidator {
     inner: Arc<dyn SubmitValidatedTransaction>,
     backend: Arc<MadaraBackend>,
     config: TransactionValidatorConfig,
+    source: MempoolIngressSource,
 }
 
 impl fmt::Debug for TransactionValidator {
@@ -250,7 +251,16 @@ impl TransactionValidator {
         backend: Arc<MadaraBackend>,
         config: TransactionValidatorConfig,
     ) -> Self {
-        Self { inner, backend, config }
+        Self::new_with_source(inner, backend, config, MempoolIngressSource::Rpc)
+    }
+
+    pub fn new_with_source(
+        inner: Arc<dyn SubmitValidatedTransaction>,
+        backend: Arc<MadaraBackend>,
+        config: TransactionValidatorConfig,
+        source: MempoolIngressSource,
+    ) -> Self {
+        Self { inner, backend, config, source }
     }
 
     #[tracing::instrument(skip(self, tx, converted_class))]
@@ -311,7 +321,7 @@ impl TransactionValidator {
             converted_class,
             account_tx.execution_flags.charge_fee,
         );
-        self.inner.submit_validated_transaction(tx).await?;
+        self.inner.submit_validated_transaction_with_source(tx, self.source).await?;
 
         Ok(())
     }

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -117,6 +117,7 @@ use http::{HeaderName, HeaderValue};
 use mc_db::MadaraBackend;
 use mc_external_db::ExternalDbService;
 use mc_gateway_client::GatewayProvider;
+use mc_mempool::metrics::MempoolIngressSource;
 use mc_settlement_client::gas_price::L1BlockMetrics;
 use mc_submit_tx::{SubmitTransaction, TransactionValidator};
 use mc_telemetry::{SysInfo, TelemetryService};
@@ -370,38 +371,53 @@ async fn main() -> anyhow::Result<()> {
 
     // Add transaction provider
 
-    let mempool_tx_validator = Arc::new(TransactionValidator::new(
+    let rpc_mempool_tx_validator = Arc::new(TransactionValidator::new_with_source(
         service_mempool.mempool() as _,
         backend.clone(),
         run_cmd.validator_params.as_validator_config(),
+        MempoolIngressSource::Rpc,
+    ));
+
+    let gateway_mempool_tx_validator = Arc::new(TransactionValidator::new_with_source(
+        service_mempool.mempool() as _,
+        backend.clone(),
+        run_cmd.validator_params.as_validator_config(),
+        MempoolIngressSource::Gateway,
     ));
 
     let gateway_submit_tx: Arc<dyn SubmitTransaction> =
         if run_cmd.validator_params.validate_then_forward_txs_to.is_some() {
-            Arc::new(TransactionValidator::new(
+            Arc::new(TransactionValidator::new_with_source(
                 Arc::clone(&gateway_client) as _,
                 backend.clone(),
                 run_cmd.validator_params.as_validator_config(),
+                MempoolIngressSource::Gateway,
             ))
         } else {
             Arc::clone(&gateway_client) as _
         };
 
-    let tx_submit =
-        MakeSubmitTransactionSwitch::new(Arc::clone(&gateway_submit_tx) as _, Arc::clone(&mempool_tx_validator) as _);
+    let tx_submit_rpc = MakeSubmitTransactionSwitch::new(
+        Arc::clone(&gateway_submit_tx) as _,
+        Arc::clone(&rpc_mempool_tx_validator) as _,
+    );
+    let tx_submit_gateway = MakeSubmitTransactionSwitch::new(
+        Arc::clone(&gateway_submit_tx) as _,
+        Arc::clone(&gateway_mempool_tx_validator) as _,
+    );
     let validated_tx_submit =
         MakeSubmitValidatedTransactionSwitch::new(Arc::clone(&gateway_client) as _, service_mempool.mempool() as _);
 
     // User-facing RPC
 
-    let service_rpc_user = RpcService::user(run_cmd.rpc_params.clone(), backend.clone(), tx_submit.clone());
+    let service_rpc_user = RpcService::user(run_cmd.rpc_params.clone(), backend.clone(), tx_submit_rpc.clone());
 
     // Admin-facing RPC (for node operators)
 
     let service_rpc_admin = RpcService::admin(
         run_cmd.rpc_params.clone(),
         backend.clone(),
-        tx_submit.clone(),
+        tx_submit_rpc.clone(),
         service_block_production.handle(),
     );
 
@@ -410,7 +426,7 @@ async fn main() -> anyhow::Result<()> {
     let service_gateway = GatewayService::new(
         run_cmd.gateway_params.clone(),
         backend.clone(),
-        tx_submit.clone(),
+        tx_submit_gateway.clone(),
         Some(validated_tx_submit.clone()),
     )
     .await

--- a/madara/node/src/submit_tx.rs
+++ b/madara/node/src/submit_tx.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use mc_mempool::metrics::MempoolIngressSource;
 use mc_submit_tx::{SubmitTransaction, SubmitTransactionError, SubmitValidatedTransaction};
 use mp_rpc::admin::BroadcastedDeclareTxnV0;
 use mp_rpc::v0_10_2::BroadcastedInvokeTxn;
@@ -110,6 +111,14 @@ impl SubmitValidatedTransactionSwitch {
 impl SubmitValidatedTransaction for SubmitValidatedTransactionSwitch {
     async fn submit_validated_transaction(&self, tx: ValidatedTransaction) -> Result<(), SubmitTransactionError> {
         self.validated_provider()?.submit_validated_transaction(tx).await
+    }
+
+    async fn submit_validated_transaction_with_source(
+        &self,
+        tx: ValidatedTransaction,
+        source: MempoolIngressSource,
+    ) -> Result<(), SubmitTransactionError> {
+        self.validated_provider()?.submit_validated_transaction_with_source(tx, source).await
     }
 
     async fn received_transaction(&self, hash: Felt) -> Option<bool> {


### PR DESCRIPTION
## Summary
- add alert-friendly mempool gauges for occupancy, capacity, ready/queued depth, and oldest transaction age
- add low-cardinality mempool counters for add attempts, add successes, add rejections, and removals
- thread ingress source labels through RPC, gateway, reinsertion, and db-restore paths so alerts can distinguish where adds came from
- record removal reasons for block consumption, TTL expiry, nonce advancement, and insertion-driven displacement
- add focused mempool tests for the new metric hooks and publish an initial zero-state snapshot at mempool startup

## Metrics added
- `mempool_transactions_current`
- `mempool_capacity_transactions`
- `mempool_accounts_current`
- `mempool_ready_transactions_current`
- `mempool_queued_transactions_current`
- `mempool_oldest_transaction_age_seconds`
- `mempool_oldest_ready_transaction_age_seconds`
- `mempool_add_attempts_total{source,tx_type}`
- `mempool_add_success_total{source,tx_type}`
- `mempool_add_rejected_total{source,tx_type,reason}`
- `mempool_removed_total{reason}`

## Notes
- `mempool_add_*` metrics are emitted for RPC, gateway, reinsertion, and unknown ingress paths; db restore is intentionally excluded from attempt/success/rejection counters
- the mempool fill rate can be derived downstream as `rate(mempool_add_success_total[5m]) - rate(mempool_removed_total[5m])`
- legacy `accepted_transaction_count`, `mempool_current_size`, and `mempool_ready_transactions` metrics are preserved

## Validation
- `cargo test -p mc-mempool --lib -- --nocapture`
- `cargo check -p mc-submit-tx --lib`
- `cargo check -p madara --bin madara`