### PR TITLE
fix(block-production): correct empty block timestamp drift

### DIFF
--- a/madara/crates/client/block_production/src/executor/thread.rs
+++ b/madara/crates/client/block_production/src/executor/thread.rs
@@ -251,11 +251,8 @@ impl ExecutorThread {
         // the timestamp reflects when the block actually started executing.
         // Otherwise use the time captured when the previous block closed, so that
         // consecutive blocks have timestamps spaced by ~block_time.
-        let block_timestamp = if self.backend.chain_config().no_empty_blocks {
-            SystemTime::now()
-        } else {
-            state.block_start_time
-        };
+        let block_timestamp =
+            if self.backend.chain_config().no_empty_blocks { SystemTime::now() } else { state.block_start_time };
         let exec_ctx = create_execution_context(
             &self.backend,
             state.state_adaptor.block_n(),

--- a/madara/crates/client/block_production/src/executor/thread.rs
+++ b/madara/crates/client/block_production/src/executor/thread.rs
@@ -14,6 +14,7 @@ use std::{
     collections::{HashMap, HashSet},
     mem,
     sync::Arc,
+    time::SystemTime,
 };
 use tokio::{sync::mpsc, time::Instant};
 
@@ -31,6 +32,10 @@ struct ExecutorStateNewBlock {
     /// Keep the cached adaptor around to keep the cache around.
     state_adaptor: LayeredStateAdapter,
     consumed_l1_to_l2_nonces: HashSet<u64>,
+    /// Wall-clock time captured when the previous block closed.
+    /// Used as the next block's timestamp so that lazy execution context
+    /// creation does not skew the timestamp forward.
+    block_start_time: SystemTime,
 }
 
 /// Note: The reason this exists is because we want to create the new block execution context (meaning, the block header) as late as possible, as to have
@@ -230,6 +235,7 @@ impl ExecutorThread {
         Ok(ExecutorThreadState::NewBlock(ExecutorStateNewBlock {
             state_adaptor: cached_adapter,
             consumed_l1_to_l2_nonces: HashSet::new(),
+            block_start_time: SystemTime::now(),
         }))
     }
 
@@ -245,6 +251,7 @@ impl ExecutorThread {
             state.state_adaptor.block_n(),
             previous_l2_gas_price,
             previous_l2_gas_used,
+            state.block_start_time,
         )?;
 
         // Create the TransactionExecutor with block_n-10 handling, reusing the layered_state_adapter.
@@ -268,6 +275,7 @@ impl ExecutorThread {
         Ok(ExecutorThreadState::NewBlock(ExecutorStateNewBlock {
             state_adaptor: LayeredStateAdapter::new(Arc::clone(&self.backend))?,
             consumed_l1_to_l2_nonces: HashSet::new(),
+            block_start_time: SystemTime::now(),
         }))
     }
 

--- a/madara/crates/client/block_production/src/executor/thread.rs
+++ b/madara/crates/client/block_production/src/executor/thread.rs
@@ -246,12 +246,22 @@ impl ExecutorThread {
         previous_l2_gas_used: u128,
     ) -> anyhow::Result<ExecutorStateExecuting> {
         let previous_l2_gas_price = state.state_adaptor.latest_gas_prices().strk_l2_gas_price;
+        // When no_empty_blocks is enabled, blocks are produced on-demand and the
+        // wait for the first tx can be arbitrarily long. Use wall-clock time so
+        // the timestamp reflects when the block actually started executing.
+        // Otherwise use the time captured when the previous block closed, so that
+        // consecutive blocks have timestamps spaced by ~block_time.
+        let block_timestamp = if self.backend.chain_config().no_empty_blocks {
+            SystemTime::now()
+        } else {
+            state.block_start_time
+        };
         let exec_ctx = create_execution_context(
             &self.backend,
             state.state_adaptor.block_n(),
             previous_l2_gas_price,
             previous_l2_gas_used,
-            state.block_start_time,
+            block_timestamp,
         )?;
 
         // Create the TransactionExecutor with block_n-10 handling, reusing the layered_state_adapter.

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -2292,4 +2292,65 @@ pub(crate) mod tests {
         // No preconfirmed block should exist (still)
         assert!(!devnet_setup.backend.has_preconfirmed_block());
     }
+
+    // Regression test: when a non-empty block is followed by an empty block,
+    // the timestamp delta should be ~block_time, not ~2*block_time.
+    //
+    // Before the fix, create_execution_context() called SystemTime::now() lazily
+    // — only after wait_take_tx_batch() returned. For a non-empty block, txs
+    // arrive quickly so the timestamp is set near block-open time. For an empty
+    // block, the full block_time elapses before the timestamp is set.
+    // This made the delta between a non-empty and subsequent empty block ≈ 2*block_time.
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(30))]
+    #[tokio::test]
+    async fn test_empty_block_timestamp_not_drifted(
+        #[future]
+        #[with(Duration::from_secs(3))]
+        devnet_setup: DevnetSetup,
+    ) {
+        let mut devnet_setup = devnet_setup.await;
+
+        // Submit a transaction so block 1 is non-empty.
+        sign_and_add_invoke_tx(
+            &devnet_setup.contracts.0[0],
+            &devnet_setup.contracts.0[1],
+            &devnet_setup.backend,
+            &devnet_setup.tx_validator,
+            Felt::ZERO,
+        )
+        .await;
+
+        let mut block_production_task = devnet_setup.block_prod_task();
+        let mut notifications = block_production_task.subscribe_state_notifications();
+        let _task =
+            AbortOnDrop::spawn(
+                async move { block_production_task.run(ServiceContext::new_for_testing()).await.unwrap() },
+            );
+
+        // Block 1: non-empty (has our tx), closes after block_time.
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::BatchExecuted);
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::ClosedBlock);
+
+        // Block 2: empty, closes after another block_time.
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::ClosedBlock);
+
+        let block_1 = devnet_setup.backend.block_view_on_confirmed(1).unwrap();
+        let block_2 = devnet_setup.backend.block_view_on_confirmed(2).unwrap();
+
+        let ts_1 = block_1.get_block_info().unwrap().header.block_timestamp.0;
+        let ts_2 = block_2.get_block_info().unwrap().header.block_timestamp.0;
+
+        let delta = ts_2.saturating_sub(ts_1);
+
+        // With block_time=3s, the delta should be ~3s.
+        // Before the fix it would be ~6s (2 * block_time) because:
+        //   - block 1 timestamp set at open (near T0)
+        //   - block 2 timestamp set after 3s wait (near T0 + 3s + 3s)
+        assert!(
+            delta <= 4,
+            "Timestamp delta between non-empty and subsequent empty block should be ~3s (block_time), \
+             but got {delta}s. This likely means the timestamp is still being set after the block_time wait."
+        );
+    }
 }

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -2399,10 +2399,8 @@ pub(crate) mod tests {
         // when the tx arrives (~3s from now), not when block 1 closed (~3s ago).
         tokio::time::sleep(Duration::from_secs(3)).await;
 
-        let wall_clock_before_tx = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let wall_clock_before_tx =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 
         sign_and_add_invoke_tx(
             &devnet_setup.contracts.0[1],

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -2358,4 +2358,76 @@ pub(crate) mod tests {
              but got {delta}s. This likely means the timestamp is still being set after the block_time wait."
         );
     }
+
+    // When no_empty_blocks=true, blocks are produced on-demand. The timestamp
+    // should reflect wall-clock time when the first tx arrives, not the time
+    // the previous block closed (which could be arbitrarily long ago).
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(30))]
+    #[tokio::test]
+    async fn test_no_empty_blocks_timestamp_uses_wall_clock(
+        #[future]
+        #[with(Duration::from_secs(30), false, true)]
+        devnet_setup: DevnetSetup,
+    ) {
+        let mut devnet_setup = devnet_setup.await;
+
+        let mut block_production_task = devnet_setup.block_prod_task();
+        let mut notifications = block_production_task.subscribe_state_notifications();
+        let control = block_production_task.handle();
+        let _task =
+            AbortOnDrop::spawn(
+                async move { block_production_task.run(ServiceContext::new_for_testing()).await.unwrap() },
+            );
+
+        // Submit a tx to trigger block 1.
+        sign_and_add_invoke_tx(
+            &devnet_setup.contracts.0[0],
+            &devnet_setup.contracts.0[1],
+            &devnet_setup.backend,
+            &devnet_setup.tx_validator,
+            Felt::ZERO,
+        )
+        .await;
+
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::BatchExecuted);
+        control.close_block().await.unwrap();
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::ClosedBlock);
+
+        // Wait 3 seconds before submitting the next tx. With no_empty_blocks=true,
+        // the executor waits indefinitely. The block timestamp should reflect
+        // when the tx arrives (~3s from now), not when block 1 closed (~3s ago).
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let wall_clock_before_tx = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        sign_and_add_invoke_tx(
+            &devnet_setup.contracts.0[1],
+            &devnet_setup.contracts.0[2],
+            &devnet_setup.backend,
+            &devnet_setup.tx_validator,
+            Felt::ZERO,
+        )
+        .await;
+
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::BatchExecuted);
+        control.close_block().await.unwrap();
+        assert_eq!(notifications.recv().await.unwrap(), BlockProductionStateNotification::ClosedBlock);
+
+        let block_2 = devnet_setup.backend.block_view_on_confirmed(2).unwrap();
+        let ts_2 = block_2.get_block_info().unwrap().header.block_timestamp.0;
+
+        // The timestamp should be within 1s of wall clock when the tx was submitted,
+        // not ~3s behind (which would indicate the stale captured time was used).
+        let drift = wall_clock_before_tx.saturating_sub(ts_2);
+        assert!(
+            drift <= 1,
+            "With no_empty_blocks=true, block timestamp should reflect wall-clock time \
+             when the first tx arrived, but it was {drift}s behind. \
+             This likely means a stale captured block_start_time was used."
+        );
+    }
 }

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -2348,6 +2348,11 @@ pub(crate) mod tests {
         //   - block 1 timestamp set at open (near T0)
         //   - block 2 timestamp set after 3s wait (near T0 + 3s + 3s)
         assert!(
+            delta >= 2,
+            "Timestamp delta between non-empty and subsequent empty block should be ~3s (block_time), \
+             but got {delta}s. Timestamps may have stalled or gone backward."
+        );
+        assert!(
             delta <= 4,
             "Timestamp delta between non-empty and subsequent empty block should be ~3s (block_time), \
              but got {delta}s. This likely means the timestamp is still being set after the block_time wait."

--- a/madara/crates/client/block_production/src/util.rs
+++ b/madara/crates/client/block_production/src/util.rs
@@ -191,6 +191,7 @@ pub(crate) fn create_execution_context(
     block_n: u64,
     previous_l2_gas_price: u128,
     previous_l2_gas_used: u128,
+    block_start_time: SystemTime,
 ) -> anyhow::Result<BlockExecutionContext> {
     let (block_timestamp, gas_prices) = if let Some(custom_header) = backend.get_custom_header(block_n) {
         // Convert Unix timestamp (seconds since Jan 1, 1970) to SystemTime
@@ -203,7 +204,7 @@ pub(crate) fn create_execution_context(
             .context("No L1 gas quote available. Ensure that the L1 gas quote is set before calculating gas prices.")?;
 
         let gas_prices = backend.calculate_gas_prices(&l1_gas_quote, previous_l2_gas_price, previous_l2_gas_used)?;
-        (SystemTime::now(), gas_prices)
+        (block_start_time, gas_prices)
     };
 
     Ok(BlockExecutionContext {


### PR DESCRIPTION
## Summary

- Block timestamps were drifted forward by one full `block_time` for empty blocks because `SystemTime::now()` was called lazily inside `create_execution_context()` — only after the `block_time` wait in `wait_take_tx_batch()` had already elapsed.
- This caused the timestamp delta between a non-empty block and a subsequent empty block to be ~2x `block_time` (e.g., 78s instead of 40s observed on block 129092 on Paradex testnet).
- Fix: capture `SystemTime::now()` when the previous block closes (`end_block` / `initial_state`) and pass it as the block timestamp. Gas prices remain lazily computed for freshness.

## Observed behavior (Paradex testnet, block_time=40s)

| Block | Txs | Timestamp | Delta | Expected |
|-------|-----|-----------|-------|----------|
| 129091 | 7 | 1779685704 | 40s | 40s |
| 129092 | 0 | 1779685782 | **78s** | 40s |
| 129093 | 8 | 1779685787 | **5s** | 40s |
| 129094 | - | 1779685827 | 40s | 40s |

## Root cause

The `ExecutorThread` creates block execution contexts lazily (for gas price freshness). After closing block N, the state machine transitions to `NewBlock` and waits for the next batch or deadline. For empty blocks, the full `block_time` elapses before `create_execution_state()` → `create_execution_context()` → `SystemTime::now()` is called, making the timestamp reflect the _end_ of the waiting period rather than the _start_ of the block period.

## Changes

- `thread.rs`: Added `block_start_time: SystemTime` to `ExecutorStateNewBlock`, captured in `end_block()` and `initial_state()`
- `util.rs`: `create_execution_context()` now takes `block_start_time` param instead of calling `SystemTime::now()`
- `lib.rs`: Added regression test `test_empty_block_timestamp_not_drifted` — verified it fails without the fix (delta=6s with block_time=3s) and passes with it

## Test plan

- [x] `test_empty_block_timestamp_not_drifted` — submits a tx to block 1, lets block 2 be empty, asserts timestamp delta ≈ block_time (not 2x)
- [x] Verified test fails on `main` (delta=6s), passes with fix (delta≤4s)
- [x] `cargo check -p mc-block-production --tests` passes
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)