### PR TITLE
Bridge SNOS log events into orchestrator logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2783,7 +2783,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2803,7 +2803,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5298,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5307,7 +5307,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6515,7 +6515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.3#39c5dbfbb6a265ea910ba8851399a3309bad5009"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8374,7 +8374,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10787,7 +10787,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12392,7 +12392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12405,7 +12405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12494,7 +12494,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13007,7 +13007,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.3#39c5dbfbb6a265ea910ba8851399a3309bad5009"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -13277,7 +13277,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13418,7 +13418,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14433,7 +14433,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.3#39c5dbfbb6a265ea910ba8851399a3309bad5009"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",
@@ -15185,7 +15185,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15205,7 +15205,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16607,7 +16607,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11242,6 +11242,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-error",
+ "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 # This rev fixes SNOS to fetch the revert reason from RPC itself instead of filtering the reason got from trace
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "v0.14.2-rc.3" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "v0.14.2-rc.4" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -109,6 +109,7 @@ opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "logs"] }
 tracing = { workspace = true }
 tracing-error = "0.2.1"
+tracing-log = "0.2"
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -8,6 +8,7 @@ use tracing::{
     Event, Level, Subscriber,
 };
 use tracing_error::ErrorLayer;
+use tracing_log::NormalizeEvent;
 use tracing_subscriber::field::{MakeVisitor, VisitFmt, VisitOutput};
 use tracing_subscriber::fmt::FmtContext;
 use tracing_subscriber::fmt::{format::Writer, FormatEvent, FormatFields};
