### PR TITLE
ci(dependabot): target starknet-full-node for cargo version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    # Active development happens on starknet-full-node; raise version-update
+    # PRs there instead of main. Note: security updates always target the
+    # default branch and are not affected by this setting.
+    target-branch: "starknet-full-node"
     schedule:
       interval: "weekly" # can be `daily` or `monthly` also
     open-pull-requests-limit: 10


### PR DESCRIPTION
Points Dependabot's cargo version-update PRs at `starknet-full-node`, where active development happens, instead of `main`.

Notes:
- Dependabot reads this config from the default branch, which is why this PR targets `main`.
- The 11 currently-open Dependabot PRs (#1122–#1132) have already been retargeted to `starknet-full-node` manually.
- GitHub always raises **security** updates against the default branch; `target-branch` only affects scheduled version updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)