### PR TITLE
fix(shutdown): harden graceful-shutdown ordering during SnapSync

### DIFF
--- a/madara/crates/primitives/utils/src/rayon.rs
+++ b/madara/crates/primitives/utils/src/rayon.rs
@@ -1,5 +1,9 @@
-use std::{panic::AssertUnwindSafe, sync::atomic::AtomicUsize, thread};
-use tokio::sync::Semaphore;
+use std::{
+    panic::AssertUnwindSafe,
+    sync::atomic::{AtomicUsize, Ordering},
+    thread,
+};
+use tokio::sync::{Notify, Semaphore};
 
 /// Wraps the rayon pool in a tokio-friendly way.
 ///
@@ -49,6 +53,71 @@ impl RayonPool {
     }
 }
 
+/// Tracks tasks that are currently queued or running on the global rayon pool through
+/// [`global_spawn_rayon_task`].
+///
+/// Rayon worker threads are detached: dropping the future returned by
+/// [`global_spawn_rayon_task`] (e.g. on graceful-shutdown cancellation) does *not* stop the
+/// task once it has been handed to the pool. Anything that wants to tear down resources those
+/// tasks may be using (the database backend, the process itself) must first wait for the pool
+/// to drain using [`wait_global_rayon_tasks_finished`]. See issue #1091: exiting the process
+/// while a snap-sync trie-apply task was still running inside RocksDB caused a SIGSEGV during
+/// process teardown.
+struct GlobalRayonTaskTracker {
+    in_flight: AtomicUsize,
+    notify: Notify,
+}
+
+static GLOBAL_RAYON_TASKS: GlobalRayonTaskTracker =
+    GlobalRayonTaskTracker { in_flight: AtomicUsize::new(0), notify: Notify::const_new() };
+
+/// Decrements the in-flight count when the rayon task finishes, even if it panics.
+struct InFlightGuard;
+
+impl InFlightGuard {
+    fn register() -> Self {
+        GLOBAL_RAYON_TASKS.in_flight.fetch_add(1, Ordering::SeqCst);
+        Self
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if GLOBAL_RAYON_TASKS.in_flight.fetch_sub(1, Ordering::SeqCst) == 1 {
+            GLOBAL_RAYON_TASKS.notify.notify_waiters();
+        }
+    }
+}
+
+/// Number of tasks currently queued or running on the global rayon pool via
+/// [`global_spawn_rayon_task`]. Note that this includes tasks whose awaiting future has been
+/// dropped (cancelled): the underlying rayon work keeps running regardless.
+pub fn global_rayon_tasks_in_flight() -> usize {
+    GLOBAL_RAYON_TASKS.in_flight.load(Ordering::SeqCst)
+}
+
+/// Waits until no task spawned through [`global_spawn_rayon_task`] is queued or running
+/// anymore.
+///
+/// This must be awaited before dropping resources shared with rayon tasks or exiting the
+/// process, as cancelling the futures returned by [`global_spawn_rayon_task`] does not cancel
+/// the detached rayon work itself.
+pub async fn wait_global_rayon_tasks_finished() {
+    loop {
+        // Register the waiter *before* checking the counter, so a task finishing in between
+        // cannot be missed (`notify_waiters` only wakes already-registered waiters).
+        let notified = GLOBAL_RAYON_TASKS.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        if GLOBAL_RAYON_TASKS.in_flight.load(Ordering::SeqCst) == 0 {
+            return;
+        }
+
+        notified.await;
+    }
+}
+
 pub async fn global_spawn_rayon_task<F, R>(func: F) -> R
 where
     F: FnOnce() -> R + Send + 'static,
