### PR TITLE
docs: full-node operator docs (build prereqs, --rpc preset, gateway rate limits, bootstrap paths)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,9 @@ Targets:
   [ BUILDING ]
 
   - build-madara                  Build Madara with Cairo 0 environment setup
+                                  (runs an LLVM 19 preflight check; skip with SKIP_LLVM_CHECK=1)
   - build-orchestrator            Build Orchestrator with Cairo 0 environment setup
+  - check-llvm19                  Verify llvm-config 19.x is available (required by Cairo Native)
 
   [ CODE QUALITY ]
 
@@ -227,8 +229,30 @@ setup-cairo:
 	@$(VENV_ACTIVATE) && pip install --upgrade pip > /dev/null 2>&1 && pip install -r cairo_requirements.txt > /dev/null 2>&1
 	@$(VENV_ACTIVATE) && cairo-compile --version > /dev/null 2>&1 && echo -e "$(PASS)✅ Cairo 0 environment ready (cairo-compile $$($(VENV_ACTIVATE) && cairo-compile --version 2>&1))$(RESET)" || (echo -e "$(WARN)❌ Cairo setup failed$(RESET)" && exit 1)
 
+# Preflight: verify LLVM 19 is available before starting a long build.
+# Cairo Native (tblgen) requires llvm-config 19.x; without it the build fails
+# late with "failed to find correct version (19.x.x) of llvm-config".
+# Skip with SKIP_LLVM_CHECK=1.
+.PHONY: check-llvm19
+check-llvm19:
+	@if [ -n "$(SKIP_LLVM_CHECK)" ]; then \
+		echo -e "$(WARN)Skipping LLVM 19 preflight check (SKIP_LLVM_CHECK is set)$(RESET)"; \
+	elif [ -n "$$MLIR_SYS_190_PREFIX" ]; then \
+		echo -e "$(PASS)✅ LLVM 19 located via MLIR_SYS_190_PREFIX=$$MLIR_SYS_190_PREFIX$(RESET)"; \
+	elif command -v llvm-config-19 > /dev/null 2>&1; then \
+		echo -e "$(PASS)✅ Found llvm-config-19 (version $$(llvm-config-19 --version))$(RESET)"; \
+	elif command -v llvm-config > /dev/null 2>&1 && llvm-config --version 2>/dev/null | grep -q "^19\."; then \
+		echo -e "$(PASS)✅ Found llvm-config (version $$(llvm-config --version))$(RESET)"; \
+	else \
+		echo -e "$(WARN)❌ LLVM 19 not found. Cairo Native requires llvm-config 19.x and the build will fail late at the tblgen build script.$(RESET)"; \
+		echo -e "$(INFO)   Ubuntu/Debian: make install-llvm19 [SUDO=sudo]$(RESET)"; \
+		echo -e "$(INFO)   macOS: brew install llvm@19 && export MLIR_SYS_190_PREFIX=\$$(brew --prefix llvm@19)$(RESET)"; \
+		echo -e "$(INFO)   To skip this check: make build-madara SKIP_LLVM_CHECK=1$(RESET)"; \
+		exit 1; \
+	fi
+
 .PHONY: build-madara
