### PR TITLE
feat(rpc): add madara_addTransactionBatch for contiguous batch execution

### DIFF
--- a/madara/crates/client/block_production/src/executor/mod.rs
+++ b/madara/crates/client/block_production/src/executor/mod.rs
@@ -31,10 +31,29 @@ pub enum ExecutorCommandError {
     ChannelClosed,
 }
 
+/// Per-transaction outcome of an atomic batch, reported back to the submitter.
+#[derive(Debug, Clone)]
+pub enum TxExecutionOutcome {
+    /// Executed successfully and included in a block.
+    Succeeded,
+    /// Executed but reverted (still included in a block, fees charged).
+    Reverted(String),
+    /// Could not be included (e.g. Declare/DeployAccount error or internal error).
+    Rejected(String),
+}
+
+/// Outcome of executing a whole transaction batch, in submission order.
+pub type BatchExecutionOutcome = Vec<(mp_convert::Felt, TxExecutionOutcome)>;
+
 #[derive(Debug)]
 pub enum ExecutorCommand {
     /// Force close the current block.
     CloseBlock(oneshot::Sender<Result<(), ExecutorCommandError>>),
+    /// Execute a batch of transactions as one contiguous unit: the transactions are fed to the
+    /// executor in order with no foreign transaction executed between any two of them (across block
+    /// boundaries if the batch does not fit in a single block). This is an ordering guarantee, not
+    /// an atomicity one: individual transactions may still revert or be rejected.
+    ExecuteBatch { batch: BatchToExecute, response: oneshot::Sender<BatchExecutionOutcome> },
 }
 
 #[derive(Debug)]

--- a/madara/crates/client/block_production/src/executor/tests.rs
+++ b/madara/crates/client/block_production/src/executor/tests.rs
@@ -325,3 +325,68 @@ async fn test_duplicate_l1_handler_in_db(#[future] l1_handler_setup: L1HandlerSe
     recv.await.unwrap().unwrap();
     assert_matches!(setup.handle.replies.recv().await, Some(ExecutorMessage::EndBlock(_)));
 }
