### PR TITLE
build: clear preflight and non-Docker artifact path for source builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ Targets:
   continuousy downloading images those are exported to a `tar.gz` as artefacts.
 
   - images             Downloads the Madara Docker image
+  - fetch-artifacts-no-docker  Download published contract artifacts from
+                       ghcr.io without a Docker daemon (curl + tar only)
 
   [ CLEANING DEPENDECIES ]
 
@@ -213,6 +215,10 @@ frestart: fclean
 artifacts:
 	@git submodule update --init --recursive
 	./scripts/artifacts.sh
+
+.PHONY: fetch-artifacts-no-docker
+fetch-artifacts-no-docker:
+	./scripts/fetch-artifacts.sh
 
 .PHONY: setup-cairo
 setup-cairo:

--- a/README.md
+++ b/README.md
@@ -72,9 +72,14 @@ cd madara
 #### 2. Build Madara
 
 > [!TIP]
-> Build scripts normally fetch the published contract artifacts automatically.
-> If you need to regenerate local artifacts, run `make artifacts` before
-> building. This requires Docker.
+> Building the `madara` binary needs a handful of pre-compiled contract
+> artifacts under `build-artifacts/`. The ones the node requires are tracked in
+> git, so a fresh checkout builds without Docker. If artifacts are missing
+> (e.g. for other workspace crates), the build scripts fetch the published
+> artifacts image automatically when Docker is available. Without a Docker
+> daemon, run `make fetch-artifacts-no-docker` from the repository root to
+> download them over plain HTTPS (curl + tar only). To regenerate artifacts
+> from source, run `make artifacts` (requires Docker).
 
 You can choose between different build modes:
 

