### PR TITLE
fix(orchestrator): use SNOS v0.14.2-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.1#aaffeb9d6e5fd01fd178bb4798e186e207e9126e"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#2ad83ea1ec89287a42197b1ff750976f12fdc8c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12998,7 +12998,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.1#aaffeb9d6e5fd01fd178bb4798e186e207e9126e"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#2ad83ea1ec89287a42197b1ff750976f12fdc8c9"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14424,7 +14424,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.1#aaffeb9d6e5fd01fd178bb4798e186e207e9126e"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#2ad83ea1ec89287a42197b1ff750976f12fdc8c9"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2783,7 +2783,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2803,7 +2803,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5298,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5307,7 +5307,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6515,7 +6515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=6a9f5a7b46201f39ab670c0d956853d5cd1f82b8#6a9f5a7b46201f39ab670c0d956853d5cd1f82b8"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c16e83a180cc2d29aebf28f4eb2937ecdf825f71#c16e83a180cc2d29aebf28f4eb2937ecdf825f71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8374,7 +8374,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10780,7 +10780,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12383,7 +12383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12396,7 +12396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12485,7 +12485,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12998,7 +12998,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=6a9f5a7b46201f39ab670c0d956853d5cd1f82b8#6a9f5a7b46201f39ab670c0d956853d5cd1f82b8"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c16e83a180cc2d29aebf28f4eb2937ecdf825f71#c16e83a180cc2d29aebf28f4eb2937ecdf825f71"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -13268,7 +13268,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13409,7 +13409,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14424,7 +14424,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=6a9f5a7b46201f39ab670c0d956853d5cd1f82b8#6a9f5a7b46201f39ab670c0d956853d5cd1f82b8"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c16e83a180cc2d29aebf28f4eb2937ecdf825f71#c16e83a180cc2d29aebf28f4eb2937ecdf825f71"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",
@@ -15176,7 +15176,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15196,7 +15196,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16598,7 +16598,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2783,7 +2783,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2803,7 +2803,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5298,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5307,7 +5307,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6515,7 +6515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=af31839e7799bbbf566145ea6fddc35013028d9a#af31839e7799bbbf566145ea6fddc35013028d9a"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=6a9f5a7b46201f39ab670c0d956853d5cd1f82b8#6a9f5a7b46201f39ab670c0d956853d5cd1f82b8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8374,7 +8374,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10780,7 +10780,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12383,7 +12383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12396,7 +12396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12485,7 +12485,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12998,7 +12998,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=af31839e7799bbbf566145ea6fddc35013028d9a#af31839e7799bbbf566145ea6fddc35013028d9a"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=6a9f5a7b46201f39ab670c0d956853d5cd1f82b8#6a9f5a7b46201f39ab670c0d956853d5cd1f82b8"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -13268,7 +13268,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13409,7 +13409,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14424,7 +14424,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=af31839e7799bbbf566145ea6fddc35013028d9a#af31839e7799bbbf566145ea6fddc35013028d9a"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=6a9f5a7b46201f39ab670c0d956853d5cd1f82b8#6a9f5a7b46201f39ab670c0d956853d5cd1f82b8"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",
@@ -15176,7 +15176,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15196,7 +15196,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16598,7 +16598,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c16e83a180cc2d29aebf28f4eb2937ecdf825f71#c16e83a180cc2d29aebf28f4eb2937ecdf825f71"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#d5674412c2032721fe245f872115c192a3a912ca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12998,7 +12998,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c16e83a180cc2d29aebf28f4eb2937ecdf825f71#c16e83a180cc2d29aebf28f4eb2937ecdf825f71"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#d5674412c2032721fe245f872115c192a3a912ca"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14424,7 +14424,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c16e83a180cc2d29aebf28f4eb2937ecdf825f71#c16e83a180cc2d29aebf28f4eb2937ecdf825f71"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#d5674412c2032721fe245f872115c192a3a912ca"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2783,7 +2783,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2803,7 +2803,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5298,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5307,7 +5307,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6515,7 +6515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#2ad83ea1ec89287a42197b1ff750976f12fdc8c9"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=af31839e7799bbbf566145ea6fddc35013028d9a#af31839e7799bbbf566145ea6fddc35013028d9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8374,7 +8374,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10780,7 +10780,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12383,7 +12383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12396,7 +12396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12485,7 +12485,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12998,7 +12998,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#2ad83ea1ec89287a42197b1ff750976f12fdc8c9"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=af31839e7799bbbf566145ea6fddc35013028d9a#af31839e7799bbbf566145ea6fddc35013028d9a"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -13268,7 +13268,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13409,7 +13409,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14424,7 +14424,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.2#2ad83ea1ec89287a42197b1ff750976f12fdc8c9"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=af31839e7799bbbf566145ea6fddc35013028d9a#af31839e7799bbbf566145ea6fddc35013028d9a"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",
@@ -15176,7 +15176,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15196,7 +15196,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16598,7 +16598,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,9 +314,9 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-# Keep this on the requested SNOS 0.14.2 RC while replay validation targets
-# that artifact set; do not move to the stable tag without rerunning replay fixtures.
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.2" }
+# Keep this pinned to the requested SNOS 0.14.2 RC line while replay validation
+# targets that artifact set; do not move to the stable tag without rerunning replay fixtures.
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "af31839e7799bbbf566145ea6fddc35013028d9a" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 # Keep this pinned to the requested SNOS 0.14.2 RC line while replay validation
 # targets that artifact set; do not move to the stable tag without rerunning replay fixtures.
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "6a9f5a7b46201f39ab670c0d956853d5cd1f82b8" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "c16e83a180cc2d29aebf28f4eb2937ecdf825f71" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 # Keep this pinned to the requested SNOS 0.14.2 RC line while replay validation
 # targets that artifact set; do not move to the stable tag without rerunning replay fixtures.
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "c16e83a180cc2d29aebf28f4eb2937ecdf825f71" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.2" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 # Keep this pinned to the requested SNOS 0.14.2 RC line while replay validation
 # targets that artifact set; do not move to the stable tag without rerunning replay fixtures.
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "af31839e7799bbbf566145ea6fddc35013028d9a" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "6a9f5a7b46201f39ab670c0d956853d5cd1f82b8" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 # Keep this on the requested SNOS 0.14.2 RC while replay validation targets
 # that artifact set; do not move to the stable tag without rerunning replay fixtures.
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.1" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.2" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }


### PR DESCRIPTION
## Summary
- update orchestrator to consume the SNOS 0.14.2 RC line
- pin `generate-pie`, `rpc-client`, and `starknet-os-types` to SNOS PR `#516` rev `af31839e7799bbbf566145ea6fddc35013028d9a`

## Testing
- skipped at request
