### PR TITLE
feat(rpc): L2 gas limit discovery in estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- feat(rpc): discover minimal L2 gas limit in estimateFee/simulateTransactions; SKIP_VALIDATE relaxes the strict nonce check
 - fix(rpc): structured CONTRACT_EXECUTION_ERROR data and real transaction_index in execution errors
 - fix(rpc): surface failed executions in starknet_call and starknet_estimateMessageFee
   (ENTRYPOINT_NOT_FOUND, CONTRACT_NOT_FOUND, CONTRACT_ERROR with revert_error data)

--- a/madara/crates/client/exec/src/execution.rs
+++ b/madara/crates/client/exec/src/execution.rs
@@ -26,6 +26,27 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
         transactions_before: impl IntoIterator<Item = Transaction>,
         transactions_to_trace: impl IntoIterator<Item = Transaction>,
     ) -> Result<Vec<ExecutionResult>, Error> {
+        self.execute_transactions_inner(transactions_before, transactions_to_trace, false)
+    }
+
+    /// Same as [`Self::execute_transactions`], for fee estimation and simulation: transactions
+    /// subject to L2 gas accounting (Sierra >= 1.7 senders, fee charge disabled) are executed with
+    /// the minimal viable L2 gas limit discovered by [`Self::find_l2_gas_limit`] instead of their
+    /// user-provided bounds, and the result carries the gas vector to price estimates with.
+    pub fn execute_transactions_for_estimation(
+        &mut self,
+        transactions_before: impl IntoIterator<Item = Transaction>,
+        transactions_to_trace: impl IntoIterator<Item = Transaction>,
+    ) -> Result<Vec<ExecutionResult>, Error> {
+        self.execute_transactions_inner(transactions_before, transactions_to_trace, true)
+    }
+
+    fn execute_transactions_inner(
+        &mut self,
+        transactions_before: impl IntoIterator<Item = Transaction>,
+        transactions_to_trace: impl IntoIterator<Item = Transaction>,
+        find_l2_gas_limits: bool,
+    ) -> Result<Vec<ExecutionResult>, Error> {
         let mut executed_prev = 0;
         for (index, tx) in transactions_before.into_iter().enumerate() {
             let hash = tx.tx_hash();
@@ -45,7 +66,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
         transactions_to_trace
             .into_iter()
             .enumerate()
-            .map(|(index, tx): (_, Transaction)| {
+            .map(|(index, mut tx): (_, Transaction)| {
                 let hash = tx.tx_hash();
                 tracing::debug!("executing {:#x} (trace)", hash.to_felt());
                 let tx_type = tx.tx_type();
@@ -59,9 +80,24 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                     Transaction::L1Handler(_) => None, // There is no minimal_l1_gas field for L1 handler transactions.
                 };
 
+                let gas_vector_computation_mode = match &tx {
+                    Transaction::Account(tx) => tx.tx.create_tx_info(tx.execution_flags.only_query).gas_mode(),
+                    Transaction::L1Handler(_) => GasVectorComputationMode::NoL2Gas,
+                };
+
                 let view = self.view().clone();
                 let make_reexec_error =
                     |err| TxExecError { view: format!("{view}"), hash, index: executed_prev + index, err };
+
+                // The L2 gas limit search executes against the protocol execution cap, which is
+                // only valid when the fee is not charged (i.e. estimation semantics).
+                let mut gas_for_fee_estimate = None;
+                if find_l2_gas_limits
+                    && matches!(&tx, Transaction::Account(tx) if !tx.execution_flags.charge_fee)
+                    && self.l2_gas_accounting_enabled(&tx, &gas_vector_computation_mode)?
+                {
+                    gas_for_fee_estimate = self.find_l2_gas_limit(&mut tx, &make_reexec_error)?;
+                }
 
                 let mut transactional_state = TransactionalState::create_transactional(&mut self.state);
                 // NB: We use execute_raw because execute already does transaactional state.
@@ -102,11 +138,6 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                     _ => None,
                 };
 
-                let gas_vector_computation_mode = match tx {
-                    Transaction::Account(tx) => tx.tx.create_tx_info(tx.execution_flags.only_query).gas_mode(),
-                    Transaction::L1Handler(_) => GasVectorComputationMode::NoL2Gas,
-                };
-
                 Ok(ExecutionResult {
                     hash,
                     tx_type,
@@ -117,6 +148,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                     state_diff: state_diff.state_maps.into(),
                     deployed_contracts,
                     deprecated_declared_class,
+                    gas_for_fee_estimate,
                 })
             })
             .collect::<Result<Vec<_>, _>>()

--- a/madara/crates/client/exec/src/fee.rs
+++ b/madara/crates/client/exec/src/fee.rs
@@ -11,7 +11,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_7_1::FeeEstimate, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector = executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
+        let gas_vector = executions_result.gas_for_fee_pricing();
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),
@@ -50,7 +50,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_8_1::FeeEstimate, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector = executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
+        let gas_vector = executions_result.gas_for_fee_pricing();
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),
@@ -91,7 +91,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_9_0::FeeEstimateCommon, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector = executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
+        let gas_vector = executions_result.gas_for_fee_pricing();
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),

--- a/madara/crates/client/exec/src/fee.rs
+++ b/madara/crates/client/exec/src/fee.rs
@@ -11,8 +11,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_7_1::FeeEstimate, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector =
-            executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
+        let gas_vector = executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),
@@ -51,8 +50,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_8_1::FeeEstimate, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector =
-            executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
+        let gas_vector = executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),
@@ -93,8 +91,7 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_9_0::FeeEstimateCommon, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector =
-            executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
+        let gas_vector = executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),