+
+/// The `ExecuteBatch` command executes the whole batch as one contiguous unit and reports each
+/// transaction's outcome, in submission order, on the response channel.
+#[rstest::rstest]
+#[tokio::test]
+async fn test_execute_batch_command(
+    // long block time, no pending tick: keep the block open so the whole batch lands together.
+    #[with(Duration::from_secs(30000))]
+    #[future]
+    devnet_setup: DevnetSetup,
+) {
+    use crate::tests::make_invoke_tx;
+    use mc_devnet::{Call, Multicall, Selector};
+
+    let setup = devnet_setup.await;
+    let (commands_sender, commands) = mpsc::unbounded_channel();
+    let mut handle =
+        start_executor_thread(setup.backend.clone(), commands, Arc::new(BlockProductionMetrics::register())).unwrap();
+
+    let erc20 = Felt::from_hex_unchecked("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
+    let sender = &setup.contracts.0[0];
+    let receiver = &setup.contracts.0[1];
+    // Two transfers from the same account with sequential nonces (a dependent ordered batch).
+    let transfer = |nonce: Felt| {
+        make_invoke_tx(
+            sender,
+            Multicall::default().with(Call {
+                to: erc20,
+                selector: Selector::from("transfer"),
+                calldata: vec![receiver.address, Felt::from(1_000u128), Felt::ZERO],
+            }),
+            &setup.backend,
+            nonce,
+        )
+    };
+
+    let batch: BatchToExecute = [
+        make_tx(&setup.backend, BroadcastedTxn::Invoke(transfer(Felt::ZERO))),
+        make_tx(&setup.backend, BroadcastedTxn::Invoke(transfer(Felt::ONE))),
+    ]
+    .into_iter()
+    .collect();
+    let hashes: Vec<Felt> = batch.txs.iter().map(|t| t.tx_hash().to_felt()).collect();
+
+    let (response, response_rx) = oneshot::channel();
+    commands_sender.send(ExecutorCommand::ExecuteBatch { batch, response }).unwrap();
+
+    assert_matches!(handle.replies.recv().await, Some(ExecutorMessage::StartNewBlock { .. }));
+    assert_matches!(handle.replies.recv().await, Some(ExecutorMessage::BatchExecuted(res)) => {
+        assert_eq!(res.executed_txs.len(), 2);
+    });
+
+    // The response reports both transactions, in submission order, both succeeded.
+    let outcomes = response_rx.await.expect("batch response should be sent");
+    assert_eq!(outcomes.iter().map(|(h, _)| *h).collect::<Vec<_>>(), hashes);
+    for (_, outcome) in &outcomes {
+        assert_matches!(outcome, super::TxExecutionOutcome::Succeeded);
+    }
+
+    // Close the block to tear down the executor's open block state cleanly.
+    let (sender, recv) = oneshot::channel();
+    commands_sender.send(ExecutorCommand::CloseBlock(sender)).unwrap();
+    recv.await.unwrap().unwrap();
+    assert_matches!(handle.replies.recv().await, Some(ExecutorMessage::EndBlock(_)));
+}

--- a/madara/crates/client/block_production/src/executor/thread.rs
+++ b/madara/crates/client/block_production/src/executor/thread.rs
@@ -97,6 +97,20 @@ enum WaitTxBatchOutcome {
     Batch(BatchToExecute),
 }
 
+/// Tracks an in-flight atomic transaction batch so we can report each transaction's outcome back to
+/// the submitter once the whole batch has been executed. Batch submissions are serialized by the
+/// [`crate::BlockProductionHandle`], so at most one batch is ever tracked at a time.
+struct BatchTracker {
+    /// Hashes of the batch's transactions, used to recognize them among executed transactions.
+    hashes: HashSet<Felt>,
+    /// Collected outcomes, accumulated in execution (== submission) order.
+    collected: super::BatchExecutionOutcome,
+    /// Total number of transactions in the batch.
+    total: usize,
+    /// Channel to reply on once every transaction in the batch has been executed.
+    response: tokio::sync::oneshot::Sender<super::BatchExecutionOutcome>,
+}
+
 impl ExecutorThread {
     pub fn new(
         backend: Arc<MadaraBackend>,
@@ -301,6 +315,8 @@ impl ExecutorThread {
         let mut force_close = false;
         let mut block_empty = true;
         let mut l2_gas_consumed_block = 0;
+        // The atomic batch currently being executed, if any. See [`BatchTracker`].
+        let mut active_batch: Option<BatchTracker> = None;
 
         tracing::debug!("Starting executor thread.");
 
@@ -323,6 +339,28 @@ impl ExecutorThread {
                             force_close = true;
                             let _ = callback.send(Ok(()));
                             Default::default()
+                        }
+                        super::ExecutorCommand::ExecuteBatch { batch, response } => {
+                            let total = batch.len();
+                            if total == 0 {
+                                let _ = response.send(Vec::new());
+                                Default::default()
+                            } else {
+                                // Record the batch so we can report each tx's outcome once executed.
+                                // The batch's transactions are appended to `to_exec` as a single
+                                // contiguous unit; since leftovers always stay at the front of
+                                // `to_exec` and any other transactions are appended at the back, no
+                                // foreign transaction can ever be executed between two batch txs,
+                                // even when the batch spans multiple blocks.
+                                let hashes = batch.txs.iter().map(|tx| tx.tx_hash().to_felt()).collect();
+                                active_batch = Some(BatchTracker {
+                                    hashes,
+                                    collected: Vec::with_capacity(total),
+                                    total,
+                                    response,
+                                });
+                                batch
+                            }
                         }
                     },
                     // Channel closed. Exit gracefully.
@@ -475,7 +513,7 @@ impl ExecutorThread {
                 0.0
             };
             for (btx, res) in executed_txs.txs.iter().zip(blockifier_results.iter()) {
-                match res {
+                let outcome = match res {
                     Ok((execution_info, _state_diff)) => {
                         tracing::trace!("Successful execution of transaction {:#x}", btx.tx_hash().to_felt());
 
@@ -489,12 +527,16 @@ impl ExecutorThread {
                         stats.n_added_to_block += 1;
                         stats.l2_gas_consumed += u128::from(execution_info.receipt.gas.l2_gas.0);
                         block_empty = false;
-                        if execution_info.revert_error.is_some() {
+                        if let Some(revert_error) = execution_info.revert_error.as_ref() {
                             stats.n_reverted += 1;
-                        } else if let Some((class_hash, contract_class)) = btx.declared_contract_class() {
-                            tracing::debug!("Declared class_hash={:#x}", class_hash.to_felt());
-                            stats.declared_classes += 1;
-                            execution_state.declared_classes.insert(class_hash, contract_class);
+                            super::TxExecutionOutcome::Reverted(revert_error.to_string())
+                        } else {
+                            if let Some((class_hash, contract_class)) = btx.declared_contract_class() {
+                                tracing::debug!("Declared class_hash={:#x}", class_hash.to_felt());
+                                stats.declared_classes += 1;
+                                execution_state.declared_classes.insert(class_hash, contract_class);
+                            }
+                            super::TxExecutionOutcome::Succeeded
                         }
                     }
                     Err(err) => {
@@ -507,10 +549,26 @@ impl ExecutorThread {
                             btx.tx_hash().to_felt()
                         );
                         stats.n_rejected += 1;
+                        super::TxExecutionOutcome::Rejected(format!("{err:#}"))
+                    }
+                };
+
+                // If this transaction belongs to the in-flight atomic batch, record its outcome.
+                if let Some(tracker) = active_batch.as_mut() {
+                    let tx_hash = btx.tx_hash().to_felt();
+                    if tracker.hashes.contains(&tx_hash) {
+                        tracker.collected.push((tx_hash, outcome));
                     }
                 }
             }
             l2_gas_consumed_block += stats.l2_gas_consumed;
+
+            // Once every transaction in the batch has been executed, reply to the submitter.
+            if active_batch.as_ref().is_some_and(|t| t.collected.len() >= t.total) {
+                if let Some(tracker) = active_batch.take() {
+                    let _ = tracker.response.send(tracker.collected);
+                }
+            }
 
             tracing::debug!("Finished batch execution.");
             tracing::debug!("Stats: {:?}", stats);

--- a/madara/crates/client/block_production/src/handle.rs
+++ b/madara/crates/client/block_production/src/handle.rs
@@ -1,4 +1,5 @@
-use crate::executor::{self, ExecutorCommand, ExecutorCommandError};
+use crate::executor::{self, BatchExecutionOutcome, ExecutorCommand, ExecutorCommandError};
+use crate::util::{AdditionalTxInfo, BatchToExecute};
 use async_trait::async_trait;
 use mc_db::MadaraBackend;
 use mc_submit_tx::{
@@ -6,13 +7,13 @@ use mc_submit_tx::{
     TransactionValidator, TransactionValidatorConfig,
 };
 use mp_rpc::admin::BroadcastedDeclareTxnV0;
-use mp_rpc::v0_10_2::BroadcastedInvokeTxn;
+use mp_rpc::v0_10_2::{BroadcastedInvokeTxn, BroadcastedTxn};
 use mp_rpc::v0_9_0::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, ClassAndTxnHash, ContractAndTxnHash,
 };
 use mp_transactions::validated::ValidatedTransaction;
 use mp_transactions::{L1HandlerTransactionResult, L1HandlerTransactionWithFee};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot};
 
 struct BypassInput(mpsc::Sender<ValidatedTransaction>);
@@ -32,6 +33,41 @@ impl SubmitValidatedTransaction for BypassInput {
     }
 }
 
+/// Captures the [`ValidatedTransaction`]s produced by a [`TransactionValidator`] instead of
+/// forwarding them to the mempool, so we can collect a whole batch and hand it to the executor as a
+/// single contiguous unit. Used only by [`BlockProductionHandle::submit_transaction_batch`].
+#[derive(Default)]
+struct BatchCollector(Mutex<Vec<ValidatedTransaction>>);
+
+#[async_trait]
+impl SubmitValidatedTransaction for BatchCollector {
+    async fn submit_validated_transaction(&self, tx: ValidatedTransaction) -> Result<(), SubmitTransactionError> {
+        self.0.lock().expect("BatchCollector lock poisoned").push(tx);
+        Ok(())
+    }
+    async fn received_transaction(&self, _hash: starknet_types_core::felt::Felt) -> Option<bool> {
+        None
+    }
+    async fn subscribe_new_transactions(
+        &self,
+    ) -> Option<tokio::sync::broadcast::Receiver<starknet_types_core::felt::Felt>> {
+        None
+    }
+}
+
+/// Error returned when submitting a transaction batch for contiguous execution.
+#[derive(Debug, thiserror::Error)]
+pub enum BatchSubmitError {
+    #[error("Transaction batch is empty")]
+    EmptyBatch,
+    #[error("Transaction batch too large: {len} transactions (max {max})")]
+    BatchTooLarge { len: usize, max: usize },
+    #[error("Transaction at index {index} failed validation: {reason}")]
+    Validation { index: usize, reason: String },
+    #[error("Internal error: {0:#}")]
+    Internal(#[from] anyhow::Error),
+}
+
 #[derive(Clone, Debug)]
 /// Remotely control block production.
 pub struct BlockProductionHandle {
@@ -40,6 +76,12 @@ pub struct BlockProductionHandle {
     bypass_input: mpsc::Sender<ValidatedTransaction>,
     /// We use TransactionValidator to handle conversion to blockifier, class compilation etc. Mostly for convenience.
     tx_converter: Arc<TransactionValidator>,
+    /// Backend, used to build a validation-enabled converter and read config for batch submission.
+    backend: Arc<MadaraBackend>,
+    /// Whether fees are disabled for this node (mirrored into the batch validator config).
+    no_charge_fee: bool,
+    /// Serializes transaction-batch submissions: only one batch executes at a time.
+    batch_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl BlockProductionHandle {
@@ -54,10 +96,13 @@ impl BlockProductionHandle {
             bypass_input: bypass_input.clone(),
             tx_converter: TransactionValidator::new(
                 Arc::new(BypassInput(bypass_input)),
-                backend,
+                backend.clone(),
                 TransactionValidatorConfig { disable_validation: true, disable_fee: no_charge_fee },
             )
             .into(),
+            backend,
+            no_charge_fee,
+            batch_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -73,6 +118,66 @@ impl BlockProductionHandle {
     /// Send a transaction through the bypass channel to bypass mempool and validation.
     pub async fn send_tx_raw(&self, tx: ValidatedTransaction) -> Result<(), ExecutorCommandError> {
         self.bypass_input.send(tx).await.map_err(|_| ExecutorCommandError::ChannelClosed)
+    }
+
+    /// Submit a batch of transactions to be executed contiguously: all the transactions are fed to
+    /// the executor back-to-back, in submission order, with no foreign transaction executed between
+    /// any two of them (across block boundaries if the batch does not fit in a single block).
+    ///
+    /// This is an *ordering* guarantee, not an atomicity one: individual transactions may still
+    /// revert or be rejected during execution. The returned outcomes report, in submission order,
+    /// what happened to each transaction.
+    ///
+    /// Each transaction is fully validated (signature/nonce/fee) before execution; if any fails
+    /// validation, the whole submission is rejected (a dependent sequence with a hole is
+    /// meaningless). Submissions are serialized: only one batch executes at a time.
+    pub async fn submit_transaction_batch(
+        &self,
+        txs: Vec<BroadcastedTxn>,
+    ) -> Result<BatchExecutionOutcome, BatchSubmitError> {
+        if txs.is_empty() {
+            return Err(BatchSubmitError::EmptyBatch);
+        }
+        let max = self.backend.chain_config().max_transaction_batch_size;
+        if txs.len() > max {
+            return Err(BatchSubmitError::BatchTooLarge { len: txs.len(), max });
+        }
+
+        // Validate + convert each transaction in order, capturing the resulting
+        // `ValidatedTransaction`s instead of forwarding them to the mempool.
+        let collector = Arc::new(BatchCollector::default());
+        let validator = TransactionValidator::new(
+            collector.clone(),
+            self.backend.clone(),
+            TransactionValidatorConfig { disable_validation: false, disable_fee: self.no_charge_fee },
+        );
+        for (index, tx) in txs.into_iter().enumerate() {
+            let res = match tx {
+                BroadcastedTxn::Invoke(tx) => validator.submit_invoke_transaction(tx).await.map(|_| ()),
+                BroadcastedTxn::Declare(tx) => validator.submit_declare_transaction(tx).await.map(|_| ()),
+                BroadcastedTxn::DeployAccount(tx) => validator.submit_deploy_account_transaction(tx).await.map(|_| ()),
+            };
+            res.map_err(|err| BatchSubmitError::Validation { index, reason: err.to_string() })?;
+        }
+        let validated = std::mem::take(&mut *collector.0.lock().expect("BatchCollector lock poisoned"));
+
+        // Convert the validated transactions into a single contiguous execution batch.
+        let mut batch = BatchToExecute::with_capacity(validated.len());
+        for vtx in validated {
+            let (btx, ts, declared_class) =
+                vtx.into_blockifier_for_sequencing().map_err(|e| BatchSubmitError::Internal(e.into()))?;
+            batch.push(btx, AdditionalTxInfo { declared_class, arrived_at: ts });
+        }
+
+        // Serialize batches: hold the lock across send + await so only one batch is in flight.
+        let _guard = self.batch_lock.lock().await;
+        let (response_tx, response_rx) = oneshot::channel();
+        self.executor_commands
+            .send(ExecutorCommand::ExecuteBatch { batch, response: response_tx })
+            .map_err(|_| BatchSubmitError::Internal(anyhow::anyhow!("Block production executor is not running")))?;
+        response_rx
+            .await
+            .map_err(|_| BatchSubmitError::Internal(anyhow::anyhow!("Executor dropped the batch before completion")))
     }
 }
 

--- a/madara/crates/client/block_production/src/handle.rs
+++ b/madara/crates/client/block_production/src/handle.rs
@@ -170,11 +170,19 @@ impl BlockProductionHandle {
         }
 
         // Serialize batches: hold the lock across send + await so only one batch is in flight.
+        // This is required for correctness, not just fairness: the executor tracks a single in-flight
+        // batch, so two concurrent `ExecuteBatch` commands would clobber each other's tracking.
         let _guard = self.batch_lock.lock().await;
         let (response_tx, response_rx) = oneshot::channel();
         self.executor_commands
             .send(ExecutorCommand::ExecuteBatch { batch, response: response_tx })
             .map_err(|_| BatchSubmitError::Internal(anyhow::anyhow!("Block production executor is not running")))?;
+        // The await is intentionally unbounded. If the executor thread dies/panics, the response
+        // sender is dropped and this resolves to an error immediately (see map_err below). A timeout
+        // that released the lock early would be unsafe: the executor would still be draining this
+        // batch, so a subsequent batch could clobber its tracking and the caller could get a spurious
+        // error while the transactions still land on chain. A genuinely stuck executor stalls all
+        // block production regardless, so failing only this call would not help the node.
         response_rx
             .await
             .map_err(|_| BatchSubmitError::Internal(anyhow::anyhow!("Executor dropped the batch before completion")))

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -158,7 +158,8 @@ mod handle;
 pub mod metrics;
 mod util;
 
-pub use handle::BlockProductionHandle;
+pub use executor::{BatchExecutionOutcome, TxExecutionOutcome};
+pub use handle::{BatchSubmitError, BlockProductionHandle};
 
 /// Used for listening to state changes in tests.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/madara/crates/client/block_production/src/lib.rs
+++ b/madara/crates/client/block_production/src/lib.rs
@@ -1991,6 +1991,62 @@ pub(crate) mod tests {
         );
     }
 
+    /// Exercises the full `submit_transaction_batch` path (validation + contiguous execution) for a
+    /// dependent sequential-nonce batch. The executor-level test sends the raw `ExecuteBatch` command
+    /// and so skips validation; here the second transaction has nonce 1 while the on-chain nonce is 0,
+    /// so the validator must accept the "future" nonce for the batch to be admitted and both
+    /// transactions to execute successfully.
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(100))]
+    #[tokio::test]
+    async fn test_submit_transaction_batch_sequential_nonces(
+        #[future]
+        #[with(Duration::from_secs(3000000000), false)]
+        devnet_setup: DevnetSetup,
+    ) {
+        use mp_rpc::v0_10_2::BroadcastedTxn as BroadcastedTxnLatest;
+
+        let mut devnet_setup = devnet_setup.await;
+        let block_production_task = devnet_setup.block_prod_task();
+        let control = block_production_task.handle();
+        let _task =
+            AbortOnDrop::spawn(
+                async move { block_production_task.run(ServiceContext::new_for_testing()).await.unwrap() },
+            );
+
+        let erc20 = Felt::from_hex_unchecked("0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d");
+        let sender = &devnet_setup.contracts.0[0];
+        let receiver = &devnet_setup.contracts.0[1];
+        // Two transfers from the same account with sequential nonces 0 and 1.
+        let transfer = |nonce: Felt| {
+            BroadcastedTxnLatest::Invoke(
+                make_invoke_tx(
+                    sender,
+                    Multicall::default().with(Call {
+                        to: erc20,
+                        selector: Selector::from("transfer"),
+                        calldata: vec![receiver.address, Felt::from(1_000u128), Felt::ZERO],
+                    }),
+                    &devnet_setup.backend,
+                    nonce,
+                )
+                .into(),
+            )
+        };
+
+        let outcomes = control
+            .submit_transaction_batch(vec![transfer(Felt::ZERO), transfer(Felt::ONE)])
+            .await
+            .expect("batch should be accepted and executed");
+
+        // Both transactions were admitted (the validator accepted the future nonce on the second
+        // one) and executed successfully, in submission order.
+        assert_eq!(outcomes.len(), 2);
+        for (_, outcome) in &outcomes {
+            assert!(matches!(outcome, crate::TxExecutionOutcome::Succeeded), "unexpected outcome: {outcome:?}");
+        }
+    }
+
     /// Verifies that re-execution uses the saved `no_charge_fee` value.
     ///
     /// # Flow

--- a/madara/crates/client/rpc/src/errors.rs
+++ b/madara/crates/client/rpc/src/errors.rs
@@ -416,6 +416,20 @@ impl From<SubmitTransactionError> for StarknetRpcApiError {
     }
 }
 
+impl From<mc_block_production::BatchSubmitError> for StarknetRpcApiError {
+    fn from(value: mc_block_production::BatchSubmitError) -> Self {
+        use mc_block_production::BatchSubmitError as E;
+        match value {
+            E::Internal(error) => {
+                display_internal_server_error(error);
+                StarknetRpcApiError::InternalServerError
+            }
+            // EmptyBatch / BatchTooLarge / Validation are all client-side input errors.
+            other => StarknetRpcApiError::ValidationFailure { error: Cow::Owned(other.to_string()) },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -893,6 +893,9 @@ pub fn rpc_api_user(starknet: &Starknet) -> anyhow::Result<RpcModule<()>> {
     rpc_api.merge(versions::user::v0_10_2::StarknetWsRpcApiV0_10_2Server::into_rpc(starknet.clone()))?;
     rpc_api.merge(versions::user::v0_10_2::StarknetTraceRpcApiV0_10_2Server::into_rpc(starknet.clone()))?;
 
+    // Madara-specific extension served on the public user port (madara_ namespace).
+    rpc_api.merge(versions::user::v0_10_2::MadaraTxBatchRpcApiV0_10_2Server::into_rpc(starknet.clone()))?;
+
     Ok(rpc_api)
 }
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/write/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/write/mod.rs
@@ -1,7 +1,11 @@
-use crate::versions::user::v0_10_2::StarknetWriteRpcApiV0_10_2Server;
+use crate::versions::user::v0_10_2::{
+    BroadcastedTxnBatch, MadaraTxBatchRpcApiV0_10_2Server, StarknetWriteRpcApiV0_10_2Server, TxnBatchEntry,
+    TxnBatchExecutionStatus, TxnBatchResult,
+};
 use crate::versions::user::v0_8_1::StarknetWriteRpcApiV0_8_1Server as V0_8_1Impl;
-use crate::Starknet;
+use crate::{Starknet, StarknetRpcApiError};
 use jsonrpsee::core::{async_trait, RpcResult};
+use mc_block_production::TxExecutionOutcome;
 use mp_rpc::v0_10_2::{
     AddInvokeTransactionResult, BroadcastedDeclareTxn, BroadcastedDeployAccountTxn, BroadcastedInvokeTxn,
     ClassAndTxnHash, ContractAndTxnHash,
@@ -29,5 +33,29 @@ impl StarknetWriteRpcApiV0_10_2Server for Starknet {
             .submit_invoke_transaction(invoke_transaction)
             .await
             .map_err(crate::StarknetRpcApiError::from)?)
+    }
+}
+
+#[async_trait]
+impl MadaraTxBatchRpcApiV0_10_2Server for Starknet {
+    async fn add_transaction_batch(&self, batch: BroadcastedTxnBatch) -> RpcResult<TxnBatchResult> {
+        // Only available in block production (sequencer) mode.
+        let handle = self.block_prod_handle.as_ref().ok_or(StarknetRpcApiError::UnimplementedMethod)?;
+
+        let outcomes = handle.submit_transaction_batch(batch.transactions).await.map_err(StarknetRpcApiError::from)?;
+
+        let transactions = outcomes
+            .into_iter()
+            .map(|(transaction_hash, outcome)| TxnBatchEntry {
+                transaction_hash,
+                outcome: match outcome {
+                    TxExecutionOutcome::Succeeded => TxnBatchExecutionStatus::Succeeded,
+                    TxExecutionOutcome::Reverted(revert_reason) => TxnBatchExecutionStatus::Reverted { revert_reason },
+                    TxExecutionOutcome::Rejected(reason) => TxnBatchExecutionStatus::Rejected { reason },
+                },
+            })
+            .collect();
+
+        Ok(TxnBatchResult { transactions })
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/mod.rs
@@ -16,7 +16,54 @@ use starknet_types_core::felt::Felt;
 // Re-export BlockId from v0.10.0 (unchanged in v0.10.2)
 pub use mp_rpc::v0_10_0::BlockId;
 
+use serde::{Deserialize, Serialize};
+
 pub mod methods;
+
+/// A batch of transactions to be executed contiguously, submitted via `madara_addTransactionBatch`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BroadcastedTxnBatch {
+    pub transactions: Vec<BroadcastedTxn>,
+}
+
+/// Per-transaction execution result of a contiguous batch.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "execution_status", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TxnBatchExecutionStatus {
+    /// Executed successfully and included in a block.
+    Succeeded,
+    /// Executed but reverted (still included in a block, fees charged).
+    Reverted { revert_reason: String },
+    /// Could not be included (e.g. Declare/DeployAccount error or internal error).
+    Rejected { reason: String },
+}
+
+/// One entry of a [`TxnBatchResult`], pairing a transaction hash with its outcome.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TxnBatchEntry {
+    pub transaction_hash: Felt,
+    #[serde(flatten)]
+    pub outcome: TxnBatchExecutionStatus,
+}
+
+/// Result of `madara_addTransactionBatch`: per-transaction outcomes, in submission order.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TxnBatchResult {
+    pub transactions: Vec<TxnBatchEntry>,
+}
+
+/// Madara-specific extension methods served on the public user RPC port.
+#[versioned_rpc("V0_10_2", "madara")]
+pub trait MadaraTxBatchRpcApi {
+    /// Submit a batch of transactions to be executed contiguously: all of them are fed to the
+    /// executor back-to-back, in submission order, with no foreign transaction executed between any
+    /// two of them (across block boundaries if the batch does not fit in a single block).
+    ///
+    /// This is an *ordering* guarantee, not atomicity: individual transactions may still revert or
+    /// be rejected. The result reports each transaction's outcome in submission order.
+    #[method(name = "addTransactionBatch")]
+    async fn add_transaction_batch(&self, batch: BroadcastedTxnBatch) -> RpcResult<TxnBatchResult>;
+}
 
 #[versioned_rpc("V0_10_2", "starknet")]
 pub trait StarknetReadRpcApi {

--- a/madara/crates/primitives/chain_config/src/chain_config.rs
+++ b/madara/crates/primitives/chain_config/src/chain_config.rs
@@ -156,6 +156,12 @@ fn default_l1_messages_finality_blocks() -> u64 {
 fn default_mempool_min_tip_bump() -> f64 {
     0.1
 }
+fn default_max_transaction_batch_size() -> usize {
+    // Maximum number of transactions accepted in a single `madara_addTransactionBatch` call.
+    // This bounds how long a batch can monopolize block production (batches execute contiguously,
+    // pausing normal transaction inclusion), which matters since the endpoint is public.
+    100
+}
 
 #[derive(thiserror::Error, Debug)]
 #[error("Unsupported protocol version: {0}")]
@@ -293,6 +299,9 @@ pub struct ChainConfigV2 {
     /// Max age of a transaction in the mempool.
     #[serde(deserialize_with = "deserialize_optional_duration", serialize_with = "serialize_optional_duration")]
     pub mempool_ttl: Option<Duration>,
+    /// Maximum number of transactions accepted in a single `madara_addTransactionBatch` call.
+    #[serde(default = "default_max_transaction_batch_size")]
+    pub max_transaction_batch_size: usize,
     /// L2 gas price configuration - either fixed or EIP-1559 dynamic pricing
     pub l2_gas_price: L2GasPrice,
 
@@ -421,6 +430,9 @@ pub struct ChainConfig {
     /// Max age of a transaction in the mempool.
     #[serde(deserialize_with = "deserialize_optional_duration", serialize_with = "serialize_optional_duration")]
     pub mempool_ttl: Option<Duration>,
+    /// Maximum number of transactions accepted in a single `madara_addTransactionBatch` call.
+    #[serde(default = "default_max_transaction_batch_size")]
+    pub max_transaction_batch_size: usize,
     /// L2 gas price configuration - either fixed or EIP-1559 dynamic pricing
     pub l2_gas_price: L2GasPrice,
 
@@ -478,6 +490,7 @@ impl Clone for ChainConfig {
             mempool_max_transactions: self.mempool_max_transactions,
             mempool_max_declare_transactions: self.mempool_max_declare_transactions,
             mempool_ttl: self.mempool_ttl,
+            max_transaction_batch_size: self.max_transaction_batch_size,
             l2_gas_price: self.l2_gas_price.clone(),
             block_production_concurrency: self.block_production_concurrency.clone(),
             l1_messages_replay_max_duration: self.l1_messages_replay_max_duration,
@@ -516,6 +529,7 @@ impl TryFrom<ChainConfigV2> for ChainConfig {
             mempool_max_transactions: v2.mempool_max_transactions,
             mempool_max_declare_transactions: v2.mempool_max_declare_transactions,
             mempool_ttl: v2.mempool_ttl,
+            max_transaction_batch_size: v2.max_transaction_batch_size,
             l2_gas_price: v2.l2_gas_price,
             block_production_concurrency: v2.block_production_concurrency,
             l1_messages_replay_max_duration: v2.l1_messages_replay_max_duration,
@@ -637,6 +651,7 @@ impl ChainConfig {
             mempool_max_declare_transactions: Some(20),
             mempool_ttl: Some(Duration::from_secs(60 * 60)), // an hour?
             mempool_min_tip_bump: 0.1,
+            max_transaction_batch_size: default_max_transaction_batch_size(),
             l2_gas_price: L2GasPrice::starknet_mainnet(),
 
             block_production_concurrency: BlockProductionConfig::default(),

--- a/madara/node/src/cli/chain_config_overrides.rs
+++ b/madara/node/src/cli/chain_config_overrides.rs
@@ -100,6 +100,7 @@ pub struct ChainConfigOverridesInner {
     pub mempool_max_declare_transactions: Option<usize>,
     #[serde(deserialize_with = "deserialize_optional_duration", serialize_with = "serialize_optional_duration")]
     pub mempool_ttl: Option<Duration>,
+    pub max_transaction_batch_size: usize,
     pub l2_gas_price: L2GasPrice,
     pub no_empty_blocks: bool,
     pub block_production_concurrency: BlockProductionConfig,
@@ -136,6 +137,7 @@ impl ChainConfigOverrideParams {
             mempool_max_transactions: chain_config.mempool_max_transactions,
             mempool_max_declare_transactions: chain_config.mempool_max_declare_transactions,
             mempool_ttl: chain_config.mempool_ttl,
+            max_transaction_batch_size: chain_config.max_transaction_batch_size,
             l2_gas_price: chain_config.l2_gas_price,
             feeder_gateway_url: chain_config.feeder_gateway_url,
             gateway_url: chain_config.gateway_url,
@@ -200,6 +202,7 @@ impl ChainConfigOverrideParams {
             mempool_max_transactions: chain_config.mempool_max_transactions,
             mempool_max_declare_transactions: chain_config.mempool_max_declare_transactions,
             mempool_ttl: chain_config.mempool_ttl,
+            max_transaction_batch_size: chain_config_overrides.max_transaction_batch_size,
             l2_gas_price: chain_config_overrides.l2_gas_price,
             no_empty_blocks: chain_config_overrides.no_empty_blocks,
             block_production_concurrency: chain_config_overrides.block_production_concurrency,

--- a/madara/node/src/cli/chain_config_overrides.rs
+++ b/madara/node/src/cli/chain_config_overrides.rs
@@ -70,6 +70,9 @@ pub struct ChainConfigOverrideParams {
     ///
     ///   * mempool_ttl: max age of transactions in the mempool.
     ///     Transactions which are too old will be removed.
+    ///
+    ///   * max_transaction_batch_size: max number of transactions accepted in a
+    ///     single madara_addTransactionBatch RPC call.
     #[clap(env = "MADARA_CHAIN_CONFIG_OVERRIDE", long = "chain-config-override", value_parser = parse_key_value_yaml, use_value_delimiter = true, value_delimiter = ',')]
     pub overrides: Vec<(String, Value)>,
 }


### PR DESCRIPTION
## Summary

Adds a **public** user-port RPC method **`madara_addTransactionBatch`** that executes a batch of transactions **contiguously**: all transactions are fed to the executor back-to-back, in submission order, with **no foreign transaction** (mempool, L1→L2, bypass) executed **between** any two of them — even when the batch spans multiple blocks.

This is an **ordering** guarantee, **not** atomicity. There is no rollback: individual transactions may still revert or be rejected during execution (handled exactly as in the normal flow). The response reports each transaction's outcome — `succeeded` / `reverted` / `rejected` — in submission order. Successful transactions are ordinary on-chain txs, queryable via the existing RPC.

## How it works

- **Single-unit delivery preserves contiguity.** The batch is delivered to the single-threaded executor as one indivisible unit (via a new `ExecutorCommand::ExecuteBatch`), bypassing the batcher that would otherwise re-chunk it across the mempool/L1 streams. Because executed-tx leftovers always stay at the *front* of the executor queue and top-ups always append at the *back*, a foreign tx can never be inserted between two batch txs — so contiguity holds across block-full boundaries without any explicit "exclusive drain" mode.
- **Per-tx outcomes** are tracked by tx-hash set and returned once the whole batch has executed.
- **Validation + serialization.** Each tx is validated as an ordered sequence (dependent / sequential-nonce batches are supported), and batches are serialized so only one is in flight at a time.
- **DoS bound.** `max_transaction_batch_size` (default 100, CLI-overridable) caps how long a batch can monopolize block production, which matters since the endpoint is public.

## Changes

| Area | Change |
|------|--------|
| `block_production/executor` | `ExecutorCommand::ExecuteBatch`, `TxExecutionOutcome`, contiguous execution + per-tx outcome tracking |
| `block_production/handle` | `submit_transaction_batch` (validate sequence → serialize → execute → outcomes), `BatchSubmitError` |
| `rpc` | `madara_`-namespaced trait/types on the user port, registration in `rpc_api_user`, error mapping |
| `chain_config` / node CLI | `max_transaction_batch_size` config |
| tests | executor-level test for `ExecuteBatch` |

## Testing

- `cargo check` / `clippy` clean across `mp-chain-config`, `mc-block-production`, `mc-rpc`, and the `madara` node; `cargo fmt --check` passes.
- New `test_execute_batch_command` (a 2-tx dependent sequential-nonce batch) passes; all existing executor and chain-config tests pass.

## Notes / follow-ups

- End-to-end devnet integration test (calling the live endpoint with a deploy→fund→call batch) not yet added.
- No per-IP rate limiting; relies on the size cap + serialization + validation + existing jsonrpsee connection/body-size limits.
