### PR TITLE
fix(orchestrator): repair build after opentelemetry_sdk 0.32 bump

### DIFF
--- a/orchestrator/src/error/mod.rs
+++ b/orchestrator/src/error/mod.rs
@@ -10,7 +10,6 @@ use aws_sdk_s3::operation::list_buckets::ListBucketsError;
 use aws_sdk_sqs::operation::set_queue_attributes::SetQueueAttributesError;
 use mongodb::bson;
 use opentelemetry_otlp::ExporterBuildError;
-use opentelemetry_sdk::trace::TraceError;
 use starknet_core::types::FromStrError;
 use thiserror::Error;
 
@@ -69,8 +68,6 @@ pub enum OrchestratorError {
     ExporterBuildError(#[from] ExporterBuildError),
     #[error("OLT Metrics Error: {0}")]
     OTLMetricsError(String),
-    #[error("OLT Trace Error: {0}")]
-    OLTTraceError(#[from] TraceError),
     #[error("Invalid layout name: {0}")]
     InvalidLayoutError(String),
     /// Configuration error


### PR DESCRIPTION
`opentelemetry_sdk` 0.32 (from #1137) removed `trace::TraceError`, breaking the orchestrator build at `starknet-full-node` HEAD:

```
error[E0432]: unresolved import `opentelemetry_sdk::trace::TraceError`
  --> orchestrator/src/error/mod.rs:13:5
```

0.32 unifies SDK errors into `OTelSdkError`, and `OrchestratorError` already has a `#[from]` variant for it (`OTLogError`) — a second wrapper variant would be a conflicting `From` impl. `OLTTraceError` was never constructed anywhere, so it's removed.

This slipped through #1137 because the orchestrator wasn't locally buildable on the validating machine at the time (#1139 fixed that since), and CI didn't gate it. Validated locally: `cargo check -p orchestrator --all-targets` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)