--- a/madara/crates/client/exec/src/fee.rs
+++ b/madara/crates/client/exec/src/fee.rs
@@ -11,7 +11,8 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_7_1::FeeEstimate, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector = executions_result.execution_info.receipt.gas;
+        let gas_vector =
+            executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),
@@ -50,7 +51,8 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_8_1::FeeEstimate, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector = executions_result.execution_info.receipt.gas;
+        let gas_vector =
+            executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),
@@ -91,7 +93,8 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
     ) -> Result<mp_rpc::v0_9_0::FeeEstimateCommon, Error> {
         let gas_price_vector = self.block_context.block_info().gas_prices.gas_price_vector(&executions_result.fee_type);
         let minimal_gas_vector = executions_result.minimal_l1_gas.unwrap_or_default();
-        let gas_vector = executions_result.execution_info.receipt.gas;
+        let gas_vector =
+            executions_result.gas_for_fee_estimate.unwrap_or(executions_result.execution_info.receipt.gas);
         let mut gas_vector = GasVector {
             l1_gas: gas_vector.l1_gas.max(minimal_gas_vector.l1_gas),
             l1_data_gas: gas_vector.l1_data_gas.max(minimal_gas_vector.l1_data_gas),

--- a/madara/crates/client/exec/src/l2_gas_search.rs
+++ b/madara/crates/client/exec/src/l2_gas_search.rs
@@ -208,7 +208,15 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
                             }
                             upper_bound = current;
                         }
-                        ProbeOutcome::OutOfGas => lower_bound = current,
+                        ProbeOutcome::OutOfGas => {
+                            // Termination guard: `upper_bound` is known-good (the max-limit probe
+                            // succeeded), so converging onto it ends the search even if execution
+                            // were not perfectly deterministic across probes.
+                            if search_done(lower_bound, upper_bound) {
+                                break upper_bound;
+                            }
+                            lower_bound = current;
+                        }
                     }
                     current = midpoint(lower_bound, upper_bound);
                 }
@@ -216,6 +224,9 @@ impl<D: MadaraStorageRead> ExecutionContext<D> {
         };
 
         set_l2_gas_limit(tx, gas_limit)?;
+        // The l1_gas/l1_data_gas components deliberately come from the max-limit probe, not the
+        // final execution: this mirrors pathfinder, where only l2_gas is replaced by the
+        // discovered limit. L1 components do not depend on the L2 gas limit.
         Ok(Some(GasVector { l2_gas: gas_limit, ..info.receipt.gas }))
     }
 }

