### PR TITLE
fix(sync): gateway CASM fallback for historical classes that fail local compilation

### DIFF
--- a/madara/crates/client/gateway/client/src/methods.rs
+++ b/madara/crates/client/gateway/client/src/methods.rs
@@ -1,6 +1,6 @@
 use super::{builder::GatewayProvider, request_builder::RequestBuilder};
 use blockifier::bouncer::BouncerWeights;
-use mp_class::{ContractClass, FlattenedSierraClass, LegacyContractClass};
+use mp_class::{CompiledSierra, ContractClass, FlattenedSierraClass, LegacyContractClass};
 use mp_gateway::block::ProviderBlockPreConfirmed;
 use mp_gateway::error::{SequencerError, StarknetError};
 use mp_gateway::feeder::{ProviderTransactionResponse, ProviderTransactionStatus};
@@ -227,6 +227,32 @@ impl GatewayProvider {
                 let err = serde::de::Error::custom("Unknown contract type".to_string());
                 Err(SequencerError::DeserializeBody { serde_error: err })
             }
+        })
+        .await
+    }
+
+    /// Fetches the canonical compiled (CASM) class for a Sierra class hash from the feeder
+    /// gateway `get_compiled_class_by_class_hash` endpoint.
+    ///
+    /// This endpoint only supports Sierra classes - the given `class_hash` must point to a
+    /// Sierra class. The response is returned as the raw JSON-serialized CASM class
+    /// ([`CompiledSierra`]) so that callers can parse and hash it themselves.
+    pub async fn get_compiled_class_by_class_hash(
+        &self,
+        class_hash: Felt,
+        block_id: BlockId,
+    ) -> Result<CompiledSierra, SequencerError> {
+        self.retry_get(|| async {
+            let request = RequestBuilder::new(&self.client, self.feeder_gateway_url.clone(), self.headers.clone())
+                .add_uri_segment("get_compiled_class_by_class_hash")
+                .expect("Failed to add URI segment. This should not fail in prod.")
+                .with_block_id(&block_id)
+                .with_class_hash(class_hash);
+
+            let value = request.send_get::<Value>().await?;
+            let json =
+                serde_json::to_string(&value).map_err(|serde_error| SequencerError::DeserializeBody { serde_error })?;
+            Ok(CompiledSierra(json))
         })
         .await
     }

--- a/madara/crates/client/sync/src/gateway/classes.rs
+++ b/madara/crates/client/sync/src/gateway/classes.rs
@@ -1,11 +1,13 @@
 use crate::{
-    import::BlockImporter,
+    import::{BlockImportError, BlockImporter},
     pipeline::{ApplyOutcome, PipelineController, PipelineSteps},
 };
 use anyhow::Context;
 use mc_db::MadaraBackend;
 use mc_gateway_client::{BlockId, GatewayProvider};
-use mp_class::{ClassInfo, ClassInfoWithHash, ConvertedClass, LegacyClassInfo, SierraClassInfo, MISSED_CLASS_HASHES};
+use mp_class::{
+    ClassInfo, ClassInfoWithHash, CompiledSierra, ConvertedClass, LegacyClassInfo, SierraClassInfo, MISSED_CLASS_HASHES,
+};
 use mp_state_update::DeclaredClassCompiledClass;
 use mp_utils::AbortOnDrop;
 use starknet_api::core::ChainId;
@@ -79,6 +81,79 @@ pub(crate) async fn get_classes(
     .await
 }
 
