### PR TITLE
feat(rpc): Starknet 0.14.3 full node compliance with RPC spec v0.10.3

### DIFF
--- a/madara/crates/client/db/src/lib.rs
+++ b/madara/crates/client/db/src/lib.rs
@@ -1286,6 +1286,12 @@ impl<D: MadaraStorage> MadaraBackend<D> {
             })
             .transpose()?;
         let (new_tip_block_n, new_tip_block_hash) = self.db.revert_to(new_tip_block_hash)?;
+        // The first-reverted block info had to be read before the revert deleted it; make sure
+        // the revert actually landed on the block that lookup was based on.
+        ensure!(
+            new_tip_block_n == requested_new_tip_block_n,
+            "Reverted tip block_n={new_tip_block_n} does not match requested target block_n={requested_new_tip_block_n}",
+        );
 
         if new_tip_block_n == previous_latest_confirmed_block_n {
             return Ok((new_tip_block_n, new_tip_block_hash));

--- a/madara/crates/client/mempool/src/chain_watcher_task.rs
+++ b/madara/crates/client/mempool/src/chain_watcher_task.rs
@@ -81,8 +81,12 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
     }
 
     /// This task updates all the l1, confirmed, pre-confirmed, candidates statuses by watching the backend chain tip and pre-confirmed block.