--- a/madara/crates/client/exec/src/l2_gas_search.rs
+++ b/madara/crates/client/exec/src/l2_gas_search.rs
@@ -1,0 +1,246 @@
+//! Minimal L2 gas limit discovery for fee estimation.
+//!
+//! Starknet 0.13.4 introduced runtime L2 gas accounting (for Sierra >= 1.7 contracts): execution
+//! halts when the transaction's `l2_gas.max_amount` is exhausted, and the worst-case-path gas
+//! requirements can exceed the actual consumption. Executing an estimation request once with the
+//! user-provided bounds therefore fails with 'Out of gas' for the standard wallet pattern
+//! (estimate with zero bounds), and even a successful run can report an `l2_gas_consumed` that is
+//! *below* the minimal viable limit.
+//!
+//! Instead, estimation maxes out the L2 gas limit, executes once to learn the consumption, and
+//! searches for the minimal limit that still executes successfully: consumption + 10% directly,
+//! else a binary search between the consumption and the maximum. The algorithm and its constants
+//! mirror pathfinder (`crates/executor/src/transaction.rs`,
+//! `find_l2_gas_limit_and_execute_transaction`) and juno
+//! (`vm/rust/src/entrypoint/execute/binary_search_execution.rs`).
+
+use crate::{Error, ExecutionContext, TxExecError};
+use blockifier::execution::contract_class::TrackedResource;
+use blockifier::state::cached_state::TransactionalState;
+use blockifier::state::state_api::StateReader;
+use blockifier::transaction::account_transaction::AccountTransaction;
+use blockifier::transaction::errors::TransactionExecutionError;
+use blockifier::transaction::objects::TransactionExecutionInfo;
+use blockifier::transaction::transaction_execution::Transaction;
+use blockifier::transaction::transactions::ExecutableTransaction;
+use mc_db::MadaraStorageRead;
+use starknet_api::core::ClassHash;
+use starknet_api::executable_transaction::AccountTransaction as ApiAccountTransaction;
+use starknet_api::execution_resources::{GasAmount, GasVector};
+use starknet_api::transaction::fields::{GasVectorComputationMode, ValidResourceBounds};
+
+/// The revert string blockifier produces when execution runs out of Sierra gas.
+const OUT_OF_GAS_CAIRO_STRING: &str = "0x4f7574206f6620676173 ('Out of gas')";
+
+/// The binary search stops once the bounds are within this margin (same value as pathfinder).
+const L2_GAS_SEARCH_MARGIN: GasAmount = GasAmount(1_000_000);
+
+/// Buffer added to the consumed L2 gas before trying it as a limit: 10%, like both references.
+fn with_estimation_buffer(gas: GasAmount) -> GasAmount {
+    GasAmount(gas.0.saturating_add(gas.0 / 10))
+}
+
+/// Midpoint with ceiling: without it the search can loop forever when the bounds are 1 apart.
+fn midpoint(lower: GasAmount, upper: GasAmount) -> GasAmount {
+    GasAmount(lower.0 + (upper.0 - lower.0).div_ceil(2))
+}
+
+fn search_done(lower: GasAmount, upper: GasAmount) -> bool {
+    upper.0 - lower.0 <= L2_GAS_SEARCH_MARGIN.0
+}
+
+fn is_deploy_account(tx: &Transaction) -> bool {
+    matches!(tx, Transaction::Account(AccountTransaction { tx: ApiAccountTransaction::DeployAccount(_), .. }))
+}
+
+fn charges_fee(tx: &Transaction) -> bool {
+    matches!(tx, Transaction::Account(tx) if tx.execution_flags.charge_fee)
+}
+
+/// Sets `l2_gas.max_amount` on a v3 all-resource-bounds account transaction.
+fn set_l2_gas_limit(tx: &mut Transaction, gas_limit: GasAmount) -> Result<(), Error> {
+    use starknet_api::transaction::{DeclareTransaction, DeployAccountTransaction, InvokeTransaction};
+
+    let resource_bounds = match tx {
+        Transaction::Account(AccountTransaction { tx: ApiAccountTransaction::Declare(tx), .. }) => match &mut tx.tx {
+            DeclareTransaction::V3(tx) => Some(&mut tx.resource_bounds),
+            _ => None,
+        },
+        Transaction::Account(AccountTransaction { tx: ApiAccountTransaction::DeployAccount(tx), .. }) => {
+            match &mut tx.tx {
+                DeployAccountTransaction::V3(tx) => Some(&mut tx.resource_bounds),
+                _ => None,
+            }
+        }
+        Transaction::Account(AccountTransaction { tx: ApiAccountTransaction::Invoke(tx), .. }) => match &mut tx.tx {
+            InvokeTransaction::V3(tx) => Some(&mut tx.resource_bounds),
+            _ => None,
+        },
+        Transaction::L1Handler(_) => None,
+    };
+
+    if let Some(ValidResourceBounds::AllResources(all_resources)) = resource_bounds {
+        all_resources.l2_gas.max_amount = gas_limit;
+        return Ok(());
+    }
+    Err(Error::Internal(anyhow::anyhow!("set_l2_gas_limit called on a transaction without all-resource bounds")))
+}
+
+enum ProbeOutcome {
+    /// Executed without running out of L2 gas (it may still have reverted for another reason).
+    Success(Box<TransactionExecutionInfo>),
+    /// Ran out of L2 gas, either as a revert or as a hard validation error.
+    OutOfGas,
+}
+
+impl<D: MadaraStorageRead> ExecutionContext<D> {
+    /// L2 gas accounting only takes effect when the transaction declares all-resource bounds and
+    /// the sender class is tracked by Sierra gas (compiled as Sierra >= 1.7). Mirrors pathfinder's
+    /// `l2_gas_accounting_enabled`: only the sender class is checked, the 10% estimation buffer
+    /// covers mixed-version call trees.
+    pub(crate) fn l2_gas_accounting_enabled(
+        &mut self,
+        tx: &Transaction,
+        gas_vector_computation_mode: &GasVectorComputationMode,
+    ) -> Result<bool, Error> {
+        if gas_vector_computation_mode != &GasVectorComputationMode::All {
+            return Ok(false);
+        }
+        if is_deploy_account(tx) {
+            return Ok(true);
+        }
+
+        let sender_class_hash = self
+            .state
+            .get_class_hash_at(tx.sender_address())
+            .map_err(TransactionExecutionError::StateError)
+            .map_err(|err| Error::Internal(anyhow::anyhow!("Getting sender class hash: {err:#}")))?;
+        // Sender not deployed yet: nothing to look up, the execution will fail anyway.
+        if sender_class_hash == ClassHash::default() {
+            return Ok(false);
+        }
+
+        let tracked_resource = self
+            .state
+            .get_compiled_class(sender_class_hash)
+            .map_err(|err| Error::Internal(anyhow::anyhow!("Getting sender compiled class: {err:#}")))?
+            .tracked_resource(&self.block_context.versioned_constants().min_sierra_version_for_sierra_gas, None);
+
+        Ok(tracked_resource == TrackedResource::SierraGas)
+    }
+
+    /// Executes `tx` on a discarded fork of the current state.
+    fn probe_l2_gas_limit(&mut self, tx: &Transaction) -> Result<ProbeOutcome, TransactionExecutionError> {
+        let mut transactional_state = TransactionalState::create_transactional(&mut self.state);
+        let result = tx.execute_raw(&mut transactional_state, &self.block_context, false);
+        transactional_state.abort();
+
+        match result {
+            Ok(info) => {
+                let out_of_gas = info
+                    .revert_error
+                    .as_ref()
+                    .is_some_and(|revert_error| revert_error.to_string().contains(OUT_OF_GAS_CAIRO_STRING));
+                if out_of_gas {
+                    Ok(ProbeOutcome::OutOfGas)
+                } else {
+                    Ok(ProbeOutcome::Success(Box::new(info)))
+                }
+            }
+            // Out of gas during validation surfaces as a hard error, not a revert.
+            Err(err) if err.to_string().contains(OUT_OF_GAS_CAIRO_STRING) => Ok(ProbeOutcome::OutOfGas),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Finds the minimal L2 gas limit (within [`L2_GAS_SEARCH_MARGIN`]) that lets `tx` execute
+    /// without running out of L2 gas, and leaves that limit set on `tx` so the caller's final
+    /// execution runs with it. Returns the gas vector to use for the fee estimate: the consumed
+    /// gas of the max-limit run with `l2_gas` replaced by the discovered limit.
+    ///
+    /// Only call this for fee estimation/simulation without fee charge: the maximum is the
+    /// protocol execution cap, not the amount covered by the account balance.
+    pub(crate) fn find_l2_gas_limit(
+        &mut self,
+        tx: &mut Transaction,
+        make_err: &impl Fn(TransactionExecutionError) -> TxExecError,
+    ) -> Result<Option<GasVector>, Error> {
+        debug_assert!(!charges_fee(tx));
+
+        let max_l2_gas_limit = self.block_context.versioned_constants().os_constants.execute_max_sierra_gas;
+        set_l2_gas_limit(tx, max_l2_gas_limit)?;
+
+        let info = match self.probe_l2_gas_limit(tx).map_err(make_err)? {
+            ProbeOutcome::Success(info) => info,
+            // Even the protocol cap is not enough: leave the limit at the maximum and let the
+            // caller's execution surface the out-of-gas revert.
+            ProbeOutcome::OutOfGas => return Ok(None),
+        };
+        // Reverted for a reason other than gas: no point searching, the caller's execution
+        // reports the revert.
+        if info.is_reverted() {
+            return Ok(None);
+        }
+
+        let l2_gas_consumed = info.receipt.gas.l2_gas;
+        let adjusted = with_estimation_buffer(l2_gas_consumed).min(max_l2_gas_limit);
+
+        set_l2_gas_limit(tx, adjusted)?;
+        let gas_limit = match self.probe_l2_gas_limit(tx).map_err(make_err)? {
+            // Consumption + 10% is enough: use it and skip the binary search.
+            ProbeOutcome::Success(_) => adjusted,
+            ProbeOutcome::OutOfGas => {
+                let mut lower_bound = l2_gas_consumed;
+                let mut upper_bound = max_l2_gas_limit;
+                let mut current = midpoint(lower_bound, upper_bound);
+                loop {
+                    tracing::debug!(
+                        lower_bound = lower_bound.0,
+                        upper_bound = upper_bound.0,
+                        current = current.0,
+                        "Searching for minimal L2 gas limit"
+                    );
+                    set_l2_gas_limit(tx, current)?;
+                    match self.probe_l2_gas_limit(tx).map_err(make_err)? {
+                        ProbeOutcome::Success(_) => {
+                            if search_done(lower_bound, upper_bound) {
+                                break current;
+                            }
+                            upper_bound = current;
+                        }
+                        ProbeOutcome::OutOfGas => lower_bound = current,
+                    }
+                    current = midpoint(lower_bound, upper_bound);
+                }
+            }
+        };
+
+        set_l2_gas_limit(tx, gas_limit)?;
+        Ok(Some(GasVector { l2_gas: gas_limit, ..info.receipt.gas }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn midpoint_uses_ceiling() {
+        assert_eq!(midpoint(GasAmount(0), GasAmount(10)), GasAmount(5));
+        // Without ceiling this would return the lower bound forever.
+        assert_eq!(midpoint(GasAmount(9), GasAmount(10)), GasAmount(10));
+        assert_eq!(midpoint(GasAmount(10), GasAmount(10)), GasAmount(10));
+    }
+
+    #[test]
+    fn search_done_within_margin() {
+        assert!(search_done(GasAmount(0), GasAmount(1_000_000)));
+        assert!(!search_done(GasAmount(0), GasAmount(1_000_001)));
+    }
+
+    #[test]
+    fn estimation_buffer_is_ten_percent() {
+        assert_eq!(with_estimation_buffer(GasAmount(100)), GasAmount(110));
+        assert_eq!(with_estimation_buffer(GasAmount(u64::MAX)), GasAmount(u64::MAX));
+    }
+}

--- a/madara/crates/client/exec/src/lib.rs
+++ b/madara/crates/client/exec/src/lib.rs
@@ -303,6 +303,14 @@ pub struct ExecutionResult {
     pub deprecated_declared_class: Option<Felt>,
 }
 
+impl ExecutionResult {
+    /// The gas amounts fee estimates are priced with: the L2-gas-search adjusted vector when the
+    /// search ran, the receipt amounts otherwise.
+    pub fn gas_for_fee_pricing(&self) -> GasVector {
+        self.gas_for_fee_estimate.unwrap_or(self.execution_info.receipt.gas)
+    }
+}
+
 pub fn state_maps_to_initial_reads(state_maps: StateMaps) -> InitialReads {
     InitialReads {
         storage: state_maps

--- a/madara/crates/client/exec/src/lib.rs
+++ b/madara/crates/client/exec/src/lib.rs
@@ -169,6 +169,7 @@ mod blockifier_state_adapter;
 mod call;
 mod execution_read_cache;
 mod fee;
+mod l2_gas_search;
 mod layered_state_adapter;
 pub mod metrics;
 pub mod trace;
@@ -291,6 +292,11 @@ pub struct ExecutionResult {
     pub execution_info: TransactionExecutionInfo,
     pub state_diff: CommitmentStateDiff,
     pub gas_vector_computation_mode: GasVectorComputationMode,
+    /// When the minimal viable L2 gas limit was discovered through
+    /// [`ExecutionContext::execute_transactions_for_estimation`], the gas vector to price fee
+    /// estimates with: the consumed gas with `l2_gas` replaced by the discovered limit. The
+    /// receipt in `execution_info` keeps the actually consumed amounts.
+    pub gas_for_fee_estimate: Option<GasVector>,
     /// Addresses that were newly deployed by this transaction (vs class replacements).
     pub deployed_contracts: HashSet<Felt>,
     /// Class hash declared as deprecated (Cairo 0) by this transaction, if any.

--- a/madara/crates/client/rpc/src/constants.rs
+++ b/madara/crates/client/rpc/src/constants.rs
@@ -2,3 +2,7 @@
 pub const MAX_EVENTS_KEYS: usize = 100;
 /// Maximum number of events that can be fetched in a single chunk for the `get_events` RPC.
 pub const MAX_EVENTS_CHUNK_SIZE: usize = 1000;
+/// Maximum number of transactions accepted per `estimateFee`/`simulateTransactions` request.
+/// Estimation can execute each transaction several times (L2 gas limit discovery), so the
+/// per-request work must be bounded.
+pub const MAX_ESTIMATE_TRANSACTIONS: usize = 100;

--- a/madara/crates/client/rpc/src/errors.rs
+++ b/madara/crates/client/rpc/src/errors.rs
@@ -111,6 +111,8 @@ pub enum StarknetRpcApiError {
     StorageProofNotSupported,
     #[error("The proof field in the invoke v3 transaction is invalid")]
     InvalidProof,
+    #[error("Invalid params")]
+    InvalidParams { error: Cow<'static, str> },
 }
 
 impl StarknetRpcApiError {
@@ -191,6 +193,8 @@ impl From<&StarknetRpcApiError> for i32 {
             StarknetRpcApiError::InternalServerError => 500,
             StarknetRpcApiError::UnimplementedMethod => 501,
             StarknetRpcApiError::ProofLimitExceeded { .. } => 10000,
+            // Standard JSON-RPC invalid params error.
+            StarknetRpcApiError::InvalidParams { .. } => -32602,
         }
     }
 }
@@ -210,6 +214,7 @@ impl StarknetRpcApiError {
                 Some(json!({ "kind": kind, "limit": limit, "got": got }))
             }
             StarknetRpcApiError::ErrUnexpectedError { error }
+            | StarknetRpcApiError::InvalidParams { error }
             | StarknetRpcApiError::NoTraceAvailable { error }
             | StarknetRpcApiError::ValidationFailure { error }
             | StarknetRpcApiError::ContractNotFound { error }

--- a/madara/crates/client/rpc/src/test_utils.rs
+++ b/madara/crates/client/rpc/src/test_utils.rs
@@ -110,6 +110,60 @@ pub async fn rpc_test_setup_with_execution() -> (Arc<MadaraBackend>, Starknet, m
     (backend, rpc, keys)
 }
 
+/// A fee-token transfer of 1 wei from `account` (a v3 invoke), signed iff `valid_signature`.
+/// For use with [`rpc_test_setup_with_execution`].
+#[cfg(test)]
+pub fn devnet_transfer_tx(
+    backend: &MadaraBackend,
+    account: &mc_devnet::DevnetPredeployedContract,
+    nonce: Felt,
+    valid_signature: bool,
+) -> mp_rpc::v0_9_0::BroadcastedTxn {
+    use mc_devnet::{Call, Multicall, Selector};
+    use mp_convert::ToFelt;
+    use mp_rpc::v0_9_0::{
+        BroadcastedInvokeTxn, BroadcastedTxn, DaMode, InvokeTxnV3, ResourceBounds, ResourceBoundsMapping,
+    };
+    use mp_transactions::IntoStarknetApiExt;
+
+    let mut tx = InvokeTxnV3 {
+        sender_address: account.address,
+        calldata: Multicall::default()
+            .with(Call {
+                to: backend.chain_config().native_fee_token_address.to_felt(),
+                selector: Selector::from("transfer"),
+                calldata: vec![account.address, Felt::ONE, Felt::ZERO],
+            })
+            .flatten()
+            .collect::<Vec<_>>()
+            .into(),
+        signature: vec![Felt::ONE, Felt::TWO].into(),
+        nonce,
+        resource_bounds: ResourceBoundsMapping {
+            l1_gas: ResourceBounds { max_amount: 60000, max_price_per_unit: 10000 },
+            l2_gas: ResourceBounds { max_amount: 6000000000, max_price_per_unit: 100000 },
+            l1_data_gas: ResourceBounds { max_amount: 60000, max_price_per_unit: 10000 },
+        },
+        tip: 0,
+        paymaster_data: vec![],
+        account_deployment_data: vec![],
+        nonce_data_availability_mode: DaMode::L1,
+        fee_data_availability_mode: DaMode::L1,
+    };
+    if valid_signature {
+        let api_tx = BroadcastedTxn::Invoke(BroadcastedInvokeTxn::V3(tx.clone()))
+            .into_validated_tx(
+                backend.chain_config().chain_id.to_felt(),
+                backend.chain_config().latest_protocol_version,
+                TxTimestamp::now(),
+            )
+            .unwrap();
+        let signature = account.secret.sign(&api_tx.hash).unwrap();
+        tx.signature = vec![signature.r, signature.s].into();
+    }
+    BroadcastedTxn::Invoke(BroadcastedInvokeTxn::V3(tx))
+}
+
 #[fixture]
 pub fn rpc_test_setup() -> (Arc<MadaraBackend>, Starknet) {
     let chain_config = Arc::new(ChainConfig::madara_test());

--- a/madara/crates/client/rpc/src/utils/mod.rs
+++ b/madara/crates/client/rpc/src/utils/mod.rs
@@ -9,3 +9,20 @@ use std::fmt;
 pub fn display_internal_server_error(err: impl fmt::Display) {
     tracing::error!(target: "rpc_errors", "{:#}", err);
 }
+
+/// Bounds the number of transactions accepted by an `estimateFee`/`simulateTransactions` request:
+/// each transaction can trigger repeated execution during L2 gas limit discovery, so the batch
+/// size caps the per-request execution work. `operation` names the request kind in the error
+/// message ("estimated" or "simulated").
+pub fn check_estimate_batch_size(len: usize, operation: &str) -> Result<(), crate::errors::StarknetRpcApiError> {
+    if len > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(crate::errors::StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be {operation} per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
+    Ok(())
+}

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
@@ -34,7 +34,8 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
+            let execution_flags =
+                ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
@@ -19,6 +19,15 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
+    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be estimated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
@@ -19,15 +19,7 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
-    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be estimated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(request.len(), "estimated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/estimate_fee.rs
@@ -34,7 +34,7 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -42,7 +42,7 @@ pub async fn estimate_fee(
     let tips = transactions.iter().map(|tx| tx.tip().unwrap_or_default()).collect::<Vec<_>>();
 
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], transactions)?, exec_context))
     })
     .await?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
@@ -17,15 +17,7 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<SimulateTransactionsResponse> {
-    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be simulated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(transactions.len(), "simulated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
@@ -34,7 +34,7 @@ pub async fn simulate_transactions(
             let only_query = tx.is_query();
             let (api_tx, _) = tx
                 .into_starknet_api(starknet.backend.chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -43,7 +43,7 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
     })
     .await?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
@@ -43,7 +43,10 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((
+            exec_context.execute_transactions_for_estimation([], user_transactions)?,
+            exec_context,
+        ))
     })
     .await?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/trace/simulate_transactions.rs
@@ -17,6 +17,15 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<SimulateTransactionsResponse> {
+    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be simulated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
@@ -27,15 +27,7 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
-    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be estimated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(request.len(), "estimated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
@@ -42,7 +42,7 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -51,7 +51,7 @@ pub async fn estimate_fee(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], transactions)?, exec_context))
     })
     .await
     .map_err(StarknetRpcApiError::from_exec_error_v0_7)?;

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
@@ -42,7 +42,8 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
+            let execution_flags =
+                ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/estimate_fee.rs
@@ -27,6 +27,15 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
+    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be estimated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
@@ -32,7 +32,7 @@ pub async fn simulate_transactions(
             let only_query = tx.is_query();
             let (api_tx, _) = tx
                 .into_starknet_api(starknet.backend.chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -41,7 +41,7 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
     })
     .await
     .map_err(StarknetRpcApiError::from_exec_error_v0_7)?;

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
@@ -16,15 +16,7 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<Vec<SimulateTransactionsResult>> {
-    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be simulated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(transactions.len(), "simulated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
@@ -16,6 +16,15 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<Vec<SimulateTransactionsResult>> {
+    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be simulated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/trace/simulate_transactions.rs
@@ -41,7 +41,10 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((
+            exec_context.execute_transactions_for_estimation([], user_transactions)?,
+            exec_context,
+        ))
     })
     .await
     .map_err(StarknetRpcApiError::from_exec_error_v0_7)?;

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
@@ -27,15 +27,7 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
-    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be estimated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(request.len(), "estimated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
@@ -42,7 +42,7 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -51,7 +51,7 @@ pub async fn estimate_fee(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], transactions)?, exec_context))
     })
     .await?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
