### PR TITLE
fix(build): let orchestrator compile without Docker once artifacts are on disk

### DIFF
--- a/orchestrator/build.rs
+++ b/orchestrator/build.rs
@@ -1,3 +1,17 @@
+/// The orchestrator crate does not `include_bytes!` anything from `build-artifacts`, but its
+/// test-suite family (`make test-orchestrator` runs `--package "orchestrator*"`) reads the mock
+/// Piltover contracts from `build-artifacts/orchestrator_tests` at runtime. Declaring them here
+/// keeps the historical behavior of pre-fetching the artifacts image when something is missing,
+/// while letting Docker-less hosts (e.g. macOS source builds) compile once the files exist on
+/// disk, via `make fetch-artifacts-no-docker`.
+const REQUIRED_ARTIFACTS: &[&str] = &[
+    "build-artifacts/orchestrator_tests/mock_contracts.starknet_artifacts.json",
+    "build-artifacts/orchestrator_tests/mock_contracts_Piltover.compiled_contract_class.json",
+    "build-artifacts/orchestrator_tests/mock_contracts_Piltover.contract_class.json",
+];
+
 fn main() {
-    build_version::get_or_compile_artifacts(1).expect("Failed to load artifacts");
+    if let Err(e) = build_version::get_or_compile_artifacts_for(1, REQUIRED_ARTIFACTS) {
+        panic!("Failed to load artifacts: {e}");
+    }
 }

--- a/orchestrator/crates/settlement-clients/starknet/build.rs
+++ b/orchestrator/crates/settlement-clients/starknet/build.rs
@@ -1,3 +1,16 @@
+/// Artifact files required by the tests in `src/tests/test.rs` (mock Piltover contracts, read at
+/// runtime from `build-artifacts/orchestrator_tests`). They ship in the published artifacts
+/// image, so a Docker-less host (e.g. a macOS source build) compiles after running
+/// `make fetch-artifacts-no-docker`; the build script only reaches for Docker if they are
+/// missing.
+const REQUIRED_ARTIFACTS: &[&str] = &[
+    "build-artifacts/orchestrator_tests/mock_contracts.starknet_artifacts.json",
+    "build-artifacts/orchestrator_tests/mock_contracts_Piltover.compiled_contract_class.json",
+    "build-artifacts/orchestrator_tests/mock_contracts_Piltover.contract_class.json",
+];
+
 fn main() {
-    build_version::get_or_compile_artifacts(4).expect("Failed to load artifacts");
+    if let Err(e) = build_version::get_or_compile_artifacts_for(4, REQUIRED_ARTIFACTS) {
+        panic!("Failed to load artifacts: {e}");
+    }
 }


### PR DESCRIPTION
## Problem

`orchestrator/build.rs` and `orchestrator/crates/settlement-clients/starknet/build.rs` still used the legacy `get_or_compile_artifacts()` call with **no required-paths list**. In `build-artifacts/src/lib.rs`, the "everything already on disk → skip Docker" fast path is gated on `!required.is_empty()`, so with an empty list these two crates always fell through to the Docker preflight and failed on Docker-less hosts — **even when all artifacts had already been fetched** with `make fetch-artifacts-no-docker`. This made orchestrator source builds impossible on macOS machines without a Docker daemon.

## Fix

Declare the artifact files the crates actually rely on — the mock Piltover contracts under `build-artifacts/orchestrator_tests/`, read at runtime by the settlement client tests — following the existing pattern in `mc-devnet` and `m-cairo-test-contracts`. Behavior:

- Files on disk (git-tracked or fetched) → build proceeds, Docker never invoked
- Files missing + Docker available → image pre-fetch as before
- Files missing + no Docker → same actionable error as today

## Validation (macOS, Apple Silicon, no Docker daemon)

Before (with artifacts fetched): both crates fail with "Docker is not available and artifact files may be missing".

After: `cargo check -p orchestrator -p orchestrator-starknet-settlement-client` → `Finished dev profile in 3m 34s`, with:
1. `./scripts/fetch-artifacts.sh` (artifacts on disk)
2. `make setup-cairo` + `sequencer_venv/bin` on PATH (needed separately by `apollo_starknet_os_program` to compile the OS programs)

`bootstrapper/build.rs` and `bootstrapper-v2/build.rs` have the same legacy call but are disabled/excluded from the workspace, so they're left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)