--- a/build-artifacts/src/lib.rs
+++ b/build-artifacts/src/lib.rs
@@ -117,13 +117,108 @@ pub fn get_version(version_file: &impl VersionFile) -> Result<u32, BuildError> {
 /// compiling the artifacts with this build script. This is used to avoid re-compiling artifacts
 /// after they have been linked as a docker volume and causing docker-in-docker errors.
 pub fn get_or_compile_artifacts(parent_levels: usize) -> Result<(), BuildError> {
-    // if the env variable is present, we return early
-    if std::env::var("RUST_BUILD_DOCKER").is_ok() {
+    get_or_compile_artifacts_for(parent_levels, &[])
+}
+
+/// Same as [`get_or_compile_artifacts`], but takes the list of artifact paths (relative to the
+/// repository root) that the calling crate actually needs.
+///
+/// If every required path already exists on disk (e.g. because it is tracked in git, was
+/// extracted by a previous build, or was fetched with `scripts/fetch-artifacts.sh`), Docker is
+/// not invoked at all. This keeps fresh source builds working on hosts without a Docker daemon.
+///
+/// If artifacts are missing and cannot be fetched, this fails fast with an actionable error
+/// instead of letting compilation die later on a cryptic `include_bytes!` failure.
+pub fn get_or_compile_artifacts_for(parent_levels: usize, required: &[&str]) -> Result<(), BuildError> {
+    let (root, version_file_artifacts) = get_paths_artifact(parent_levels)?;
+
+    // Re-run this build script if any required artifact changes or goes missing.
+    for path in required {
+        println!("cargo::rerun-if-changed={}", root.0.join(path).display());
+    }
+
+    // Preflight: if everything this crate needs is already on disk, skip Docker entirely.
+    let missing = missing_paths(&root, required);
+    if !required.is_empty() && missing.is_empty() {
         return Ok(());
     }
 
-    let (root, version_file_artifacts) = get_paths_artifact(parent_levels)?;
-    get_artifacts(&root, &version_file_artifacts).or_else(|err| build_artifacts(&root).map_err(|_| err))
+    // if the env variable is present, we return early instead of fetching artifacts
+    if std::env::var("RUST_BUILD_DOCKER").is_ok() {
+        if missing.is_empty() {
+            return Ok(());
+        }
+        return Err(artifact_help_error(
+            &root,
+            &version_file_artifacts,
+            &missing,
+            "RUST_BUILD_DOCKER is set so artifacts are not fetched, but required artifact files are missing",
+        ));
+    }
+
+    // Preflight: fail fast with instructions if no Docker daemon is reachable, instead of
+    // panicking on a missing `docker` binary or running a long `make artifacts` fallback.
+    if !docker_available() {
+        return Err(artifact_help_error(
+            &root,
+            &version_file_artifacts,
+            &missing,
+            "artifact files are missing and Docker is not available to fetch them",
+        ));
+    }
+
+    get_artifacts(&root, &version_file_artifacts).or_else(|err| build_artifacts(&root).map_err(|_| err)).map_err(
+        |err| {
+            let msg = format!("failed to fetch or build artifacts with Docker: {err}");
+            artifact_help_error(&root, &version_file_artifacts, &missing, &msg)
+        },
+    )
+}
+
+fn missing_paths(root: &RootDir, required: &[&str]) -> Vec<String> {
+    required.iter().filter(|path| !root.0.join(path).exists()).map(|path| path.to_string()).collect()
+}
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .args(["version", "--format", "{{.Server.Version}}"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Builds an error that tells the operator exactly how to get the artifacts, with and without
+/// Docker. Build script output is shown by cargo when the script fails.
+fn artifact_help_error(
+    root: &RootDir,
+    version_file: &VersionFileArtifacts,
+    missing: &[String],
+    reason: &str,
+) -> BuildError {
+    let version = std::fs::read_to_string(version_file.path()).ok().and_then(|content| parse_version(&content).ok());
+    let image = match version {
+        Some(version) => format!("ghcr.io/madara-alliance/artifacts:{version}"),
+        None => "ghcr.io/madara-alliance/artifacts:<version from .artifact-versions.yml>".to_string(),
+    };
+
+    let mut msg = format!("{reason}.\n\nRepository root: {}\n", root.0.display());
+    if !missing.is_empty() {
+        msg.push_str("\nMissing artifact files:\n");
+        for path in missing {
+            msg.push_str(&format!("  - {path}\n"));
+        }
+    }
+    msg.push_str(&format!(
+        "\nTo fix this, from the repository root, do one of:\n\
+         \x20 1. Without Docker: run `make fetch-artifacts-no-docker` (or `./scripts/fetch-artifacts.sh`).\n\
+         \x20    This downloads {image} over plain HTTPS and extracts it.\n\
+         \x20 2. With Docker running: simply re-run the build; the build script pulls {image} automatically.\n\
+         \x20 3. To regenerate artifacts from source (requires Docker): run `make artifacts`.\n\
+         \nNote: some artifacts (e.g. build-artifacts/cairo_artifacts and build-artifacts/js_tests) are\n\
+         tracked in git; `git checkout -- build-artifacts` restores them if they were deleted locally.\n"
+    ));
+
+    BuildError::Cmd(msg)
 }
 
 fn get_artifacts(root: &RootDir, artifacts: &VersionFileArtifacts) -> Result<(), BuildError> {

--- a/build-artifacts/src/lib.rs
+++ b/build-artifacts/src/lib.rs
@@ -159,12 +159,14 @@ pub fn get_or_compile_artifacts_for(parent_levels: usize, required: &[&str]) -> 
     // Preflight: fail fast with instructions if no Docker daemon is reachable, instead of
     // panicking on a missing `docker` binary or running a long `make artifacts` fallback.
     if !docker_available() {
-        return Err(artifact_help_error(
-            &root,
-            &version_file_artifacts,
-            &missing,
-            "artifact files are missing and Docker is not available to fetch them",
-        ));
+        // Callers that pass an empty `required` slice always reach here with no missing paths
+        // to report, so avoid claiming files are missing when none are listed.
+        let reason = if required.is_empty() {
+            "Docker is not available and artifact files may be missing"
+        } else {
+            "artifact files are missing and Docker is not available to fetch them"
+        };
+        return Err(artifact_help_error(&root, &version_file_artifacts, &missing, reason));
     }
 
     get_artifacts(&root, &version_file_artifacts).or_else(|err| build_artifacts(&root).map_err(|_| err)).map_err(

--- a/build-artifacts/src/lib.rs
+++ b/build-artifacts/src/lib.rs
@@ -174,7 +174,23 @@ pub fn get_or_compile_artifacts_for(parent_levels: usize, required: &[&str]) -> 
             let msg = format!("failed to fetch or build artifacts with Docker: {err}");
             artifact_help_error(&root, &version_file_artifacts, &missing, &msg)
         },
-    )
+    )?;
+
+    // The published artifacts image does not contain every required file (e.g. git-tracked
+    // cairo_artifacts/), so a successful fetch can still leave gaps. Fail here with the help
+    // message instead of letting compilation die later on a cryptic `include_bytes!` error.
+    let still_missing = missing_paths(&root, required);
+    if !still_missing.is_empty() {
+        return Err(artifact_help_error(
+            &root,
+            &version_file_artifacts,
+            &still_missing,
+            "artifacts were fetched, but some required files are still missing; if they are tracked in git, \
+             restore them with `git checkout -- build-artifacts`",
+        ));
+    }
+
+    Ok(())
 }
 
 fn missing_paths(root: &RootDir, required: &[&str]) -> Vec<String> {

--- a/madara/crates/cairo-test-contracts/build.rs
+++ b/madara/crates/cairo-test-contracts/build.rs
@@ -1,3 +1,14 @@
+/// Artifact files required by `src/lib.rs` (`include_bytes!`). These are tracked in git, so a
+/// fresh source checkout builds without Docker; the build script only reaches for Docker if they
+/// are missing.
+const REQUIRED_ARTIFACTS: &[&str] = &[
+    "build-artifacts/js_tests/madara_contracts_TestContract.contract_class.json",
+    "build-artifacts/js_tests/madara_contracts_StateUpdateContract.contract_class.json",
+    "build-artifacts/js_tests/madara_contracts_MessagingContract.contract_class.json",
+];
+
 fn main() {
-    build_version::get_or_compile_artifacts(3).expect("Failed to load artifacts");
+    if let Err(e) = build_version::get_or_compile_artifacts_for(3, REQUIRED_ARTIFACTS) {
+        panic!("Failed to load artifacts: {e}");
+    }
 }

--- a/madara/crates/client/devnet/build.rs
+++ b/madara/crates/client/devnet/build.rs
@@ -1,3 +1,14 @@
+/// Artifact files required by `src/lib.rs` (`include_bytes!`). These are tracked in git, so a
+/// fresh source checkout builds without Docker; the build script only reaches for Docker if they
+/// are missing.
+const REQUIRED_ARTIFACTS: &[&str] = &[
+    "build-artifacts/cairo_artifacts/madara_contracts_UDC.json",
+    "build-artifacts/cairo_artifacts/openzeppelin_ERC20Upgradeable.contract_class.json",
+    "build-artifacts/cairo_artifacts/openzeppelin_AccountUpgradeable.contract_class.json",
+];
+
 fn main() {
-    build_version::get_or_compile_artifacts(4).expect("Failed to load artifacts");
+    if let Err(e) = build_version::get_or_compile_artifacts_for(4, REQUIRED_ARTIFACTS) {
+        panic!("Failed to load artifacts: {e}");
+    }
 }

--- a/scripts/fetch-artifacts.sh
+++ b/scripts/fetch-artifacts.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Fetch the published Madara contract artifacts from ghcr.io WITHOUT a Docker daemon.
+#
+# The artifacts image (ghcr.io/madara-alliance/artifacts) is built FROM scratch and contains a
+# single file, /artifacts.tar.gz, which itself unpacks `build-artifacts/...` relative to the
+# repository root. This script downloads the image layer over plain HTTPS using the public GHCR
+# registry API (anonymous pull token), then extracts the artifacts in place.
+#
+# Usage: ./scripts/fetch-artifacts.sh [version]
+#   version defaults to `current_version` in .artifact-versions.yml
+#
+# Requirements: curl, tar, gzip (POSIX sh; no docker, jq, crane, or oras needed).
+set -eu
+
+REGISTRY="ghcr.io"
+REPOSITORY="madara-alliance/artifacts"
+
+# Resolve the repository root from this script's location.
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  VERSION=$(sed -n 's/^current_version:[[:space:]]*//p' "$ROOT/.artifact-versions.yml" | head -n 1)
+fi
+if [ -z "$VERSION" ]; then
+  echo "error: could not determine artifact version from $ROOT/.artifact-versions.yml" >&2
+  exit 1
+fi
+
+IMAGE="$REGISTRY/$REPOSITORY:$VERSION"
+echo "Fetching artifacts from $IMAGE (no Docker daemon required)..."
+
+TMPDIR_FETCH=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_FETCH"' EXIT INT TERM
+
+# 1. Anonymous pull token for the public image.
+TOKEN=$(curl -fsSL "https://$REGISTRY/token?scope=repository:$REPOSITORY:pull" |
+  sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+if [ -z "$TOKEN" ]; then
+  echo "error: failed to obtain a pull token from https://$REGISTRY/token" >&2
+  exit 1
+fi
+
+ACCEPT="application/vnd.oci.image.manifest.v1+json"
+ACCEPT="$ACCEPT,application/vnd.docker.distribution.manifest.v2+json"
+ACCEPT="$ACCEPT,application/vnd.oci.image.index.v1+json"
+ACCEPT="$ACCEPT,application/vnd.docker.distribution.manifest.list.v2+json"
+
+fetch_manifest() {
+  curl -fsSL -H "Authorization: Bearer $TOKEN" -H "Accept: $ACCEPT" \
+    "https://$REGISTRY/v2/$REPOSITORY/manifests/$1"
+}
+
+# 2. Image manifest. If the tag points at a multi-arch index, follow the first entry (the
+#    artifacts image is platform-independent data).
+MANIFEST=$(fetch_manifest "$VERSION")
+case "$MANIFEST" in
+*image.index* | *manifest.list*)
+  CHILD_DIGEST=$(printf '%s' "$MANIFEST" | grep -o 'sha256:[a-f0-9]\{64\}' | head -n 1)
+  MANIFEST=$(fetch_manifest "$CHILD_DIGEST")
+  ;;
+esac
+
+# 3. Layer digests: everything after the "layers" key (the config digest comes before it).
+LAYER_DIGESTS=$(printf '%s' "$MANIFEST" | tr -d ' \t\n' | sed 's/.*"layers"://' |
+  grep -o 'sha256:[a-f0-9]\{64\}')
+if [ -z "$LAYER_DIGESTS" ]; then
+  echo "error: could not find any layers in the manifest for $IMAGE" >&2
+  exit 1
+fi
+
+# 4. Download and unpack each layer (gzipped tar). The layer filesystem contains artifacts.tar.gz.
+for DIGEST in $LAYER_DIGESTS; do
+  echo "Downloading layer $DIGEST..."
+  curl -fsSL -H "Authorization: Bearer $TOKEN" \
+    "https://$REGISTRY/v2/$REPOSITORY/blobs/$DIGEST" -o "$TMPDIR_FETCH/layer.tar.gz"
+  tar -xzf "$TMPDIR_FETCH/layer.tar.gz" -C "$TMPDIR_FETCH"
+  rm -f "$TMPDIR_FETCH/layer.tar.gz"
+done
+
+if [ ! -f "$TMPDIR_FETCH/artifacts.tar.gz" ]; then
+  echo "error: artifacts.tar.gz not found inside the image layers of $IMAGE" >&2
+  exit 1
+fi
+
+# 5. Extract build-artifacts/... into the repository root.
+tar -xzf "$TMPDIR_FETCH/artifacts.tar.gz" -C "$ROOT"
+
+echo "Done. Artifacts extracted under $ROOT/build-artifacts/"


### PR DESCRIPTION
Addresses #1105.

## Investigation

- The `madara` binary depends on `mc-devnet` unconditionally (devnet mode is wired into the node CLI), and `mc-devnet` depends on `m-cairo-test-contracts`, so both build scripts run on every `cargo build --bin madara`. Feature-gating them out was therefore not viable.
- Since 42388209c, **every artifact file these two crates `include_bytes!` is tracked in git** (`build-artifacts/js_tests/*` and `build-artifacts/cairo_artifacts/*`). A fresh checkout already contains everything the node binary needs — the only thing breaking Docker-less builds was the build scripts unconditionally reaching for Docker.
- Notable: the published `ghcr.io/madara-alliance/artifacts:11` image does **not** contain `cairo_artifacts/` (the devnet UDC/OZ classes) — those exist only in git. So even the Docker pull path was never the source of those files.
- The old failure modes: a missing `docker` binary caused a build-script **panic** via `.expect(...)`, a present-but-unreachable daemon fell through to the Docker-heavy `make artifacts`, and `RUST_BUILD_DOCKER=1` with missing files died much later on a cryptic `include_bytes!` error.

## What changed

- **`build-artifacts/src/lib.rs`**: new `get_or_compile_artifacts_for(parent_levels, required)`.
  - If every required path (relative to repo root) exists, Docker is never invoked — fresh source builds of the node binary now work with no Docker daemon and no network.
  - Emits `cargo::rerun-if-changed` for required files, so deleting one re-triggers the build script (and its clear error) instead of a stale fingerprint.
  - Preflights `docker version` before attempting a pull or the `make artifacts` fallback; on any failure (including `RUST_BUILD_DOCKER=1` with missing files) it returns an actionable error listing the missing files, the exact `ghcr.io/madara-alliance/artifacts:<version>` tag, and all three fix options.
  - `get_or_compile_artifacts` (orchestrator, bootstrapper, etc.) keeps its old semantics, just with the faster/clearer failure mode instead of a panic.
- **`madara/crates/cairo-test-contracts/build.rs`**, **`madara/crates/client/devnet/build.rs`**: declare the exact files they `include_bytes!`; report errors via `Display`.
- **`scripts/fetch-artifacts.sh`** + **`make fetch-artifacts-no-docker`**: POSIX-sh (curl + tar only, no jq/crane/oras) download of the artifacts image via the GHCR registry API with an anonymous pull token: token → manifest (follows a multi-arch index if ever published) → layer blob(s) → extract `artifacts.tar.gz` into the repo root. Takes an optional version argument, defaulting to `current_version` in `.artifact-versions.yml`.
- **`README.md`**: source-build section now documents the artifact requirement, that the node's artifacts are tracked in git, and the non-Docker fetch path.

## Tested

- `cargo check -p mc-devnet -p m-cairo-test-contracts` passes with **zero Docker interaction** (previously every cold build attempted a pull).
- Removed `cairo_artifacts/madara_contracts_UDC.json` and ran with `RUST_BUILD_DOCKER=1`: build script fails immediately with the full help message (missing file list, image tag, fix options).
- Same with a fake failing `docker` shim on `PATH`: fast failure before any compilation, no `make artifacts` fallback launched.
- **GHCR fetch verified live**: `scripts/fetch-artifacts.sh` run for real against `ghcr.io/madara-alliance/artifacts:11` (and `:9` via the version argument). Deleted a tracked `js_tests` contract class, restored it with the script (byte-identical to the git-tracked copy, per `git diff`), and `cargo check -p m-cairo-test-contracts` then passed with Docker still shimmed out.
- `cargo test -p build-version --lib`, `cargo clippy -p build-version -p m-cairo-test-contracts`, and `cargo fmt --check` all pass.

## Deliberately not done

- **No devnet/test-contract decoupling from the `madara` binary** — `mc-devnet` is a genuine runtime dependency of the node (devnet mode), so feature-gating would be an invasive behavioral change for little gain now that no Docker is needed anyway.
- **No required-file lists for orchestrator/bootstrapper build scripts** — they consume untracked artifact dirs (`starkgate_*`, `argent`, `braavos`, `cairo_lang`, ...) whose exact per-crate needs I did not want to guess; they keep the fetch-always behavior but inherit the better diagnostics and can adopt `get_or_compile_artifacts_for` later.
- The fetch script and failure paths were validated on macOS while the issue reporter is on Ubuntu; the script is POSIX sh with curl + tar only (no GNU-only flags), but a Linux smoke run by a reviewer wouldn't hurt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)