### PR TITLE
[codex] Fix transaction lookup missing provider test

### DIFF
--- a/madara/node/src/submit_tx.rs
+++ b/madara/node/src/submit_tx.rs
@@ -258,7 +258,7 @@ mod tests {
         let lookup = TransactionLookupSwitch {
             redirect_to_gateway: Arc::new(StubLookup),
             mempool_with_validator: Arc::new(StubLookup),
-            ctx: ServiceContext::new_for_testing(),
+            ctx: ServiceContext::default(),
         };
 
         let status_err = lookup.feeder_transaction_status(Felt::ZERO).await.unwrap_err();


### PR DESCRIPTION
## Summary

- Use an empty ServiceContext in the transaction lookup missing-provider test.
- Keep L2 sync and block production off so feeder lookup methods exercise the Internal error path.

Closes #1138

## Validation

- cargo test -p madara --bin madara transaction_lookup_switch
- cargo fmt --all -- --check
- git diff --check