@@ -42,7 +42,8 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
+            let execution_flags =
+                ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/estimate_fee.rs
@@ -27,6 +27,15 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
+    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be estimated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
@@ -32,7 +32,7 @@ pub async fn simulate_transactions(
             let only_query = tx.is_query();
             let (api_tx, _) = tx
                 .into_starknet_api(starknet.backend.chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -41,7 +41,7 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
     })
     .await?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
@@ -16,15 +16,7 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<Vec<SimulateTransactionsResult>> {
-    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be simulated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(transactions.len(), "simulated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
@@ -16,6 +16,15 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<Vec<SimulateTransactionsResult>> {
+    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be simulated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/trace/simulate_transactions.rs
@@ -41,7 +41,10 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((
+            exec_context.execute_transactions_for_estimation([], user_transactions)?,
+            exec_context,
+        ))
     })
     .await?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
@@ -27,15 +27,7 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
-    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be estimated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(request.len(), "estimated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
@@ -27,6 +27,15 @@ pub async fn estimate_fee(
     block_id: BlockId,
 ) -> StarknetRpcResult<Vec<FeeEstimate>> {
     tracing::debug!("estimate fee on block_id {block_id:?}");
+    if request.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be estimated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 
@@ -136,6 +145,19 @@ mod tests {
                 .unwrap();
 
         assert_eq!(estimates.len(), 1);
+    }
+
+    /// Estimation executes each transaction (several times with L2 gas discovery): the
+    /// per-request transaction count must be bounded.
+    #[tokio::test]
+    async fn estimate_fee_rejects_oversized_batch() {
+        let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
+
+        let tx = devnet_transfer_tx(&backend, &keys.0[0], Felt::ZERO, false);
+        let txs = vec![tx; crate::constants::MAX_ESTIMATE_TRANSACTIONS + 1];
+        let result = estimate_fee(&rpc, txs, vec![], BlockId::Tag(BlockTag::Latest)).await;
+
+        assert_matches!(result.unwrap_err(), StarknetRpcApiError::InvalidParams { .. });
     }
 
     /// Without SKIP_VALIDATE the strict nonce check still applies.

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
@@ -42,7 +42,7 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -51,7 +51,7 @@ pub async fn estimate_fee(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], transactions)?, exec_context))
     })
     .await?;
 
