### PR TITLE
chore: upgrade to alloy 2.0 and Rust 1.91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dc44b606f29348ce7c127e7f872a6d2df3cfeff85b7d6bba62faca75112fdd"
+checksum = "5e1e915a830ea2ee123c9d3886bfec3302a7ddcd73a973ab165ed45aca2e42c3"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -101,19 +101,19 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "num_enum",
  "strum 0.27.2",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
+checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
@@ -135,13 +135,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
+checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "serde",
@@ -149,25 +149,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
+checksum = "3ae8b60d71b92824e095b4003ff01fd2bc923017b7568997c5f459240e83499c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-json-abi 1.6.0",
+ "alloy-json-abi",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types-eth",
- "alloy-sol-types 1.6.0",
+ "alloy-sol-types",
  "alloy-transport",
  "futures",
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -177,10 +178,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
- "alloy-json-abi 1.6.0",
- "alloy-primitives 1.6.0",
+ "alloy-json-abi",
+ "alloy-primitives",
  "alloy-rlp",
- "alloy-sol-types 1.6.0",
+ "alloy-sol-types",
 ]
 
 [[package]]
@@ -189,10 +190,10 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
- "alloy-json-abi 1.6.0",
- "alloy-primitives 1.6.0",
- "alloy-sol-type-parser 1.6.0",
- "alloy-sol-types 1.6.0",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
  "itoa",
  "serde",
  "serde_json",
@@ -205,7 +206,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "crc",
  "serde",