-build-madara: setup-cairo
+build-madara: check-llvm19 setup-cairo
 	@echo -e "$(DIM)Building Madara with Cairo 0 environment...$(RESET)"
 	@$(VENV_ACTIVATE) && cargo build --bin madara --release
 	@echo -e "$(PASS)✅ Build complete!$(RESET)"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Madara is a powerful Starknet client written in Rust.
   - [Basic Command-Line Options](#basic-command-line-options)
   - [Environment variables](#environment-variables)
   - [Gateway Rate Limits During Sync](#gateway-rate-limits-during-sync)
-    🌐 [Interactions](#-interactions)
+- 🌐 [Interactions](#-interactions)
   - [Supported JSON-RPC Methods](#supported-json-rpc-methods)
   - [Madara-specific JSON-RPC Methods](#madara-specific-json-rpc-methods)
   - [Example of Calling a JSON-RPC Method](#example-of-calling-a-json-rpc-method)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Madara is a powerful Starknet client written in Rust.
 - ⚙️ [Configuration](#%EF%B8%8F-configuration)
   - [Basic Command-Line Options](#basic-command-line-options)
   - [Environment variables](#environment-variables)
+  - [Gateway Rate Limits During Sync](#gateway-rate-limits-during-sync)
     🌐 [Interactions](#-interactions)
   - [Supported JSON-RPC Methods](#supported-json-rpc-methods)
   - [Madara-specific JSON-RPC Methods](#madara-specific-json-rpc-methods)
@@ -35,6 +36,7 @@ Madara is a powerful Starknet client written in Rust.
   - [Feeder-Gateway State Synchronization](#feeder-gateway-state-synchronization)
   - [State Commitment Computation](#state-commitment-computation)
   - [SnapSync](#snapsync)
+  - [Mainnet Full-Node Bootstrap](#mainnet-full-node-bootstrap)
   - [Cairo Native Execution](#cairo-native-execution)
   - [L3 Support](#l3-support)
   - [Automatic Database Migrations](#automatic-database-migrations)
@@ -55,11 +57,22 @@ Madara is a powerful Starknet client written in Rust.
 
 Ensure you have all the necessary dependencies available on your host system.
 
-| Dependency | Version    | Installation                                                      |
-| ---------- | ---------- | ----------------------------------------------------------------- |
-| Rust       | rustc 1.89 | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
-| Clang      | Latest     | `sudo apt-get install clang`                                      |
-| Openssl    | 0.10       | `sudo apt install openssl`                                        |
+| Dependency | Version    | Installation                                                                        |
+| ---------- | ---------- | ----------------------------------------------------------------------------------- |
+| Rust       | rustc 1.89 | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh`                   |
+| Clang      | Latest     | `sudo apt-get install clang`                                                        |
+| Openssl    | 0.10       | `sudo apt install openssl`                                                          |
+| LLVM       | 19         | `make install-llvm19 [SUDO=sudo]` (Ubuntu/Debian) or `brew install llvm@19` (macOS) |
+
+> [!IMPORTANT]
+> Source builds require LLVM 19 (`llvm-config-19`) for Cairo Native and the
+> `tblgen` build script. Without it, the build fails late with an error like
+> `failed to find correct version (19.x.x) of llvm-config (found 18.1.3)`.
+> On Ubuntu/Debian, run `make install-llvm19 [SUDO=sudo]` before building. If
+> the build scripts still cannot locate LLVM 19, export
+> `MLIR_SYS_190_PREFIX`, `LLVM_SYS_191_PREFIX`, and `TABLEGEN_190_PREFIX` to
+> your LLVM 19 prefix (`/usr/lib/llvm-19` on Ubuntu/Debian,
+> `$(brew --prefix llvm@19)` on macOS).
 
 Once all dependencies are satisfied, you can clone the Madara repository:
 
@@ -329,6 +342,35 @@ You can find examples on [configs](configs/).
 > If the command-line argument is specified then it takes precedent over the
 > environment variable.
 
+### Gateway Rate Limits During Sync
+
+During catchup (especially on mainnet), you may see repeated INFO logs like:
+
+```text
+⏳ Rate limited, retrying
+```
+
+This means the public feeder gateway returned HTTP 429. Madara automatically
+pauses gateway requests for the duration indicated by the `Retry-After` header
+(10 seconds if absent) and then retries. Sync continues, just slower — no
+action is required for correctness, only for speed.
+
+Options to reduce rate limiting:
+
+- **`--gateway-key <API KEY>`** (`MADARA_GATEWAY_KEY`): bypasses gateway
+  throttling for operators who have been issued an API key. Keys are issued by
+  the gateway operator; Madara does not provide them.
+- **`--gateway-url <URL>`** (`MADARA_GATEWAY_URL`): syncs from a custom or
+  alternative feeder gateway instead of the default public one. This can also
+  point at a local Madara node serving its own feeder gateway — see
+  [warp update](#warp-update) (`--warp-update-sender`) for the local-source
+  setup.
+
+When reporting rate-limit-related sync performance, please capture: the block
+sync rate (blocks/sec), database size growth, a count or sample of the
+`Rate limited, retrying` logs over time, and your gateway configuration
+(default public gateway vs `--gateway-url`, with or without `--gateway-key`).
+
 ## 🌐 Interactions
 
 [⬅️ back to top](#-madara-starknet-client)
@@ -344,6 +386,17 @@ Admin RPC methods are exposed under `rpc/v0_1_0` (default port `9943`) when `--r
 These methods can be categorized into three main types: Read-Only Access Methods,
 Trace Generation Methods, and Write Methods. They are accessible through port
 **9944** unless specified otherwise with `--rpc-port`.
+
+> [!NOTE]
+> User RPC is enabled by default on **localhost** (disable it with
+> `--rpc-disable`). The `--rpc` flag is _not_ needed to enable RPC: it is an
+> external RPC _provider_ preset that exposes user RPC on `0.0.0.0`, enables
+> admin RPC on localhost, and allows all CORS origins. For a private full node,
+> omit `--rpc` and just pick a port:
+>
+> ```bash
+> cargo run --bin madara --release -- --full --network mainnet --rpc-port 9944
+> ```
 
 > [!TIP]
 > You can use the special `rpc_methods` call to view a list of all the methods
@@ -786,6 +839,28 @@ state diffs and returns to block-by-block trie updates.
 > - Reverting into the snap-synced range is blocked by design. The admin revert
 >   API rejects targets lower than the recorded `snap_sync_latest_block` because
 >   trie data is only available from that boundary onward.
+
+### Mainnet Full-Node Bootstrap
+
+There are several ways to bring up a mainnet full node, with different
+speed/data tradeoffs:
+
+| Path                   | How                                               | Pros                                                                                     | Cons                                                                                                                                    |
+| ---------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Full-trie from genesis | `--full --network mainnet`                        | Maximum historical trie data; storage proofs and admin revert work for all synced blocks | Slow with high DB growth (one observed run: ~0.4–0.6 blocks/sec and ~180 GiB at block ~64k on a 12 vCPU host)                           |
+| SnapSync               | add `--snap-sync`                                 | Much faster catchup (same benchmark: ~3–11 blocks/sec, ~14 GiB at 31k blocks)            | Storage proofs not available for snap-synced ranges; reverting into snap-synced ranges is blocked by design (see [SnapSync](#snapsync)) |
+| Warp update            | `--warp-update-sender` / `--warp-update-receiver` | Fast trusted migration from a local source node                                          | Requires an existing synced node (see [Warp Update](#warp-update))                                                                      |
+| Custom gateway / key   | `--gateway-url` and/or `--gateway-key`            | Better catchup reliability, fewer rate limits                                            | Requires issued gateway access (see [Gateway Rate Limits During Sync](#gateway-rate-limits-during-sync))                                |
+
+> [!NOTE]
+> The benchmark figures above are a single observed datapoint from one
+> operator's hardware, not a guarantee. Your numbers will vary with hardware,
+> network, and gateway rate limiting.
+
+If you need storage proofs or the ability to revert to arbitrary historical
+blocks via the admin API, use full-trie sync from genesis (or warp update from
+a full-trie source). Native database snapshots are tracked as future work in
+[#194](https://github.com/madara-alliance/madara/issues/194).
 
 ### Cairo Native Execution
 

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -97,10 +97,10 @@ pub struct ArgsPresetParams {
     #[clap(env = "MADARA_GATEWAY", long, value_name = "GATEWAY", group = "args-preset")]
     pub gateway: bool,
 
-    /// Sets up the node as an externally facing rpc provider exposed on
-    /// 0.0.0.0. Generally speaking, this means the node will be accessible
-    /// from the outside world. Admin rpc methods are also enabled, but are only
-    /// exposed on localhost.
+    /// External RPC provider preset. Exposes user RPC on 0.0.0.0, enables
+    /// admin RPC on localhost, and sets CORS to allow all origins. Local-only
+    /// RPC is already enabled by default; omit this flag and use --rpc-port
+    /// for a private node.
     #[clap(env = "MADARA_RPC", long, value_name = "RPC", group = "args-preset")]
     pub rpc: bool,
 }
@@ -114,7 +114,10 @@ impl ArgsPresetParams {
         } else if self.gateway {
             tracing::info!("💫 Running Gateway preset")
         } else if self.rpc {
-            tracing::info!("💫 Running Rpc preset")
+            tracing::info!("💫 Running Rpc preset");
+            tracing::warn!(
+                "--rpc exposes user RPC on 0.0.0.0 with admin RPC enabled on localhost and CORS allowing all origins"
+            )
         }
     }
 }


### PR DESCRIPTION
Operator-facing documentation improvements for the full node, in one PR.

## LLVM 19 build prerequisite

Addresses #1104

- README install-dependencies section now lists LLVM 19 and explains that source builds require `llvm-config-19` (Cairo Native / `tblgen`), with the late-failure error message operators actually see, `make install-llvm19 [SUDO=sudo]` for Ubuntu/Debian, `brew install llvm@19` for macOS, and the `MLIR_SYS_190_PREFIX` / `LLVM_SYS_191_PREFIX` / `TABLEGEN_190_PREFIX` fallback (matching the Dockerfile).
- New `check-llvm19` Makefile preflight runs before `build-madara`, so a missing LLVM 19 fails fast with install instructions instead of ~30 minutes into the build. It accepts `llvm-config-19`, an `llvm-config` reporting 19.x, or `MLIR_SYS_190_PREFIX` being set (homebrew/macOS), and is skippable with `SKIP_LLVM_CHECK=1`.

## `--rpc` is an external provider preset

Addresses #1094

- Reworded the clap help for the `--rpc` preset: it exposes user RPC on 0.0.0.0, enables admin RPC on localhost, and sets CORS to allow all origins — it is not the switch that enables RPC (local RPC is on by default). Verified against `apply_arg_preset` (`rpc_admin = true`, `rpc_external = true`, `rpc_cors = Some(Cors::All)`).
- `ArgsPresetParams::greet()` now logs a warning when the preset is active, spelling out the exposure.
- README RPC section gained a note: localhost user RPC is on by default (`--rpc-disable` to turn off), `--rpc` is the external/provider preset, with a private full-node example (`--full --network mainnet --rpc-port 9944`, no `--rpc`).

## Gateway rate limits during mainnet catchup

Addresses #1093

- New README runbook subsection under Configuration: what the `Rate limited, retrying` INFO log means (public feeder gateway HTTP 429; the client honors `Retry-After`, defaulting to 10s, pauses gateway requests, and retries — sync continues, just slower; verified against the retry policy in `mc-gateway-client`).
- Documents `--gateway-key` (throttling bypass for operators issued a key by the gateway operator — no claims about how to obtain one) and `--gateway-url` (custom/alternative gateway, including a local Madara feeder gateway via the warp-update sender path).
- Lists what to capture when reporting rate-limit-related sync performance: block rate, DB growth, rate-limit log counts, gateway configuration.

## Mainnet full-node bootstrap decision matrix

Addresses #1092

- New "Mainnet Full-Node Bootstrap" README section right after SnapSync, with a table comparing full-trie-from-genesis, `--snap-sync`, warp update from a local source node, and custom gateway/key access — including the SnapSync storage-proof and admin-revert limits already documented in the SnapSync section, and a pointer to #194 (native snapshots) as future work.
- Benchmark figures (~0.4–0.6 blocks/sec and ~180 GiB at block ~64k full-trie; ~3–11 blocks/sec and ~14 GiB at 31k blocks with `--snap-sync`, 12 vCPU host) come from the reporter's shadow-node runs and are framed explicitly as a single observed datapoint, not a guarantee.

## Validation

- `cargo check -p madara` passes (only `madara/node/src/cli/mod.rs` touched in Rust); `cargo fmt` clean.
- `make check-llvm19` exercised in all branches (missing → clear error + exit 1; `SKIP_LLVM_CHECK=1` → skip; `MLIR_SYS_190_PREFIX` set → pass); `make -n build-madara` confirms the preflight runs first.
- `npx prettier --check README.md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)