@@ -115,7 +116,8 @@ where
     N: for<'a> FormatFields<'a> + 'static,
 {
     fn format_event(&self, ctx: &FmtContext<'_, S, N>, mut writer: Writer<'_>, event: &Event<'_>) -> std::fmt::Result {
-        let meta = event.metadata();
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
         let now = Utc::now().format("%y-%m-%d %H:%M:%S").to_string();
 
         // Extract queue from span fields
@@ -257,7 +259,8 @@ where
     N: for<'a> FormatFields<'a> + 'static,
 {
     fn format_event(&self, ctx: &FmtContext<'_, S, N>, mut writer: Writer<'_>, event: &Event<'_>) -> std::fmt::Result {
-        let meta = event.metadata();
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
         let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
         // Extract event message and fields
@@ -400,6 +403,10 @@ pub fn init_logging() {
         .install()
         .expect("Unable to install color_eyre");
 
+    // Bridge library crates using the `log` facade, such as SNOS, into the
+    // orchestrator tracing subscriber so `RUST_LOG` filtering applies to them.
+    let _ = tracing_log::LogTracer::init();
+
     // Read from `RUST_LOG` environment variable, with fallback to default
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         // Fallback if RUST_LOG is not set or invalid
@@ -457,6 +464,7 @@ pub fn init_logging() {
 ///
 /// - **Orchestrator crates** → Specific service names (ATLANTIC, UTILS, GPS_FACT_CHK, etc.)
 /// - **Generic orchestrator** → "-" (no specific service, core orchestrator code)
+/// - **SNOS crates** → "SNOS" (`generate_pie` / `rpc_client` logs bridged through `log`)
 /// - **Third-party dependencies** → "EXTERNAL" (logs from Rust ecosystem crates)
 ///
 /// Note: "EXTERNAL" refers to third-party Rust crates (tokio, hyper, reqwest, etc.),
@@ -467,6 +475,8 @@ pub fn init_logging() {
 /// ```ignore
 /// extract_service_name("orchestrator_atlantic_service::client") → "ATLANTIC"
 /// extract_service_name("orchestrator_utils::logging")           → "UTILS"
+/// extract_service_name("generate_pie::state_update")            → "SNOS"
+/// extract_service_name("rpc_client::client")                    → "SNOS"
 /// extract_service_name("orchestrator::core::config")            → "-"
 /// extract_service_name("tokio::runtime")                        → "EXTERNAL"
 /// extract_service_name("hyper::client")                         → "EXTERNAL"
@@ -480,10 +490,23 @@ fn extract_service_name(target: &str) -> &'static str {
         "PROVER_IFACE"
     } else if target.starts_with("orchestrator_utils") {
         "UTILS"
+    } else if target.starts_with("generate_pie") || target.starts_with("rpc_client") {
+        "SNOS"
     } else if target.starts_with("orchestrator") {
         "-"
     } else {
         "EXTERNAL"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_service_name;
+
+    #[test]
+    fn classify_snos_targets() {
+        assert_eq!(extract_service_name("generate_pie::state_update"), "SNOS");
+        assert_eq!(extract_service_name("rpc_client::client"), "SNOS");
     }
 }
 

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -498,17 +498,6 @@ fn extract_service_name(target: &str) -> &'static str {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::extract_service_name;
-
-    #[test]
-    fn classify_snos_targets() {
-        assert_eq!(extract_service_name("generate_pie::state_update"), "SNOS");
-        assert_eq!(extract_service_name("rpc_client::client"), "SNOS");
-    }
-}
-
 /// Function used by the logger to display queue with pretty formatting
 pub fn queue_type_to_parts(queue_type: &str) -> (String, String) {
     // Special cases
@@ -526,4 +515,15 @@ pub fn queue_type_to_parts(queue_type: &str) -> (String, String) {
     // Remove "_job" or "_JOB" if present
     let prefix = prefix.trim_end_matches("_job").trim_end_matches("_JOB");
     (prefix.to_uppercase(), suffix.to_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_service_name;
+
+    #[test]
+    fn classify_snos_targets() {
+        assert_eq!(extract_service_name("generate_pie::state_update"), "SNOS");
+        assert_eq!(extract_service_name("rpc_client::client"), "SNOS");
+    }
 }

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -412,9 +412,7 @@ pub fn init_logging() {
         // Fallback if RUST_LOG is not set or invalid. Keep orchestrator INFO
         // logs by default, but require explicit opt-in for bridged SNOS and
         // other third-party log targets.
-        EnvFilter::builder()
-            .parse("error,orchestrator=info")
-            .expect("Invalid filter directive and Logger control")
+        EnvFilter::builder().parse("error,orchestrator=info").expect("Invalid filter directive and Logger control")
     });
 
     // Check LOG_FORMAT environment variable

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -489,7 +489,7 @@ fn extract_service_name(target: &str) -> &'static str {
         "PROVER_IFACE"
     } else if target.starts_with("orchestrator_utils") {
         "UTILS"
-    } else if target.starts_with("generate_pie") || target.starts_with("rpc_client") {
+    } else if target.starts_with("generate_pie") || target == "rpc_client" || target.starts_with("rpc_client::") {
         "SNOS"
     } else if target.starts_with("orchestrator") {
         "-"

--- a/orchestrator/src/utils/logging.rs
+++ b/orchestrator/src/utils/logging.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::fmt as stdfmt;
 use tracing::{
     field::{Field, Visit},
-    Event, Level, Subscriber,
+    Event, Subscriber,
 };
 use tracing_error::ErrorLayer;
 use tracing_log::NormalizeEvent;
@@ -409,10 +409,11 @@ pub fn init_logging() {
 
     // Read from `RUST_LOG` environment variable, with fallback to default
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        // Fallback if RUST_LOG is not set or invalid
+        // Fallback if RUST_LOG is not set or invalid. Keep orchestrator INFO
+        // logs by default, but require explicit opt-in for bridged SNOS and
+        // other third-party log targets.
         EnvFilter::builder()
-            .with_default_directive(Level::INFO.into())
-            .parse("orchestrator=info")
+            .parse("error,orchestrator=info")
             .expect("Invalid filter directive and Logger control")
     });
 


### PR DESCRIPTION
## Summary
- install a `tracing_log::LogTracer` bridge in orchestrator logging init
- preserve original `log` metadata when formatting bridged events
- classify `generate_pie` and `rpc_client` targets as SNOS in orchestrator log output

## Why
Orchestrator calls SNOS as a library. SNOS emits via the `log` facade, while orchestrator configures a `tracing` subscriber. This bridge makes SNOS library logs visible through orchestrator logging so `RUST_LOG` filters can target them.

## Notes
Use `RUST_LOG=generate_pie=warn,rpc_client=warn,orchestrator=info` to surface the SNOS retry warnings through orchestrator logs.

## Testing
- started `cargo check -p orchestrator` in the clean worktree but did not wait for the full workspace compile to complete
- added a small unit test for SNOS target classification