@@ -218,7 +219,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "serde",
@@ -230,7 +231,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "k256",
@@ -244,7 +245,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
@@ -253,15 +254,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-eip7928",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
@@ -272,17 +273,16 @@ dependencies = [
  "serde",
  "serde_with 3.21.0",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
  "borsh",
@@ -298,21 +298,9 @@ checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "auto_impl",
  "dyn-clone",
-]
-
-[[package]]
-name = "alloy-json-abi"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4584e3641181ff073e9d5bec5b3b8f78f9749d9fb108a1cfbc4399a4a139c72a"
-dependencies = [
- "alloy-primitives 0.8.26",
- "alloy-sol-type-parser 0.8.26",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -321,20 +309,20 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
- "alloy-primitives 1.6.0",
- "alloy-sol-type-parser 1.6.0",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
+checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
 dependencies = [
- "alloy-primitives 1.6.0",
- "alloy-sol-types 1.6.0",
+ "alloy-primitives",
+ "alloy-sol-types",
  "http 1.4.2",
  "serde",
  "serde_json",
@@ -344,21 +332,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
+checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
- "alloy-sol-types 1.6.0",
+ "alloy-sol-types",
  "async-trait",
  "auto_impl",
  "derive_more 2.1.1",
@@ -370,27 +358,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
+checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce6930ce52e43b0768dc99ceeff5cb9e673e8c9f87d926914cd028b2e3f7233"
+checksum = "c3f2f7dac66147d165063c670dabca7b34807428130bef4583a7976523140f8d"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-network",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
  "k256",
@@ -401,33 +389,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777d58b30eb9a4db0e5f59bc30e8c2caef877fee7dc8734cf242a51a60f22e05"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 2.1.1",
- "foldhash 0.1.5",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "itoa",
- "k256",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.8.6",
- "ruint",
- "rustc-hash 2.1.2",
- "serde",
- "sha3 0.10.9",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -460,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
+checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -471,7 +432,7 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-node-bindings",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
@@ -480,7 +441,7 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
  "alloy-signer",
- "alloy-sol-types 1.6.0",
+ "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -495,7 +456,7 @@ dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -507,12 +468,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
+checksum = "7cd85cfea1fa8ebd20d3475e961fe3a3624c0eb4659ea137715c0c83c8aeaff0"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-transport",
  "auto_impl",
  "bimap",
@@ -551,12 +512,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
+checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -564,7 +525,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -577,11 +538,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
+checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
@@ -594,11 +555,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22250cf438b6a3926de67683c08163bfa1fd1efa47ee9512cbcd631b6b0243c"
+checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -606,22 +567,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
+checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779f70ab16a77e305571881b07a9bc6b0068ae6f962497baf5762825c5b839fb"
+checksum = "48b9ad6eee93dd35a9ec0a6c1c6b180892a900ee17a6ed6500921552dd71e846"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
+ "alloy-rlp",
  "derive_more 2.1.1",
  "serde",
  "serde_with 3.21.0",
@@ -629,13 +595,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
+checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.1.1",
@@ -646,18 +612,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
+checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "alloy-sol-types 1.6.0",
+ "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
  "serde_json",
@@ -667,11 +633,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
+checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -681,11 +647,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
+checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -693,22 +659,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
+checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
+checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "async-trait",
  "auto_impl",
  "either",
@@ -719,13 +685,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-signer",
  "async-trait",
  "k256",
@@ -735,48 +701,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68b32b6fa0d09bb74b4cefe35ccc8269d711c26629bc7cd98a47eeb12fe353f"
-dependencies = [
- "alloy-sol-macro-expander 0.8.26",
- "alloy-sol-macro-input 0.8.26",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "alloy-sol-macro"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
- "alloy-sol-macro-expander 1.6.0",
- "alloy-sol-macro-input 1.6.0",
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afe6879ac373e58fd53581636f2cce843998ae0b058ebe1e4f649195e2bd23c"
-dependencies = [
- "alloy-sol-macro-input 0.8.26",
- "const-hex",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "syn-solidity 0.8.26",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -785,8 +719,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
- "alloy-json-abi 1.6.0",
- "alloy-sol-macro-input 1.6.0",
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.14.0",
@@ -795,23 +729,7 @@ dependencies = [
  "quote",
  "sha3 0.11.0",
  "syn 2.0.117",
- "syn-solidity 1.6.0",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ba01aee235a8c699d07e5be97ba215607564e71be72f433665329bec307d28"
-dependencies = [
- "const-hex",
- "dunce",
- "heck 0.5.0",
- "macro-string 0.1.4",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "syn-solidity 0.8.26",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -820,26 +738,16 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
- "alloy-json-abi 1.6.0",
+ "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck 0.5.0",
- "macro-string 0.2.0",
+ "macro-string",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.117",
- "syn-solidity 1.6.0",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c13fc168b97411e04465f03e632f31ef94cad1c7c8951bf799237fd7870d535"
-dependencies = [
- "serde",
- "winnow 0.7.15",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -854,34 +762,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e960c4b52508ef2ae1e37cae5058e905e9ae099b107900067a503f8c454036f"
-dependencies = [
- "alloy-json-abi 0.8.26",
- "alloy-primitives 0.8.26",
- "alloy-sol-macro 0.8.26",
- "const-hex",
- "serde",
-]
-
-[[package]]
-name = "alloy-sol-types"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
- "alloy-json-abi 1.6.0",
- "alloy-primitives 1.6.0",
- "alloy-sol-macro 1.6.0",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
  "serde",
 ]
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -902,14 +797,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
+checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "serde_json",
  "tower 0.5.3",
  "tracing",
@@ -918,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
+checksum = "bfb89df168b24773ef603af14f2449c05a7d3f27d05d3eceaea6bf96cccae168"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -938,18 +833,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
+checksum = "33e32e0b47d3b3bf5770b7c132090c614b008d307c5e1544f1925f5b7e9e9af6"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.4.2",
+ "rustls 0.23.40",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -959,7 +856,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
- "alloy-primitives 1.6.0",
+ "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.1.1",
  "nybbles",
@@ -971,11 +868,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.6.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
+checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1080,7 +977,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1091,7 +988,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1111,7 +1008,7 @@ dependencies = [
  "rlimit",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 1.0.69",
@@ -1220,7 +1117,7 @@ version = "0.19.0-rc.0"
 source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_sizeof_macros",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -1242,7 +1139,7 @@ dependencies = [
  "cairo-vm",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -3116,7 +3013,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "strum 0.27.2",
  "thiserror 1.0.69",
@@ -3134,7 +3031,7 @@ dependencies = [
  "expect-test",
  "serde_json",
  "sha2 0.10.9",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "strum 0.27.2",
  "tempfile",
@@ -3254,7 +3151,7 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
 ]
 
@@ -4002,7 +3899,7 @@ dependencies = [
  "postcard",
  "salsa 0.26.2",
  "serde",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4304,7 +4201,7 @@ dependencies = [
  "salsa 0.26.2",
  "serde",
  "sha2 0.11.0",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
 ]
 
@@ -4402,7 +4299,7 @@ dependencies = [
  "salsa 0.26.2",
  "serde",
  "sha3 0.11.0",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]
@@ -4496,7 +4393,7 @@ dependencies = [
  "serde_json",
  "sha3 0.11.0",
  "smol_str 0.3.6",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
 ]
 
@@ -4791,7 +4688,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
 ]
 
@@ -4953,7 +4850,7 @@ dependencies = [
  "salsa 0.26.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
  "typetag",
 ]
@@ -4978,7 +4875,7 @@ dependencies = [
  "serde_json",
  "sha3 0.11.0",
  "smol_str 0.3.6",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
 ]
 
@@ -5200,7 +5097,7 @@ dependencies = [
  "educe 0.5.11",
  "itertools 0.14.0",
  "keccak 0.1.6",
- "lambdaworks-math 0.13.0",
+ "lambdaworks-math",
  "lazy_static",
  "libc",
  "libloading",
@@ -5214,8 +5111,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "starknet-curve 0.6.0",
- "starknet-types-core 0.2.4",
+ "starknet-curve",
+ "starknet-types-core",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -5245,8 +5142,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3 0.10.9",
- "starknet-crypto 0.8.1",
- "starknet-types-core 0.2.4",
+ "starknet-crypto",
+ "starknet-types-core",
  "thiserror 2.0.18",
  "tracing",
  "zip 0.6.6",
@@ -5507,7 +5404,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5975,16 +5872,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -6037,21 +5924,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "serde",
- "strsim 0.11.1",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -6059,6 +5931,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim 0.11.1",
  "syn 2.0.117",
 ]
@@ -6092,17 +5965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -6500,8 +6362,8 @@ name = "e2e-tests"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-primitives 0.8.26",
- "alloy-sol-types 0.8.26",
+ "alloy-primitives",
+ "alloy-sol-types",
  "async-trait",
  "aws-config",
  "aws-sdk-eventbridge",
@@ -6768,7 +6630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7327,7 +7189,7 @@ dependencies = [
  "starknet-os-types",
  "starknet-rust",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "starknet_os",
  "starknet_patricia",
@@ -7700,7 +7562,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -8656,7 +8517,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9171,38 +9032,16 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
-dependencies = [
- "lambdaworks-math 0.10.0",
- "serde",
- "sha2 0.10.9",
- "sha3 0.10.9",
-]
-
-[[package]]
-name = "lambdaworks-crypto"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
 dependencies = [
- "lambdaworks-math 0.13.0",
+ "lambdaworks-math",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "sha2 0.10.9",
  "sha3 0.10.9",
-]
-
-[[package]]
-name = "lambdaworks-math"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -9471,17 +9310,6 @@ dependencies = [
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "macro-string"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
@@ -9641,7 +9469,7 @@ dependencies = [
  "starknet-rust-crypto 0.19.1",
  "starknet-rust-providers",
  "starknet-rust-signers",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "syn 2.0.117",
  "tempfile",
@@ -9775,7 +9603,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde_json",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tokio",
@@ -9803,7 +9631,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 2.0.18",
@@ -9861,7 +9689,7 @@ dependencies = [
  "siphasher",
  "smallvec",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 2.0.18",
@@ -9911,7 +9739,7 @@ dependencies = [
  "serde_json",
  "starknet-rust-core 0.19.1",
  "starknet-rust-signers",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "tokio",
  "tracing",
@@ -9946,7 +9774,7 @@ dependencies = [
  "starknet-rust",
  "starknet-rust-core 0.19.1",
  "starknet-rust-providers",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "tokio",
@@ -9982,7 +9810,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rstest 0.18.2",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tokio",
@@ -10061,7 +9889,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -10096,7 +9924,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10138,7 +9966,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde_json",
  "smallvec",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tokio",
@@ -10181,7 +10009,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tokio",
@@ -10235,7 +10063,7 @@ dependencies = [
  "starknet-rust-crypto 0.19.1",
  "starknet-rust-providers",
  "starknet-rust-signers",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "tempfile",
  "thiserror 2.0.18",
@@ -10269,7 +10097,7 @@ dependencies = [
  "mp-rpc",
  "mp-transactions",
  "mp-utils",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tokio",
@@ -10751,7 +10579,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tracing",
@@ -10776,7 +10604,7 @@ dependencies = [
  "serde",
  "serde_json",
  "siphasher",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
  "twox-hash",
 ]
@@ -10794,7 +10622,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tracing",
@@ -10828,7 +10656,7 @@ dependencies = [
  "serde_json",
  "starknet-rust-core 0.19.1",
  "starknet-rust-providers",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tokio",
@@ -10847,7 +10675,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.21.0",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
 ]
@@ -10871,7 +10699,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.21.0",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "thiserror 2.0.18",
  "url",
 ]
@@ -10906,7 +10734,7 @@ dependencies = [
  "serde_with 3.21.0",
  "sha3 0.10.9",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tracing",
@@ -10920,7 +10748,7 @@ dependencies = [
  "rstest 0.18.2",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -10933,7 +10761,7 @@ dependencies = [
  "mp-convert",
  "mp-rpc",
  "serde",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
 ]
 
@@ -10957,7 +10785,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.21.0",
  "starknet-rust-core 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 2.0.18",
  "tracing",
@@ -10985,7 +10813,7 @@ dependencies = [
  "serde_yaml",
  "starknet-rust-core 0.19.1",
  "starknet-rust-crypto 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "tokio",
  "tokio-util",
  "tracing",
@@ -11094,7 +10922,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11562,7 +11390,7 @@ dependencies = [
  "starknet-rust",
  "starknet-rust-core 0.19.1",
  "starknet-rust-crypto 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -11589,7 +11417,7 @@ dependencies = [
  "apollo_starknet_os_program",
  "cairo-vm",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_os",
  "tempfile",
  "thiserror 2.0.18",
@@ -11675,7 +11503,7 @@ name = "orchestrator-ethereum-settlement-client"
 version = "0.10.0"
 dependencies = [
  "alloy",
- "alloy-primitives 0.8.26",
+ "alloy-primitives",
  "async-trait",
  "bytes",
  "c-kzg",
@@ -11711,7 +11539,7 @@ name = "orchestrator-gps-fact-checker"
 version = "0.10.0"
 dependencies = [
  "alloy",
- "alloy-primitives 0.8.26",
+ "alloy-primitives",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
@@ -11836,7 +11664,7 @@ name = "orchestrator-starknet-settlement-client"
 version = "0.10.0"
 dependencies = [
  "alloy",
- "alloy-primitives 0.8.26",
+ "alloy-primitives",
  "async-std",
  "async-trait",
  "build-version",
@@ -11879,7 +11707,7 @@ name = "orchestrator-utils"
 version = "0.10.0"
 dependencies = [
  "alloy",
- "alloy-primitives 0.8.26",
+ "alloy-primitives",
  "base64 0.22.1",
  "color-eyre",
  "dotenv",
@@ -11963,7 +11791,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
 ]
 
@@ -13410,7 +13238,7 @@ dependencies = [
  "starknet-rust",
  "starknet-rust-core 0.19.1",
  "starknet-rust-crypto 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
  "tokio",
@@ -13662,7 +13490,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13803,7 +13631,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14616,12 +14444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
-name = "size-of"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e36eca171fddeda53901b0a436573b3f2391eaa9189d439b2bd8ea8cebd7e3"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14710,7 +14532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14804,8 +14626,8 @@ dependencies = [
  "serde_with 3.21.0",
  "sha3 0.10.9",
  "starknet-core-derive",
- "starknet-crypto 0.8.1",
- "starknet-types-core 0.2.4",
+ "starknet-crypto",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -14817,25 +14639,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "starknet-crypto"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039a3bad70806b494c9e6b21c5238a6c8a373d66a26071859deb0ccca6f93634"
-dependencies = [
- "crypto-bigint 0.5.5",
- "hex",
- "hmac",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rfc6979 0.4.0",
- "sha2 0.10.9",
- "starknet-curve 0.5.1",
- "starknet-types-core 0.1.9",
- "zeroize",
 ]
 
 [[package]]
@@ -14852,18 +14655,9 @@ dependencies = [
  "num-traits",
  "rfc6979 0.4.0",
  "sha2 0.10.9",
- "starknet-curve 0.6.0",
- "starknet-types-core 0.2.4",
+ "starknet-curve",
+ "starknet-types-core",
  "zeroize",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
-dependencies = [
- "starknet-types-core 0.1.9",
 ]
 
 [[package]]
@@ -14872,7 +14666,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
 dependencies = [
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -14891,7 +14685,7 @@ dependencies = [
  "serde_with 3.21.0",
  "starknet-rust-core 0.19.1",
  "starknet-rust-crypto 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
 ]
@@ -14959,7 +14753,7 @@ dependencies = [
  "sha3 0.10.9",
  "starknet-rust-core-derive 0.1.0",
  "starknet-rust-crypto 0.8.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -14983,7 +14777,7 @@ dependencies = [
  "sha3 0.10.9",
  "starknet-rust-core-derive 0.19.1",
  "starknet-rust-crypto 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -15025,7 +14819,7 @@ dependencies = [
  "rfc6979 0.4.0",
  "sha2 0.10.9",
  "starknet-rust-curve 0.6.0",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "zeroize",
 ]
 
@@ -15046,7 +14840,7 @@ dependencies = [
  "rfc6979 0.4.0",
  "sha2 0.10.9",
  "starknet-rust-curve 0.19.1",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "zeroize",
 ]
 
@@ -15056,7 +14850,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1977caca63a4e6439968abe0c9d8c0d2074df7641f1153e8a551f8200470d8da"
 dependencies = [
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -15065,7 +14859,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf807adc0b881c58efa7cbdec303da1308250691a3969fb46b5eb47dfb125eca"
 dependencies = [
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -15120,24 +14914,6 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87af771d7f577931913089f9ca9a9f85d8a6238d59b2977f4c383d133c8abd3b"
-dependencies = [
- "blake2",
- "digest 0.10.7",
- "lambdaworks-crypto 0.10.0",
- "lambdaworks-math 0.10.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
- "size-of",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-types-core"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90d23b1bc014ee4cce40056ab3114bcbcdc2dbc1e845bbfb1f8bd0bab63507d4"
@@ -15145,8 +14921,8 @@ dependencies = [
  "arbitrary",
  "blake2",
  "digest 0.10.7",
- "lambdaworks-crypto 0.13.0",
- "lambdaworks-math 0.13.0",
+ "lambdaworks-crypto",
+ "lambdaworks-math",
  "lazy_static",
  "num-bigint",
  "num-integer",
@@ -15188,8 +14964,8 @@ dependencies = [
  "serde_json",
  "sha3 0.10.9",
  "starknet-core",
- "starknet-crypto 0.8.1",
- "starknet-types-core 0.2.4",
+ "starknet-crypto",
+ "starknet-types-core",
  "strum 0.27.2",
  "thiserror 1.0.69",
  "time",
@@ -15211,7 +14987,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-rust-core 0.16.0",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "starknet_patricia",
  "starknet_patricia_storage",
@@ -15259,7 +15035,7 @@ dependencies = [
  "sha2 0.10.9",
  "sha3 0.10.9",
  "shared_execution_objects",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "starknet_committer",
  "starknet_patricia",
@@ -15282,7 +15058,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-rust-core 0.16.0",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "starknet_patricia_storage",
  "strum 0.27.2",
@@ -15302,7 +15078,7 @@ dependencies = [
  "lru 0.12.5",
  "serde",
  "serde_json",
- "starknet-types-core 0.2.4",
+ "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
  "tokio",
@@ -15452,8 +15228,7 @@ dependencies = [
 [[package]]
 name = "swiftness_proof_parser"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d86780ddec535b0acb5515190d205cf9623def0ab88661ef8f64399e26fc870"
+source = "git+https://github.com/madara-alliance/swiftness?rev=1227d56690bdd90f6872c048140f8340560244b9#1227d56690bdd90f6872c048140f8340560244b9"
 dependencies = [
  "anyhow",
  "clap",
@@ -15461,8 +15236,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "starknet-crypto 0.7.4",
- "starknet-types-core 0.1.9",
+ "starknet-crypto",
+ "starknet-types-core",
  "thiserror 1.0.69",
 ]
 
@@ -15486,18 +15261,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4e6eed052a117409a1a744c8bda9c3ea6934597cf7419f791cb7d590871c4c"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -15667,7 +15430,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15687,7 +15450,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16012,9 +15775,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -16489,9 +16252,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -17164,7 +16927,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ casm-classes-v2 = { package = "cairo-lang-starknet-classes", version = "=2.19.0-
 casm-utils-v2 = { package = "cairo-lang-utils", version = "=2.19.0-rc.0" }
 cairo-vm = "=3.2.0"
 cairo-native = "0.9.0-rc.7"
-alloy = { version = "1.1.0", features = [
+alloy = { version = "2.0", features = [
   "node-bindings",
   "eips",
   "rpc-types",
@@ -280,8 +280,8 @@ subxt-lightclient = { version = "0.35.3", default-features = false }
 
 # Orchestrator
 num = { version = "0.4.1" }
-alloy-primitives = { version = "0.8.5", default-features = false }
-alloy-sol-types = "0.8.5"
+alloy-primitives = { version = "1.4", default-features = false }
+alloy-sol-types = "1.4"
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1.38.0", features = ["behavior-version-latest"] }
 aws-sdk-eventbridge = { version = "1.41.0", features = [
@@ -343,3 +343,9 @@ zip = "4.3.0"
 [patch.crates-io]
 rocksdb = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
 librocksdb-sys = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
+# rustc 1.91 turned unsupported-ABI fn-pointer impls (E0570) from a future-incompat warning into
+# a hard error, which breaks size-of 0.1.5 (unmaintained since 2023), pulled in only through
+# swiftness_proof_parser 0.1.3 -> starknet-crypto 0.7 -> starknet-types-core 0.1. This patch is
+# upstream v0.1.3 plus a two-line dependency bump to starknet-crypto 0.8 (types-core 0.2, which
+# dropped size-of); the parser only uses pedersen_hash/Felt, identical across 0.7 -> 0.8.
+swiftness_proof_parser = { git = "https://github.com/madara-alliance/swiftness", rev = "1227d56690bdd90f6872c048140f8340560244b9" }

--- a/madara/crates/client/cairo_native/src/config.rs
+++ b/madara/crates/client/cairo_native/src/config.rs
@@ -131,19 +131,14 @@ pub struct NativeExecutionConfig {
 ///
 /// This design prevents accidental access to execution config when native is disabled,
 /// providing better type safety than a boolean flag.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum NativeConfig {
     /// Native execution is disabled - all contracts use Cairo VM.
+    #[default]
     Disabled,
 
     /// Native execution is enabled with the provided configuration.
     Enabled(NativeExecutionConfig),
-}
-
-impl Default for NativeConfig {
-    fn default() -> Self {
-        Self::Disabled
-    }
 }
 
 impl Default for NativeExecutionConfig {

--- a/madara/crates/client/db/src/rocksdb/snapshots.rs
+++ b/madara/crates/client/db/src/rocksdb/snapshots.rs
@@ -54,7 +54,10 @@ impl Snapshots {
 
         let mut inner = self.inner.write().expect("Poisoned lock");
 
-        if self.max_kept_snapshots != Some(0) && self.snapshot_interval != 0 && block_n % self.snapshot_interval == 0 {
+        if self.max_kept_snapshots != Some(0)
+            && self.snapshot_interval != 0
+            && block_n.is_multiple_of(self.snapshot_interval)
+        {
             tracing::debug!("Saving snapshot at {block_n:?}");
             inner.historical.insert(block_n, Arc::clone(&snapshot));
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_storage_proof.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_storage_proof.rs
@@ -121,7 +121,7 @@ pub fn get_storage_proof(
     let n_tries = saturating_sum(
         iter::once(!class_hashes.is_empty() as usize)
             .chain(iter::once(!contract_addresses.is_empty() as usize))
-            .chain(contracts_storage_keys.iter().map(|keys| (!keys.storage_keys.is_empty() as usize))),
+            .chain(contracts_storage_keys.iter().map(|keys| !keys.storage_keys.is_empty() as usize)),
     );
     if n_tries > starknet.storage_proof_config.max_tries {
         return Err(StarknetRpcApiError::ProofLimitExceeded {

--- a/madara/examples/backfill_legacy_class.rs
+++ b/madara/examples/backfill_legacy_class.rs
@@ -1,3 +1,6 @@
+// This is a CLI example; printing the outcome to stdout is its user interface.
+#![allow(clippy::print_stdout)]
+
 use anyhow::{bail, Context};
 use clap::Parser;
 use mc_class_exec::config::NativeConfig;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89"
+channel = "1.91"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
Supersedes Dependabot #1126 (alloy 2.0), done as a coherent upgrade. Heads-up: the branch name says 1.90 but the PR pins **1.91** — see below for why 1.90 is impossible. Rebased onto current `starknet-full-node` (post-#1137/#1140/#1142/#1143), which slimmed the diff considerably: the OTel 0.32 and rand 0.9 work this PR originally carried landed via #1137.

## alloy 1.1 → 2.0.5

- `alloy-primitives` / `alloy-sol-types` move 0.8.5 → 1.4 in the same change (alloy 2 pairs with primitives 1.x; bumping alloy alone leaves two primitives generations in the lock and type mismatches).
- **Zero source changes needed** — the alloy APIs used by `mc-settlement-client`, `mp-convert`, the orchestrator ethereum clients, and the e2e crates are unchanged between 1.x and 2.0.

## Rust 1.89 → 1.91

Every alloy 2.0.x release declares `rust-version = 1.91`, so 1.90 cannot satisfy it — the toolchain moves straight to 1.91. Fallout handled here:

1. **Five new clippy lints** fixed: derivable `Default` (NativeConfig), `u64::is_multiple_of` (rocksdb snapshots), closure-body parens (storage proof), and two `print_stdout` hits in `examples/backfill_legacy_class.rs` (a CLI example — scoped `#![allow]` with a comment).
2. **`size-of 0.1.5` hard-fails on rustc 1.91**: its `extern "aapcs"/"win64"/…` fn-pointer impls (E0570) graduated from future-incompat warning to error. The crate is unmaintained (last commit 2023) and reaches the workspace only via `swiftness_proof_parser 0.1.3 → starknet-crypto 0.7 → starknet-types-core 0.1.9` (`size-of` is a non-optional dep there; no compatible newer release of any link in that chain exists). **Fix: a [madara-alliance/swiftness](https://github.com/madara-alliance/swiftness) fork pinned by rev — upstream v0.1.3 plus a two-line bump of `proof_parser` to starknet-crypto 0.8 / starknet-types-core 0.2 (which dropped size-of).** This evicts the entire stale chain from the lock: `size-of`, `starknet-crypto 0.7.4`, `starknet-curve 0.5.1`, `starknet-types-core 0.1.9`, and `lambdaworks 0.10`. The parser only uses `pedersen_hash`/`Felt` — identical, deterministic output across starknet-crypto 0.7 → 0.8 — and all upstream `proof_parser` tests pass on the forked commit. Upstream PR with the same bump: [iosis-tech/swiftness#68](https://github.com/iosis-tech/swiftness/pull/68); once released, the `[patch]` can be dropped.

## Local validation (Apple Silicon, no Docker, post-rebase)

- `cargo clippy --all-targets` over the 30 madara-tree packages: clean
- `cargo check --all-targets` for **orchestrator + orchestrator-atlantic-service + e2e + e2e-tests**: clean
- `cargo fmt --check`: clean
- Unit/integration test sweep: failures are a strict subset of the clean-baseline profile (local-env-only: anvil/mongo/devnet-spawn)

## Review notes

- The `[patch.crates-io]` for `swiftness_proof_parser` points at the org fork, pinned by exact rev; the fork diff is two dependency version lines on top of the v0.1.3 tag.
- The proof-parser change is proof-registration-adjacent (pedersen program-hash extraction), so worth a second pair of eyes even though the hash function output is unchanged across crypto crate versions.
- CI runners must have/install Rust 1.91 via `rust-toolchain.toml` (no workflow files hardcode 1.89).
- `omniqueue 0.2.0` is next on the future-incompat list (same class of issue as size-of, not yet an error; `redis` cleared itself via #1137's update) — flagged for a future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)