@@ -166,5 +166,36 @@ mod tests {
 
         assert_eq!(estimates.len(), 1);
         assert!(estimates[0].common.overall_fee > 0);
+    }
+
+    /// SKIP_VALIDATE must relax the strict nonce check, like pathfinder
+    /// (`strict_nonce_check: !skip_validate`) and juno: wallets estimate queued transactions with
+    /// future nonces.
+    #[tokio::test]
+    async fn estimate_fee_skip_validate_allows_future_nonce() {
+        let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
+
+        let txs = vec![transfer_tx(&backend, &keys.0[0], Felt::from(5), false)];
+        let estimates = estimate_fee(
+            &rpc,
+            txs,
+            vec![SimulationFlagForEstimateFee::SkipValidate],
+            BlockId::Tag(BlockTag::Latest),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(estimates.len(), 1);
+    }
+
+    /// Without SKIP_VALIDATE the strict nonce check still applies.
+    #[tokio::test]
+    async fn estimate_fee_future_nonce_fails_without_skip_validate() {
+        let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
+
+        let txs = vec![transfer_tx(&backend, &keys.0[0], Felt::from(5), true)];
+        let result = estimate_fee(&rpc, txs, vec![], BlockId::Tag(BlockTag::Latest)).await;
+
+        assert_matches!(result.unwrap_err(), StarknetRpcApiError::TxnExecutionError { tx_index: 0, .. });
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/estimate_fee.rs
@@ -42,7 +42,8 @@ pub async fn estimate_fee(
             let only_query = tx.is_query();
             let (api_tx, _) =
                 tx.into_starknet_api(view.backend().chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
+            let execution_flags =
+                ExecutionFlags { only_query, charge_fee: false, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -86,57 +87,10 @@ pub async fn estimate_fee(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::rpc_test_setup_with_execution;
+    use crate::test_utils::{devnet_transfer_tx, rpc_test_setup_with_execution};
     use assert_matches::assert_matches;
-    use mc_devnet::{Call, DevnetPredeployedContract, Multicall, Selector};
-    use mp_rpc::v0_9_0::{BlockTag, BroadcastedInvokeTxn, DaMode, InvokeTxnV3, ResourceBounds, ResourceBoundsMapping};
-    use mp_transactions::validated::TxTimestamp;
+    use mp_rpc::v0_9_0::BlockTag;
     use starknet_types_core::felt::Felt;
-
-    /// A fee-token transfer of 1 wei from `account`, signed iff `valid_signature`.
-    fn transfer_tx(
-        backend: &mc_db::MadaraBackend,
-        account: &DevnetPredeployedContract,
-        nonce: Felt,
-        valid_signature: bool,
-    ) -> BroadcastedTxn {
-        let mut tx = InvokeTxnV3 {
-            sender_address: account.address,
-            calldata: Multicall::default()
-                .with(Call {
-                    to: backend.chain_config().native_fee_token_address.to_felt(),
-                    selector: Selector::from("transfer"),
-                    calldata: vec![account.address, Felt::ONE, Felt::ZERO],
-                })
-                .flatten()
-                .collect::<Vec<_>>()
-                .into(),
-            signature: vec![Felt::ONE, Felt::TWO].into(),
-            nonce,
-            resource_bounds: ResourceBoundsMapping {
-                l1_gas: ResourceBounds { max_amount: 60000, max_price_per_unit: 10000 },
-                l2_gas: ResourceBounds { max_amount: 6000000000, max_price_per_unit: 100000 },
-                l1_data_gas: ResourceBounds { max_amount: 60000, max_price_per_unit: 10000 },
-            },
-            tip: 0,
-            paymaster_data: vec![],
-            account_deployment_data: vec![],
-            nonce_data_availability_mode: DaMode::L1,
-            fee_data_availability_mode: DaMode::L1,
-        };
-        if valid_signature {
-            let api_tx = BroadcastedTxn::Invoke(BroadcastedInvokeTxn::V3(tx.clone()))
-                .into_validated_tx(
-                    backend.chain_config().chain_id.to_felt(),
-                    backend.chain_config().latest_protocol_version,
-                    TxTimestamp::now(),
-                )
-                .unwrap();
-            let signature = account.secret.sign(&api_tx.hash).unwrap();
-            tx.signature = vec![signature.r, signature.s].into();
-        }
-        BroadcastedTxn::Invoke(BroadcastedInvokeTxn::V3(tx))
-    }
 
     /// The error 41 data must blame the actual failing transaction, not transaction 0: the first
     /// transaction is valid, the second fails validation (bad signature).
@@ -145,8 +99,8 @@ mod tests {
         let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
 
         let txs = vec![
-            transfer_tx(&backend, &keys.0[0], Felt::ZERO, true),
-            transfer_tx(&backend, &keys.0[1], Felt::ZERO, false),
+            devnet_transfer_tx(&backend, &keys.0[0], Felt::ZERO, true),
+            devnet_transfer_tx(&backend, &keys.0[1], Felt::ZERO, false),
         ];
         let result = estimate_fee(&rpc, txs, vec![], BlockId::Tag(BlockTag::Latest)).await;
 
@@ -161,7 +115,7 @@ mod tests {
     async fn estimate_fee_success() {
         let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
 
-        let txs = vec![transfer_tx(&backend, &keys.0[0], Felt::ZERO, true)];
+        let txs = vec![devnet_transfer_tx(&backend, &keys.0[0], Felt::ZERO, true)];
         let estimates = estimate_fee(&rpc, txs, vec![], BlockId::Tag(BlockTag::Latest)).await.unwrap();
 
         assert_eq!(estimates.len(), 1);
@@ -170,20 +124,16 @@ mod tests {
 
     /// SKIP_VALIDATE must relax the strict nonce check, like pathfinder
     /// (`strict_nonce_check: !skip_validate`) and juno: wallets estimate queued transactions with
-    /// future nonces.
+    /// future nonces. The signature is valid so the future nonce is the only relaxed check.
     #[tokio::test]
     async fn estimate_fee_skip_validate_allows_future_nonce() {
         let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
 
-        let txs = vec![transfer_tx(&backend, &keys.0[0], Felt::from(5), false)];
-        let estimates = estimate_fee(
-            &rpc,
-            txs,
-            vec![SimulationFlagForEstimateFee::SkipValidate],
-            BlockId::Tag(BlockTag::Latest),
-        )
-        .await
-        .unwrap();
+        let txs = vec![devnet_transfer_tx(&backend, &keys.0[0], Felt::from(5), true)];
+        let estimates =
+            estimate_fee(&rpc, txs, vec![SimulationFlagForEstimateFee::SkipValidate], BlockId::Tag(BlockTag::Latest))
+                .await
+                .unwrap();
 
         assert_eq!(estimates.len(), 1);
     }
@@ -193,7 +143,7 @@ mod tests {
     async fn estimate_fee_future_nonce_fails_without_skip_validate() {
         let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
 
-        let txs = vec![transfer_tx(&backend, &keys.0[0], Felt::from(5), true)];
+        let txs = vec![devnet_transfer_tx(&backend, &keys.0[0], Felt::from(5), true)];
         let result = estimate_fee(&rpc, txs, vec![], BlockId::Tag(BlockTag::Latest)).await;
 
         assert_matches!(result.unwrap_err(), StarknetRpcApiError::TxnExecutionError { tx_index: 0, .. });

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
@@ -87,6 +87,19 @@ mod tests {
     use mp_rpc::v0_9_0::BlockTag;
     use starknet_types_core::felt::Felt;
 
+    /// Simulation executes each transaction (several times with L2 gas discovery): the
+    /// per-request transaction count must be bounded, mirroring estimateFee.
+    #[tokio::test]
+    async fn simulate_rejects_oversized_batch() {
+        let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
+
+        let tx = devnet_transfer_tx(&backend, &keys.0[0], Felt::ZERO, false);
+        let txs = vec![tx; crate::constants::MAX_ESTIMATE_TRANSACTIONS + 1];
+        let result = simulate_transactions(&rpc, BlockId::Tag(BlockTag::Latest), txs, vec![]).await;
+
+        assert_matches::assert_matches!(result.unwrap_err(), StarknetRpcApiError::InvalidParams { .. });
+    }
+
     /// SKIP_VALIDATE must relax the strict nonce check here too, mirroring estimateFee: wallets
     /// simulate queued transactions with future nonces. The signature is valid so the future
     /// nonce is the only relaxed check.

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
@@ -32,7 +32,7 @@ pub async fn simulate_transactions(
             let only_query = tx.is_query();
             let (api_tx, _) = tx
                 .into_starknet_api(starknet.backend.chain_config().chain_id.to_felt(), exec_context.protocol_version)?;
-            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: true };
+            let execution_flags = ExecutionFlags { only_query, charge_fee, validate, strict_nonce_check: validate };
             Ok(tx_api_to_blockifier(api_tx, execution_flags)?)
         })
         .collect::<Result<Vec<_>, ToBlockifierError>>()?;
@@ -41,7 +41,7 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
     })
     .await?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
@@ -16,15 +16,7 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<Vec<SimulateTransactionsResult>> {
-    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
-        return Err(StarknetRpcApiError::InvalidParams {
-            error: format!(
-                "Too many transactions: at most {} transactions can be simulated per request",
-                crate::constants::MAX_ESTIMATE_TRANSACTIONS
-            )
-            .into(),
-        });
-    }
+    crate::utils::check_estimate_batch_size(transactions.len(), "simulated")?;
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
@@ -16,6 +16,15 @@ pub async fn simulate_transactions(
     transactions: Vec<BroadcastedTxn>,
     simulation_flags: Vec<SimulationFlag>,
 ) -> StarknetRpcResult<Vec<SimulateTransactionsResult>> {
+    if transactions.len() > crate::constants::MAX_ESTIMATE_TRANSACTIONS {
+        return Err(StarknetRpcApiError::InvalidParams {
+            error: format!(
+                "Too many transactions: at most {} transactions can be simulated per request",
+                crate::constants::MAX_ESTIMATE_TRANSACTIONS
+            )
+            .into(),
+        });
+    }
     let view = starknet.resolve_block_view(block_id)?;
     let mut exec_context = view.new_execution_context()?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/trace/simulate_transactions.rs
@@ -41,7 +41,10 @@ pub async fn simulate_transactions(
 
     // spawn_blocking: avoid starving the tokio workers during execution.
     let (execution_results, exec_context) = mp_utils::spawn_blocking(move || {
-        Ok::<_, mc_exec::Error>((exec_context.execute_transactions_for_estimation([], user_transactions)?, exec_context))
+        Ok::<_, mc_exec::Error>((
+            exec_context.execute_transactions_for_estimation([], user_transactions)?,
+            exec_context,
+        ))
     })
     .await?;
 
@@ -66,4 +69,32 @@ pub async fn simulate_transactions(
         .collect::<Result<Vec<_>, StarknetRpcApiError>>()?;
 
     Ok(simulated_transactions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{devnet_transfer_tx, rpc_test_setup_with_execution};
+    use mp_rpc::v0_9_0::BlockTag;
+    use starknet_types_core::felt::Felt;
+
+    /// SKIP_VALIDATE must relax the strict nonce check here too, mirroring estimateFee: wallets
+    /// simulate queued transactions with future nonces. The signature is valid so the future
+    /// nonce is the only relaxed check.
+    #[tokio::test]
+    async fn simulate_skip_validate_allows_future_nonce() {
+        let (backend, rpc, keys) = rpc_test_setup_with_execution().await;
+
+        let txs = vec![devnet_transfer_tx(&backend, &keys.0[0], Felt::from(5), true)];
+        let result = simulate_transactions(
+            &rpc,
+            BlockId::Tag(BlockTag::Latest),
+            txs,
+            vec![SimulationFlag::SkipValidate, SimulationFlag::SkipFeeCharge],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+    }
 }


### PR DESCRIPTION
> Stacked on #1145. Only the last commit is new.

Two estimation behaviors where pathfinder v0.22.5 and juno v0.16.2 agree against Madara:
1. **No L2 gas limit discovery** (Starknet 0.13.4 runtime gas accounting, Sierra ≥ 1.7 senders): estimating with zero/low bounds reverts `'Out of gas'` → error 41, and even successful runs can report `l2_gas_consumed` below the minimal *viable* limit — estimates that revert when used as bounds.
2. **SKIP_VALIDATE didn't relax the strict nonce check** — both references use `strict_nonce_check = !skip_validate` so wallets can estimate queued (future-nonce) transactions.

```mermaid
flowchart TD
    A["probe at protocol cap<br/>(discarded fork)"] -->|out of gas| Z[⛔ revert surfaces as before]
    A -->|"success: consumed = X"| B["probe at X + 10%"]
    B -->|success| F
    B -->|out of gas| C["binary search (X, cap)<br/>converge within 1M gas"]
    C --> F["final execution at found limit<br/>fee priced with limit,<br/>trace keeps actual receipt"]
```

Faithful port of pathfinder's `find_l2_gas_limit_and_execute_transaction` (same 10% buffer, 1M margin, out-of-gas sentinel, ceiling midpoint); juno implements the same. Gated to all-resource-bounds + SierraGas-tracked senders + `charge_fee=false`; traces untouched.

**Tests:** 186/186 pass. New: future-nonce + SKIP_VALIDATE succeeds (fails on base) and still fails without the flag; search-arithmetic unit tests. Note: the search can't activate on the repo's Sierra-1.6 test artifacts (CairoSteps-tracked — correctly gated off, behavior unchanged); end-to-end search coverage needs a Sierra ≥ 1.7 test class, suggested as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)