@@ -56,14 +125,76 @@ where
 {
     let (tx, rx) = tokio::sync::oneshot::channel();
 
+    // Register synchronously, before the task is handed to rayon, so that the task is always
+    // visible to `wait_global_rayon_tasks_finished` — even if the future we return is dropped
+    // (cancelled) before the rayon task gets a chance to run.
+    let guard = InFlightGuard::register();
+
     // Important: fifo mode.
     rayon::spawn_fifo(move || {
         // We bubble up the panics to the tokio pool.
         let _result = tx.send(std::panic::catch_unwind(AssertUnwindSafe(func)));
+        drop(guard);
     });
 
     match rx.await.expect("Tokio channel closed") {
         Ok(r) => r,
         Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Regression test for issue #1091: a task offloaded to the global rayon pool keeps
+    /// running even when the future awaiting it is dropped (as happens when a service is
+    /// cancelled during graceful shutdown). The shutdown path must be able to observe that
+    /// work and wait for it to finish before tearing down shared resources (e.g. the database
+    /// backend) or exiting the process.
+    #[tokio::test]
+    async fn dropped_future_is_still_tracked_until_rayon_task_finishes() {
+        // Note: the tracker is global and tests may run concurrently within this crate, so we
+        // assert on deltas/joins rather than absolute zero where possible.
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+
+        let mut task = Box::pin(global_spawn_rayon_task(move || {
+            started_tx.send(()).expect("send started");
+            // Block the rayon worker until the test releases it, simulating a long
+            // snap-sync trie-apply batch.
+            release_rx.recv_timeout(Duration::from_secs(30)).expect("release signal");
+        }));
+
+        // Poll once so the task is handed to the rayon pool (this is what awaiting does), then
+        // simulate graceful-shutdown cancellation: the awaiting future is dropped while the
+        // rayon task is queued or running.
+        assert!(futures::poll!(task.as_mut()).is_pending());
+        drop(task);
+
+        // Wait until the task is actually running on the pool.
+        started_rx.recv_timeout(Duration::from_secs(30)).expect("task should start");
+        assert!(global_rayon_tasks_in_flight() >= 1, "cancelled task must still be tracked");
+
+        // While the task is blocked, the drain must not complete.
+        let drain = tokio::time::timeout(Duration::from_millis(100), wait_global_rayon_tasks_finished()).await;
+        assert!(drain.is_err(), "drain must wait for the in-flight rayon task");
+
+        // Release the task: the drain must now complete.
+        release_tx.send(()).expect("send release");
+        tokio::time::timeout(Duration::from_secs(30), wait_global_rayon_tasks_finished())
+            .await
+            .expect("drain should complete once the rayon task finishes");
+    }
+
+    #[tokio::test]
+    async fn panicking_task_is_untracked() {
+        let task = global_spawn_rayon_task(|| panic!("boom"));
+        // The panic is bubbled up; catch it so the test can continue.
+        assert!(futures::FutureExt::catch_unwind(AssertUnwindSafe(task)).await.is_err());
+        tokio::time::timeout(Duration::from_secs(30), wait_global_rayon_tasks_finished())
+            .await
+            .expect("panicked task must still decrement the in-flight count");
     }
 }

--- a/madara/crates/primitives/utils/src/rayon.rs
+++ b/madara/crates/primitives/utils/src/rayon.rs
@@ -83,6 +83,8 @@ impl InFlightGuard {
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
+        // Only the last task in flight wakes drain waiters; earlier completions leave the
+        // counter nonzero, so `wait_global_rayon_tasks_finished` must keep waiting anyway.
         if GLOBAL_RAYON_TASKS.in_flight.fetch_sub(1, Ordering::SeqCst) == 1 {
             GLOBAL_RAYON_TASKS.notify.notify_waiters();
         }

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -131,6 +131,15 @@ use submit_tx::{MakeSubmitTransactionSwitch, MakeSubmitValidatedTransactionSwitc
 const GREET_IMPL_NAME: &str = "Madara";
 const GREET_SUPPORT_URL: &str = "https://github.com/madara-alliance/madara/issues";
 
+/// Maximum time to wait, after all services have shut down, for work that was offloaded onto
+/// the detached global rayon pool (e.g. a snap-sync batched global-trie update) to finish
+/// before exiting the process. Exiting while those threads are still inside RocksDB can
+/// SIGSEGV during process teardown (issue #1091). A large snap-sync trie batch can legitimately
+/// take minutes on slow hardware, so this is intentionally generous; node operators using
+/// systemd should make sure `TimeoutStopSec` accounts for it (a timeout there results in
+/// SIGKILL, which RocksDB recovers from, rather than a segfault).
+const SHUTDOWN_POOL_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
@@ -513,6 +522,29 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let result = app.start().await;
+
+    // All services have stopped, but service shutdown is cooperative-cancellation based:
+    // dropping a cancelled service future does not stop CPU work it already offloaded onto the
+    // detached global rayon pool (e.g. snap-sync applying a batched global-trie update, which
+    // can run for a long time). Those rayon workers hold references into the RocksDB backend.
+    // Returning from `main` while they are still running tears the process down (libc `exit`
+    // runs static destructors) under live threads, which can SIGSEGV — see issue #1091.
+    // Wait for the pool to drain *before* the final flush, so the flush also captures those
+    // tasks' writes and so the backend drop (final flush + RocksDB background-work cancel)
+    // happens after all of its users are gone.
+    let in_flight = mp_utils::rayon::global_rayon_tasks_in_flight();
+    if in_flight > 0 {
+        tracing::info!("⏳ Waiting for {in_flight} in-flight background task(s) to finish before shutdown...");
+    }
+    if tokio::time::timeout(SHUTDOWN_POOL_DRAIN_TIMEOUT, mp_utils::rayon::wait_global_rayon_tasks_finished())
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            "Background tasks did not finish within {SHUTDOWN_POOL_DRAIN_TIMEOUT:?}; shutting down anyway. \
+             The database may need to replay un-flushed work on next startup."
+        );
+    }
 
     // Critical: Flush database before exit to ensure data persistence (WAL is disabled)
     if let Err(e) = backend.flush() {


### PR DESCRIPTION
Addresses #1091.

## Context

A mainnet SnapSync full node logged "Gracefully shutting down node" during `systemctl restart` and then exited with status=11/SEGV. No core dump exists and the crash was not reproducible under controlled conditions, so this PR is **hardening of concretely identified shutdown hazards, not a verified root-cause fix**. That said, the audit below found a real exit-while-threads-live hazard whose signature matches the report exactly (graceful log line followed by SEGV, only when specific work is in flight — hence the flaky reproduction).

## Shutdown-path audit (what actually happens today)

1. **SIGTERM/SIGINT** is received by a dedicated service loop registered in `ServiceMonitor::start` (`madara/crates/primitives/utils/src/service.rs`), which calls `ctx.cancel_global()` (this prints "Gracefully shutting down node") and cancels the global `CancellationToken`.
2. **Cancellation propagation** is cooperative. Each service races its main future against the token. `SyncController::run` (`madara/crates/client/sync/src/sync.rs:134`) does `tokio::select! { _ = ctx.cancelled() => return Ok(()), ... }` — on cancellation it returns immediately, **dropping** the in-flight `run_inner()`/`forward_pipeline.run()` future. `ServiceRunner::stopper` additionally force-drops any service future that takes longer than `SERVICE_GRACE_PERIOD` (10s).
3. **The dropped future does not stop the work.** The snap-sync apply path (`madara/crates/client/sync/src/apply_state.rs::apply_accumulated_diffs`) offloads the batched global-trie application (up to 1000 blocks of accumulated state diffs — seconds to minutes of RocksDB/bonsai-trie writes) onto the **detached global rayon pool** via `global_spawn_rayon_task` (`mp_utils::rayon`). Dropping the awaiting future only drops the oneshot receiver; the rayon closure keeps running on a detached worker thread, holding `Arc<MadaraBackend>` (so no Rust-level use-after-free, but the thread stays live).
4. **Monitor exit**: once every service's `service_loop` task joins, `app.start()` returns to `main`.
5. **`main` tail** (`madara/node/src/main.rs`): `backend.flush()` is called (potentially concurrent with the still-running rayon trie writer), then `main` returns → tokio runtime drops → **libc `exit()` runs static destructors (RocksDB/C++ runtime, allocator teardown) while the rayon worker thread — and the RocksDB background threads it keeps alive — are still executing**. This is the classic exit-while-threads-live SIGSEGV. Note also that on this path the backend's `RocksDBStorageInner::Drop` (final flush + `cancel_all_background_work(wait=true)`) never runs, because the rayon closure still holds an `Arc` to the backend.
6. **`process::exit` / `abort` audit**: `node/src/cli/mod.rs:274` and `node/src/service/l1.rs:81` call `std::process::exit(1)` only on early-startup config-error paths (before services/rayon work start) — not on the graceful path. `mc-db/build.rs` is build-time only. The settlement-client `abort()`s are tokio task aborts in tests.
7. **Cairo-native AOT executors**: the compiled-class cache (`mc-class-exec`, `madara/crates/client/cairo_native/src/cache.rs`) is a `static LazyLock<DashMap>` holding `NativeCompiledClass` entries; Rust statics are not destructed at exit, so the loaded `.so`s are never `dlclose`d during shutdown — no unload-while-executing hazard there. (Native execution is also opt-in and unlikely to be on for the reporter's full node.) The compilation timeout paths do leak detached `std::thread`s that could in principle still be inside LLVM at exit, but that is pre-existing, opt-in, and out of scope here.

**Most plausible crash sequence for #1091**: SIGTERM arrived while a snap-sync trie batch was being applied on the rayon pool → sync service returned instantly → node "gracefully" exited → process teardown ran under the live rayon/RocksDB threads → SIGSEGV. Rare by construction: it needs an in-flight batch at the exact moment of shutdown, matching the failed reproduction attempts.

## Fixes

- **`mp-utils` (`rayon.rs`)**: every task spawned through `global_spawn_rayon_task` — which is the single funnel for all detached rayon work in the workspace, including `RayonPool` users (sync verify/apply, block production, class compilation) — is now registered in a global in-flight counter *before* being handed to rayon, and unregistered when the closure finishes (via a drop guard, so panics and cancelled/dropped awaiting futures are still counted correctly). New `wait_global_rayon_tasks_finished()` / `global_rayon_tasks_in_flight()` APIs let the shutdown path drain the pool.
- **`node/src/main.rs`**: after `app.start()` returns and before the final `backend.flush()`, `main` now waits (with a generous 5-minute timeout and operator-facing logging) for the global rayon pool to drain. Ordering is now: services stopped → rayon work joined → final flush (now also capturing the joined work's writes) → backend drop (which can now actually run its own flush + RocksDB background-work cancellation, since no rayon task holds an `Arc` anymore) → process exit with no live workers. On timeout we log a warning and proceed — same behavior as today, and a systemd `TimeoutStopSec` SIGKILL (no core, RocksDB crash-safe) is strictly better than a SIGSEGV.

Intentionally *not* changed: `SyncController`'s immediate return on cancellation (blocking every shutdown on a minutes-long trie batch inside the 10s service grace period would be a larger behavioral change; the drain in `main` covers it at the only place where it matters — before process teardown).

## Tests

- `mp-utils::rayon::tests::dropped_future_is_still_tracked_until_rayon_task_finishes` — regression test for the exact mechanism: a global rayon task whose awaiting future is dropped (simulating graceful-shutdown cancellation) must remain visible to the drain API until the detached work completes, and the drain must then complete.
- `mp-utils::rayon::tests::panicking_task_is_untracked` — panicking tasks still decrement the in-flight count.

A full-node SIGTERM e2e test was considered but is disproportionate: reproducing the crash requires hitting a narrow timing window inside a mainnet-scale snap-sync trie batch, and no existing e2e harness has a SIGTERM-during-snap-sync pattern to extend. The unit tests above cover the load-bearing invariant directly.

## Validation

- `cargo check -p mp-utils -p mc-sync -p madara` — clean
- `cargo clippy -p mp-utils --tests -p mc-sync -p madara` — no warnings
- `cargo test -p mp-utils` — 6/6 unit + doc tests pass (incl. the 2 new ones)
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)