### PR TITLE
feat(sync): verification hardening and log redaction for gateway CASM fallback

### DIFF
--- a/madara/crates/client/gateway/client/src/request_builder.rs
+++ b/madara/crates/client/gateway/client/src/request_builder.rs
@@ -165,7 +165,12 @@ impl<'a> RequestBuilder<'a> {
             url.set_query(Some(&query));
         }
 
-        let uri: Uri = url.as_str().try_into().map_err(|_| SequencerError::InvalidUrl(url))?;
+        // Redact the URL before it enters the error chain: user-supplied gateway URLs may embed
+        // API keys, and `SequencerError`s end up in logs.
+        let uri: Uri = url
+            .as_str()
+            .try_into()
+            .map_err(|_| SequencerError::InvalidUrl(mp_gateway::error::redact_url_for_logging(&url)))?;
         Ok(uri)
     }
 }

--- a/madara/crates/client/sync/src/gateway/classes.rs
+++ b/madara/crates/client/sync/src/gateway/classes.rs
@@ -6,10 +6,12 @@ use anyhow::Context;
 use mc_db::MadaraBackend;
 use mc_gateway_client::{BlockId, GatewayProvider};
 use mp_class::{
-    ClassInfo, ClassInfoWithHash, CompiledSierra, ConvertedClass, LegacyClassInfo, SierraClassInfo, MISSED_CLASS_HASHES,
+    compile::ClassCompilationError, ClassInfo, ClassInfoWithHash, CompiledSierra, ConvertedClass, LegacyClassInfo,
+    SierraClassInfo, MISSED_CLASS_HASHES,
 };
 use mp_state_update::DeclaredClassCompiledClass;
 use mp_utils::AbortOnDrop;
+use rayon::prelude::*;
 use starknet_api::core::ChainId;
 use starknet_core::types::Felt;
 use std::{collections::HashMap, ops::Range, sync::Arc};