+/// Verifies and compiles the declared classes of a block, falling back to the canonical CASM
+/// served by the feeder gateway when local Sierra-to-CASM compilation fails.
+///
+/// Some early-2023 historical Sierra classes (e.g. mainnet class
+/// `0x78d552edf8d22e566b050c9158d7f770b55021c36a9f5a98170ff8fcabc9e10`, declared around block
+/// 80000) were compiled with ancient Cairo toolchains and can no longer be recompiled by the
+/// modern `cairo-lang-starknet-classes` crates. Reference nodes (Juno, Pathfinder) handle these
+/// classes by using the canonical CASM from the feeder gateway instead of recompiling locally.
+///
+/// Trust model: in gateway sync mode the feeder gateway is already the trust root for blocks,
+/// state diffs and class definitions, so falling back to its CASM does not extend trust. We still
+/// verify what is verifiable:
+/// - The fallback only engages when local compilation *errors* (never on a plain hash mismatch),
+///   so it cannot mask compiler regressions on classes that still compile.
+/// - The fetched CASM is re-hashed; the hash check in
+///   [`crate::import::BlockImporterCtx::verify_compile_classes`] then applies as usual: a match
+///   is accepted, a mismatch is only tolerated under the pre-existing historical
+///   compiled_class_hash tolerance (pre-v0.14.1 Poseidon classes) and is rejected for modern
+///   (v0.14.1+, BLAKE) classes.
+pub(crate) async fn verify_compile_classes_with_gateway_casm_fallback(
+    importer: &BlockImporter,
+    client: &Arc<GatewayProvider>,
+    block_n: u64,
+    declared_classes: Vec<ClassInfoWithHash>,
+    check_against: &HashMap<Felt, DeclaredClassCompiledClass>,
+) -> Result<Vec<ConvertedClass>, BlockImportError> {
+    let mut gateway_casm_fallback: HashMap<Felt, CompiledSierra> = HashMap::new();
+    // Each iteration either succeeds, fails for good, or adds a fallback CASM for a class hash
+    // that did not have one yet, so this loop runs at most `len + 1` times.
+    for _ in 0..=check_against.len() {
+        let declared_classes_ = declared_classes.clone();
+        let check_against_ = check_against.clone();
+        let gateway_casm_fallback_ = gateway_casm_fallback.clone();
+        let res = importer
+            .run_in_rayon_pool(move |importer| {
+                importer.verify_compile_classes(
+                    Some(block_n),
+                    declared_classes_,
+                    &check_against_,
+                    &gateway_casm_fallback_,
+                )
+            })
+            .await;
+        match res {
+            Err(BlockImportError::CompilationClassError { class_hash, error })
+                if !gateway_casm_fallback.contains_key(&class_hash) =>
+            {
+                tracing::warn!(
+                    class_hash = %format!("{class_hash:#x}"),
+                    block_n,
+                    error = %error,
+                    "Local CASM compilation failed for class; falling back to the compiled class \
+                     (CASM) served by the feeder gateway",
+                );
+                let compiled = client
+                    .get_compiled_class_by_class_hash(class_hash, BlockId::Number(block_n))
+                    .await
+                    .map_err(|fetch_error| {
+                        BlockImportError::Internal(anyhow::Error::new(fetch_error).context(format!(
+                            "Fetching compiled class (CASM) from the gateway for class_hash={class_hash:#x} \
+                             block_n={block_n} after local compilation failed: {error}"
+                        )))
+                    })?;
+                gateway_casm_fallback.insert(class_hash, compiled);
+            }
+            res => return res,
+        }
+    }
+    Err(BlockImportError::Internal(anyhow::anyhow!(
+        "Gateway CASM fallback did not converge for block_n={block_n} (this is a bug)"
+    )))
+}
+
 pub type ClassesSync = PipelineController<ClassesSyncSteps>;
 pub fn classes_pipeline(
     backend: Arc<MadaraBackend>,
@@ -132,13 +207,15 @@ impl PipelineSteps for ClassesSyncSteps {
                 let declared_classes =
                     get_classes(&self.client, BlockId::Number(block_n), &classes, uses_blake_hash).await?;
 
-                let ret = self
-                    .importer
-                    .run_in_rayon_pool(move |importer| {
-                        importer.verify_compile_classes(Some(block_n), declared_classes, &classes)
-                    })
-                    .await
-                    .with_context(|| format!("Verifying and compiling classes for block_n={block_n:?}"))?;
+                let ret = verify_compile_classes_with_gateway_casm_fallback(
+                    &self.importer,
+                    &self.client,
+                    block_n,
+                    declared_classes,
+                    &classes,
+                )
+                .await
+                .with_context(|| format!("Verifying and compiling classes for block_n={block_n:?}"))?;
 
                 out.push(ret);
             }
@@ -176,7 +253,229 @@ impl PipelineSteps for ClassesSyncSteps {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::import::{BlockImportError, BlockImporter, BlockValidationConfig};
+    use crate::tests::gateway_mock::GatewayMock;
+    use assert_matches::assert_matches;
+    use mp_block::{BlockHeaderWithSignatures, Header};
+    use mp_chain_config::{ChainConfig, StarknetVersion};
+    use mp_class::compile::CompiledClassHashes;
+    use mp_class::FlattenedSierraClass;
+    use starknet_api::felt;
     use std::collections::HashMap;
+
+    const CLASS_HASH: Felt =
+        Felt::from_hex_unchecked("0x78d552edf8d22e566b050c9158d7f770b55021c36a9f5a98170ff8fcabc9e10");
+
+    struct FallbackFixture {
+        backend: Arc<mc_db::MadaraBackend>,
+        importer: BlockImporter,
+        gateway_mock: GatewayMock,
+        /// A Sierra class that compiles fine locally.
+        good_sierra: Arc<FlattenedSierraClass>,
+        /// A Sierra class that fails local compilation (truncated program), standing in for the
+        /// early-2023 historical classes that modern compilers can no longer compile.
+        broken_sierra: Arc<FlattenedSierraClass>,
+        /// JSON-serialized canonical CASM of `good_sierra`, as the feeder gateway would serve it.
+        casm_json: String,
+        /// Hashes of `casm_json`.
+        casm_hashes: CompiledClassHashes,
+    }
+
+    fn fallback_fixture() -> FallbackFixture {
+        let mut json: serde_json::Value = serde_json::from_slice(m_cairo_test_contracts::TEST_CONTRACT_SIERRA).unwrap();
+        let abi_string = serde_json::to_string(&json["abi"]).unwrap();
+        json["abi"] = serde_json::Value::String(abi_string);
+        let good_sierra: FlattenedSierraClass = serde_json::from_value(json).unwrap();
+
+        let (_poseidon_hash, casm) = good_sierra.compile_to_casm().unwrap();
+        let casm_json = serde_json::to_string(&casm).unwrap();
+        let casm_hashes = CompiledClassHashes::from_casm(casm).unwrap();
+
+        let mut broken_sierra = good_sierra.clone();
+        // Keep the version header felts so version parsing succeeds, but make the program
+        // impossible to compile.
+        broken_sierra.sierra_program.truncate(3);
+        assert!(broken_sierra.compile_to_casm().is_err(), "the broken fixture class must fail to compile");
+
+        let backend = mc_db::MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
+        // `trust_class_hashes` only skips the (expensive) sierra class hash recomputation: the
+        // fixture class hash is arbitrary. All other checks stay enabled.
+        let importer = BlockImporter::new(
+            backend.clone(),
+            BlockValidationConfig { trust_class_hashes: true, ..Default::default() },
+        );
+
+        FallbackFixture {
+            backend,
+            importer,
+            gateway_mock: GatewayMock::new(),
+            good_sierra: Arc::new(good_sierra),
+            broken_sierra: Arc::new(broken_sierra),
+            casm_json,
+            casm_hashes,
+        }
+    }
+
+    fn declared_sierra_class(
+        contract_class: Arc<FlattenedSierraClass>,
+        compiled_class_hash: Felt,
+    ) -> ClassInfoWithHash {
+        ClassInfoWithHash {
+            class_hash: CLASS_HASH,
+            class_info: ClassInfo::Sierra(SierraClassInfo {
+                contract_class,
+                compiled_class_hash: Some(compiled_class_hash),
+                compiled_class_hash_v2: None,
+            }),
+        }
+    }
+
+    /// Compile failure -> CASM fetched from the gateway -> recomputed hash matches the declared
+    /// compiled_class_hash -> accepted.
+    #[tokio::test]
+    async fn casm_fallback_verified_accept() {
+        let fixture = fallback_fixture();
+        let declared_hash = fixture.casm_hashes.poseidon_hash;
+        let casm_mock =
+            fixture.gateway_mock.mock_compiled_class_from_json(format!("{CLASS_HASH:#x}"), fixture.casm_json.clone());
+
+        let check_against = HashMap::from([(CLASS_HASH, DeclaredClassCompiledClass::Sierra(declared_hash))]);
+        let converted = verify_compile_classes_with_gateway_casm_fallback(
+            &fixture.importer,
+            &fixture.gateway_mock.client(),
+            0,
+            vec![declared_sierra_class(fixture.broken_sierra.clone(), declared_hash)],
+            &check_against,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(casm_mock.hits(), 1);
+        assert_eq!(converted.len(), 1);
+        let sierra = converted[0].as_sierra().unwrap();
+        assert_eq!(sierra.class_hash, CLASS_HASH);
+        assert_eq!(sierra.info.compiled_class_hash, Some(declared_hash));
+        // The stored CASM is the gateway-provided one.
+        assert_eq!(
+            CompiledClassHashes::from_compiled_sierra(&sierra.compiled).unwrap().poseidon_hash,
+            fixture.casm_hashes.poseidon_hash
+        );
+    }
+
+    /// Compile failure -> CASM fetched from the gateway -> recomputed hash does NOT match, but the
+    /// class is historical (pre-v0.14.1, Poseidon) -> accepted with the gateway-declared hash,
+    /// mirroring the pre-existing "Retaining gateway-provided historical compiled_class_hash"
+    /// tolerance for local compiles.
+    #[tokio::test]
+    async fn casm_fallback_historical_mismatch_accepted() {
+        let fixture = fallback_fixture();
+        let declared_hash = felt!("0xdeadbeef"); // does not match the fetched CASM
+        fixture.gateway_mock.mock_compiled_class_from_json(format!("{CLASS_HASH:#x}"), fixture.casm_json.clone());
+
+        let check_against = HashMap::from([(CLASS_HASH, DeclaredClassCompiledClass::Sierra(declared_hash))]);
+        let converted = verify_compile_classes_with_gateway_casm_fallback(
+            &fixture.importer,
+            &fixture.gateway_mock.client(),
+            0,
+            vec![declared_sierra_class(fixture.broken_sierra.clone(), declared_hash)],
+            &check_against,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(converted.len(), 1);
+        let sierra = converted[0].as_sierra().unwrap();
+        // The gateway-declared (state diff) hash is retained, not the recomputed one.
+        assert_eq!(sierra.info.compiled_class_hash, Some(declared_hash));
+    }
+
+    /// Compile failure -> CASM fetched from the gateway -> recomputed hash does NOT match and the
+    /// class is NOT historical (v0.14.1+, BLAKE) -> rejected: the historical tolerance must not
+    /// mask mismatches on modern classes.
+    #[tokio::test]
+    async fn casm_fallback_non_historical_mismatch_rejected() {
+        let fixture = fallback_fixture();
+        let declared_hash = felt!("0xdeadbeef"); // does not match the fetched CASM
+        fixture.gateway_mock.mock_compiled_class_from_json(format!("{CLASS_HASH:#x}"), fixture.casm_json.clone());
+
+        // Store a v0.14.1 header for block 0 so the class is treated as a modern (BLAKE) class.
+        fixture
+            .backend
+            .write_access()
+            .write_header(BlockHeaderWithSignatures {
+                block_hash: felt!("0x123"),
+                consensus_signatures: vec![],
+                header: Header { block_number: 0, protocol_version: StarknetVersion::V0_14_1, ..Default::default() },
+            })
+            .unwrap();
+
+        let check_against = HashMap::from([(CLASS_HASH, DeclaredClassCompiledClass::Sierra(declared_hash))]);
+        let result = verify_compile_classes_with_gateway_casm_fallback(
+            &fixture.importer,
+            &fixture.gateway_mock.client(),
+            0,
+            vec![declared_sierra_class(fixture.broken_sierra.clone(), declared_hash)],
+            &check_against,
+        )
+        .await;
+
+        assert_matches!(
+            result,
+            Err(BlockImportError::CompiledClassHash { class_hash, got, expected }) => {
+                assert_eq!(class_hash, CLASS_HASH);
+                assert_eq!(got, declared_hash);
+                assert_eq!(expected, fixture.casm_hashes.blake_hash);
+            }
+        );
+    }
+
+    /// Compile failure -> the gateway CASM fetch itself fails -> the error is propagated and sync
+    /// fails as it does today.
+    #[tokio::test]
+    async fn casm_fallback_fetch_error_propagates() {
+        let fixture = fallback_fixture();
+        let declared_hash = fixture.casm_hashes.poseidon_hash;
+        fixture.gateway_mock.mock_compiled_class_not_found(format!("{CLASS_HASH:#x}"));
+
+        let check_against = HashMap::from([(CLASS_HASH, DeclaredClassCompiledClass::Sierra(declared_hash))]);
+        let result = verify_compile_classes_with_gateway_casm_fallback(
+            &fixture.importer,
+            &fixture.gateway_mock.client(),
+            0,
+            vec![declared_sierra_class(fixture.broken_sierra.clone(), declared_hash)],
+            &check_against,
+        )
+        .await;
+
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(err.contains("Fetching compiled class (CASM) from the gateway"), "{err}");
+        assert!(err.contains(&format!("{CLASS_HASH:#x}")), "{err}");
+    }
+
+    /// The fallback must only engage on local compilation *failure*: a class that compiles
+    /// locally never triggers a gateway CASM fetch, even if its hash mismatches (which keeps the
+    /// pre-existing tolerance behavior and cannot mask local compiler regressions).
+    #[tokio::test]
+    async fn casm_fallback_not_engaged_when_local_compile_succeeds() {
+        let fixture = fallback_fixture();
+        let declared_hash = fixture.casm_hashes.poseidon_hash;
+        let casm_mock =
+            fixture.gateway_mock.mock_compiled_class_from_json(format!("{CLASS_HASH:#x}"), fixture.casm_json.clone());
+
+        let check_against = HashMap::from([(CLASS_HASH, DeclaredClassCompiledClass::Sierra(declared_hash))]);
+        let converted = verify_compile_classes_with_gateway_casm_fallback(
+            &fixture.importer,
+            &fixture.gateway_mock.client(),
+            0,
+            vec![declared_sierra_class(fixture.good_sierra.clone(), declared_hash)],
+            &check_against,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(casm_mock.hits(), 0);
+        assert_eq!(converted.len(), 1);
+    }
 
     #[test]
     fn fixup_missed_mainnet_classes_leaves_unknown_blocks_unchanged() {

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -7,8 +7,10 @@ use mp_block::{
 };
 use mp_chain_config::StarknetVersion;
 use mp_class::{
-    class_hash::ComputeClassHashError, compile::ClassCompilationError, ClassInfo, ClassInfoWithHash, ClassType,
-    ConvertedClass, LegacyClassInfo, LegacyConvertedClass, SierraClassInfo, SierraConvertedClass,
+    class_hash::ComputeClassHashError,
+    compile::{ClassCompilationError, CompiledClassHashes},
+    ClassInfo, ClassInfoWithHash, ClassType, CompiledSierra, ConvertedClass, LegacyClassInfo, LegacyConvertedClass,
+    SierraClassInfo, SierraConvertedClass,
 };
 use mp_convert::ToFelt;
 use mp_receipt::EventWithTransactionHash;
@@ -342,11 +344,17 @@ impl BlockImporterCtx {
     // CLASSES
 
     /// Called in a rayon-pool context.
+    ///
+    /// `gateway_casm_fallback` maps class hashes to a canonical CASM fetched from the (trusted)
+    /// feeder gateway. When a Sierra class hash is present in this map, the provided CASM is used
+    /// instead of compiling the Sierra class locally. This is used to recover from historical
+    /// classes that modern compiler toolchains can no longer compile (see issue #1097).
     pub fn verify_compile_classes(
         &self,
         block_n: Option<u64>,
         declared_classes: Vec<ClassInfoWithHash>,
         check_against: &HashMap<Felt, DeclaredClassCompiledClass>,
+        gateway_casm_fallback: &HashMap<Felt, CompiledSierra>,
     ) -> Result<Vec<ConvertedClass>, BlockImportError> {
         if check_against.len() != declared_classes.len() {
             return Err(BlockImportError::ClassCount {
@@ -356,7 +364,7 @@ impl BlockImporterCtx {
         }
         let classes = declared_classes
             .into_par_iter()
-            .map(|class| self.verify_compile_class(block_n, class, check_against))
+            .map(|class| self.verify_compile_class(block_n, class, check_against, gateway_casm_fallback))
             .collect::<Result<_, _>>()?;
         Ok(classes)
     }
@@ -367,6 +375,7 @@ impl BlockImporterCtx {
         block_n: Option<u64>,
         class: ClassInfoWithHash,
         check_against: &HashMap<Felt, DeclaredClassCompiledClass>,
+        gateway_casm_fallback: &HashMap<Felt, CompiledSierra>,
     ) -> Result<ConvertedClass, BlockImportError> {
         let class_hash = class.class_hash;
 
@@ -416,11 +425,19 @@ impl BlockImporterCtx {
                     .map(|info| info.header.protocol_version.uses_blake_compiled_class_hash())
                     .unwrap_or(false);
 
-                // Compile and get both Poseidon and BLAKE hashes
-                let hashes = sierra
-                    .contract_class
-                    .compile_to_casm_with_hashes()
-                    .map_err(|e| BlockImportError::CompilationClassError { class_hash, error: Box::new(e) })?;
+                // Compile and get both Poseidon and BLAKE hashes. If a canonical CASM fetched
+                // from the (trusted) feeder gateway is available for this class, use it instead
+                // of compiling locally: some early-2023 historical Sierra classes can no longer
+                // be compiled by modern toolchains (see issue #1097).
+                let gateway_provided_casm = gateway_casm_fallback.get(&class_hash);
+                let hashes = match gateway_provided_casm {
+                    Some(compiled) => CompiledClassHashes::from_compiled_sierra(compiled)
+                        .map_err(|e| BlockImportError::CompilationClassError { class_hash, error: Box::new(e) })?,
+                    None => sierra
+                        .contract_class
+                        .compile_to_casm_with_hashes()
+                        .map_err(|e| BlockImportError::CompilationClassError { class_hash, error: Box::new(e) })?,
+                };
 
                 // Verify compiled class hash based on protocol version.
                 // For v0.14.1+ the gateway-provided hash is the canonical BLAKE hash and must match
@@ -428,6 +445,8 @@ impl BlockImporterCtx {
                 // Poseidon hash, since historical gateway hashes may not match a local recomputation
                 // after compiler/toolchain upgrades.
                 let (stored_poseidon, stored_blake) = if uses_blake {
+                    // Modern (v0.14.1+) classes get no historical tolerance: a recomputed hash
+                    // mismatch is always an error, even for a gateway-provided CASM.
                     if !self.config.no_check && hashes.blake_hash != gateway_hash {
                         return Err(BlockImportError::CompiledClassHash {
                             class_hash,
@@ -435,14 +454,40 @@ impl BlockImporterCtx {
                             expected: hashes.blake_hash,
                         });
                     }
+                    if gateway_provided_casm.is_some() {
+                        tracing::warn!(
+                            class_hash = %format!("{class_hash:#x}"),
+                            block_n = ?block_n,
+                            compiled_class_hash = %format!("{gateway_hash:#x}"),
+                            "Accepted gateway-provided CASM: BLAKE compiled class hash verified",
+                        );
+                    }
                     (None, Some(gateway_hash))
                 } else {
                     if !self.config.no_check && hashes.poseidon_hash != gateway_hash {
+                        if let Some(compiled) = gateway_provided_casm {
+                            tracing::warn!(
+                                class_hash = %format!("{class_hash:#x}"),
+                                block_n = ?block_n,
+                                declared_compiled_class_hash = %format!("{gateway_hash:#x}"),
+                                computed_poseidon_hash = %format!("{:#x}", hashes.poseidon_hash),
+                                casm_size = compiled.0.len(),
+                                "Accepted gateway-provided CASM under historical compiled_class_hash tolerance",
+                            );
+                        } else {
+                            tracing::warn!(
+                                class_hash = %format!("{class_hash:#x}"),
+                                gateway_hash = %format!("{gateway_hash:#x}"),
+                                computed_poseidon_hash = %format!("{:#x}", hashes.poseidon_hash),
+                                "Retaining gateway-provided historical compiled_class_hash for Sierra class",
+                            );
+                        }
+                    } else if gateway_provided_casm.is_some() {
                         tracing::warn!(
                             class_hash = %format!("{class_hash:#x}"),
-                            gateway_hash = %format!("{gateway_hash:#x}"),
-                            computed_poseidon_hash = %format!("{:#x}", hashes.poseidon_hash),
-                            "Retaining gateway-provided historical compiled_class_hash for Sierra class",
+                            block_n = ?block_n,
+                            compiled_class_hash = %format!("{gateway_hash:#x}"),
+                            "Accepted gateway-provided CASM: Poseidon compiled class hash verified",
                         );
                     }
                     (Some(gateway_hash), None)

--- a/madara/crates/client/sync/src/tests/gateway_mock.rs
+++ b/madara/crates/client/sync/src/tests/gateway_mock.rs
@@ -44,6 +44,23 @@ impl GatewayMock {
         });
     }
 
+    pub fn mock_compiled_class_from_json(&self, class_hash: impl Into<String>, json: impl Into<String>) -> Mock<'_> {
+        self.mock_server.mock(|when, then| {
+            when.method("GET").path_contains("get_compiled_class_by_class_hash").query_param("classHash", class_hash);
+            then.status(200).header("content-type", "application/json").body(json.into());
+        })
+    }
+
+    pub fn mock_compiled_class_not_found(&self, class_hash: impl Into<String>) -> Mock<'_> {
+        self.mock_server.mock(|when, then| {
+            when.method("GET").path_contains("get_compiled_class_by_class_hash").query_param("classHash", class_hash);
+            then.status(400).header("content-type", "application/json").json_body(json!({
+                "code": "StarknetErrorCode.UNDECLARED_CLASS",
+                "message": "Class with hash is not declared"
+            }));
+        })
+    }
+
     pub fn mock_header_latest(&self, block_number: u64, hash: Felt) -> Mock<'_> {
         self.mock_server.mock(|when, then| {
             when.method("GET")

--- a/madara/crates/client/sync/src/tests/mod.rs
+++ b/madara/crates/client/sync/src/tests/mod.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-mod gateway_mock;
+pub(crate) mod gateway_mock;
 mod pipeline;
 mod realistic;
 mod reorg;

--- a/madara/crates/primitives/class/src/compile.rs
+++ b/madara/crates/primitives/class/src/compile.rs
@@ -61,6 +61,25 @@ pub struct CompiledClassHashes {
     pub casm_class: CasmContractClass,
 }
 
+impl CompiledClassHashes {
+    /// Computes both Poseidon and BLAKE2s compiled class hashes for an already-compiled CASM
+    /// class (e.g. a canonical CASM fetched from a trusted feeder gateway instead of being
+    /// compiled locally).
+    pub fn from_casm(casm_class: CasmContractClass) -> Result<Self, ClassCompilationError> {
+        let poseidon_hash = casm_class.compiled_class_hash();
+        let blake_hash = v2::compute_blake_compiled_class_hash(&casm_class)?;
+        Ok(Self { poseidon_hash, blake_hash, casm_class })
+    }
+
+    /// Parses a JSON-serialized CASM class (as returned by the feeder gateway
+    /// `get_compiled_class_by_class_hash` endpoint) and computes both compiled class hash
+    /// variants for it.
+    pub fn from_compiled_sierra(compiled: &CompiledSierra) -> Result<Self, ClassCompilationError> {
+        let casm_class: CasmContractClass = compiled.try_into()?;
+        Self::from_casm(casm_class)
+    }
+}
+
 impl CompressedLegacyContractClass {
     // Returns `impl serde::Serialize` because the fact that it returns a serde_json::Value is an impl detail
     pub fn abi(&self) -> Result<impl serde::Serialize, ClassCompilationError> {


### PR DESCRIPTION
Addresses #1097

## Problem

Mainnet SnapSync hard-fails at block ~80000: Sierra class `0x78d552edf8d22e566b050c9158d7f770b55021c36a9f5a98170ff8fcabc9e10` fails local Sierra→CASM compilation (`failed solving the symbol tables`). It is an early-2023 class that no modern `cairo-lang-starknet-classes` toolchain can recompile, right after the existing "Retaining gateway-provided historical compiled_class_hash" tolerance fires. The node enters a restart loop. Reference nodes (Juno, Pathfinder) handle these classes by using the canonical CASM from the feeder gateway instead of recompiling locally.

## Design

**Trust model**: in gateway sync mode the feeder gateway is already the trust root for blocks, state diffs and class definitions, so fetching its CASM (`get_compiled_class_by_class_hash`) does not extend trust. We still verify what is verifiable:

- The fallback only engages when local compilation **errors** — never on a plain hash mismatch — so it cannot mask compiler regressions on classes that still compile.
- The fetched CASM is re-hashed locally (both Poseidon and BLAKE variants) and checked against the compiled class hash declared in the state diff:
  - **match** → accepted, with a WARN so operators can see the fallback engaged;
  - **mismatch on a historical class** (pre-v0.14.1, Poseidon hash) → accepted under the same pre-existing historical `compiled_class_hash` tolerance already applied to local compiles, with a loud WARN carrying both hashes;
  - **mismatch on a modern class** (v0.14.1+, BLAKE hash) → rejected, sync fails as today.
- If the gateway CASM fetch itself fails, the original compilation error context is propagated and sync fails as it does today.

No new CLI flag: the fallback is on by default and only changes behavior in the case that previously hard-failed sync.

## Implementation

- `mc-gateway-client`: new `get_compiled_class_by_class_hash` feeder method returning the raw JSON CASM.
- `mp-class`: `CompiledClassHashes::from_casm` / `from_compiled_sierra` to hash an already-compiled CASM (both Poseidon and BLAKE2s variants).
- `mc-sync`: `verify_compile_classes_with_gateway_casm_fallback` wraps class verification in the gateway classes pipeline; on `CompilationClassError` it fetches the gateway CASM for that class hash and re-runs verification with it. `verify_compile_class` uses the provided CASM instead of compiling when one is available; all other checks (class count, class hash, class type, compiled class hash) are unchanged.

## Tests (`mc-sync`)

- `casm_fallback_verified_accept`: compile failure → gateway CASM fetched → hash matches → accepted; stored CASM is the gateway one.
- `casm_fallback_historical_mismatch_accepted`: hash mismatch on a historical (Poseidon) class → accepted under the historical tolerance.
- `casm_fallback_non_historical_mismatch_rejected`: hash mismatch on a modern (v0.14.1+/BLAKE) class → rejected with `CompiledClassHash` error.
- `casm_fallback_fetch_error_propagates`: gateway fetch failure → error propagates, sync fails.
- `casm_fallback_not_engaged_when_local_compile_succeeds`: classes that compile locally never trigger a gateway CASM fetch (asserted via mock hit count).

Validated with `cargo check`, `cargo clippy` (clean) and `cargo test -p mc-sync` (40 passed; the two `mc-sync` doctest failures are pre-existing on `starknet-full-node`).

## Note for reviewers

The motivating class at mainnet block ~80000 needs a live mainnet sync to confirm end-to-end; the unit tests reproduce the failure mode with a deliberately corrupted Sierra program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)