-    /// It is also responsible for adding transactions back into the mempool.
-    pub(super) async fn run_chain_watcher_task(&self, mut ctx: ServiceContext) -> anyhow::Result<()> {
+    /// When `update_mempool` is enabled, it is also responsible for adding transactions back into the mempool.
+    pub(super) async fn run_chain_watcher_task(
+        &self,
+        mut ctx: ServiceContext,
+        update_mempool: bool,
+    ) -> anyhow::Result<()> {
         let mut l1_new_heads_subscription = self.backend.subscribe_new_l1_confirmed_heads();
 
         let mut new_heads_subscription =
@@ -253,34 +257,40 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
                 removed.len()
             );
 
-            self.remove_saved_txs_by_hashes(confirmed_tx_hashes);
+            if update_mempool {
+                self.remove_saved_txs_by_hashes(confirmed_tx_hashes);
 
-            // Update nonces
-            let mut removed_txs = smallvec::SmallVec::<[ValidatedTransaction; 1]>::new();
-            if !nonce_updates.is_empty() {
-                let mut guard = self.inner.write().await;
-                for (contract_address, account_nonce) in nonce_updates {
-                    guard.update_account_nonce(
-                        &contract_address.try_into().context("Invalid contract address")?,
-                        &Nonce(account_nonce),
-                        &mut removed_txs,
-                    );
-                }
-                self.metrics.record_mempool_state(&guard.summary());
-            }
-            self.on_txs_removed(&removed_txs);
-
-            // Update the mempool with the modifications.
-            for (tx_hash, tx) in removed {
-                if put_back_into_mempool {
-                    // Try to add back to mempool.
-                    if let Err(err) = self.accept_tx((*tx).clone()).await {
-                        // Re-insertion may fail for various valid reasons: the tx has reached its TTL, the tx is a L1HandlerTransaction..
-                        // TODO: it may fail because of tip-bump / eviction score. Maybe we shouldn't drop the tx in these cases?
-                        tracing::debug!("Could not add transaction {:#x} back into mempool: {err:#}", tx.hash);
+                // Update nonces
+                let mut removed_txs = smallvec::SmallVec::<[ValidatedTransaction; 1]>::new();
+                if !nonce_updates.is_empty() {
+                    let mut guard = self.inner.write().await;
+                    for (contract_address, account_nonce) in nonce_updates {
+                        guard.update_account_nonce(
+                            &contract_address.try_into().context("Invalid contract address")?,
+                            &Nonce(account_nonce),
+                            &mut removed_txs,
+                        );
                     }
-                } else {
-                    // Drop the transaction entirely.
+                    self.metrics.record_mempool_state(&guard.summary());
+                }
+                self.on_txs_removed(&removed_txs);
+
+                // Update the mempool with the modifications.
+                for (tx_hash, tx) in removed {
+                    if put_back_into_mempool {
+                        // Try to add back to mempool.
+                        if let Err(err) = self.accept_tx((*tx).clone()).await {
+                            // Re-insertion may fail for various valid reasons: the tx has reached its TTL, the tx is a L1HandlerTransaction..
+                            // TODO: it may fail because of tip-bump / eviction score. Maybe we shouldn't drop the tx in these cases?
+                            tracing::debug!("Could not add transaction {:#x} back into mempool: {err:#}", tx.hash);
+                        }
+                    } else {
+                        // Drop the transaction entirely.
+                        self.set_transaction_status(tx_hash, None);
+                    }
+                }
+            } else {
+                for tx_hash in removed.into_keys() {
                     self.set_transaction_status(tx_hash, None);
                 }
             }
@@ -295,6 +305,7 @@ mod tests {
     use mc_db::test_utils::{add_test_block, l1_handler_tx_with_receipt};
     use mp_chain_config::ChainConfig;
     use mp_transactions::{validated::TxTimestamp, L1HandlerTransaction, Transaction};
+    use mp_utils::service::ServiceContext;
     use std::sync::Arc;
 
     fn saved_mempool_txs(backend: &mc_db::MadaraBackend) -> Vec<ValidatedTransaction> {
@@ -342,5 +353,36 @@ mod tests {
         mempool.remove_saved_txs_by_hashes(confirmed_tx_hashes);
 
         assert!(saved_mempool_txs(&backend).is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_task_publishes_future_confirmed_transactions_without_full_mempool() {
+        let backend = mc_db::MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
+        let tx_hash = Felt::from(456_u64);
+        let mempool = Arc::new(Mempool::new(backend.clone(), MempoolConfig::default().with_save_to_db(false)));
+        let mut watch = mempool.watch_transaction_status(tx_hash).unwrap();
+        let ctx = ServiceContext::new();
+
+        let task = {
+            let mempool = mempool.clone();
+            let ctx = ctx.clone();
+            tokio::spawn(async move { mempool.run_status_task(ctx).await })
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        add_test_block(&backend, 0, vec![l1_handler_tx_with_receipt(0, tx_hash)]);
+
+        let status = tokio::time::timeout(std::time::Duration::from_secs(5), watch.recv())
+            .await
+            .expect("Timed out waiting for status update")
+            .clone();
+
+        assert_eq!(
+            status,
+            Some(TransactionStatus::Confirmed { block_number: 0, transaction_index: 0, is_on_l1: false })
+        );
+
+        ctx.cancel_global();
+        task.await.expect("Status task panicked").expect("Status task failed");
     }
 }

--- a/madara/crates/client/mempool/src/lib.rs
+++ b/madara/crates/client/mempool/src/lib.rs
@@ -415,7 +415,12 @@ impl<D: MadaraStorageRead + MadaraStorageWrite> Mempool<D> {
     pub async fn run_mempool_task(&self, ctx: ServiceContext) -> anyhow::Result<()> {
         self.load_txs_from_db().await.context("Loading transactions from db on mempool startup.")?;
 
-        tokio::try_join!(self.run_ttl_task(ctx.clone()), self.run_chain_watcher_task(ctx))?;
+        tokio::try_join!(self.run_ttl_task(ctx.clone()), self.run_chain_watcher_task(ctx, true))?;
+        Ok(())
+    }
+
+    pub async fn run_status_task(&self, ctx: ServiceContext) -> anyhow::Result<()> {
+        self.run_chain_watcher_task(ctx, false).await?;
         Ok(())
     }
 

--- a/madara/crates/client/mempool/src/transaction_status.rs
+++ b/madara/crates/client/mempool/src/transaction_status.rs
@@ -31,7 +31,7 @@ pub enum PreConfirmationStatus {
 /// Subscription to transaction statuses.
 /// This struct only notifies of the most recent known status when it changes. The current value
 /// can be returned using [`WatchTransactionStatus::current`]. This current value will not change
-/// until you either call [`WatchTransactionStatus::refresh`], or you listen to the subscription using
+/// until you either call [`WatchTransactionStatus::take_current`], or you listen to the subscription using
 /// [`WatchTransactionStatus::recv`] and an update is processed.
 ///
 /// Note that it is possible to listen to a transaction status for a transaction that has not arrived yet. In that
@@ -59,8 +59,9 @@ impl<D: MadaraStorageRead> WatchTransactionStatus<D> {
     pub fn current(&self) -> &Option<TransactionStatus> {
         &self.current_value
     }
-    pub fn refresh(&mut self) {
+    pub fn take_current(&mut self) -> &Option<TransactionStatus> {
         self.current_value = self.subscription.borrow_and_update().clone();
+        &self.current_value
     }
     pub async fn recv(&mut self) -> &Option<TransactionStatus> {
         self.subscription.changed().await;

--- a/madara/crates/client/rpc/src/lib.rs
+++ b/madara/crates/client/rpc/src/lib.rs
@@ -832,9 +832,15 @@ pub enum TxStatusSnapshot {
     AcceptedOnL1,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxStatusUpdate {
+    Status(TxStatusSnapshot),
+    NotFound,
+}
+
 pub trait TxStatusWatch: Send {
-    fn take_current(&mut self) -> Option<TxStatusSnapshot>;
-    fn recv(&mut self) -> Pin<Box<dyn Future<Output = Option<TxStatusSnapshot>> + Send + '_>>;
+    fn take_current(&mut self) -> TxStatusUpdate;
+    fn recv(&mut self) -> Pin<Box<dyn Future<Output = Option<TxStatusUpdate>> + Send + '_>>;
 }
 
 pub trait TxStatusWatcher: Send + Sync {
@@ -858,44 +864,33 @@ pub trait NewTransactionsWatcher: Send + Sync {
 }
 
 impl<D: mc_db::MadaraStorageRead> TxStatusWatch for WatchTransactionStatus<D> {
-    fn take_current(&mut self) -> Option<TxStatusSnapshot> {
-        let snapshot = match WatchTransactionStatus::current(self).clone() {
-            Some(MempoolTransactionStatus::Preconfirmed(status)) => match status {
-                PreConfirmationStatus::Received(_) => Some(TxStatusSnapshot::Received),
-                PreConfirmationStatus::Candidate { .. } => Some(TxStatusSnapshot::Candidate),
-                PreConfirmationStatus::Executed { .. } => Some(TxStatusSnapshot::PreConfirmed),
-            },
-            Some(MempoolTransactionStatus::Confirmed { is_on_l1, .. }) => {
-                if is_on_l1 {
-                    Some(TxStatusSnapshot::AcceptedOnL1)
-                } else {
-                    Some(TxStatusSnapshot::AcceptedOnL2)
-                }
-            }
-            None => None,
-        };
-        WatchTransactionStatus::refresh(self);
-        snapshot
+    fn take_current(&mut self) -> TxStatusUpdate {
+        tx_status_update_from_mempool(WatchTransactionStatus::take_current(self).clone())
     }
 
-    fn recv(&mut self) -> Pin<Box<dyn Future<Output = Option<TxStatusSnapshot>> + Send + '_>> {
+    fn recv(&mut self) -> Pin<Box<dyn Future<Output = Option<TxStatusUpdate>> + Send + '_>> {
         Box::pin(async move {
-            match WatchTransactionStatus::recv(self).await.clone() {
-                Some(MempoolTransactionStatus::Preconfirmed(status)) => match status {
-                    PreConfirmationStatus::Received(_) => Some(TxStatusSnapshot::Received),
-                    PreConfirmationStatus::Candidate { .. } => Some(TxStatusSnapshot::Candidate),
-                    PreConfirmationStatus::Executed { .. } => Some(TxStatusSnapshot::PreConfirmed),
-                },
-                Some(MempoolTransactionStatus::Confirmed { is_on_l1, .. }) => {
-                    if is_on_l1 {
-                        Some(TxStatusSnapshot::AcceptedOnL1)
-                    } else {
-                        Some(TxStatusSnapshot::AcceptedOnL2)
-                    }
-                }
-                None => None,
-            }
+            let status = WatchTransactionStatus::recv(self).await.clone();
+            Some(tx_status_update_from_mempool(status))
         })
+    }
+}
+
+fn tx_status_update_from_mempool(status: Option<MempoolTransactionStatus>) -> TxStatusUpdate {
+    match status {
+        Some(MempoolTransactionStatus::Preconfirmed(status)) => match status {
+            PreConfirmationStatus::Received(_) => TxStatusUpdate::Status(TxStatusSnapshot::Received),
+            PreConfirmationStatus::Candidate { .. } => TxStatusUpdate::Status(TxStatusSnapshot::Candidate),
+            PreConfirmationStatus::Executed { .. } => TxStatusUpdate::Status(TxStatusSnapshot::PreConfirmed),
+        },
+        Some(MempoolTransactionStatus::Confirmed { is_on_l1, .. }) => {
+            if is_on_l1 {
+                TxStatusUpdate::Status(TxStatusSnapshot::AcceptedOnL1)
+            } else {
+                TxStatusUpdate::Status(TxStatusSnapshot::AcceptedOnL2)
+            }
+        }
+        None => TxStatusUpdate::NotFound,
     }
 }
 

--- a/madara/crates/client/rpc/src/test_utils.rs
+++ b/madara/crates/client/rpc/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::Starknet;
 use crate::{
-    NewTransactionsWatch, NewTransactionsWatchError, NewTransactionsWatcher, TxStatusSnapshot, TxStatusWatch,
-    TxStatusWatcher,
+    NewTransactionsWatch, NewTransactionsWatchError, NewTransactionsWatcher, TxStatusSnapshot, TxStatusUpdate,
+    TxStatusWatch, TxStatusWatcher,
 };
 use jsonrpsee::core::async_trait;
 use mc_db::{
@@ -141,14 +141,20 @@ impl TxStatusWatcher for TestTxStatusWatcher {
 
 #[cfg(test)]
 impl TxStatusWatch for TestTxStatusWatch {
-    fn take_current(&mut self) -> Option<TxStatusSnapshot> {
-        *self.receiver.borrow_and_update()
+    fn take_current(&mut self) -> TxStatusUpdate {
+        match *self.receiver.borrow_and_update() {
+            Some(status) => TxStatusUpdate::Status(status),
+            None => TxStatusUpdate::NotFound,
+        }
     }
 
-    fn recv(&mut self) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<TxStatusSnapshot>> + Send + '_>> {
+    fn recv(&mut self) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<TxStatusUpdate>> + Send + '_>> {
         Box::pin(async move {
             self.receiver.changed().await.ok()?;
-            *self.receiver.borrow_and_update()
+            Some(match *self.receiver.borrow_and_update() {
+                Some(status) => TxStatusUpdate::Status(status),
+                None => TxStatusUpdate::NotFound,
+            })
         })
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/ws/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/ws/mod.rs
@@ -7,22 +7,20 @@ const BLOCK_PAST_LIMIT: u64 = 1024;
 #[allow(unused)]
 const ADDRESS_FILTER_LIMIT: u64 = 128;
 const REORG_NOTIFICATION_METHOD: &str = "starknet_subscriptionReorg";
+const NEW_TRANSACTION_RECEIPTS_NOTIFICATION_METHOD: &str = "starknet_subscriptionNewTransactionReceipts";
 
-#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
-pub struct SubscriptionItem<T> {
-    subscription_id: String,
-    result: T,
-}
-
-impl<T> SubscriptionItem<T> {
-    pub fn new(subscription_id: jsonrpsee::types::SubscriptionId, result: T) -> Self {
-        let subscription_id = match subscription_id {
-            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
-            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
-        };
-
-        Self { subscription_id, result }
-    }
+/// Builds a spec-shaped subscription notification frame.
+///
+/// The spec requires notifications to use the dedicated `starknet_subscriptionX` method names,
+/// not the subscribe method name jsonrpsee would default to. [`jsonrpsee::SubscriptionMessage::new`]
+/// produces a complete frame with the given method, the subscription id, and the payload as
+/// `params.result`.
+pub(crate) fn notification_message<T: serde::Serialize>(
+    method: &str,
+    sink: &jsonrpsee::core::server::SubscriptionSink,
+    payload: &T,
+) -> Result<jsonrpsee::SubscriptionMessage, serde_json::Error> {
+    jsonrpsee::SubscriptionMessage::new(method, sink.subscription_id(), payload)
 }
 
 pub fn reorg_data(reorg: &mc_db::ReorgNotification) -> mp_rpc::v0_10_0::ReorgData {

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/ws/subscribe_new_transaction_receipts.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/ws/subscribe_new_transaction_receipts.rs
@@ -94,13 +94,11 @@ async fn send_block_receipts(
             FinalityStatus::PreConfirmed => TxnFinalityStatus::PreConfirmed,
             FinalityStatus::AcceptedOnL2 => TxnFinalityStatus::L2,
         });
-        let item = super::SubscriptionItem::new(
-            sink.subscription_id(),
-            TxnReceiptWithBlockInfo { transaction_receipt, block_hash, block_number },
-        );
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
-            format!("SubscribeNewTransactionReceipts failed to create response for tx hash {tx_hash:#x}")
-        })?;
+        let payload = TxnReceiptWithBlockInfo { transaction_receipt, block_hash, block_number };
+        let msg = super::notification_message(super::NEW_TRANSACTION_RECEIPTS_NOTIFICATION_METHOD, sink, &payload)
+            .or_else_internal_server_error(|| {
+                format!("SubscribeNewTransactionReceipts failed to create response for tx hash {tx_hash:#x}")
+            })?;
 
         sink.send(msg)
             .await

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/mod.rs
@@ -132,11 +132,11 @@ pub trait StarknetReadRpcApi {
     fn get_compiled_casm(&self, class_hash: Felt) -> RpcResult<serde_json::Value>;
 }
 
-type SubscriptionItemEvents = methods::ws::SubscriptionItem<mp_rpc::v0_10_0::EmittedEventWithFinality>;
-type SubscriptionItemNewHeads = methods::ws::SubscriptionItem<mp_rpc::v0_10_0::BlockHeader>;
-type SubscriptionItemNewTransactions = methods::ws::SubscriptionItem<mp_rpc::v0_10_0::TxnWithHashAndStatus>;
-type SubscriptionItemNewTransactionReceipts = methods::ws::SubscriptionItem<mp_rpc::v0_10_0::TxnReceiptWithBlockInfo>;
-type SubscriptionItemTransactionStatus = methods::ws::SubscriptionItem<mp_rpc::v0_10_0::TxnStatus>;
+type SubscriptionItemEvents = mp_rpc::v0_10_0::EmittedEventWithFinality;
+type SubscriptionItemNewHeads = mp_rpc::v0_10_0::BlockHeader;
+type SubscriptionItemNewTransactions = mp_rpc::v0_10_0::TxnWithHashAndStatus;
+type SubscriptionItemNewTransactionReceipts = mp_rpc::v0_10_0::TxnReceiptWithBlockInfo;
+type SubscriptionItemTransactionStatus = mp_rpc::v0_9_0::NewTxnStatus;
 
 #[versioned_rpc("V0_10_0", "starknet")]
 pub trait StarknetWsRpcApi {

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/lib.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/lib.rs
@@ -489,6 +489,41 @@ mod test {
     }
 
     #[tokio::test]
+    async fn subscribe_transaction_status_not_found_keeps_subscription_open_v0_10_2() {
+        let (_backend, mut starknet) = rpc_test_setup();
+        let watcher = TestTxStatusWatcher::new();
+        starknet.set_tx_status_watcher(Some(watcher.clone()));
+
+        let (_handle, server_url) = start_server(starknet).await;
+        let client = WsClientBuilder::default().build(&server_url).await.expect("Building client");
+
+        let mut sub = StarknetWsRpcApiV0_10_2Client::subscribe_transaction_status(&client, TX_HASH)
+            .await
+            .expect("Failed subscription");
+
+        watcher.set_status(Some(crate::TxStatusSnapshot::Received));
+        let first = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("Timed out waiting for received status")
+            .expect("Subscription closed unexpectedly")
+            .expect("Failed to retrieve received status");
+        assert_eq!(first.status.finality_status, mp_rpc::v0_10_2::TxnStatus::Received);
+
+        watcher.set_status(None);
+        tokio::time::timeout(Duration::from_millis(200), sub.next())
+            .await
+            .expect_err("NotFound should not emit or close the subscription");
+
+        watcher.set_status(Some(crate::TxStatusSnapshot::AcceptedOnL2));
+        let second = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("Timed out waiting for re-added status")
+            .expect("Subscription closed unexpectedly")
+            .expect("Failed to retrieve re-added status");
+        assert_eq!(second.status.finality_status, mp_rpc::v0_10_2::TxnStatus::AcceptedOnL2);
+    }
+
+    #[tokio::test]
     async fn subscribe_transaction_status_unsubscribe_v0_10_2() {
         let (_backend, mut starknet) = rpc_test_setup();
         let watcher = TestTxStatusWatcher::new();

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_events.rs
@@ -84,7 +84,10 @@ pub async fn subscribe_events(
     }
 
     'backfill: loop {
-        let backfill_to_block_n = starknet.backend.view_on_latest().latest_block_n();
+        // Bound the backfill to the confirmed tip: a preconfirmed block must be handled by the live
+        // phase, otherwise the backfill walks past it without emitting its ACCEPTED_ON_L2 events
+        // once it confirms.
+        let backfill_to_block_n = starknet.backend.latest_confirmed_block_n();
 
         while backfill_to_block_n.is_some_and(|end_block_n| next_block_n <= end_block_n) {
             if sink.is_closed() {
@@ -329,6 +332,84 @@ mod test {
         )
         .await
         .expect("starknet_V0_10_2_subscribeEvents")
+    }
+
+    #[tokio::test]
+    async fn subscribe_events_backfill_does_not_skip_block_preconfirmed_at_subscribe_time_v0_10_2() {
+        let (backend, starknet) = rpc_test_setup();
+        let (_handle, server_url) = start_server(starknet).await;
+        let client = WsClientBuilder::default().build(&server_url).await.expect("Failed to start ws client");
+
+        let event_from_address = Felt::from_hex_unchecked("0x1234");
+        let confirmed_tx_hash = Felt::from_hex_unchecked("0x4242");
+        let preconfirmed_tx_hash = Felt::from_hex_unchecked("0x4343");
+
+        // Confirmed block 0 anchors the backfill; block 1 is preconfirmed at subscription time.
+        add_confirmed_event_block(&backend, 0, event_from_address, event_from_address, confirmed_tx_hash);
+        let tx = transaction_with_event(event_from_address, preconfirmed_tx_hash, event_from_address);
+        backend
+            .write_access()
+            .new_preconfirmed(PreconfirmedBlock::new_with_content(
+                PreconfirmedHeader { block_number: 1, ..Default::default() },
+                vec![PreconfirmedExecutedTransaction {
+                    transaction: tx.clone(),
+                    state_diff: Default::default(),
+                    declared_class: None,
+                    arrived_at: Default::default(),
+                    paid_fee_on_l1: None,
+                }],
+                vec![],
+            ))
+            .expect("Failed to store preconfirmed block");
+
+        let mut sub = client
+            .subscribe_events(None, None, Some(BlockId::Tag(BlockTag::Latest)), None)
+            .await
+            .expect("Failed subscription");
+
+        // Receiving block 0's event proves the backfill bound was computed while block 1 was
+        // still preconfirmed. Block 1 is then handled by the live phase: its ACCEPTED_ON_L2
+        // event below must be delivered once the block confirms.
+        let first = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("Timed out waiting for confirmed block 0 event")
+            .expect("Subscription closed unexpectedly")
+            .expect("Failed to retrieve event");
+        assert_eq!(first.emitted_event.transaction_hash, confirmed_tx_hash);
+
+        // Let the subscription settle into its live phase before confirming block 1.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let events = tx
+            .receipt
+            .events()
+            .iter()
+            .cloned()
+            .map(|event| mp_receipt::EventWithTransactionHash { transaction_hash: preconfirmed_tx_hash, event })
+            .collect::<Vec<_>>();
+        backend
+            .write_access()
+            .add_full_block_with_classes(
+                &FullBlockWithoutCommitments {
+                    header: PreconfirmedHeader { block_number: 1, ..Default::default() },
+                    state_diff: mp_state_update::StateDiff::default(),
+                    transactions: vec![tx],
+                    events,
+                },
+                &[],
+                true,
+            )
+            .expect("Failed to confirm block");
+
+        let item = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("Timed out waiting for confirmed event of the previously preconfirmed block")
+            .expect("Subscription closed unexpectedly")
+            .expect("Failed to retrieve event");
+
+        assert_eq!(item.finality_status, TxnFinalityStatus::L2);
+        assert_eq!(item.emitted_event.event.from_address, event_from_address);
+        assert_eq!(item.emitted_event.transaction_hash, preconfirmed_tx_hash);
     }
 
     #[tokio::test]

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
@@ -45,7 +45,7 @@ async fn subscribe_new_transactions_inner(
         finality_status.unwrap_or_else(|| vec![TxnStatusWithoutL1::AcceptedOnL2]).into_iter().collect::<HashSet<_>>();
     let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
     let include_proof_facts = tags.as_ref().is_some_and(|tags| tags.contains(&SubscriptionTag::IncludeProofFacts));
-    let mut emitted = HashSet::<(Felt, TxnStatusWithoutL1)>::new();
+    let mut emitted = EmittedTracker::default();
 
     let mut received_watch = if allowed_statuses.contains(&TxnStatusWithoutL1::Received) {
         Some(
@@ -153,6 +153,9 @@ async fn subscribe_new_transactions_inner(
                         include_proof_facts,
                         &mut emitted,
                     ).await?;
+                    // Transactions older than the previous confirmed block can no longer be
+                    // re-observed, so their dedup entries can be evicted.
+                    emitted.rotate();
                     current_preconfirmed = starknet
                         .backend
                         .block_view_on_preconfirmed_or_fake()
@@ -184,7 +187,7 @@ async fn send_preconfirmed_view_transactions(
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
     include_proof_facts: bool,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     if allowed_statuses.contains(&TxnStatusWithoutL1::PreConfirmed) {
         for tx in preconfirmed.get_executed_transactions(..) {
@@ -225,7 +228,7 @@ async fn send_confirmed_block_transactions(
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
     include_proof_facts: bool,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     if !allowed_statuses.contains(&TxnStatusWithoutL1::AcceptedOnL2) {
         return Ok(());
@@ -257,11 +260,11 @@ async fn send_validated_transaction(
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
     include_proof_facts: bool,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     if !allowed_statuses.contains(&status)
         || !sender_address.is_none_or(|addresses| addresses.contains(&tx.contract_address))
-        || !mark_emitted(emitted, tx.hash, &status)
+        || !emitted.mark_emitted(tx.hash, &status)
     {
         return Ok(());
     }
@@ -286,12 +289,12 @@ async fn send_executed_transaction(
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
     include_proof_facts: bool,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     let tx_hash = *tx.receipt.transaction_hash();
     if !allowed_statuses.contains(&status)
         || !transaction_matches_sender(&tx.transaction, sender_address)
-        || !mark_emitted(emitted, tx_hash, &status)
+        || !emitted.mark_emitted(tx_hash, &status)
     {
         return Ok(());
     }
@@ -322,8 +325,34 @@ async fn send_transaction_item(
     sink.send(msg).await.or_internal_server_error("SubscribeNewTransactions failed to respond to websocket request")
 }
 
-fn mark_emitted(emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>, tx_hash: Felt, status: &TxnStatusWithoutL1) -> bool {
-    emitted.insert((tx_hash, status.clone()))
+/// Dedup set for emitted (transaction, status) pairs, bounded by keeping only the two most
+/// recent confirmed-block generations. Entries are only needed while a transaction can still be
+/// re-observed (preconfirmed view refreshes and the preconfirmed-to-confirmed transition), which
+/// the previous generation covers; older entries are evicted on rotation so the set does not grow
+/// for the lifetime of the subscription.
+#[derive(Default)]
+struct EmittedTracker {
+    current: HashSet<(Felt, TxnStatusWithoutL1)>,
+    previous: HashSet<(Felt, TxnStatusWithoutL1)>,
+}
+
+impl EmittedTracker {
+    fn mark_emitted(&mut self, tx_hash: Felt, status: &TxnStatusWithoutL1) -> bool {
+        let key = (tx_hash, status.clone());
+        if self.previous.contains(&key) {
+            return false;
+        }
+        self.current.insert(key)
+    }
+
+    fn rotate(&mut self) {
+        self.previous = std::mem::take(&mut self.current);
+    }
+
+    fn clear(&mut self) {
+        self.current.clear();
+        self.previous.clear();
+    }
 }
 
 fn transaction_matches_sender(transaction: &Transaction, sender_address: Option<&HashSet<Felt>>) -> bool {

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
@@ -33,40 +33,39 @@ async fn subscribe_new_transactions_inner(
     tags: Option<Vec<SubscriptionTag>>,
     emit_reorg_notifications: bool,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
-    let sink = if sender_address.as_ref().map_or(0, Vec::len) as u64 <= super::ADDRESS_FILTER_LIMIT {
-        subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?
-    } else {
+    if sender_address.as_ref().map_or(0, Vec::len) as u64 > super::ADDRESS_FILTER_LIMIT {
         subscription_sink.reject(crate::errors::StarknetWsApiError::TooManyAddressesInFilter).await;
         return Ok(());
-    };
+    }
 
-    let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
     let allowed_statuses =
         finality_status.unwrap_or_else(|| vec![TxnStatusWithoutL1::AcceptedOnL2]).into_iter().collect::<HashSet<_>>();
-    let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
-    let include_proof_facts = tags.as_ref().is_some_and(|tags| tags.contains(&SubscriptionTag::IncludeProofFacts));
-    let mut emitted = EmittedTracker::default();
 
+    // Resolve the received-transactions watcher before accepting the subscription, so
+    // configurations without one reject the subscribe call instead of accepting the connection
+    // and then closing it with an opaque Internal error.
     let mut received_watch = if allowed_statuses.contains(&TxnStatusWithoutL1::Received) {
-        Some(
-            starknet
-                .new_transactions_watcher
-                .as_ref()
-                .ok_or_else(|| {
-                    crate::errors::StarknetWsApiError::internal_server_error(
-                        "SubscribeNewTransactions failed: new-transactions watcher is not configured",
-                    )
-                })?
-                .watch_new_transactions()
-                .ok_or_else(|| {
-                    crate::errors::StarknetWsApiError::internal_server_error(
-                        "SubscribeNewTransactions failed to create new-transactions watcher",
-                    )
-                })?,
-        )
+        match starknet.new_transactions_watcher.as_ref().and_then(|watcher| watcher.watch_new_transactions()) {
+            Some(watch) => Some(watch),
+            None => {
+                subscription_sink
+                    .reject(crate::errors::StarknetWsApiError::internal_server_error(
+                        "SubscribeNewTransactions with RECEIVED status is not available: new-transactions watcher is not configured",
+                    ))
+                    .await;
+                return Ok(());
+            }
+        }
     } else {
         None
     };
+
+    let sink =
+        subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
+    let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
+    let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
+    let include_proof_facts = tags.as_ref().is_some_and(|tags| tags.contains(&SubscriptionTag::IncludeProofFacts));
+    let mut emitted = EmittedTracker::default();
 
     let mut heads = starknet.backend.subscribe_new_heads(SubscribeNewBlocksTag::Preconfirmed);
     let mut current_preconfirmed = starknet

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
@@ -60,8 +60,7 @@ async fn subscribe_new_transactions_inner(
         None
     };
 
-    let sink =
-        subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
+    let sink = subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
     let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
     let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
     let include_proof_facts = tags.as_ref().is_some_and(|tags| tags.contains(&SubscriptionTag::IncludeProofFacts));

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_new_transactions.rs
@@ -153,9 +153,9 @@ async fn subscribe_new_transactions_inner(
                         include_proof_facts,
                         &mut emitted,
                     ).await?;
-                    // Transactions older than the previous confirmed block can no longer be
-                    // re-observed, so their dedup entries can be evicted.
-                    emitted.rotate();
+                    // PreConfirmed / AcceptedOnL2 entries can be evicted after a confirmed block;
+                    // Received / Candidate entries stay in the persistent set until reorg.
+                    emitted.rotate_ephemeral();
                     current_preconfirmed = starknet
                         .backend
                         .block_view_on_preconfirmed_or_fake()
@@ -325,13 +325,20 @@ async fn send_transaction_item(
     sink.send(msg).await.or_internal_server_error("SubscribeNewTransactions failed to respond to websocket request")
 }
 
-/// Dedup set for emitted (transaction, status) pairs, bounded by keeping only the two most
-/// recent confirmed-block generations. Entries are only needed while a transaction can still be
-/// re-observed (preconfirmed view refreshes and the preconfirmed-to-confirmed transition), which
-/// the previous generation covers; older entries are evicted on rotation so the set does not grow
-/// for the lifetime of the subscription.
+/// Dedup state for emitted (transaction, status) pairs.
+///
+/// Short-lived statuses (`PreConfirmed`, `AcceptedOnL2`) use a two-generation tracker rotated on
+/// each confirmed block. Long-lived statuses (`Received`, `Candidate`) use a persistent set that
+/// survives confirmed-block rotation, since those transactions can remain observable across many
+/// blocks until they are executed or dropped from the mempool.
 #[derive(Default)]
 struct EmittedTracker {
+    ephemeral: EphemeralEmittedTracker,
+    persistent: HashSet<(Felt, TxnStatusWithoutL1)>,
+}
+
+#[derive(Default)]
+struct EphemeralEmittedTracker {
     current: HashSet<(Felt, TxnStatusWithoutL1)>,
     previous: HashSet<(Felt, TxnStatusWithoutL1)>,
 }
@@ -339,6 +346,24 @@ struct EmittedTracker {
 impl EmittedTracker {
     fn mark_emitted(&mut self, tx_hash: Felt, status: &TxnStatusWithoutL1) -> bool {
         let key = (tx_hash, status.clone());
+        match status {
+            TxnStatusWithoutL1::Received | TxnStatusWithoutL1::Candidate => self.persistent.insert(key),
+            TxnStatusWithoutL1::PreConfirmed | TxnStatusWithoutL1::AcceptedOnL2 => self.ephemeral.mark_emitted(key),
+        }
+    }
+
+    fn rotate_ephemeral(&mut self) {
+        self.ephemeral.rotate();
+    }
+
+    fn clear(&mut self) {
+        self.ephemeral.clear();
+        self.persistent.clear();
+    }
+}
+
+impl EphemeralEmittedTracker {
+    fn mark_emitted(&mut self, key: (Felt, TxnStatusWithoutL1)) -> bool {
         if self.previous.contains(&key) {
             return false;
         }
@@ -352,6 +377,33 @@ impl EmittedTracker {
     fn clear(&mut self) {
         self.current.clear();
         self.previous.clear();
+    }
+}
+
+#[cfg(test)]
+mod emitted_tracker_tests {
+    use super::*;
+
+    #[test]
+    fn candidate_dedup_survives_ephemeral_rotation() {
+        let mut tracker = EmittedTracker::default();
+        let hash = Felt::from_hex_unchecked("0xabc");
+
+        assert!(tracker.mark_emitted(hash, &TxnStatusWithoutL1::Candidate));
+        tracker.rotate_ephemeral();
+        tracker.rotate_ephemeral();
+        assert!(!tracker.mark_emitted(hash, &TxnStatusWithoutL1::Candidate));
+    }
+
+    #[test]
+    fn accepted_on_l2_dedup_evicted_after_two_rotations() {
+        let mut tracker = EmittedTracker::default();
+        let hash = Felt::from_hex_unchecked("0xdef");
+
+        assert!(tracker.mark_emitted(hash, &TxnStatusWithoutL1::AcceptedOnL2));
+        tracker.rotate_ephemeral();
+        tracker.rotate_ephemeral();
+        assert!(tracker.mark_emitted(hash, &TxnStatusWithoutL1::AcceptedOnL2));
     }
 }
 
@@ -645,6 +697,86 @@ mod test {
                 },
                 finality_status: TxnStatusWithoutL1::Candidate,
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_new_transactions_candidate_not_reemitted_across_confirmed_blocks_v0_10_2() {
+        let (backend, starknet) = rpc_test_setup();
+        let (_handle, server_url) = start_server(starknet).await;
+        let client = WsClientBuilder::default().build(&server_url).await.expect("Failed to start ws client");
+
+        let mut sub = StarknetWsRpcApiV0_10_2Client::subscribe_new_transactions(
+            &client,
+            Some(vec![TxnStatusWithoutL1::Candidate]),
+            Some(vec![SENDER_ADDRESS]),
+            None,
+        )
+        .await
+        .expect("Failed subscription");
+
+        let candidate = Arc::new(validated_tx(SENDER_ADDRESS));
+        backend
+            .write_access()
+            .new_preconfirmed(PreconfirmedBlock::new_with_content(
+                PreconfirmedHeader {
+                    block_number: 0,
+                    protocol_version: StarknetVersion::V0_13_2,
+                    ..Default::default()
+                },
+                vec![],
+                vec![candidate.clone()],
+            ))
+            .expect("Failed to store preconfirmed block");
+
+        let first = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("Timed out waiting for candidate notification")
+            .expect("Subscription closed unexpectedly")
+            .expect("Failed to retrieve candidate notification");
+
+        assert_eq!(first.finality_status, TxnStatusWithoutL1::Candidate);
+        assert_eq!(first.transaction.transaction_hash, candidate.hash);
+
+        for block_number in 0..2 {
+            backend
+                .write_access()
+                .add_full_block_with_classes(
+                    &FullBlockWithoutCommitments {
+                        header: PreconfirmedHeader {
+                            block_number,
+                            protocol_version: StarknetVersion::V0_13_2,
+                            ..Default::default()
+                        },
+                        state_diff: Default::default(),
+                        transactions: vec![],
+                        events: vec![],
+                    },
+                    &[],
+                    true,
+                )
+                .expect("Failed to store confirmed block");
+
+            backend
+                .write_access()
+                .new_preconfirmed(PreconfirmedBlock::new_with_content(
+                    PreconfirmedHeader {
+                        block_number: block_number + 1,
+                        protocol_version: StarknetVersion::V0_13_2,
+                        ..Default::default()
+                    },
+                    vec![],
+                    vec![candidate.clone()],
+                ))
+                .expect("Failed to restore preconfirmed block with lingering candidate");
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let duplicate = tokio::time::timeout(Duration::from_millis(500), sub.next()).await;
+        assert!(
+            duplicate.is_err(),
+            "Candidate transaction should not be re-emitted after confirmed blocks: got {duplicate:?}",
         );
     }
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_transaction_status.rs
@@ -5,26 +5,25 @@ pub async fn subscribe_transaction_status(
     subscription_sink: jsonrpsee::PendingSubscriptionSink,
     transaction_hash: mp_convert::Felt,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
+    // Resolve the watcher before accepting the subscription, so configurations without a
+    // tx-status watcher reject the subscribe call instead of accepting the connection and then
+    // closing it with an opaque Internal error.
+    let watch =
+        starknet.tx_status_watcher.as_ref().and_then(|watcher| watcher.watch_transaction_status(transaction_hash));
+    let Some(mut watch) = watch else {
+        subscription_sink
+            .reject(crate::errors::StarknetWsApiError::internal_server_error(
+                "SubscribeTransactionStatus is not available: tx-status watcher is not configured",
+            ))
+            .await;
+        return Ok(());
+    };
+
     let sink = subscription_sink
         .accept()
         .await
         .or_internal_server_error("SubscribeTransactionStatus failed to establish websocket connection")?;
     let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
-
-    let mut watch = starknet
-        .tx_status_watcher
-        .as_ref()
-        .ok_or_else(|| {
-            crate::errors::StarknetWsApiError::internal_server_error(
-                "SubscribeTransactionStatus failed: tx-status watcher is not configured",
-            )
-        })?
-        .watch_transaction_status(transaction_hash)
-        .ok_or_else(|| {
-            crate::errors::StarknetWsApiError::internal_server_error(
-                "SubscribeTransactionStatus failed to create transaction status watcher",
-            )
-        })?;
     let mut reorgs = starknet.backend.subscribe_reorgs();
 
     let mut allow_current = true;

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/ws/subscribe_transaction_status.rs
@@ -32,7 +32,7 @@ pub async fn subscribe_transaction_status(
             return Ok(());
         };
         match update {
-            SubscriptionUpdate::Snapshot(snapshot) => {
+            SubscriptionUpdate::Status(crate::TxStatusUpdate::Status(snapshot)) => {
                 allow_current = false;
 
                 send_txn_status(starknet, &sink, transaction_hash, snapshot).await?;
@@ -40,6 +40,9 @@ pub async fn subscribe_transaction_status(
                     crate::close_ws_subscription(starknet, sink.subscription_id()).await?;
                     return Ok(());
                 }
+            }
+            SubscriptionUpdate::Status(crate::TxStatusUpdate::NotFound) => {
+                allow_current = false;
             }
             SubscriptionUpdate::Reorg(reorg) => super::send_reorg_notification(&sink, &reorg).await?,
             SubscriptionUpdate::WatcherClosed => {
@@ -51,7 +54,7 @@ pub async fn subscribe_transaction_status(
 }
 
 enum SubscriptionUpdate {
-    Snapshot(crate::TxStatusSnapshot),
+    Status(crate::TxStatusUpdate),
     Reorg(mc_db::ReorgNotification),
     WatcherClosed,
 }
@@ -64,9 +67,7 @@ async fn next_update(
     allow_current: bool,
 ) -> Result<Option<SubscriptionUpdate>, crate::errors::StarknetWsApiError> {
     if allow_current {
-        if let Some(snapshot) = watch.take_current() {
-            return Ok(Some(SubscriptionUpdate::Snapshot(snapshot)));
-        }
+        return Ok(Some(SubscriptionUpdate::Status(watch.take_current())));
     }
 
     tokio::select! {
@@ -82,7 +83,7 @@ async fn next_update(
             }
         },
         next = watch.recv() => {
-            Ok(Some(next.map(SubscriptionUpdate::Snapshot).unwrap_or(SubscriptionUpdate::WatcherClosed)))
+            Ok(Some(next.map(SubscriptionUpdate::Status).unwrap_or(SubscriptionUpdate::WatcherClosed)))
         },
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/mod.rs
@@ -16,22 +16,23 @@ const BLOCK_PAST_LIMIT: u64 = 1024;
 #[allow(unused)]
 const ADDRESS_FILTER_LIMIT: u64 = 128;
 const REORG_NOTIFICATION_METHOD: &str = "starknet_subscriptionReorg";
+const NEW_HEADS_NOTIFICATION_METHOD: &str = "starknet_subscriptionNewHeads";
+const EVENTS_NOTIFICATION_METHOD: &str = "starknet_subscriptionEvents";
+const TRANSACTION_STATUS_NOTIFICATION_METHOD: &str = "starknet_subscriptionTransactionStatus";
+const PENDING_TRANSACTIONS_NOTIFICATION_METHOD: &str = "starknet_subscriptionPendingTransactions";
 
-#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
-pub struct SubscriptionItem<T> {
-    subscription_id: String,
-    result: T,
-}
-
-impl<T> SubscriptionItem<T> {
-    pub fn new(subscription_id: jsonrpsee::types::SubscriptionId, result: T) -> Self {
-        let subscription_id = match subscription_id {
-            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
-            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
-        };
-
-        Self { subscription_id, result }
-    }
+/// Builds a spec-shaped subscription notification frame.
+///
+/// The spec requires notifications to use the dedicated `starknet_subscriptionX` method names,
+/// not the subscribe method name jsonrpsee would default to. [`jsonrpsee::SubscriptionMessage::new`]
+/// produces a complete frame with the given method, the subscription id, and the payload as
+/// `params.result`.
+pub(crate) fn notification_message<T: serde::Serialize>(
+    method: &str,
+    sink: &jsonrpsee::core::server::SubscriptionSink,
+    payload: &T,
+) -> Result<jsonrpsee::SubscriptionMessage, serde_json::Error> {
+    jsonrpsee::SubscriptionMessage::new(method, sink.subscription_id(), payload)
 }
 
 pub fn reorg_data(reorg: &mc_db::ReorgNotification) -> mp_rpc::v0_8_1::ReorgData {

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_events.rs
@@ -48,7 +48,10 @@ pub async fn subscribe_events(
     }
 
     'backfill: loop {
-        let backfill_to_block_n = starknet.backend.view_on_latest().latest_block_n();
+        // Bound the backfill to the confirmed tip: a preconfirmed block must be handled by the live
+        // phase, otherwise the backfill walks past it without emitting its ACCEPTED_ON_L2 events
+        // once it confirms.
+        let backfill_to_block_n = starknet.backend.latest_confirmed_block_n();
 
         while backfill_to_block_n.is_some_and(|end_block_n| next_block_n <= end_block_n) {
             if sink.is_closed() {
@@ -153,8 +156,7 @@ async fn send_event(
     sink: &jsonrpsee::server::SubscriptionSink,
 ) -> Result<(), StarknetWsApiError> {
     let event = EmittedEvent::from(event);
-    let item = super::SubscriptionItem::new(sink.subscription_id(), event);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let msg = super::notification_message(super::EVENTS_NOTIFICATION_METHOD, sink, &event)
         .or_internal_server_error("Failed to create response message")?;
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")
 }
@@ -304,7 +306,7 @@ mod test {
             let events = generator.next().expect("Retrieving block");
             for event in events {
                 let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-                assert_eq!(received.result, event);
+                assert_eq!(received, event);
                 nb_events += 1;
             }
         }
@@ -336,7 +338,7 @@ mod test {
             for event in events {
                 if event.event.from_address == from_address {
                     let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-                    assert_eq!(received.result, event);
+                    assert_eq!(received, event);
                     nb_events += 1;
                 }
             }
@@ -380,7 +382,7 @@ mod test {
 
         for event in expected_events {
             let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-            assert_eq!(received.result, event);
+            assert_eq!(received, event);
         }
     }
 
@@ -442,7 +444,7 @@ mod test {
 
         for event in expected_events {
             let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-            assert_eq!(received.result, event);
+            assert_eq!(received, event);
         }
     }
 
@@ -460,13 +462,20 @@ mod test {
         let mut sub = client.subscribe_events(None, None, None).await.expect("Subscribing to events");
 
         let events = generator.next().expect("Retrieving block");
-        let subscription_id = sub.next().await.unwrap().unwrap().subscription_id;
+        let _first = sub.next().await.unwrap().unwrap();
+        let jsonrpsee::core::client::SubscriptionKind::Subscription(sub_id) = sub.kind().clone() else {
+            panic!("Expected a subscription id");
+        };
+        let subscription_id = match sub_id {
+            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
+            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
+        };
         client.starknet_unsubscribe(subscription_id).await.expect("Failed to close subscription");
 
         let mut nb_events = 0;
         for event in events.into_iter().skip(1) {
             let received = sub.next().await.expect("Subscribing closed").expect("Failed to retrieve event");
-            assert_eq!(received.result, event);
+            assert_eq!(received, event);
             nb_events += 1;
         }
         assert_eq!(nb_events, 2);

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_new_heads.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_new_heads.rs
@@ -502,8 +502,7 @@ mod test {
             .expect("Timed out waiting for new-fork head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve new-fork head");
-        let item: BlockHeader =
-            serde_json::from_value(next).expect("Failed to deserialize block header item");
+        let item: BlockHeader = serde_json::from_value(next).expect("Failed to deserialize block header item");
 
         assert_eq!(item, new_block_1);
     }
@@ -567,8 +566,7 @@ mod test {
             .expect("Timed out waiting for replacement head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement head");
-        let item: BlockHeader =
-            serde_json::from_value(next).expect("Failed to deserialize replacement head");
+        let item: BlockHeader = serde_json::from_value(next).expect("Failed to deserialize replacement head");
 
         assert_eq!(item, replacement_head);
     }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_new_heads.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_new_heads.rs
@@ -147,8 +147,7 @@ async fn send_block_header(
     block_n: u64,
 ) -> Result<(), StarknetWsApiError> {
     let header = block_info.to_rpc_v0_8();
-    let item = super::SubscriptionItem::new(sink.subscription_id(), header);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let msg = super::notification_message(super::NEW_HEADS_NOTIFICATION_METHOD, sink, &header)
         .or_else_internal_server_error(|| format!("Failed to create response message for block {block_n}"))?;
 
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")?;
@@ -259,7 +258,7 @@ mod test {
             client.subscribe_new_heads(BlockId::Tag(BlockTag::Latest)).await.expect("starknet_subscribeNewHeads");
 
         let next = sub.next().await;
-        let header = next.expect("Waiting for block header").expect("Waiting for block header").result;
+        let header = next.expect("Waiting for block header").expect("Waiting for block header");
 
         assert_eq!(
             header,
@@ -287,7 +286,7 @@ mod test {
 
         for e in expected {
             let next = sub.next().await;
-            let header = next.expect("Waiting for block header").expect("Waiting for block header").result;
+            let header = next.expect("Waiting for block header").expect("Waiting for block header");
 
             assert_eq!(
                 header,
@@ -315,7 +314,7 @@ mod test {
         let mut sub = client.subscribe_new_heads(BlockId::Number(0)).await.expect("starknet_subscribeNewHeads");
 
         let next = sub.next().await;
-        let header = next.expect("Waiting for block header").expect("Waiting for block header").result;
+        let header = next.expect("Waiting for block header").expect("Waiting for block header");
 
         assert_eq!(
             header,
@@ -347,7 +346,7 @@ mod test {
         let block_1 = generator.next().expect("Retrieving block from backend");
 
         let next = sub.next().await;
-        let header = next.expect("Waiting for block header").expect("Waiting for block header").result;
+        let header = next.expect("Waiting for block header").expect("Waiting for block header");
 
         // Note that `sub` does not yield block 0. This is because it starts
         // from block 1, ignoring any block before. This can server to notify
@@ -378,8 +377,14 @@ mod test {
 
         let _block_1 = generator.next().expect("Retrieving block from backend");
 
-        let next = sub.next().await;
-        let subscription_id = next.unwrap().unwrap().subscription_id;
+        let _next = sub.next().await.unwrap().unwrap();
+        let jsonrpsee::core::client::SubscriptionKind::Subscription(sub_id) = sub.kind().clone() else {
+            panic!("Expected a subscription id");
+        };
+        let subscription_id = match sub_id {
+            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
+            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
+        };
         client.starknet_unsubscribe(subscription_id).await.expect("Failed to close subscription");
 
         assert!(sub.next().await.is_none());
@@ -497,10 +502,10 @@ mod test {
             .expect("Timed out waiting for new-fork head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve new-fork head");
-        let item: super::super::SubscriptionItem<BlockHeader> =
+        let item: BlockHeader =
             serde_json::from_value(next).expect("Failed to deserialize block header item");
 
-        assert_eq!(item.result, new_block_1);
+        assert_eq!(item, new_block_1);
     }
 
     #[tokio::test]
@@ -562,9 +567,9 @@ mod test {
             .expect("Timed out waiting for replacement head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement head");
-        let item: super::super::SubscriptionItem<BlockHeader> =
+        let item: BlockHeader =
             serde_json::from_value(next).expect("Failed to deserialize replacement head");
 
-        assert_eq!(item.result, replacement_head);
+        assert_eq!(item, replacement_head);
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_pending_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_pending_transactions.rs
@@ -113,9 +113,7 @@ async fn next_matching_transaction(
 mod test {
     use crate::{
         test_utils::{TestNewTransactionsWatcher, TestTransactionProvider},
-        versions::user::v0_8_1::{
-StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
-        },
+        versions::user::v0_8_1::{StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server},
         Starknet,
     };
     use assert_matches::assert_matches;

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_pending_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_pending_transactions.rs
@@ -71,10 +71,10 @@ pub async fn subscribe_pending_transactions(
             mp_rpc::v0_8_1::PendingTxnInfo::Hash(tx_hash)
         };
 
-        let item = super::SubscriptionItem::new(sink.subscription_id(), tx_info);
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
-            format!("SubscribePendingTransactions failed to create response message at tx {tx_hash:#x}")
-        })?;
+        let msg = super::notification_message(super::PENDING_TRANSACTIONS_NOTIFICATION_METHOD, &sink, &tx_info)
+            .or_else_internal_server_error(|| {
+                format!("SubscribePendingTransactions failed to create response message at tx {tx_hash:#x}")
+            })?;
 
         sink.send(msg).await.or_else_internal_server_error(|| {
             format!("SubscribePendingTransactions failed to respond to websocket request at tx {tx_hash:#x}")
@@ -114,7 +114,7 @@ mod test {
     use crate::{
         test_utils::{TestNewTransactionsWatcher, TestTransactionProvider},
         versions::user::v0_8_1::{
-            methods::ws::SubscriptionItem, StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
+StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
         },
         Starknet,
     };
@@ -238,13 +238,13 @@ mod test {
 
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for tx"),
-            Some(Ok(SubscriptionItem { result: tx, .. })) => {
+            Some(Ok(tx)) => {
                 assert_eq!(tx, mp_rpc::v0_8_1::PendingTxnInfo::Hash(tx_1.hash));
             }
         );
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for tx"),
-            Some(Ok(SubscriptionItem { result: tx, .. })) => {
+            Some(Ok(tx)) => {
                 assert_eq!(tx, mp_rpc::v0_8_1::PendingTxnInfo::Hash(tx_2.hash));
             }
         );
@@ -265,7 +265,7 @@ mod test {
         for expected_hash in [tx_1.hash, tx_2.hash] {
             assert_matches!(
                 tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for tx"),
-                Some(Ok(SubscriptionItem { result: tx, .. })) => {
+                Some(Ok(tx)) => {
                     assert_eq!(tx, mp_rpc::v0_8_1::PendingTxnInfo::Hash(expected_hash));
                 }
             );
@@ -289,13 +289,13 @@ mod test {
 
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for tx"),
-            Some(Ok(SubscriptionItem { result: tx, .. })) => {
+            Some(Ok(tx)) => {
                 assert_eq!(tx, mp_rpc::v0_8_1::PendingTxnInfo::Full(tx_1.transaction.clone().to_rpc_v0_7()));
             }
         );
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for tx"),
-            Some(Ok(SubscriptionItem { result: tx, .. })) => {
+            Some(Ok(tx)) => {
                 assert_eq!(tx, mp_rpc::v0_8_1::PendingTxnInfo::Full(tx_2.transaction.clone().to_rpc_v0_7()));
             }
         );
@@ -323,7 +323,7 @@ mod test {
         for expected_hash in [deploy_account.hash, deploy.hash, declare.hash, l1_handler.hash, invoke.hash] {
             assert_matches!(
                 tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for tx"),
-                Some(Ok(SubscriptionItem { result: tx, .. })) => {
+                Some(Ok(tx)) => {
                     assert_eq!(tx, mp_rpc::v0_8_1::PendingTxnInfo::Hash(expected_hash));
                 }
             );

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_transaction_status.rs
@@ -34,7 +34,7 @@ pub async fn subscribe_transaction_status(
             return Ok(());
         };
         match update {
-            SubscriptionUpdate::Snapshot(snapshot) => {
+            SubscriptionUpdate::Status(crate::TxStatusUpdate::Status(snapshot)) => {
                 allow_current = false;
 
                 if let Some(status) = map_txn_status(snapshot) {
@@ -48,6 +48,10 @@ pub async fn subscribe_transaction_status(
                     return Ok(());
                 }
             }
+            SubscriptionUpdate::Status(crate::TxStatusUpdate::NotFound) => {
+                allow_current = false;
+                last_emitted = None;
+            }
             SubscriptionUpdate::Reorg(reorg) => super::send_reorg_notification(&sink, &reorg).await?,
             SubscriptionUpdate::WatcherClosed => {
                 crate::close_ws_subscription(starknet, sink.subscription_id()).await?;
@@ -58,7 +62,7 @@ pub async fn subscribe_transaction_status(
 }
 
 enum SubscriptionUpdate {
-    Snapshot(crate::TxStatusSnapshot),
+    Status(crate::TxStatusUpdate),
     Reorg(mc_db::ReorgNotification),
     WatcherClosed,
 }
@@ -82,9 +86,7 @@ async fn next_update(
     allow_current: bool,
 ) -> Result<Option<SubscriptionUpdate>, crate::errors::StarknetWsApiError> {
     if allow_current {
-        if let Some(snapshot) = watch.take_current() {
-            return Ok(Some(SubscriptionUpdate::Snapshot(snapshot)));
-        }
+        return Ok(Some(SubscriptionUpdate::Status(watch.take_current())));
     }
 
     tokio::select! {
@@ -100,7 +102,7 @@ async fn next_update(
             }
         },
         next = watch.recv() => {
-            Ok(Some(next.map(SubscriptionUpdate::Snapshot).unwrap_or(SubscriptionUpdate::WatcherClosed)))
+            Ok(Some(next.map(SubscriptionUpdate::Status).unwrap_or(SubscriptionUpdate::WatcherClosed)))
         },
     }
 }
@@ -123,9 +125,7 @@ async fn send_txn_status(
 mod test {
     use crate::{
         test_utils::{TestTransactionProvider, TestTxStatusWatcher},
-        versions::user::v0_8_1::{
-StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
-        },
+        versions::user::v0_8_1::{StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server},
         Starknet,
     };
     use assert_matches::assert_matches;
@@ -289,6 +289,40 @@ StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
     }
 
     #[tokio::test]
+    async fn subscribe_transaction_status_not_found_keeps_subscription_open() {
+        let (_backend, starknet, watcher) = starknet_with_status_watcher();
+
+        let builder = jsonrpsee::server::Server::builder();
+        let server = builder.build(SERVER_ADDR).await.expect("Failed to start jsonrpsee server");
+        let server_url = format!("ws://{}", server.local_addr().expect("Failed to retrieve server local addr"));
+        let _server_handle = server.start(StarknetWsRpcApiV0_8_1Server::into_rpc(starknet));
+        let client = WsClientBuilder::default().build(&server_url).await.expect("Failed to start jsonrpsee ws client");
+
+        let mut sub = client.subscribe_transaction_status(TX_HASH).await.expect("Failed subscription");
+
+        watcher.set_status(Some(crate::TxStatusSnapshot::Received));
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
+            Some(Ok(status)) => {
+                assert_eq!(status.status, mp_rpc::v0_8_1::TxnStatus::Received);
+            }
+        );
+
+        watcher.set_status(None);
+        tokio::time::timeout(Duration::from_millis(200), sub.next())
+            .await
+            .expect_err("NotFound should not emit or close the subscription");
+
+        watcher.set_status(Some(crate::TxStatusSnapshot::Received));
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for re-added status"),
+            Some(Ok(status)) => {
+                assert_eq!(status.status, mp_rpc::v0_8_1::TxnStatus::Received);
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn subscribe_transaction_status_candidate_is_silent_and_preconfirmed_is_deduped() {
         let (_backend, starknet, watcher) = starknet_with_status_watcher();
 
@@ -346,19 +380,18 @@ StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
         let mut sub = client.subscribe_transaction_status(TX_HASH).await.expect("Failed subscription");
         watcher.set_status(Some(crate::TxStatusSnapshot::Received));
 
-        match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status")
-            {
-                Some(Ok(status)) => {
-                    assert_eq!(
-                        status,
-                        mp_rpc::v0_8_1::NewTxnStatus {
-                            transaction_hash: TX_HASH,
-                            status: mp_rpc::v0_8_1::TxnStatus::Received
-                        }
-                    );
-                }
-                other => panic!("Unexpected subscription result: {other:?}"),
-            };
+        match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status") {
+            Some(Ok(status)) => {
+                assert_eq!(
+                    status,
+                    mp_rpc::v0_8_1::NewTxnStatus {
+                        transaction_hash: TX_HASH,
+                        status: mp_rpc::v0_8_1::TxnStatus::Received
+                    }
+                );
+            }
+            other => panic!("Unexpected subscription result: {other:?}"),
+        };
 
         let jsonrpsee::core::client::SubscriptionKind::Subscription(sub_id) = sub.kind().clone() else {
             panic!("Expected a subscription id");

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_transaction_status.rs
@@ -111,10 +111,10 @@ async fn send_txn_status(
     status: mp_rpc::v0_8_1::TxnStatus,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     let txn_status = mp_rpc::v0_8_1::NewTxnStatus { transaction_hash: tx_hash, status };
-    let item = super::SubscriptionItem::new(sink.subscription_id(), txn_status);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
-        format!("SubscribeTransactionStatus failed to create response for tx hash {tx_hash:#x}")
-    })?;
+    let msg = super::notification_message(super::TRANSACTION_STATUS_NOTIFICATION_METHOD, sink, &txn_status)
+        .or_else_internal_server_error(|| {
+            format!("SubscribeTransactionStatus failed to create response for tx hash {tx_hash:#x}")
+        })?;
 
     sink.send(msg).await.or_internal_server_error("SubscribeTransactionStatus failed to respond to websocket request")
 }
@@ -124,7 +124,7 @@ mod test {
     use crate::{
         test_utils::{TestTransactionProvider, TestTxStatusWatcher},
         versions::user::v0_8_1::{
-            methods::ws::SubscriptionItem, StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
+StarknetWsRpcApiV0_8_1Client, StarknetWsRpcApiV0_8_1Server,
         },
         Starknet,
     };
@@ -209,7 +209,7 @@ mod test {
 
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
+            Some(Ok(status)) => {
                 assert_eq!(status, mp_rpc::v0_8_1::NewTxnStatus {
                     transaction_hash: TX_HASH,
                     status: mp_rpc::v0_8_1::TxnStatus::Received
@@ -233,7 +233,7 @@ mod test {
 
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
+            Some(Ok(status)) => {
                 assert_eq!(status, mp_rpc::v0_8_1::NewTxnStatus {
                     transaction_hash: TX_HASH,
                     status: mp_rpc::v0_8_1::TxnStatus::Received
@@ -257,7 +257,7 @@ mod test {
         watcher.set_status(Some(crate::TxStatusSnapshot::Received));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
+            Some(Ok(status)) => {
                 assert_eq!(status, mp_rpc::v0_8_1::NewTxnStatus {
                     transaction_hash: TX_HASH,
                     status: mp_rpc::v0_8_1::TxnStatus::Received
@@ -268,7 +268,7 @@ mod test {
         watcher.set_status(Some(crate::TxStatusSnapshot::AcceptedOnL2));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
+            Some(Ok(status)) => {
                 assert_eq!(status, mp_rpc::v0_8_1::NewTxnStatus {
                     transaction_hash: TX_HASH,
                     status: mp_rpc::v0_8_1::TxnStatus::AcceptedOnL2
@@ -279,7 +279,7 @@ mod test {
         watcher.set_status(Some(crate::TxStatusSnapshot::AcceptedOnL1));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
+            Some(Ok(status)) => {
                 assert_eq!(status, mp_rpc::v0_8_1::NewTxnStatus {
                     transaction_hash: TX_HASH,
                     status: mp_rpc::v0_8_1::TxnStatus::AcceptedOnL1
@@ -308,7 +308,7 @@ mod test {
         watcher.set_status(Some(crate::TxStatusSnapshot::PreConfirmed));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
+            Some(Ok(status)) => {
                 assert_eq!(status, mp_rpc::v0_8_1::NewTxnStatus {
                     transaction_hash: TX_HASH,
                     status: mp_rpc::v0_8_1::TxnStatus::AcceptedOnL2
@@ -324,7 +324,7 @@ mod test {
         watcher.set_status(Some(crate::TxStatusSnapshot::AcceptedOnL1));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
+            Some(Ok(status)) => {
                 assert_eq!(status, mp_rpc::v0_8_1::NewTxnStatus {
                     transaction_hash: TX_HASH,
                     status: mp_rpc::v0_8_1::TxnStatus::AcceptedOnL1
@@ -346,10 +346,9 @@ mod test {
         let mut sub = client.subscribe_transaction_status(TX_HASH).await.expect("Failed subscription");
         watcher.set_status(Some(crate::TxStatusSnapshot::Received));
 
-        let subscription_id =
-            match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status")
+        match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status")
             {
-                Some(Ok(SubscriptionItem { subscription_id, result: status })) => {
+                Some(Ok(status)) => {
                     assert_eq!(
                         status,
                         mp_rpc::v0_8_1::NewTxnStatus {
@@ -357,11 +356,17 @@ mod test {
                             status: mp_rpc::v0_8_1::TxnStatus::Received
                         }
                     );
-                    subscription_id
                 }
                 other => panic!("Unexpected subscription result: {other:?}"),
             };
 
+        let jsonrpsee::core::client::SubscriptionKind::Subscription(sub_id) = sub.kind().clone() else {
+            panic!("Expected a subscription id");
+        };
+        let subscription_id = match sub_id {
+            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
+            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
+        };
         client.starknet_unsubscribe(subscription_id).await.expect("Failed to close subscription");
         assert!(sub.next().await.is_none());
     }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/mod.rs
@@ -11,10 +11,10 @@ use mp_rpc::v0_8_1::{
 };
 use starknet_types_core::felt::Felt;
 
-type SubscriptionItemPendingTxs = methods::ws::SubscriptionItem<mp_rpc::v0_8_1::PendingTxnInfo>;
-type SubscriptionItemEvents = methods::ws::SubscriptionItem<mp_rpc::v0_8_1::EmittedEvent>;
-type SubscriptionItemNewHeads = methods::ws::SubscriptionItem<mp_rpc::v0_8_1::BlockHeader>;
-type SubscriptionItemTransactionStatus = methods::ws::SubscriptionItem<mp_rpc::v0_8_1::NewTxnStatus>;
+type SubscriptionItemPendingTxs = mp_rpc::v0_8_1::PendingTxnInfo;
+type SubscriptionItemEvents = mp_rpc::v0_8_1::EmittedEvent;
+type SubscriptionItemNewHeads = mp_rpc::v0_8_1::BlockHeader;
+type SubscriptionItemTransactionStatus = mp_rpc::v0_8_1::NewTxnStatus;
 
 pub mod methods;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/mod.rs
@@ -13,22 +13,24 @@ const BLOCK_PAST_LIMIT: u64 = 1024;
 #[allow(unused)]
 const ADDRESS_FILTER_LIMIT: u64 = 128;
 const REORG_NOTIFICATION_METHOD: &str = "starknet_subscriptionReorg";
+const NEW_HEADS_NOTIFICATION_METHOD: &str = "starknet_subscriptionNewHeads";
+const EVENTS_NOTIFICATION_METHOD: &str = "starknet_subscriptionEvents";
+const TRANSACTION_STATUS_NOTIFICATION_METHOD: &str = "starknet_subscriptionTransactionStatus";
+const NEW_TRANSACTION_NOTIFICATION_METHOD: &str = "starknet_subscriptionNewTransaction";
+const NEW_TRANSACTION_RECEIPTS_NOTIFICATION_METHOD: &str = "starknet_subscriptionNewTransactionReceipts";
 
-#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
-pub struct SubscriptionItem<T> {
-    subscription_id: String,
-    result: T,
-}
-
-impl<T> SubscriptionItem<T> {
-    pub fn new(subscription_id: jsonrpsee::types::SubscriptionId, result: T) -> Self {
-        let subscription_id = match subscription_id {
-            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
-            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
-        };
-
-        Self { subscription_id, result }
-    }
+/// Builds a spec-shaped subscription notification frame.
+///
+/// The spec requires notifications to use the dedicated `starknet_subscriptionX` method names,
+/// not the subscribe method name jsonrpsee would default to. [`jsonrpsee::SubscriptionMessage::new`]
+/// produces a complete frame with the given method, the subscription id, and the payload as
+/// `params.result`.
+pub(crate) fn notification_message<T: serde::Serialize>(
+    method: &str,
+    sink: &jsonrpsee::core::server::SubscriptionSink,
+    payload: &T,
+) -> Result<jsonrpsee::SubscriptionMessage, serde_json::Error> {
+    jsonrpsee::SubscriptionMessage::new(method, sink.subscription_id(), payload)
 }
 
 pub fn reorg_data(reorg: &mc_db::ReorgNotification) -> mp_rpc::v0_9_0::ReorgData {

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_events.rs
@@ -52,7 +52,10 @@ pub async fn subscribe_events(
     }
 
     'backfill: loop {
-        let backfill_to_block_n = starknet.backend.view_on_latest().latest_block_n();
+        // Bound the backfill to the confirmed tip: a preconfirmed block must be handled by the live
+        // phase, otherwise the backfill walks past it without emitting its ACCEPTED_ON_L2 events
+        // once it confirms.
+        let backfill_to_block_n = starknet.backend.latest_confirmed_block_n();
 
         while backfill_to_block_n.is_some_and(|end_block_n| next_block_n <= end_block_n) {
             if sink.is_closed() {
@@ -184,11 +187,8 @@ async fn send_event(
     sink: &jsonrpsee::core::server::SubscriptionSink,
 ) -> Result<(), StarknetWsApiError> {
     let emitted_event = EmittedEvent::from(event);
-    let item = super::SubscriptionItem::new(
-        sink.subscription_id(),
-        mp_rpc::v0_9_0::EmittedEventWithFinality { emmitted_event: emitted_event, finality_status },
-    );
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let payload = mp_rpc::v0_9_0::EmittedEventWithFinality { emmitted_event: emitted_event, finality_status };
+    let msg = super::notification_message(super::EVENTS_NOTIFICATION_METHOD, sink, &payload)
         .or_internal_server_error("Failed to create response message")?;
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")
 }
@@ -310,8 +310,8 @@ mod test {
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve event");
 
-        assert_eq!(item.result.finality_status, TxnFinalityStatus::L2);
-        assert_eq!(item.result.emmitted_event.event.from_address, event_from_address);
+        assert_eq!(item.finality_status, TxnFinalityStatus::L2);
+        assert_eq!(item.emmitted_event.event.from_address, event_from_address);
     }
 
     #[tokio::test]
@@ -352,9 +352,9 @@ mod test {
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve event");
 
-        assert_eq!(item.result.finality_status, TxnFinalityStatus::PreConfirmed);
-        assert!(item.result.emmitted_event.block_number.is_none());
-        assert_eq!(item.result.emmitted_event.event.from_address, event_from_address);
+        assert_eq!(item.finality_status, TxnFinalityStatus::PreConfirmed);
+        assert!(item.emmitted_event.block_number.is_none());
+        assert_eq!(item.emmitted_event.event.from_address, event_from_address);
     }
 
     #[tokio::test]
@@ -430,9 +430,9 @@ mod test {
             .expect("Timed out waiting for replacement event")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement event");
-        let item: super::super::SubscriptionItem<mp_rpc::v0_9_0::EmittedEventWithFinality> =
+        let item: mp_rpc::v0_9_0::EmittedEventWithFinality =
             serde_json::from_value(next).expect("Failed to deserialize event item");
-        let event = item.result;
+        let event = item;
 
         assert_eq!(event.finality_status, TxnFinalityStatus::L2);
         assert_eq!(event.emmitted_event.event.from_address, event_from_address);
@@ -504,10 +504,10 @@ mod test {
             .expect("Timed out waiting for replacement event")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement event");
-        let item: super::super::SubscriptionItem<mp_rpc::v0_9_0::EmittedEventWithFinality> =
+        let item: mp_rpc::v0_9_0::EmittedEventWithFinality =
             serde_json::from_value(next).expect("Failed to deserialize replacement event");
 
-        assert_eq!(item.result.finality_status, TxnFinalityStatus::L2);
-        assert_eq!(item.result.emmitted_event.transaction_hash, replacement_tx_hash);
+        assert_eq!(item.finality_status, TxnFinalityStatus::L2);
+        assert_eq!(item.emmitted_event.transaction_hash, replacement_tx_hash);
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_heads.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_heads.rs
@@ -149,8 +149,7 @@ async fn send_block_header(
     block_n: u64,
 ) -> Result<(), StarknetWsApiError> {
     let header: BlockHeader = block_info.to_rpc_v0_8();
-    let item = super::SubscriptionItem::new(sink.subscription_id(), header);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let msg = super::notification_message(super::NEW_HEADS_NOTIFICATION_METHOD, sink, &header)
         .or_else_internal_server_error(|| format!("Failed to create response message for block {block_n}"))?;
 
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")?;
@@ -259,7 +258,7 @@ mod test {
             client.subscribe_new_heads(BlockId::Tag(BlockTag::Latest)).await.expect("starknet_subscribeNewHeads");
 
         let next = sub.next().await;
-        let header = next.expect("Waiting for block header").expect("Waiting for block header").result;
+        let header = next.expect("Waiting for block header").expect("Waiting for block header");
 
         assert_eq!(header, expected);
     }
@@ -281,7 +280,7 @@ mod test {
         let block_1 = generator.next().expect("Retrieving block from backend");
 
         let next = sub.next().await;
-        let header = next.expect("Waiting for block header").expect("Waiting for block header").result;
+        let header = next.expect("Waiting for block header").expect("Waiting for block header");
 
         assert_eq!(header, block_1);
     }
@@ -302,8 +301,14 @@ mod test {
 
         let _block_1 = generator.next().expect("Retrieving block from backend");
 
-        let next = sub.next().await;
-        let subscription_id = next.unwrap().unwrap().subscription_id;
+        let _next = sub.next().await.unwrap().unwrap();
+        let jsonrpsee::core::client::SubscriptionKind::Subscription(sub_id) = sub.kind().clone() else {
+            panic!("Expected a subscription id");
+        };
+        let subscription_id = match sub_id {
+            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
+            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
+        };
         client.starknet_unsubscribe(subscription_id).await.expect("Failed to close subscription");
 
         assert!(sub.next().await.is_none());
@@ -366,10 +371,10 @@ mod test {
             .expect("Timed out waiting for new-fork head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve new-fork head");
-        let item: super::super::SubscriptionItem<BlockHeader> =
+        let item: BlockHeader =
             serde_json::from_value(next).expect("Failed to deserialize block header item");
 
-        assert_eq!(item.result, new_block_1);
+        assert_eq!(item, new_block_1);
     }
 
     #[tokio::test]
@@ -431,9 +436,9 @@ mod test {
             .expect("Timed out waiting for replacement head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement head");
-        let item: super::super::SubscriptionItem<BlockHeader> =
+        let item: BlockHeader =
             serde_json::from_value(next).expect("Failed to deserialize replacement head");
 
-        assert_eq!(item.result, replacement_head);
+        assert_eq!(item, replacement_head);
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_heads.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_heads.rs
@@ -371,8 +371,7 @@ mod test {
             .expect("Timed out waiting for new-fork head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve new-fork head");
-        let item: BlockHeader =
-            serde_json::from_value(next).expect("Failed to deserialize block header item");
+        let item: BlockHeader = serde_json::from_value(next).expect("Failed to deserialize block header item");
 
         assert_eq!(item, new_block_1);
     }
@@ -436,8 +435,7 @@ mod test {
             .expect("Timed out waiting for replacement head")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement head");
-        let item: BlockHeader =
-            serde_json::from_value(next).expect("Failed to deserialize replacement head");
+        let item: BlockHeader = serde_json::from_value(next).expect("Failed to deserialize replacement head");
 
         assert_eq!(item, replacement_head);
     }

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transaction_receipts.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transaction_receipts.rs
@@ -118,13 +118,11 @@ async fn send_block_receipts(
             FinalityStatus::PreConfirmed => TxnFinalityStatus::PreConfirmed,
             FinalityStatus::AcceptedOnL2 => TxnFinalityStatus::L2,
         });
-        let item = super::SubscriptionItem::new(
-            sink.subscription_id(),
-            TxnReceiptWithBlockInfo { transaction_receipt, block_hash, block_number },
-        );
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
-            format!("SubscribeNewTransactionReceipts failed to create response for tx hash {tx_hash:#x}")
-        })?;
+        let payload = TxnReceiptWithBlockInfo { transaction_receipt, block_hash, block_number };
+        let msg = super::notification_message(super::NEW_TRANSACTION_RECEIPTS_NOTIFICATION_METHOD, sink, &payload)
+            .or_else_internal_server_error(|| {
+                format!("SubscribeNewTransactionReceipts failed to create response for tx hash {tx_hash:#x}")
+            })?;
 
         sink.send(msg)
             .await
@@ -282,7 +280,7 @@ mod test {
             .expect("Failed to retrieve receipt");
 
         assert_eq!(
-            serde_json::to_value(&item).expect("Failed to serialize receipt item")["result"],
+            serde_json::to_value(&item).expect("Failed to serialize receipt item"),
             serde_json::to_value(TxnReceiptWithBlockInfo {
                 transaction_receipt: transaction_with_receipt(SENDER_ADDRESS, transaction_hash)
                     .receipt
@@ -337,7 +335,7 @@ mod test {
             .expect("Failed to retrieve receipt");
 
         assert_eq!(
-            serde_json::to_value(&item).expect("Failed to serialize receipt item")["result"],
+            serde_json::to_value(&item).expect("Failed to serialize receipt item"),
             serde_json::to_value(TxnReceiptWithBlockInfoV10 {
                 transaction_receipt: tx.receipt.to_rpc_v0_10(TxnFinalityStatusV10::L2),
                 block_hash: Some(expected_block_hash),
@@ -437,11 +435,11 @@ mod test {
             .expect("Timed out waiting for replacement receipt")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement receipt");
-        let item: super::super::SubscriptionItem<TxnReceiptWithBlockInfoV10> =
+        let item: TxnReceiptWithBlockInfoV10 =
             serde_json::from_value(next).expect("Failed to deserialize replacement receipt item");
 
         assert_eq!(
-            item.result,
+            item,
             TxnReceiptWithBlockInfoV10 {
                 transaction_receipt: tx.receipt.to_rpc_v0_10(TxnFinalityStatusV10::L2),
                 block_hash: Some(new_block_hash),
@@ -563,11 +561,11 @@ mod test {
             .expect("Timed out waiting for replacement receipt")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement receipt");
-        let item: super::super::SubscriptionItem<TxnReceiptWithBlockInfo> =
+        let item: TxnReceiptWithBlockInfo =
             serde_json::from_value(next).expect("Failed to deserialize replacement receipt item");
 
         assert_eq!(
-            item.result,
+            item,
             TxnReceiptWithBlockInfo {
                 transaction_receipt: tx.receipt.to_rpc_v0_9(TxnFinalityStatus::L2),
                 block_hash: Some(new_block_hash),

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
@@ -295,10 +295,10 @@ async fn send_transaction_item(
     item: TxnWithHashAndStatus,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     let tx_hash = item.transaction.transaction_hash;
-    let item = super::SubscriptionItem::new(sink.subscription_id(), item);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
-        format!("SubscribeNewTransactions failed to create response for tx hash {tx_hash:#x}")
-    })?;
+    let msg = super::notification_message(super::NEW_TRANSACTION_NOTIFICATION_METHOD, sink, &item)
+        .or_else_internal_server_error(|| {
+            format!("SubscribeNewTransactions failed to create response for tx hash {tx_hash:#x}")
+        })?;
 
     sink.send(msg).await.or_internal_server_error("SubscribeNewTransactions failed to respond to websocket request")
 }
@@ -553,7 +553,7 @@ mod test {
             .expect("Failed to retrieve transaction");
 
         assert_eq!(
-            serde_json::to_value(&item).expect("Failed to serialize transaction item")["result"],
+            serde_json::to_value(&item).expect("Failed to serialize transaction item"),
             serde_json::to_value(TxnWithHashAndStatus {
                 transaction: TxnWithHash { transaction: tx.transaction.to_rpc_v0_8(), transaction_hash },
                 finality_status: TxnStatusWithoutL1::AcceptedOnL2,
@@ -593,7 +593,7 @@ mod test {
             .expect("Failed to retrieve transaction");
 
         assert_eq!(
-            item.result,
+            item,
             TxnWithHashAndStatus {
                 transaction: TxnWithHash { transaction: tx_1.transaction.to_rpc_v0_8(), transaction_hash: tx_1.hash },
                 finality_status: TxnStatusWithoutL1::Received,
@@ -648,7 +648,7 @@ mod test {
             .expect("Failed to retrieve second transaction");
 
         assert_eq!(
-            first.result,
+            first,
             TxnWithHashAndStatus {
                 transaction: TxnWithHash {
                     transaction: transaction_with_receipt(SENDER_ADDRESS, preconfirmed_hash).transaction.to_rpc_v0_8(),
@@ -658,7 +658,7 @@ mod test {
             }
         );
         assert_eq!(
-            second.result,
+            second,
             TxnWithHashAndStatus {
                 transaction: TxnWithHash {
                     transaction: candidate.transaction.clone().to_rpc_v0_8(),
@@ -703,8 +703,8 @@ mod test {
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve candidate notification");
 
-        assert_eq!(first.result.finality_status, TxnStatusWithoutL1::Candidate);
-        assert_eq!(first.result.transaction.transaction_hash, candidate.hash);
+        assert_eq!(first.finality_status, TxnStatusWithoutL1::Candidate);
+        assert_eq!(first.transaction.transaction_hash, candidate.hash);
 
         for block_number in 0..2 {
             backend
@@ -870,11 +870,11 @@ mod test {
             .expect("Timed out waiting for replacement transaction")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement transaction");
-        let item: super::super::SubscriptionItem<TxnWithHashAndStatus> =
+        let item: TxnWithHashAndStatus =
             serde_json::from_value(next).expect("Failed to deserialize replacement transaction item");
 
         assert_eq!(
-            item.result,
+            item,
             TxnWithHashAndStatus {
                 transaction: TxnWithHash { transaction: tx.transaction.to_rpc_v0_8(), transaction_hash },
                 finality_status: TxnStatusWithoutL1::AcceptedOnL2,
@@ -971,11 +971,11 @@ mod test {
             .expect("Timed out waiting for replacement transaction")
             .expect("Subscription closed unexpectedly")
             .expect("Failed to retrieve replacement transaction");
-        let item: super::super::SubscriptionItem<TxnWithHashAndStatus> =
+        let item: TxnWithHashAndStatus =
             serde_json::from_value(next).expect("Failed to deserialize replacement transaction item");
 
         assert_eq!(
-            item.result,
+            item,
             TxnWithHashAndStatus {
                 transaction: TxnWithHash { transaction: tx.transaction.to_rpc_v0_8(), transaction_hash },
                 finality_status: TxnStatusWithoutL1::AcceptedOnL2,

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
@@ -57,8 +57,7 @@ async fn subscribe_new_transactions_inner(
         None
     };
 
-    let sink =
-        subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
+    let sink = subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
     let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
     let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
     let mut emitted = EmittedTracker::default();

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
@@ -751,9 +751,11 @@ mod test {
     async fn subscribe_new_transactions_rejects_too_many_sender_addresses_v0_9() {
         let chain_config = Arc::new(ChainConfig::madara_test());
         let backend = mc_db::MadaraBackend::open_for_testing(chain_config);
+        let provider = Arc::new(crate::test_utils::TestTransactionProvider);
         let mut starknet = Starknet::new(
             backend,
-            Arc::new(crate::test_utils::TestTransactionProvider),
+            Arc::clone(&provider) as _,
+            provider,
             Default::default(),
             None,
             ServiceContext::new_for_testing(),

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
@@ -146,9 +146,9 @@ async fn subscribe_new_transactions_inner(
                         &allowed_statuses,
                         &mut emitted,
                     ).await?;
-                    // Transactions older than the previous confirmed block can no longer be
-                    // re-observed, so their dedup entries can be evicted.
-                    emitted.rotate();
+                    // PreConfirmed / AcceptedOnL2 entries can be evicted after a confirmed block;
+                    // Received / Candidate entries stay in the persistent set until reorg.
+                    emitted.rotate_ephemeral();
                     current_preconfirmed = starknet
                         .backend
                         .block_view_on_preconfirmed_or_fake()
@@ -304,13 +304,20 @@ async fn send_transaction_item(
     sink.send(msg).await.or_internal_server_error("SubscribeNewTransactions failed to respond to websocket request")
 }
 
-/// Dedup set for emitted (transaction, status) pairs, bounded by keeping only the two most
-/// recent confirmed-block generations. Entries are only needed while a transaction can still be
-/// re-observed (preconfirmed view refreshes and the preconfirmed-to-confirmed transition), which
-/// the previous generation covers; older entries are evicted on rotation so the set does not grow
-/// for the lifetime of the subscription.
+/// Dedup state for emitted (transaction, status) pairs.
+///
+/// Short-lived statuses (`PreConfirmed`, `AcceptedOnL2`) use a two-generation tracker rotated on
+/// each confirmed block. Long-lived statuses (`Received`, `Candidate`) use a persistent set that
+/// survives confirmed-block rotation, since those transactions can remain observable across many
+/// blocks until they are executed or dropped from the mempool.
 #[derive(Default)]
 struct EmittedTracker {
+    ephemeral: EphemeralEmittedTracker,
+    persistent: HashSet<(Felt, TxnStatusWithoutL1)>,
+}
+
+#[derive(Default)]
+struct EphemeralEmittedTracker {
     current: HashSet<(Felt, TxnStatusWithoutL1)>,
     previous: HashSet<(Felt, TxnStatusWithoutL1)>,
 }
@@ -318,6 +325,24 @@ struct EmittedTracker {
 impl EmittedTracker {
     fn mark_emitted(&mut self, tx_hash: Felt, status: &TxnStatusWithoutL1) -> bool {
         let key = (tx_hash, status.clone());
+        match status {
+            TxnStatusWithoutL1::Received | TxnStatusWithoutL1::Candidate => self.persistent.insert(key),
+            TxnStatusWithoutL1::PreConfirmed | TxnStatusWithoutL1::AcceptedOnL2 => self.ephemeral.mark_emitted(key),
+        }
+    }
+
+    fn rotate_ephemeral(&mut self) {
+        self.ephemeral.rotate();
+    }
+
+    fn clear(&mut self) {
+        self.ephemeral.clear();
+        self.persistent.clear();
+    }
+}
+
+impl EphemeralEmittedTracker {
+    fn mark_emitted(&mut self, key: (Felt, TxnStatusWithoutL1)) -> bool {
         if self.previous.contains(&key) {
             return false;
         }
@@ -331,6 +356,33 @@ impl EmittedTracker {
     fn clear(&mut self) {
         self.current.clear();
         self.previous.clear();
+    }
+}
+
+#[cfg(test)]
+mod emitted_tracker_tests {
+    use super::*;
+
+    #[test]
+    fn candidate_dedup_survives_ephemeral_rotation() {
+        let mut tracker = EmittedTracker::default();
+        let hash = Felt::from_hex_unchecked("0xabc");
+
+        assert!(tracker.mark_emitted(hash, &TxnStatusWithoutL1::Candidate));
+        tracker.rotate_ephemeral();
+        tracker.rotate_ephemeral();
+        assert!(!tracker.mark_emitted(hash, &TxnStatusWithoutL1::Candidate));
+    }
+
+    #[test]
+    fn accepted_on_l2_dedup_evicted_after_two_rotations() {
+        let mut tracker = EmittedTracker::default();
+        let hash = Felt::from_hex_unchecked("0xdef");
+
+        assert!(tracker.mark_emitted(hash, &TxnStatusWithoutL1::AcceptedOnL2));
+        tracker.rotate_ephemeral();
+        tracker.rotate_ephemeral();
+        assert!(tracker.mark_emitted(hash, &TxnStatusWithoutL1::AcceptedOnL2));
     }
 }
 
@@ -615,6 +667,85 @@ mod test {
                 },
                 finality_status: TxnStatusWithoutL1::Candidate,
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_new_transactions_candidate_not_reemitted_across_confirmed_blocks_v0_9() {
+        let (backend, starknet) = rpc_test_setup();
+        let (_handle, server_url) = start_v0_9_server(starknet).await;
+        let client = WsClientBuilder::default().build(&server_url).await.expect("Failed to start ws client");
+
+        let mut sub = StarknetWsRpcApiV0_9_0Client::subscribe_new_transactions(
+            &client,
+            Some(vec![TxnStatusWithoutL1::Candidate]),
+            Some(vec![SENDER_ADDRESS]),
+        )
+        .await
+        .expect("Failed subscription");
+
+        let candidate = Arc::new(validated_tx(SENDER_ADDRESS));
+        backend
+            .write_access()
+            .new_preconfirmed(PreconfirmedBlock::new_with_content(
+                PreconfirmedHeader {
+                    block_number: 0,
+                    protocol_version: StarknetVersion::V0_13_2,
+                    ..Default::default()
+                },
+                vec![],
+                vec![candidate.clone()],
+            ))
+            .expect("Failed to store preconfirmed block");
+
+        let first = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("Timed out waiting for candidate notification")
+            .expect("Subscription closed unexpectedly")
+            .expect("Failed to retrieve candidate notification");
+
+        assert_eq!(first.result.finality_status, TxnStatusWithoutL1::Candidate);
+        assert_eq!(first.result.transaction.transaction_hash, candidate.hash);
+
+        for block_number in 0..2 {
+            backend
+                .write_access()
+                .add_full_block_with_classes(
+                    &FullBlockWithoutCommitments {
+                        header: PreconfirmedHeader {
+                            block_number,
+                            protocol_version: StarknetVersion::V0_13_2,
+                            ..Default::default()
+                        },
+                        state_diff: Default::default(),
+                        transactions: vec![],
+                        events: vec![],
+                    },
+                    &[],
+                    true,
+                )
+                .expect("Failed to store confirmed block");
+
+            backend
+                .write_access()
+                .new_preconfirmed(PreconfirmedBlock::new_with_content(
+                    PreconfirmedHeader {
+                        block_number: block_number + 1,
+                        protocol_version: StarknetVersion::V0_13_2,
+                        ..Default::default()
+                    },
+                    vec![],
+                    vec![candidate.clone()],
+                ))
+                .expect("Failed to restore preconfirmed block with lingering candidate");
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let duplicate = tokio::time::timeout(Duration::from_millis(500), sub.next()).await;
+        assert!(
+            duplicate.is_err(),
+            "Candidate transaction should not be re-emitted after confirmed blocks: got {duplicate:?}",
         );
     }
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
@@ -41,7 +41,7 @@ async fn subscribe_new_transactions_inner(
     let allowed_statuses =
         finality_status.unwrap_or_else(|| vec![TxnStatusWithoutL1::AcceptedOnL2]).into_iter().collect::<HashSet<_>>();
     let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
-    let mut emitted = HashSet::<(Felt, TxnStatusWithoutL1)>::new();
+    let mut emitted = EmittedTracker::default();
 
     let mut received_watch = if allowed_statuses.contains(&TxnStatusWithoutL1::Received) {
         Some(
@@ -146,6 +146,9 @@ async fn subscribe_new_transactions_inner(
                         &allowed_statuses,
                         &mut emitted,
                     ).await?;
+                    // Transactions older than the previous confirmed block can no longer be
+                    // re-observed, so their dedup entries can be evicted.
+                    emitted.rotate();
                     current_preconfirmed = starknet
                         .backend
                         .block_view_on_preconfirmed_or_fake()
@@ -175,7 +178,7 @@ async fn send_preconfirmed_view_transactions(
     preconfirmed: &mc_db::view::MadaraPreconfirmedBlockView,
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     if allowed_statuses.contains(&TxnStatusWithoutL1::PreConfirmed) {
         for tx in preconfirmed.get_executed_transactions(..) {
@@ -213,7 +216,7 @@ async fn send_confirmed_block_transactions(
     block_view: &mc_db::MadaraBlockView,
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     if !allowed_statuses.contains(&TxnStatusWithoutL1::AcceptedOnL2) {
         return Ok(());
@@ -243,11 +246,11 @@ async fn send_validated_transaction(
     status: TxnStatusWithoutL1,
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     if !allowed_statuses.contains(&status)
         || !sender_address.is_none_or(|addresses| addresses.contains(&tx.contract_address))
-        || !mark_emitted(emitted, tx.hash, &status)
+        || !emitted.mark_emitted(tx.hash, &status)
     {
         return Ok(());
     }
@@ -268,12 +271,12 @@ async fn send_executed_transaction(
     status: TxnStatusWithoutL1,
     sender_address: Option<&HashSet<Felt>>,
     allowed_statuses: &HashSet<TxnStatusWithoutL1>,
-    emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>,
+    emitted: &mut EmittedTracker,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
     let tx_hash = *tx.receipt.transaction_hash();
     if !allowed_statuses.contains(&status)
         || !transaction_matches_sender(&tx.transaction, sender_address)
-        || !mark_emitted(emitted, tx_hash, &status)
+        || !emitted.mark_emitted(tx_hash, &status)
     {
         return Ok(());
     }
@@ -301,8 +304,34 @@ async fn send_transaction_item(
     sink.send(msg).await.or_internal_server_error("SubscribeNewTransactions failed to respond to websocket request")
 }
 
-fn mark_emitted(emitted: &mut HashSet<(Felt, TxnStatusWithoutL1)>, tx_hash: Felt, status: &TxnStatusWithoutL1) -> bool {
-    emitted.insert((tx_hash, status.clone()))
+/// Dedup set for emitted (transaction, status) pairs, bounded by keeping only the two most
+/// recent confirmed-block generations. Entries are only needed while a transaction can still be
+/// re-observed (preconfirmed view refreshes and the preconfirmed-to-confirmed transition), which
+/// the previous generation covers; older entries are evicted on rotation so the set does not grow
+/// for the lifetime of the subscription.
+#[derive(Default)]
+struct EmittedTracker {
+    current: HashSet<(Felt, TxnStatusWithoutL1)>,
+    previous: HashSet<(Felt, TxnStatusWithoutL1)>,
+}
+
+impl EmittedTracker {
+    fn mark_emitted(&mut self, tx_hash: Felt, status: &TxnStatusWithoutL1) -> bool {
+        let key = (tx_hash, status.clone());
+        if self.previous.contains(&key) {
+            return false;
+        }
+        self.current.insert(key)
+    }
+
+    fn rotate(&mut self) {
+        self.previous = std::mem::take(&mut self.current);
+    }
+
+    fn clear(&mut self) {
+        self.current.clear();
+        self.previous.clear();
+    }
 }
 
 fn transaction_matches_sender(transaction: &Transaction, sender_address: Option<&HashSet<Felt>>) -> bool {

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_transactions.rs
@@ -30,39 +30,38 @@ async fn subscribe_new_transactions_inner(
     sender_address: Option<Vec<Felt>>,
     emit_reorg_notifications: bool,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
-    let sink = if sender_address.as_ref().map_or(0, Vec::len) as u64 <= super::ADDRESS_FILTER_LIMIT {
-        subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?
-    } else {
+    if sender_address.as_ref().map_or(0, Vec::len) as u64 > super::ADDRESS_FILTER_LIMIT {
         subscription_sink.reject(crate::errors::StarknetWsApiError::TooManyAddressesInFilter).await;
         return Ok(());
-    };
+    }
 
-    let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
     let allowed_statuses =
         finality_status.unwrap_or_else(|| vec![TxnStatusWithoutL1::AcceptedOnL2]).into_iter().collect::<HashSet<_>>();
-    let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
-    let mut emitted = EmittedTracker::default();
 
+    // Resolve the received-transactions watcher before accepting the subscription, so
+    // configurations without one reject the subscribe call instead of accepting the connection
+    // and then closing it with an opaque Internal error.
     let mut received_watch = if allowed_statuses.contains(&TxnStatusWithoutL1::Received) {
-        Some(
-            starknet
-                .new_transactions_watcher
-                .as_ref()
-                .ok_or_else(|| {
-                    crate::errors::StarknetWsApiError::internal_server_error(
-                        "SubscribeNewTransactions failed: new-transactions watcher is not configured",
-                    )
-                })?
-                .watch_new_transactions()
-                .ok_or_else(|| {
-                    crate::errors::StarknetWsApiError::internal_server_error(
-                        "SubscribeNewTransactions failed to create new-transactions watcher",
-                    )
-                })?,
-        )
+        match starknet.new_transactions_watcher.as_ref().and_then(|watcher| watcher.watch_new_transactions()) {
+            Some(watch) => Some(watch),
+            None => {
+                subscription_sink
+                    .reject(crate::errors::StarknetWsApiError::internal_server_error(
+                        "SubscribeNewTransactions with RECEIVED status is not available: new-transactions watcher is not configured",
+                    ))
+                    .await;
+                return Ok(());
+            }
+        }
     } else {
         None
     };
+
+    let sink =
+        subscription_sink.accept().await.or_internal_server_error("Failed to establish websocket connection")?;
+    let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
+    let sender_address = sender_address.map(|addresses| addresses.into_iter().collect::<HashSet<_>>());
+    let mut emitted = EmittedTracker::default();
 
     let mut heads = starknet.backend.subscribe_new_heads(SubscribeNewBlocksTag::Preconfirmed);
     let mut current_preconfirmed = starknet

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
@@ -5,26 +5,25 @@ pub async fn subscribe_transaction_status(
     subscription_sink: jsonrpsee::PendingSubscriptionSink,
     transaction_hash: mp_convert::Felt,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
+    // Resolve the watcher before accepting the subscription, so configurations without a
+    // tx-status watcher reject the subscribe call instead of accepting the connection and then
+    // closing it with an opaque Internal error.
+    let watch =
+        starknet.tx_status_watcher.as_ref().and_then(|watcher| watcher.watch_transaction_status(transaction_hash));
+    let Some(mut watch) = watch else {
+        subscription_sink
+            .reject(crate::errors::StarknetWsApiError::internal_server_error(
+                "SubscribeTransactionStatus is not available: tx-status watcher is not configured",
+            ))
+            .await;
+        return Ok(());
+    };
+
     let sink = subscription_sink
         .accept()
         .await
         .or_internal_server_error("SubscribeTransactionStatus failed to establish websocket connection")?;
     let ctx = starknet.ws_handles.subscription_register(sink.subscription_id()).await;
-
-    let mut watch = starknet
-        .tx_status_watcher
-        .as_ref()
-        .ok_or_else(|| {
-            crate::errors::StarknetWsApiError::internal_server_error(
-                "SubscribeTransactionStatus failed: tx-status watcher is not configured",
-            )
-        })?
-        .watch_transaction_status(transaction_hash)
-        .ok_or_else(|| {
-            crate::errors::StarknetWsApiError::internal_server_error(
-                "SubscribeTransactionStatus failed to create transaction status watcher",
-            )
-        })?;
     let mut reorgs = starknet.backend.subscribe_reorgs();
 
     let mut allow_current = true;

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
@@ -35,7 +35,7 @@ pub async fn subscribe_transaction_status(
             SubscriptionUpdate::Snapshot(snapshot) => {
                 allow_current = false;
 
-                send_txn_status(&sink, snapshot).await?;
+                send_txn_status(starknet, &sink, transaction_hash, snapshot).await?;
                 if matches!(snapshot, crate::TxStatusSnapshot::AcceptedOnL1) {
                     crate::close_ws_subscription(starknet, sink.subscription_id()).await?;
                     return Ok(());
@@ -88,10 +88,12 @@ async fn next_update(
 }
 
 async fn send_txn_status(
+    starknet: &crate::Starknet,
     sink: &jsonrpsee::core::server::SubscriptionSink,
+    transaction_hash: mp_convert::Felt,
     snapshot: crate::TxStatusSnapshot,
 ) -> Result<(), crate::errors::StarknetWsApiError> {
-    let status = match snapshot {
+    let finality_status = match snapshot {
         crate::TxStatusSnapshot::Received => mp_rpc::v0_9_0::TxnStatus::Received,
         crate::TxStatusSnapshot::Candidate => mp_rpc::v0_9_0::TxnStatus::Candidate,
         crate::TxStatusSnapshot::PreConfirmed => mp_rpc::v0_9_0::TxnStatus::PreConfirmed,
@@ -99,8 +101,21 @@ async fn send_txn_status(
         crate::TxStatusSnapshot::AcceptedOnL1 => mp_rpc::v0_9_0::TxnStatus::AcceptedOnL1,
     };
 
-    let item = super::SubscriptionItem::new(sink.subscription_id(), status);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    // The watcher only tracks finality; enrich with the execution status when the transaction is
+    // already executed, falling back to finality-only if it cannot be retrieved.
+    let execution_status = match finality_status {
+        mp_rpc::v0_9_0::TxnStatus::Received | mp_rpc::v0_9_0::TxnStatus::Candidate => None,
+        _ => super::super::read::get_transaction_status::get_transaction_status(starknet, transaction_hash)
+            .await
+            .ok()
+            .and_then(|status| status.execution_status),
+    };
+
+    let payload = mp_rpc::v0_9_0::NewTxnStatus {
+        transaction_hash,
+        status: mp_rpc::v0_9_0::TxnFinalityAndExecutionStatus { finality_status, execution_status },
+    };
+    let msg = super::notification_message(super::TRANSACTION_STATUS_NOTIFICATION_METHOD, sink, &payload)
         .or_else_internal_server_error(|| "SubscribeTransactionStatus failed to create response".to_owned())?;
 
     sink.send(msg).await.or_internal_server_error("SubscribeTransactionStatus failed to respond to websocket request")
@@ -111,7 +126,7 @@ mod test {
     use crate::{
         test_utils::{TestTransactionProvider, TestTxStatusWatcher},
         versions::user::v0_9_0::{
-            methods::ws::SubscriptionItem, StarknetWsRpcApiV0_9_0Client, StarknetWsRpcApiV0_9_0Server,
+StarknetWsRpcApiV0_9_0Client, StarknetWsRpcApiV0_9_0Server,
         },
         Starknet,
     };
@@ -196,8 +211,9 @@ mod test {
 
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
-                assert_eq!(status, mp_rpc::v0_9_0::TxnStatus::Received);
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::Received);
+                    assert_eq!(status.transaction_hash, TX_HASH);
             }
         );
     }
@@ -217,40 +233,45 @@ mod test {
         watcher.set_status(Some(crate::TxStatusSnapshot::Received));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
-                assert_eq!(status, mp_rpc::v0_9_0::TxnStatus::Received);
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::Received);
+                    assert_eq!(status.transaction_hash, TX_HASH);
             }
         );
 
         watcher.set_status(Some(crate::TxStatusSnapshot::Candidate));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
-                assert_eq!(status, mp_rpc::v0_9_0::TxnStatus::Candidate);
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::Candidate);
+                    assert_eq!(status.transaction_hash, TX_HASH);
             }
         );
 
         watcher.set_status(Some(crate::TxStatusSnapshot::PreConfirmed));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
-                assert_eq!(status, mp_rpc::v0_9_0::TxnStatus::PreConfirmed);
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::PreConfirmed);
+                    assert_eq!(status.transaction_hash, TX_HASH);
             }
         );
 
         watcher.set_status(Some(crate::TxStatusSnapshot::AcceptedOnL2));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
-                assert_eq!(status, mp_rpc::v0_9_0::TxnStatus::AcceptedOnL2);
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::AcceptedOnL2);
+                    assert_eq!(status.transaction_hash, TX_HASH);
             }
         );
 
         watcher.set_status(Some(crate::TxStatusSnapshot::AcceptedOnL1));
         assert_matches!(
             tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
-            Some(Ok(SubscriptionItem { result: status, .. })) => {
-                assert_eq!(status, mp_rpc::v0_9_0::TxnStatus::AcceptedOnL1);
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::AcceptedOnL1);
+                    assert_eq!(status.transaction_hash, TX_HASH);
             }
         );
     }
@@ -268,16 +289,22 @@ mod test {
         let mut sub = client.subscribe_transaction_status(TX_HASH).await.expect("Failed subscription");
         watcher.set_status(Some(crate::TxStatusSnapshot::Received));
 
-        let subscription_id =
-            match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status")
+        match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status")
             {
-                Some(Ok(SubscriptionItem { subscription_id, result: status })) => {
-                    assert_eq!(status, mp_rpc::v0_9_0::TxnStatus::Received);
-                    subscription_id
+                Some(Ok(status)) => {
+                    assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::Received);
+                    assert_eq!(status.transaction_hash, TX_HASH);
                 }
                 other => panic!("Unexpected subscription result: {other:?}"),
             };
 
+        let jsonrpsee::core::client::SubscriptionKind::Subscription(sub_id) = sub.kind().clone() else {
+            panic!("Expected a subscription id");
+        };
+        let subscription_id = match sub_id {
+            jsonrpsee::types::SubscriptionId::Num(id) => id.to_string(),
+            jsonrpsee::types::SubscriptionId::Str(id) => id.into_owned(),
+        };
         client.starknet_unsubscribe(subscription_id).await.expect("Failed to close subscription");
         assert!(sub.next().await.is_none());
     }

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
@@ -32,7 +32,7 @@ pub async fn subscribe_transaction_status(
             return Ok(());
         };
         match update {
-            SubscriptionUpdate::Snapshot(snapshot) => {
+            SubscriptionUpdate::Status(crate::TxStatusUpdate::Status(snapshot)) => {
                 allow_current = false;
 
                 send_txn_status(starknet, &sink, transaction_hash, snapshot).await?;
@@ -40,6 +40,9 @@ pub async fn subscribe_transaction_status(
                     crate::close_ws_subscription(starknet, sink.subscription_id()).await?;
                     return Ok(());
                 }
+            }
+            SubscriptionUpdate::Status(crate::TxStatusUpdate::NotFound) => {
+                allow_current = false;
             }
             SubscriptionUpdate::Reorg(reorg) => super::send_reorg_notification(&sink, &reorg).await?,
             SubscriptionUpdate::WatcherClosed => {
@@ -51,7 +54,7 @@ pub async fn subscribe_transaction_status(
 }
 
 enum SubscriptionUpdate {
-    Snapshot(crate::TxStatusSnapshot),
+    Status(crate::TxStatusUpdate),
     Reorg(mc_db::ReorgNotification),
     WatcherClosed,
 }
@@ -64,9 +67,7 @@ async fn next_update(
     allow_current: bool,
 ) -> Result<Option<SubscriptionUpdate>, crate::errors::StarknetWsApiError> {
     if allow_current {
-        if let Some(snapshot) = watch.take_current() {
-            return Ok(Some(SubscriptionUpdate::Snapshot(snapshot)));
-        }
+        return Ok(Some(SubscriptionUpdate::Status(watch.take_current())));
     }
 
     tokio::select! {
@@ -82,7 +83,7 @@ async fn next_update(
             }
         },
         next = watch.recv() => {
-            Ok(Some(next.map(SubscriptionUpdate::Snapshot).unwrap_or(SubscriptionUpdate::WatcherClosed)))
+            Ok(Some(next.map(SubscriptionUpdate::Status).unwrap_or(SubscriptionUpdate::WatcherClosed)))
         },
     }
 }
@@ -125,9 +126,7 @@ async fn send_txn_status(
 mod test {
     use crate::{
         test_utils::{TestTransactionProvider, TestTxStatusWatcher},
-        versions::user::v0_9_0::{
-StarknetWsRpcApiV0_9_0Client, StarknetWsRpcApiV0_9_0Server,
-        },
+        versions::user::v0_9_0::{StarknetWsRpcApiV0_9_0Client, StarknetWsRpcApiV0_9_0Server},
         Starknet,
     };
     use assert_matches::assert_matches;
@@ -277,6 +276,42 @@ StarknetWsRpcApiV0_9_0Client, StarknetWsRpcApiV0_9_0Server,
     }
 
     #[tokio::test]
+    async fn subscribe_transaction_status_not_found_keeps_subscription_open() {
+        let (_backend, starknet, watcher) = starknet_with_status_watcher();
+
+        let builder = jsonrpsee::server::Server::builder();
+        let server = builder.build(SERVER_ADDR).await.expect("Failed to start jsonrpsee server");
+        let server_url = format!("ws://{}", server.local_addr().expect("Failed to retrieve server local addr"));
+        let _server_handle = server.start(StarknetWsRpcApiV0_9_0Server::into_rpc(starknet));
+        let client = WsClientBuilder::default().build(&server_url).await.expect("Failed to start jsonrpsee ws client");
+
+        let mut sub = client.subscribe_transaction_status(TX_HASH).await.expect("Failed subscription");
+
+        watcher.set_status(Some(crate::TxStatusSnapshot::Received));
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status"),
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::Received);
+                assert_eq!(status.transaction_hash, TX_HASH);
+            }
+        );
+
+        watcher.set_status(None);
+        tokio::time::timeout(Duration::from_millis(200), sub.next())
+            .await
+            .expect_err("NotFound should not emit or close the subscription");
+
+        watcher.set_status(Some(crate::TxStatusSnapshot::AcceptedOnL2));
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for re-added status"),
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::AcceptedOnL2);
+                assert_eq!(status.transaction_hash, TX_HASH);
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn subscribe_transaction_status_unsubscribe() {
         let (_backend, starknet, watcher) = starknet_with_status_watcher();
 
@@ -289,14 +324,13 @@ StarknetWsRpcApiV0_9_0Client, StarknetWsRpcApiV0_9_0Server,
         let mut sub = client.subscribe_transaction_status(TX_HASH).await.expect("Failed subscription");
         watcher.set_status(Some(crate::TxStatusSnapshot::Received));
 
-        match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status")
-            {
-                Some(Ok(status)) => {
-                    assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::Received);
-                    assert_eq!(status.transaction_hash, TX_HASH);
-                }
-                other => panic!("Unexpected subscription result: {other:?}"),
-            };
+        match tokio::time::timeout(Duration::from_secs(5), sub.next()).await.expect("Timed out waiting for status") {
+            Some(Ok(status)) => {
+                assert_eq!(status.status.finality_status, mp_rpc::v0_9_0::TxnStatus::Received);
+                assert_eq!(status.transaction_hash, TX_HASH);
+            }
+            other => panic!("Unexpected subscription result: {other:?}"),
+        };
 
         let jsonrpsee::core::client::SubscriptionKind::Subscription(sub_id) = sub.kind().clone() else {
             panic!("Expected a subscription id");

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/mod.rs
@@ -132,11 +132,11 @@ pub trait StarknetReadRpcApi {
     fn get_compiled_casm(&self, class_hash: Felt) -> RpcResult<serde_json::Value>;
 }
 
-type SubscriptionItemEvents = methods::ws::SubscriptionItem<mp_rpc::v0_9_0::EmittedEventWithFinality>;
-type SubscriptionItemNewHeads = methods::ws::SubscriptionItem<mp_rpc::v0_9_0::BlockHeader>;
-type SubscriptionItemNewTransactions = methods::ws::SubscriptionItem<mp_rpc::v0_9_0::TxnWithHashAndStatus>;
-type SubscriptionItemNewTransactionReceipts = methods::ws::SubscriptionItem<mp_rpc::v0_9_0::TxnReceiptWithBlockInfo>;
-type SubscriptionItemTransactionStatus = methods::ws::SubscriptionItem<mp_rpc::v0_9_0::TxnStatus>;
+type SubscriptionItemEvents = mp_rpc::v0_9_0::EmittedEventWithFinality;
+type SubscriptionItemNewHeads = mp_rpc::v0_9_0::BlockHeader;
+type SubscriptionItemNewTransactions = mp_rpc::v0_9_0::TxnWithHashAndStatus;
+type SubscriptionItemNewTransactionReceipts = mp_rpc::v0_9_0::TxnReceiptWithBlockInfo;
+type SubscriptionItemTransactionStatus = mp_rpc::v0_9_0::NewTxnStatus;
 
 #[versioned_rpc("V0_9_0", "starknet")]
 pub trait StarknetWsRpcApi {

--- a/madara/crates/primitives/rpc/src/v0_9_0/starknet_ws_api.rs
+++ b/madara/crates/primitives/rpc/src/v0_9_0/starknet_ws_api.rs
@@ -19,6 +19,13 @@ pub enum FinalityStatus {
     AcceptedOnL2,
 }
 
+/// Result payload for `starknet_subscriptionTransactionStatus` notifications (spec `NEW_TXN_STATUS`).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NewTxnStatus {
+    pub transaction_hash: starknet_types_core::felt::Felt,
+    pub status: super::TxnFinalityAndExecutionStatus,
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EmittedEventWithFinality {
     #[serde(flatten)]

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -475,7 +475,8 @@ async fn main() -> anyhow::Result<()> {
     let l1_endpoint_some = run_cmd.l1_sync_params.l1_endpoint.is_some();
     let warp_update_receiver = run_cmd.args_preset.warp_update_receiver;
 
-    if run_cmd.should_run_mempool() {
+    let rpc_configured = !run_cmd.rpc_params.rpc_disable || run_cmd.rpc_params.rpc_admin;
+    if run_cmd.should_run_mempool() || rpc_configured {
         app.activate(MadaraServiceId::Mempool);
     }
     app.activate(MadaraServiceId::Telemetry);

--- a/madara/node/src/service/mempool.rs
+++ b/madara/node/src/service/mempool.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 pub struct MempoolService {
     mempool: Arc<Mempool>,
+    run_pool: bool,
 }
 
 impl MempoolService {
@@ -20,6 +21,7 @@ impl MempoolService {
                 Arc::clone(&backend),
                 MempoolConfig { save_to_db: run_cmd.should_save_mempool_to_db(), external_outbox },
             )),
+            run_pool: run_cmd.should_run_mempool(),
         }
     }
 
@@ -32,7 +34,17 @@ impl MempoolService {
 impl Service for MempoolService {
     async fn start<'a>(&mut self, runner: ServiceRunner<'a>) -> anyhow::Result<()> {
         let mempool = self.mempool.clone();
-        runner.service_loop(move |ctx| async move { mempool.run_mempool_task(ctx).await });
+        let run_pool = self.run_pool;
+        runner.service_loop(move |ctx| {
+            let mempool = mempool.clone();
+            async move {
+                if run_pool {
+                    mempool.run_mempool_task(ctx).await
+                } else {
+                    mempool.run_status_task(ctx).await
+                }
+            }
+        });
 
         Ok(())
     }


### PR DESCRIPTION
## What

Brings the node to full RPC v0.10.3 (spec tag `v0.10.3-rc.1`) compliance on top of the 0.14.3 stack.

### Changes

1. **Revive WebSocket subscriptions** (`02d59e839`) — merges `codex/starknet-ws-implementation`: full 0.10.x WS surface (`subscribeNewTransactions`, `subscribeNewTransactionReceipts`, `subscribeEvents` with `finality_status`, reorg notifications) replacing the disabled `FIXME(subscriptions)` stubs that returned 501 on every method.

2. **Fix proof wire format** (`47a16e406`) — `proof` on broadcasted invoke v3 is now a base64 string of the underlying byte array per the spec `PROOF` schema (matching `starknet_api::transaction::fields::Proof`), instead of a JSON array of integers, end-to-end through gateway forwarding. Also removes the fallback that fabricated hash-relevant `proof_facts` from proof integers — facts are client-provided only (apollo gateway semantics: both-or-neither, verified against each other).

3. **Serve v0.10.3** (`816787153`) — `/rpc/v0_10_3` endpoint via a thin delegation layer over v0.10.2 (the spec delta is version strings + `PROOF`/`PROOF_FACTS` schema extraction only), `specVersion` → `0.10.3`, `RPC_VERSION_LATEST` bumped so unversioned requests get v0.10.3.

4. **Spec conformance suite** (`b1979e5ec`) — checksums pinned to `v0.10.3-rc.1`, new `v0_10_3` js fixture set.

5. **Make live WS subscriptions actually work and be spec-shaped** (`f1b5ccc35`) — two production bugs invisible to unit tests (test servers use jsonrpsee's default integer subscription ids; the real server uses `RandomStringIdProvider`):
   - the subscription registry assumed u64 ids and **panicked on every real connection**; now string-keyed across all versions, unsubscribe takes string ids
   - notification frames used the version-mangled subscribe method name (`starknet_V0_10_2_subscribeNewHeads`) with a double-nested payload; now proper `starknet_subscriptionX` methods with the result object directly in `params.result`, and `subscriptionTransactionStatus` payloads follow `NEW_TXN_STATUS`
   - also removes spurious per-block "Missed reorg" ERROR logs (error was constructed eagerly as an argument)

### Verification

- 254/254 `mc-rpc` tests, all touched crates green, clippy clean
- Live devnet smoke test: correct `specVersion` on all six endpoints, WS subscribe → string id → spec-method notifications across consecutive blocks → unsubscribe, zero errors/panics in the node log

### Known limitations / review notes

- **Residual spec deviation**: jsonrpsee hardcodes the notification params key as `"subscription"`; the spec says `"subscription_id"`. Fixing requires patching `jsonrpsee-types` — needs a team decision (vendor vs upstream).
- The WS revival merges `codex/starknet-ws-implementation`; its author should sanity-check the merge.
- Live verification covered devnet mode only; full-node sync against Sepolia (reorg paths especially) relies on the unit/contract tests.
- Client-side proving (`starknet_proveTransaction`) and wallet-API STRK20 additions in the 0.10.3 spec are separate prover/wallet services, intentionally out of scope for the node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)