@@ -96,7 +98,7 @@ pub(crate) async fn get_classes(
 /// - The fallback only engages when local compilation *errors* (never on a plain hash mismatch),
 ///   so it cannot mask compiler regressions on classes that still compile.
 /// - The fetched CASM is re-hashed; the hash check in
-///   [`crate::import::BlockImporterCtx::verify_compile_classes`] then applies as usual: a match
+///   [`crate::import::BlockImporterCtx::verify_compile_class`] then applies as usual: a match
 ///   is accepted, a mismatch is only tolerated under the pre-existing historical
 ///   compiled_class_hash tolerance (pre-v0.14.1 Poseidon classes) and is rejected for modern
 ///   (v0.14.1+, BLAKE) classes.
@@ -107,51 +109,83 @@ pub(crate) async fn verify_compile_classes_with_gateway_casm_fallback(
     declared_classes: Vec<ClassInfoWithHash>,
     check_against: &HashMap<Felt, DeclaredClassCompiledClass>,
 ) -> Result<Vec<ConvertedClass>, BlockImportError> {
-    let mut gateway_casm_fallback: HashMap<Felt, CompiledSierra> = HashMap::new();
-    // Each iteration either succeeds, fails for good, or adds a fallback CASM for a class hash
-    // that did not have one yet, so this loop runs at most `len + 1` times.
-    for _ in 0..=check_against.len() {
-        let declared_classes_ = declared_classes.clone();
-        let check_against_ = check_against.clone();
-        let gateway_casm_fallback_ = gateway_casm_fallback.clone();
-        let res = importer
-            .run_in_rayon_pool(move |importer| {
-                importer.verify_compile_classes(
-                    Some(block_n),
-                    declared_classes_,
-                    &check_against_,
-                    &gateway_casm_fallback_,
-                )
-            })
-            .await;
-        match res {
-            Err(BlockImportError::CompilationClassError { class_hash, error })
-                if !gateway_casm_fallback.contains_key(&class_hash) =>
-            {
-                tracing::warn!(
-                    class_hash = %format!("{class_hash:#x}"),
-                    block_n,
-                    error = %error,
-                    "Local CASM compilation failed for class; falling back to the compiled class \
-                     (CASM) served by the feeder gateway",
-                );
-                let compiled = client
-                    .get_compiled_class_by_class_hash(class_hash, BlockId::Number(block_n))
-                    .await
-                    .map_err(|fetch_error| {
-                        BlockImportError::Internal(anyhow::Error::new(fetch_error).context(format!(
-                            "Fetching compiled class (CASM) from the gateway for class_hash={class_hash:#x} \
-                             block_n={block_n} after local compilation failed: {error}"
-                        )))
-                    })?;
-                gateway_casm_fallback.insert(class_hash, compiled);
+    if check_against.len() != declared_classes.len() {
+        return Err(BlockImportError::ClassCount {
+            got: declared_classes.len() as _,
+            expected: check_against.len() as _,
+        });
+    }
+
+    // First pass: verify and compile every class exactly once, keeping per-class results so that
+    // a single pass discovers all locally-broken classes instead of stopping at the first one.
+    let declared_classes_ = declared_classes.clone();
+    let check_against_ = check_against.clone();
+    let first_pass = importer
+        .run_in_rayon_pool(move |importer| {
+            declared_classes_
+                .into_par_iter()
+                .map(|class| importer.verify_compile_class(Some(block_n), class, &check_against_, &HashMap::new()))
+                .collect::<Vec<_>>()
+        })
+        .await;
+
+    let mut converted: Vec<Option<ConvertedClass>> = Vec::with_capacity(first_pass.len());
+    let mut failed: Vec<(usize, Felt, Box<ClassCompilationError>)> = vec![];
+    for (index, result) in first_pass.into_iter().enumerate() {
+        match result {
+            Ok(class) => converted.push(Some(class)),
+            Err(BlockImportError::CompilationClassError { class_hash, error }) => {
+                converted.push(None);
+                failed.push((index, class_hash, error));
             }
-            res => return res,
+            Err(other) => return Err(other),
         }
     }
-    Err(BlockImportError::Internal(anyhow::anyhow!(
-        "Gateway CASM fallback did not converge for block_n={block_n} (this is a bug)"
-    )))
+    if failed.is_empty() {
+        return Ok(converted.into_iter().flatten().collect());
+    }
+
+    // Fetch the canonical CASM for every locally-broken class.
+    let mut gateway_casm_fallback: HashMap<Felt, CompiledSierra> = HashMap::new();
+    for (_, class_hash, error) in &failed {
+        let class_hash = *class_hash;
+        tracing::warn!(
+            class_hash = %format!("{class_hash:#x}"),
+            block_n,
+            error = %error,
+            "Local CASM compilation failed for class; falling back to the compiled class \
+             (CASM) served by the feeder gateway",
+        );
+        let compiled = client.get_compiled_class_by_class_hash(class_hash, BlockId::Number(block_n)).await.map_err(
+            |fetch_error| {
+                BlockImportError::Internal(anyhow::Error::new(fetch_error).context(format!(
+                    "Fetching compiled class (CASM) from the gateway for class_hash={class_hash:#x} \
+                     block_n={block_n} after local compilation failed: {error}"
+                )))
+            },
+        )?;
+        gateway_casm_fallback.insert(class_hash, compiled);
+    }
+
+    // Second pass: re-verify only the locally-broken classes, with the gateway CASM standing in
+    // for local compilation. Any error here is final.
+    let retry_classes: Vec<ClassInfoWithHash> =
+        failed.iter().map(|&(index, _, _)| declared_classes[index].clone()).collect();
+    let check_against_ = check_against.clone();
+    let retried = importer
+        .run_in_rayon_pool(move |importer| {
+            retry_classes
+                .into_par_iter()
+                .map(|class| {
+                    importer.verify_compile_class(Some(block_n), class, &check_against_, &gateway_casm_fallback)
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .await?;
+    for (&(index, _, _), class) in failed.iter().zip(retried) {
+        converted[index] = Some(class);
+    }
+    Ok(converted.into_iter().flatten().collect())
 }
 
 pub type ClassesSync = PipelineController<ClassesSyncSteps>;
@@ -475,6 +509,48 @@ mod tests {
 
         assert_eq!(casm_mock.hits(), 0);
         assert_eq!(converted.len(), 1);
+    }
+
+    /// A block mixing classes that compile locally and classes that do not: only the broken class
+    /// triggers a gateway CASM fetch (exactly once), the good class is compiled a single time, and
+    /// the declared order is preserved in the output.
+    #[tokio::test]
+    async fn casm_fallback_mixed_block_fetches_broken_class_once() {
+        let fixture = fallback_fixture();
+        let declared_hash = fixture.casm_hashes.poseidon_hash;
+        let good_class_hash = felt!("0x1");
+        let casm_mock =
+            fixture.gateway_mock.mock_compiled_class_from_json(format!("{CLASS_HASH:#x}"), fixture.casm_json.clone());
+
+        let check_against = HashMap::from([
+            (CLASS_HASH, DeclaredClassCompiledClass::Sierra(declared_hash)),
+            (good_class_hash, DeclaredClassCompiledClass::Sierra(declared_hash)),
+        ]);
+        let declared = vec![
+            declared_sierra_class(fixture.broken_sierra.clone(), declared_hash),
+            ClassInfoWithHash {
+                class_hash: good_class_hash,
+                class_info: ClassInfo::Sierra(SierraClassInfo {
+                    contract_class: fixture.good_sierra.clone(),
+                    compiled_class_hash: Some(declared_hash),
+                    compiled_class_hash_v2: None,
+                }),
+            },
+        ];
+        let converted = verify_compile_classes_with_gateway_casm_fallback(
+            &fixture.importer,
+            &fixture.gateway_mock.client(),
+            0,
+            declared,
+            &check_against,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(casm_mock.hits(), 1);
+        assert_eq!(converted.len(), 2);
+        assert_eq!(converted[0].as_sierra().unwrap().class_hash, CLASS_HASH);
+        assert_eq!(converted[1].as_sierra().unwrap().class_hash, good_class_hash);
     }
 
     #[test]

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -16,7 +16,7 @@ use mp_convert::ToFelt;
 use mp_receipt::EventWithTransactionHash;
 use mp_state_update::{DeclaredClassCompiledClass, StateDiff};
 use mp_utils::rayon::{global_spawn_rayon_task, RayonPool};
-use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use starknet_api::core::ChainId;
 use starknet_core::types::Felt;
 use std::{borrow::Cow, collections::HashMap, ops::Range, sync::Arc};
@@ -163,15 +163,21 @@ impl BlockImporter {
 /// directly. The instrument is re-created per event, which is fine at this frequency: the
 /// fallback engages at most a handful of times over a full mainnet sync.
 fn record_gateway_casm_fallback_metric(outcome: &'static str) {
-    use opentelemetry::{global, KeyValue};
-    global::meter("crates.sync.opentelemetry")
-        .u64_counter("class_gateway_casm_fallback")
-        .with_description(
-            "Number of declared classes whose CASM was fetched from the feeder gateway because \
+    use opentelemetry::{global, InstrumentationScope, KeyValue};
+    // Same instrumentation scope as `crate::metrics::SyncMetrics`, so the counter is grouped with
+    // the other sync metrics in OTel backends.
+    global::meter_with_scope(
+        InstrumentationScope::builder("crates.sync.opentelemetry")
+            .with_attributes([KeyValue::new("crate", "sync")])
+            .build(),
+    )
+    .u64_counter("class_gateway_casm_fallback")
+    .with_description(
+        "Number of declared classes whose CASM was fetched from the feeder gateway because \
              local Sierra-to-CASM compilation failed",
-        )
-        .build()
-        .add(1, &[KeyValue::new("outcome", outcome)]);
+    )
+    .build()
+    .add(1, &[KeyValue::new("outcome", outcome)]);
 }
 
 pub struct BlockImporterCtx {
@@ -372,27 +378,6 @@ impl BlockImporterCtx {
     ///
     /// Each accepted gateway CASM is counted in the `class_gateway_casm_fallback` metric, with an
     /// `outcome` attribute of `verified_blake`, `verified_poseidon` or `historical_tolerance`.
-    pub fn verify_compile_classes(
-        &self,
-        block_n: Option<u64>,
-        declared_classes: Vec<ClassInfoWithHash>,
-        check_against: &HashMap<Felt, DeclaredClassCompiledClass>,
-        gateway_casm_fallback: &HashMap<Felt, CompiledSierra>,
-    ) -> Result<Vec<ConvertedClass>, BlockImportError> {
-        if check_against.len() != declared_classes.len() {
-            return Err(BlockImportError::ClassCount {
-                got: declared_classes.len() as _,
-                expected: check_against.len() as _,
-            });
-        }
-        let classes = declared_classes
-            .into_par_iter()
-            .map(|class| self.verify_compile_class(block_n, class, check_against, gateway_casm_fallback))
-            .collect::<Result<_, _>>()?;
-        Ok(classes)
-    }
-
-    /// Called in a rayon-pool context.
     ///
     /// # Compiled class hash variants
     ///
@@ -405,7 +390,7 @@ impl BlockImporterCtx {
     ///   fallback — declare the Poseidon compiled class hash, where a mismatch is tolerated with
     ///   a WARN, because historical gateway hashes may not match a local recomputation after
     ///   compiler/toolchain upgrades.
-    fn verify_compile_class(
+    pub(crate) fn verify_compile_class(
         &self,
         block_n: Option<u64>,
         class: ClassInfoWithHash,

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -154,6 +154,26 @@ impl BlockImporter {
     }
 }
 
+/// Counts declared classes whose CASM was taken from the feeder gateway because local
+/// Sierra-to-CASM compilation failed (see issue #1097), so operators can alert on the fallback
+/// engaging. `outcome` is one of `verified_blake`, `verified_poseidon` or `historical_tolerance`.
+///
+/// Class verification runs in a rayon-pool context with no access to the sync service's
+/// [`crate::metrics::SyncMetrics`] registry, so this records through the OTel global meter
+/// directly. The instrument is re-created per event, which is fine at this frequency: the
+/// fallback engages at most a handful of times over a full mainnet sync.
+fn record_gateway_casm_fallback_metric(outcome: &'static str) {
+    use opentelemetry::{global, KeyValue};
+    global::meter("crates.sync.opentelemetry")
+        .u64_counter("class_gateway_casm_fallback")
+        .with_description(
+            "Number of declared classes whose CASM was fetched from the feeder gateway because \
+             local Sierra-to-CASM compilation failed",
+        )
+        .build()
+        .add(1, &[KeyValue::new("outcome", outcome)]);
+}
+
 pub struct BlockImporterCtx {
     backend: Arc<MadaraBackend>,
     config: BlockValidationConfig,
@@ -349,6 +369,9 @@ impl BlockImporterCtx {
     /// feeder gateway. When a Sierra class hash is present in this map, the provided CASM is used
     /// instead of compiling the Sierra class locally. This is used to recover from historical
     /// classes that modern compiler toolchains can no longer compile (see issue #1097).
+    ///
+    /// Each accepted gateway CASM is counted in the `class_gateway_casm_fallback` metric, with an
+    /// `outcome` attribute of `verified_blake`, `verified_poseidon` or `historical_tolerance`.
     pub fn verify_compile_classes(
         &self,
         block_n: Option<u64>,
@@ -370,6 +393,18 @@ impl BlockImporterCtx {
     }
 
     /// Called in a rayon-pool context.
+    ///
+    /// # Compiled class hash variants
+    ///
+    /// The recomputed compiled class hash is compared against the hash declared by the gateway
+    /// using the variant canonical for the block's protocol version (see
+    /// [`StarknetVersion::uses_blake_compiled_class_hash`]):
+    /// - v0.14.1+ blocks declare the BLAKE2s compiled class hash, which must match the local
+    ///   recomputation exactly (even when the CASM comes from the gateway fallback);
+    /// - older blocks — this includes every historical class that may need the gateway CASM
+    ///   fallback — declare the Poseidon compiled class hash, where a mismatch is tolerated with
+    ///   a WARN, because historical gateway hashes may not match a local recomputation after
+    ///   compiler/toolchain upgrades.
     fn verify_compile_class(
         &self,
         block_n: Option<u64>,
@@ -461,6 +496,7 @@ impl BlockImporterCtx {
                             compiled_class_hash = %format!("{gateway_hash:#x}"),
                             "Accepted gateway-provided CASM: BLAKE compiled class hash verified",
                         );
+                        record_gateway_casm_fallback_metric("verified_blake");
                     }
                     (None, Some(gateway_hash))
                 } else {
@@ -474,6 +510,7 @@ impl BlockImporterCtx {
                                 casm_size = compiled.0.len(),
                                 "Accepted gateway-provided CASM under historical compiled_class_hash tolerance",
                             );
+                            record_gateway_casm_fallback_metric("historical_tolerance");
                         } else {
                             tracing::warn!(
                                 class_hash = %format!("{class_hash:#x}"),
@@ -489,6 +526,7 @@ impl BlockImporterCtx {
                             compiled_class_hash = %format!("{gateway_hash:#x}"),
                             "Accepted gateway-provided CASM: Poseidon compiled class hash verified",
                         );
+                        record_gateway_casm_fallback_metric("verified_poseidon");
                     }
                     (Some(gateway_hash), None)
                 };

--- a/madara/crates/client/sync/src/import.rs
+++ b/madara/crates/client/sync/src/import.rs
@@ -16,6 +16,7 @@ use mp_convert::ToFelt;
 use mp_receipt::EventWithTransactionHash;
 use mp_state_update::{DeclaredClassCompiledClass, StateDiff};
 use mp_utils::rayon::{global_spawn_rayon_task, RayonPool};
+use opentelemetry::{global, metrics::Counter, InstrumentationScope, KeyValue};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use starknet_api::core::ChainId;
 use starknet_core::types::Felt;
@@ -122,11 +123,17 @@ pub struct BlockImporter {
     db: Arc<MadaraBackend>,
     config: BlockValidationConfig,
     rayon_pool: Arc<RayonPool>,
+    gateway_casm_fallback_counter: Counter<u64>,
 }
 
 impl BlockImporter {
     pub fn new(db: Arc<MadaraBackend>, config: BlockValidationConfig) -> BlockImporter {
-        Self { db, config, rayon_pool: Arc::new(RayonPool::new()) }
+        Self {
+            db,
+            config,
+            rayon_pool: Arc::new(RayonPool::new()),
+            gateway_casm_fallback_counter: gateway_casm_fallback_counter(),
+        }
     }
 
     pub async fn run_in_rayon_pool<F, R>(&self, func: F) -> R
@@ -150,20 +157,24 @@ impl BlockImporter {
     }
 
     fn ctx(&self) -> BlockImporterCtx {
-        BlockImporterCtx { backend: self.db.clone(), config: self.config.clone() }
+        BlockImporterCtx {
+            backend: self.db.clone(),
+            config: self.config.clone(),
+            gateway_casm_fallback_counter: self.gateway_casm_fallback_counter.clone(),
+        }
     }
 }
 
 /// Counts declared classes whose CASM was taken from the feeder gateway because local
 /// Sierra-to-CASM compilation failed (see issue #1097), so operators can alert on the fallback
-/// engaging. `outcome` is one of `verified_blake`, `verified_poseidon` or `historical_tolerance`.
+/// engaging. Recorded with an `outcome` attribute of `verified_blake`, `verified_poseidon` or
+/// `historical_tolerance`.
 ///
 /// Class verification runs in a rayon-pool context with no access to the sync service's
-/// [`crate::metrics::SyncMetrics`] registry, so this records through the OTel global meter
-/// directly. The instrument is re-created per event, which is fine at this frequency: the
-/// fallback engages at most a handful of times over a full mainnet sync.
-fn record_gateway_casm_fallback_metric(outcome: &'static str) {
-    use opentelemetry::{global, InstrumentationScope, KeyValue};
+/// [`crate::metrics::SyncMetrics`] registry, so the counter is created through the OTel global
+/// meter once at [`BlockImporter`] construction and carried into the rayon context by
+/// [`BlockImporterCtx`].
+fn gateway_casm_fallback_counter() -> Counter<u64> {
     // Same instrumentation scope as `crate::metrics::SyncMetrics`, so the counter is grouped with
     // the other sync metrics in OTel backends.
     global::meter_with_scope(
@@ -174,17 +185,22 @@ fn record_gateway_casm_fallback_metric(outcome: &'static str) {
     .u64_counter("class_gateway_casm_fallback")
     .with_description(
         "Number of declared classes whose CASM was fetched from the feeder gateway because \
-             local Sierra-to-CASM compilation failed",
+         local Sierra-to-CASM compilation failed",
     )
     .build()
-    .add(1, &[KeyValue::new("outcome", outcome)]);
 }
 
 pub struct BlockImporterCtx {
     backend: Arc<MadaraBackend>,
     config: BlockValidationConfig,
+    gateway_casm_fallback_counter: Counter<u64>,
 }
 impl BlockImporterCtx {
+    /// See [`gateway_casm_fallback_counter`].
+    fn record_gateway_casm_fallback(&self, outcome: &'static str) {
+        self.gateway_casm_fallback_counter.add(1, &[KeyValue::new("outcome", outcome)]);
+    }
+
     // HEADERS
 
     pub fn verify_header(
@@ -481,7 +497,7 @@ impl BlockImporterCtx {
                             compiled_class_hash = %format!("{gateway_hash:#x}"),
                             "Accepted gateway-provided CASM: BLAKE compiled class hash verified",
                         );
-                        record_gateway_casm_fallback_metric("verified_blake");
+                        self.record_gateway_casm_fallback("verified_blake");
                     }
                     (None, Some(gateway_hash))
                 } else {
@@ -495,7 +511,7 @@ impl BlockImporterCtx {
                                 casm_size = compiled.0.len(),
                                 "Accepted gateway-provided CASM under historical compiled_class_hash tolerance",
                             );
-                            record_gateway_casm_fallback_metric("historical_tolerance");
+                            self.record_gateway_casm_fallback("historical_tolerance");
                         } else {
                             tracing::warn!(
                                 class_hash = %format!("{class_hash:#x}"),
@@ -511,7 +527,7 @@ impl BlockImporterCtx {
                             compiled_class_hash = %format!("{gateway_hash:#x}"),
                             "Accepted gateway-provided CASM: Poseidon compiled class hash verified",
                         );
-                        record_gateway_casm_fallback_metric("verified_poseidon");
+                        self.record_gateway_casm_fallback("verified_poseidon");
                     }
                     (Some(gateway_hash), None)
                 };

--- a/madara/crates/primitives/gateway/src/error.rs
+++ b/madara/crates/primitives/gateway/src/error.rs
@@ -13,8 +13,11 @@ pub enum SequencerError {
     HyperError(#[from] hyper::Error),
     #[error("No URL available to use this request")]
     NoUrl,
+    /// The URL stored here must already be redacted with [`redact_url_for_logging`]: operators
+    /// commonly embed API keys in custom gateway URLs (`--gateway-url`), and this error (like the
+    /// whole [`SequencerError`] chain) ends up in logs and error contexts.
     #[error("Invalid URL: {0}")]
-    InvalidUrl(url::Url),
+    InvalidUrl(String),
     #[error("HTTP error: {0:#}")]
     HttpError(#[from] hyper::http::Error),
     #[error("Error calling HTTP client: {0:#}")]
@@ -27,6 +30,51 @@ pub enum SequencerError {
     CompressError(#[from] starknet_core::types::contract::CompressProgramError),
     #[error("Failed to parse returned error with http status {http_status}: {serde_error:#}")]
     InvalidStarknetError { http_status: StatusCode, serde_error: serde_json::Error },
+}
+
+/// Renders a gateway URL so that it is safe to embed in logs and error messages.
+///
+/// Operators commonly embed API keys in custom gateway URLs (`--gateway-url`), either as
+/// userinfo (`https://user:key@host/...`), as a query parameter (`?apikey=...`), or as a path
+/// segment (`https://host/<api-key>/feeder_gateway`, the style used by most RPC providers).
+/// Anything that could carry a credential is masked:
+///
+/// - userinfo (username and password) is replaced with `***`,
+/// - every query parameter *value* is masked (parameter names are kept),
+/// - path segments that look like tokens (16+ characters of `[A-Za-z0-9_-]` containing at least
+///   one digit) are masked. Standard gateway path segments (`feeder_gateway`, `get_block`,
+///   `get_compiled_class_by_class_hash`, ...) contain no digits and are preserved.
+///
+/// Note that the `--gateway-key` flag is sent as an HTTP header and never appears in URLs; this
+/// helper protects keys embedded in the URL itself.
+pub fn redact_url_for_logging(url: &url::Url) -> String {
+    fn is_token_like(segment: &str) -> bool {
+        segment.len() >= 16
+            && segment.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+            && segment.chars().any(|c| c.is_ascii_digit())
+    }
+
+    let mut url = url.clone();
+    if url.password().is_some() {
+        let _ = url.set_password(Some("***"));
+    }
+    if !url.username().is_empty() {
+        let _ = url.set_username("***");
+    }
+    if url.query().is_some() {
+        let masked = url.query_pairs().map(|(key, _)| format!("{key}=***")).collect::<Vec<_>>().join("&");
+        url.set_query(Some(&masked));
+    }
+    if url.path_segments().is_some_and(|mut segments| segments.any(is_token_like)) {
+        let masked = url
+            .path_segments()
+            .expect("checked by the condition above")
+            .map(|segment| if is_token_like(segment) { "***" } else { segment })
+            .collect::<Vec<_>>()
+            .join("/");
+        url.set_path(&masked);
+    }
+    url.to_string()
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -183,4 +231,57 @@ pub enum StarknetErrorCode {
     InvalidContractClassVersion,
     #[serde(rename = "StarknetErrorCode.RATE_LIMITED")]
     RateLimited,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    #[test]
+    fn redact_url_masks_query_param_values() {
+        let url = Url::parse("https://gateway.example.com/feeder_gateway/get_block?apikey=SECRETKEY123&x=1").unwrap();
+        let redacted = redact_url_for_logging(&url);
+        assert!(!redacted.contains("SECRETKEY123"), "{redacted}");
+        assert_eq!(redacted, "https://gateway.example.com/feeder_gateway/get_block?apikey=***&x=***");
+    }
+
+    #[test]
+    fn redact_url_masks_userinfo() {
+        let url = Url::parse("https://user:hunter2@gateway.example.com/feeder_gateway").unwrap();
+        let redacted = redact_url_for_logging(&url);
+        assert!(!redacted.contains("hunter2"), "{redacted}");
+        assert!(!redacted.contains("user:"), "{redacted}");
+        assert_eq!(redacted, "https://***:***@gateway.example.com/feeder_gateway");
+    }
+
+    #[test]
+    fn redact_url_masks_token_like_path_segments() {
+        // RPC-provider style URL with the project API key as a path segment.
+        let url =
+            Url::parse("https://starknet-mainnet.example.io/8237aafe06d8f6213d839e25a8637b3c/feeder_gateway").unwrap();
+        let redacted = redact_url_for_logging(&url);
+        assert!(!redacted.contains("8237aafe06d8f6213d839e25a8637b3c"), "{redacted}");
+        assert_eq!(redacted, "https://starknet-mainnet.example.io/***/feeder_gateway");
+    }
+
+    #[test]
+    fn redact_url_keeps_normal_gateway_urls_readable() {
+        let url =
+            Url::parse("https://feeder.alpha-mainnet.starknet.io/feeder_gateway/get_compiled_class_by_class_hash")
+                .unwrap();
+        assert_eq!(redact_url_for_logging(&url), url.as_str());
+    }
+
+    #[test]
+    fn invalid_url_error_string_does_not_leak_api_key() {
+        let url =
+            Url::parse("https://host.example.com/0123456789abcdef0123456789abcdef/feeder_gateway?api_key=TOPSECRET9")
+                .unwrap();
+        let error = SequencerError::InvalidUrl(redact_url_for_logging(&url));
+        let message = error.to_string();
+        assert!(!message.contains("0123456789abcdef"), "{message}");
+        assert!(!message.contains("TOPSECRET9"), "{message}");
+        assert!(message.contains("host.example.com"), "{message}");
+    }
 }

--- a/madara/node/src/cli/l2.rs
+++ b/madara/node/src/cli/l2.rs
@@ -117,10 +117,11 @@ impl L2SyncParams {
         let mut client = GatewayProvider::new(gateway, feeder_gateway);
 
         if let Some(api_key) = &self.gateway_key {
-            client.add_header(
-                HeaderName::from_static("x-throttling-bypass"),
-                HeaderValue::from_str(api_key).with_context(|| "Invalid API key format")?,
-            )
+            let mut value = HeaderValue::from_str(api_key).with_context(|| "Invalid API key format")?;
+            // Mark the API key as sensitive so it is masked in any `Debug` output (e.g. if the
+            // provider, its headers, or a request ever end up in a log or error message).
+            value.set_sensitive(true);
+            client.add_header(HeaderName::from_static("x-throttling-bypass"), value)
         }
 
         Ok(Arc::new(client))

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -360,10 +360,11 @@ async fn main() -> anyhow::Result<()> {
         provider = provider.with_madara_gateway_url(url)
     }
     if let Some(api_key) = run_cmd.l2_sync_params.gateway_key.clone() {
-        provider.add_header(
-            HeaderName::from_static("x-throttling-bypass"),
-            HeaderValue::from_str(&api_key).with_context(|| "Invalid API key format")?,
-        )
+        let mut value = HeaderValue::from_str(&api_key).with_context(|| "Invalid API key format")?;
+        // Mark the API key as sensitive so it is masked in any `Debug` output (e.g. if the
+        // provider, its headers, or a request ever end up in a log or error message).
+        value.set_sensitive(true);
+        provider.add_header(HeaderName::from_static("x-throttling-bypass"), value)
     }
 
     let gateway_client = Arc::new(provider);


### PR DESCRIPTION
Addresses #1106

**Re-targeted from #1120**, which was accidentally merged into its stacked base branch (`fix/historical-class-casm-fallback-1097`) instead of being retargeted to `starknet-full-node` after #1119 merged. Same content, cherry-picked onto `starknet-full-node`, plus the follow-up two-pass rework of the fallback loop.

Hardens the gateway CASM fallback from #1119:

## URL / credential redaction

- New `mp_gateway::error::redact_url_for_logging`: masks userinfo (`https://user:key@host`), every query parameter value (`?apikey=...`), and token-like path segments (16+ chars of `[A-Za-z0-9_-]` with at least one digit — the RPC-provider style `https://host/<api-key>/feeder_gateway`). Normal gateway path segments (`feeder_gateway`, `get_compiled_class_by_class_hash`, ...) contain no digits and stay readable.
- `SequencerError::InvalidUrl` now stores the redacted string, so neither `Display` nor `Debug` of the error chain (including the `retry_get` WARN that debug-prints errors) can leak a key embedded in a user-supplied `--gateway-url`.
- `--gateway-key` flows into the `x-throttling-bypass` header (never into URLs); it is now marked `HeaderValue::set_sensitive(true)` at both injection sites (`node/src/cli/l2.rs`, `node/src/main.rs`) so any `Debug` of the provider, its headers or a request prints `Sensitive` instead of the key.

## Observability

- The stable grep-able WARN `"Accepted gateway-provided CASM under historical compiled_class_hash tolerance"` (declared + computed hashes, CASM size) shipped with PR 1; its message is now documented as the operator-facing signal and left unchanged.
- New `class_gateway_casm_fallback` counter (attribute `outcome` = `verified_blake` | `verified_poseidon` | `historical_tolerance`), recorded through the OTel global meter following the crate's existing instrument conventions. The `SyncMetrics` registry is not reachable from the rayon-pool verification context, so the instrument is created per event — fine at this frequency (a handful of times per full mainnet sync).

## Hash-variant documentation

`verify_compile_class` now documents which compiled class hash variant is compared per protocol version (per `StarknetVersion::uses_blake_compiled_class_hash`): Poseidon for pre-v0.14.1 blocks — which covers every class eligible for the historical tolerance — and BLAKE2s, matched exactly with no tolerance, for v0.14.1+.

## Tests

- `redact_url_masks_query_param_values`
- `redact_url_masks_userinfo`
- `redact_url_masks_token_like_path_segments`
- `redact_url_keeps_normal_gateway_urls_readable`
- `invalid_url_error_string_does_not_leak_api_key` (API key stripped from a `SequencerError` string)
- The negative test "remote CASM hash mismatch on a NON-historical class → sync rejects" (`casm_fallback_non_historical_mismatch_rejected`) already landed in #1119 together with the fallback itself, per the verification rules in that PR.

Validated with `cargo check -p madara`, `cargo clippy -p mp-gateway -p mc-gateway-client -p mc-sync --all-targets` (clean), `cargo test -p mp-gateway` (11 passed) and `cargo test -p mc-sync --lib gateway::classes` (8 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
