### PR TITLE
chore: pin starknet-rust family to stable 0.19.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,15 +106,15 @@ m-cairo-test-contracts = { path = "madara/crates/cairo-test-contracts" }
 mc-e2e-tests = { path = "madara/crates/tests" }
 
 # Starknet dependencies
-starknet-accounts = { package = "starknet-rust-accounts", version = "0.19.0-rc.2" }
-starknet-contract = { package = "starknet-rust-contract", version = "0.19.0-rc.2" }
-starknet-core = { package = "starknet-rust-core", version = "0.19.0-rc.2" }
-starknet-core-derive = { package = "starknet-rust-core-derive", version = "0.19.0-rc.2" }
-starknet-crypto = { package = "starknet-rust-crypto", version = "0.19.0-rc.2" }
-starknet-providers = { package = "starknet-rust-providers", version = "0.19.0-rc.2" }
-starknet-signers = { package = "starknet-rust-signers", version = "0.19.0-rc.2" }
-starknet-macros = { package = "starknet-rust-macros", version = "0.19.0-rc.2" }
-starknet = { package = "starknet-rust", version = "0.19.0-rc.2" }
+starknet-accounts = { package = "starknet-rust-accounts", version = "0.19.1" }
+starknet-contract = { package = "starknet-rust-contract", version = "0.19.1" }
+starknet-core = { package = "starknet-rust-core", version = "0.19.1" }
+starknet-core-derive = { package = "starknet-rust-core-derive", version = "0.19.1" }
+starknet-crypto = { package = "starknet-rust-crypto", version = "0.19.1" }
+starknet-providers = { package = "starknet-rust-providers", version = "0.19.1" }
+starknet-signers = { package = "starknet-rust-signers", version = "0.19.1" }
+starknet-macros = { package = "starknet-rust-macros", version = "0.19.1" }
+starknet = { package = "starknet-rust", version = "0.19.1" }
 
 starknet-types-core = { version = "0.2.4", default-features = false, features = [
   "hash",


### PR DESCRIPTION
Moves the nine `starknet-rust-*` workspace pins from `0.19.0-rc.2` to stable `0.19.1`.

Note this is a manifest-only change: the lockfile **already resolves to 0.19.1** — the full `cargo update` in #1137 moved it there silently, since `^0.19.0-rc.2` admits stable `0.19.x`. This PR makes the floor explicit and gets the manifests off a release-candidate pin.

What the rc.2 → 0.19.1 jump contains upstream ([software-mansion/starknet-rust](https://github.com/software-mansion/starknet-rust)):
- **0.19.0** (2026-04-14): Starknet JSON-RPC **v0.10.2** support (rc.2 targeted v0.10.1) — notable since madara already serves v0.10.2 server-side
- **0.19.1** (2026-05-18): generics support in the `Encode`/`Decode` derive macros

Validation (on the already-0.19.1 lock): clippy clean over the 30 madara packages, full unit-test sweep matches the clean-baseline failure profile (env-only failures + the known flaky metrics test; the #1138 lookup failure is gone since #1140). The orchestrator needs #1142 to compile at branch HEAD — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)