### PR TITLE
[codex] Remove sensitive signer debug log

### DIFF
--- a/bootstrapper/src/contract_clients/utils.rs
+++ b/bootstrapper/src/contract_clients/utils.rs
@@ -200,7 +200,6 @@ pub(crate) async fn deploy_account_using_priv_key(
     let chain_id = provider.chain_id().await.unwrap();
 
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(Felt::from_hex(&priv_key).unwrap()));
-    log::debug!("signer : {:?}", signer);
     let mut oz_account_factory =
         OpenZeppelinAccountFactory::new(oz_account_class_hash, chain_id, signer, provider).await.unwrap();
     oz_account_factory.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));


### PR DESCRIPTION
## Summary

- removes the debug log that printed the `LocalWallet` created from `SigningKey::from_secret_scalar`
- keeps the later public account deployment address log intact

## Why

CodeQL alert #102 reports cleartext logging of sensitive material. In the legacy bootstrapper, `LocalWallet` derives `Debug` and contains a `SigningKey`, which also derives `Debug` and stores `secret_scalar`, so logging the signer can expose private key material.

## Validation

- `cargo fmt -- --check` in `bootstrapper/`
- `cargo check` in `bootstrapper/` was attempted, but the legacy build failed because required bridge artifact JSON files are missing after the build script failed to pull `ghcr.io/madara-alliance/artifacts:9` with Docker:
  - `../build-artifacts/starkgate_latest/eth_bridge_upgraded.json`
  - `../build-artifacts/starkgate_latest/eic_eth_bridge.json`