### PR TITLE
fix(rpc): read-method spec gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- fix(rpc): failure_reason in tx status, getEvents numeric bounds past tip, BLOCK_NOT_FOUND for tag resolution
 - feat(rpc): discover minimal L2 gas limit in estimateFee/simulateTransactions; SKIP_VALIDATE relaxes the strict nonce check
 - fix(rpc): structured CONTRACT_EXECUTION_ERROR data and real transaction_index in execution errors
 - fix(rpc): surface failed executions in starknet_call and starknet_estimateMessageFee

--- a/madara/crates/client/rpc/src/block_id.rs
+++ b/madara/crates/client/rpc/src/block_id.rs
@@ -10,6 +10,10 @@ pub trait StateViewResolvable: Sized {
     fn resolve_state_view(&self, starknet: &Starknet) -> Result<MadaraStateView, StarknetRpcApiError>;
 }
 
+pub trait EventRangeBoundResolvable: StateViewResolvable {
+    fn event_range_number(&self) -> Option<u64>;
+}
+
 // v0.7/v0.8 rpc
 
 impl StateViewResolvable for mp_rpc::v0_7_1::BlockId {
@@ -39,6 +43,15 @@ impl StateViewResolvable for mp_rpc::v0_7_1::BlockId {
     }
 }
 
+impl EventRangeBoundResolvable for mp_rpc::v0_7_1::BlockId {
+    fn event_range_number(&self) -> Option<u64> {
+        match self {
+            Self::Number(block_n) => Some(*block_n),
+            _ => None,
+        }
+    }
+}
+
 impl BlockViewResolvable for mp_rpc::v0_7_1::BlockId {
     fn resolve_block_view(&self, starknet: &Starknet) -> Result<MadaraBlockView, StarknetRpcApiError> {
         match self {
@@ -49,9 +62,11 @@ impl BlockViewResolvable for mp_rpc::v0_7_1::BlockId {
                 }
                 Ok(view.into())
             }
-            Self::Tag(mp_rpc::v0_7_1::BlockTag::Latest) => {
-                starknet.backend.block_view_on_last_confirmed().map(|b| b.into()).ok_or(StarknetRpcApiError::NoBlocks)
-            }
+            Self::Tag(mp_rpc::v0_7_1::BlockTag::Latest) => starknet
+                .backend
+                .block_view_on_last_confirmed()
+                .map(|b| b.into())
+                .ok_or(StarknetRpcApiError::BlockNotFound),
             Self::Hash(hash) => {
                 if let Some(block_n) = starknet.backend.db.find_block_hash(hash)? {
                     Ok(starknet
@@ -85,7 +100,7 @@ impl StateViewResolvable for mp_rpc::v0_9_0::BlockId {
                 .backend
                 .latest_l1_confirmed_block_n()
                 .and_then(|block_number| starknet.backend.view_on_confirmed(block_number))
-                .ok_or(StarknetRpcApiError::NoBlocks),
+                .ok_or(StarknetRpcApiError::BlockNotFound),
             Self::Hash(hash) => {
                 if let Some(block_n) = starknet.backend.view_on_latest().find_block_by_hash(hash)? {
                     Ok(starknet.backend.view_on_confirmed(block_n).with_context(|| {
@@ -102,21 +117,32 @@ impl StateViewResolvable for mp_rpc::v0_9_0::BlockId {
     }
 }
 
+impl EventRangeBoundResolvable for mp_rpc::v0_9_0::BlockId {
+    fn event_range_number(&self) -> Option<u64> {
+        match self {
+            Self::Number(block_n) => Some(*block_n),
+            _ => None,
+        }
+    }
+}
+
 impl BlockViewResolvable for mp_rpc::v0_9_0::BlockId {
     fn resolve_block_view(&self, starknet: &Starknet) -> Result<MadaraBlockView, StarknetRpcApiError> {
         match self {
             Self::Tag(mp_rpc::v0_9_0::BlockTag::PreConfirmed) => {
                 Ok(starknet.backend.block_view_on_preconfirmed_or_fake()?.into())
             }
-            Self::Tag(mp_rpc::v0_9_0::BlockTag::Latest) => {
-                starknet.backend.block_view_on_last_confirmed().map(|b| b.into()).ok_or(StarknetRpcApiError::NoBlocks)
-            }
+            Self::Tag(mp_rpc::v0_9_0::BlockTag::Latest) => starknet
+                .backend
+                .block_view_on_last_confirmed()
+                .map(|b| b.into())
+                .ok_or(StarknetRpcApiError::BlockNotFound),
             Self::Tag(mp_rpc::v0_9_0::BlockTag::L1Accepted) => starknet
                 .backend
                 .latest_l1_confirmed_block_n()
                 .and_then(|block_number| starknet.backend.block_view_on_confirmed(block_number))
                 .map(|b| b.into())
-                .ok_or(StarknetRpcApiError::NoBlocks),
+                .ok_or(StarknetRpcApiError::BlockNotFound),
             Self::Hash(hash) => {
                 if let Some(block_n) = starknet.backend.db.find_block_hash(hash)? {
                     Ok(starknet
@@ -151,5 +177,31 @@ impl Starknet {
 
     pub fn resolve_view_on<R: StateViewResolvable>(&self, block_id: R) -> Result<MadaraStateView, StarknetRpcApiError> {
         block_id.resolve_state_view(self)
+    }
+
+    /// Resolves a `getEvents` lower bound. Numeric bounds are raw block numbers and may point past
+    /// the current tip. Hash/tag bounds must resolve to an actual block number; for example,
+    /// `from_block = latest` on an empty chain is `BLOCK_NOT_FOUND`, matching Pathfinder.
+    pub fn resolve_event_from_block_bound<R: EventRangeBoundResolvable>(
+        &self,
+        block_id: R,
+    ) -> Result<u64, StarknetRpcApiError> {
+        match block_id.event_range_number() {
+            Some(block_n) => Ok(block_n),
+            None => self.resolve_view_on(block_id)?.latest_block_n().ok_or(StarknetRpcApiError::BlockNotFound),
+        }
+    }
+
+    /// Resolves a `getEvents` upper bound. Numeric bounds are raw block numbers and may point past
+    /// the current tip. Hash/tag bounds resolve through the backend, but an empty-chain upper tag
+    /// still scans up to block 0 so the range can collapse to an empty page.
+    pub fn resolve_event_to_block_bound<R: EventRangeBoundResolvable>(
+        &self,
+        block_id: R,
+    ) -> Result<u64, StarknetRpcApiError> {
+        match block_id.event_range_number() {
+            Some(block_n) => Ok(block_n),
+            None => Ok(self.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0)),
+        }
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/read/get_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/read/get_events.rs
@@ -24,11 +24,11 @@ pub fn get_events(starknet: &Starknet, filter: EventFilterWithPageRequest) -> St
     }
 
     let from_block_n = match filter.from_block {
-        Some(block_id) => starknet.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0),
+        Some(block_id) => starknet.resolve_event_from_block_bound(block_id)?,
         None => 0,
     };
     let to_block_n = match filter.to_block {
-        Some(block_id) => starknet.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0),
+        Some(block_id) => starknet.resolve_event_to_block_bound(block_id)?,
         None => view.latest_block_n().unwrap_or(0),
     };
 
@@ -64,4 +64,60 @@ pub fn get_events(starknet: &Starknet, filter: EventFilterWithPageRequest) -> St
         events: events_infos.into_iter().map(|event_info| event_info.into()).collect(),
         continuation_token: continuation_token.map(|token| token.to_string()),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::rpc_test_setup;
+    use mp_rpc::v0_10_0::BlockId;
+    use mp_rpc::v0_9_0::BlockTag;
+    use rstest::rstest;
+
+    /// Numeric range bounds past the chain tip return an empty page instead of BLOCK_NOT_FOUND,
+    /// like pathfinder and juno: clients paginating by block number at the tip must not error.
+    #[rstest]
+    fn get_events_beyond_chain_tip_returns_empty_page(
+        rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet),
+    ) {
+        let (_backend, rpc) = rpc_test_setup;
+
+        let chunk = get_events(
+            &rpc,
+            EventFilterWithPageRequest {
+                address: None,
+                from_block: Some(BlockId::Number(100)),
+                to_block: Some(BlockId::Number(200)),
+                keys: None,
+                chunk_size: 10,
+                continuation_token: None,
+            },
+        )
+        .unwrap();
+
+        assert!(chunk.events.is_empty());
+        assert!(chunk.continuation_token.is_none());
+    }
+
+    #[rstest]
+    fn get_events_from_latest_on_empty_chain_returns_block_not_found(
+        rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet),
+    ) {
+        let (_backend, rpc) = rpc_test_setup;
+
+        let err = get_events(
+            &rpc,
+            EventFilterWithPageRequest {
+                address: None,
+                from_block: Some(BlockId::Tag(BlockTag::Latest)),
+                to_block: None,
+                keys: None,
+                chunk_size: 10,
+                continuation_token: None,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err, StarknetRpcApiError::BlockNotFound);
+    }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/read/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_0/methods/read/mod.rs
@@ -150,7 +150,7 @@ impl StarknetReadRpcApiV0_10_0Server for Starknet {
         V0_8_1Impl::get_storage_proof(
             self,
             mp_rpc::v0_8_1::BlockId::Number(
-                block_view.latest_confirmed_block_n().ok_or(StarknetRpcApiError::NoBlocks)?,
+                block_view.latest_confirmed_block_n().ok_or(StarknetRpcApiError::BlockNotFound)?,
             ),
             class_hashes,
             contract_addresses,

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/get_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/get_events.rs
@@ -98,17 +98,14 @@ fn resolve_block_range(
     from_block: Option<BlockId>,
     to_block: Option<BlockId>,
 ) -> StarknetRpcResult<(u64, u64)> {
-    let from_block_n = from_block.map(|block_id| resolve_block_n(starknet, block_id)).transpose()?.unwrap_or(0);
+    let from_block_n =
+        from_block.map(|block_id| starknet.resolve_event_from_block_bound(block_id)).transpose()?.unwrap_or(0);
     let to_block_n = to_block
-        .map(|block_id| resolve_block_n(starknet, block_id))
+        .map(|block_id| starknet.resolve_event_to_block_bound(block_id))
         .transpose()?
         .unwrap_or_else(|| view.latest_block_n().unwrap_or(0));
 
     Ok((from_block_n, to_block_n))
-}
-
-fn resolve_block_n(starknet: &Starknet, block_id: BlockId) -> StarknetRpcResult<u64> {
-    Ok(starknet.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0))
 }
 
 fn parse_continuation_token(
@@ -234,6 +231,7 @@ fn empty_events_chunk() -> EventsChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::rpc_test_setup;
     use rstest::rstest;
 
     fn dummy_event(block_number: u64, event_index_in_block: u64) -> EventWithInfo {
@@ -309,5 +307,52 @@ mod tests {
     fn validate_filter_limits_rejects_zero_chunk_size() {
         let err = validate_filter_limits(0, None).expect_err("zero-sized event pages should be rejected");
         assert_eq!(err, StarknetRpcApiError::PageSizeTooBig);
+    }
+
+    /// Numeric range bounds past the chain tip return an empty page instead of BLOCK_NOT_FOUND,
+    /// like pathfinder and juno: clients paginating by block number at the tip must not error.
+    #[rstest]
+    fn get_events_beyond_chain_tip_returns_empty_page(
+        rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet),
+    ) {
+        let (_backend, rpc) = rpc_test_setup;
+
+        let chunk = get_events(
+            &rpc,
+            EventFilterWithPageRequest {
+                address: None,
+                from_block: Some(BlockId::Number(100)),
+                to_block: Some(BlockId::Number(200)),
+                keys: None,
+                chunk_size: 10,
+                continuation_token: None,
+            },
+        )
+        .unwrap();
+
+        assert!(chunk.events.is_empty());
+        assert!(chunk.continuation_token.is_none());
+    }
+
+    #[rstest]
+    fn get_events_from_latest_on_empty_chain_returns_block_not_found(
+        rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet),
+    ) {
+        let (_backend, rpc) = rpc_test_setup;
+
+        let err = get_events(
+            &rpc,
+            EventFilterWithPageRequest {
+                address: None,
+                from_block: Some(BlockId::Tag(mp_rpc::v0_9_0::BlockTag::Latest)),
+                to_block: None,
+                keys: None,
+                chunk_size: 10,
+                continuation_token: None,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err, StarknetRpcApiError::BlockNotFound);
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/get_storage_proof.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_10_2/methods/read/get_storage_proof.rs
@@ -21,9 +21,32 @@ pub fn get_storage_proof(
 
     Ok(v0_8_1_get_storage_proof::get_storage_proof(
         starknet,
-        mp_rpc::v0_8_1::BlockId::Number(block_view.latest_confirmed_block_n().ok_or(StarknetRpcApiError::NoBlocks)?),
+        mp_rpc::v0_8_1::BlockId::Number(
+            block_view.latest_confirmed_block_n().ok_or(StarknetRpcApiError::BlockNotFound)?,
+        ),
         class_hashes,
         contract_addresses,
         contracts_storage_keys_v0_8_1,
     )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::rpc_test_setup;
+    use mp_rpc::v0_10_0::BlockTag;
+    use rstest::rstest;
+
+    /// With no confirmed block yet, the error is BLOCK_NOT_FOUND (24), not NO_BLOCKS (32):
+    /// NO_BLOCKS is reserved for blockNumber/blockHashAndNumber.
+    #[rstest]
+    fn get_storage_proof_empty_chain_returns_block_not_found(
+        rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet),
+    ) {
+        let (_backend, rpc) = rpc_test_setup;
+
+        let err = get_storage_proof(&rpc, BlockId::Tag(BlockTag::Latest), None, None, None).unwrap_err();
+
+        assert_eq!(err.code(), 24);
+    }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_7_1/methods/read/get_events.rs
@@ -43,11 +43,11 @@ pub fn get_events(starknet: &Starknet, filter: EventFilterWithPageRequest) -> St
     // Get the block numbers for the requested range
 
     let from_block_n = match filter.from_block {
-        Some(block_id) => starknet.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0),
+        Some(block_id) => starknet.resolve_event_from_block_bound(block_id)?,
         None => 0,
     };
     let to_block_n = match filter.to_block {
-        Some(block_id) => starknet.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0),
+        Some(block_id) => starknet.resolve_event_to_block_bound(block_id)?,
         None => view.latest_block_n().unwrap_or(0),
     };
 
@@ -84,4 +84,34 @@ pub fn get_events(starknet: &Starknet, filter: EventFilterWithPageRequest) -> St
         events: events_infos.into_iter().map(|event_info| event_info.into()).collect(),
         continuation_token: continuation_token.map(|token| token.to_string()),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::rpc_test_setup;
+    use mp_rpc::v0_7_1::{BlockId, BlockTag};
+    use rstest::rstest;
+
+    #[rstest]
+    fn get_events_from_latest_on_empty_chain_returns_block_not_found(
+        rpc_test_setup: (std::sync::Arc<mc_db::MadaraBackend>, crate::Starknet),
+    ) {
+        let (_backend, rpc) = rpc_test_setup;
+
+        let err = get_events(
+            &rpc,
+            EventFilterWithPageRequest {
+                address: None,
+                from_block: Some(BlockId::Tag(BlockTag::Latest)),
+                to_block: None,
+                keys: None,
+                chunk_size: 10,
+                continuation_token: None,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(err, StarknetRpcApiError::BlockNotFound);
+    }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_storage_proof.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/read/get_storage_proof.rs
@@ -90,7 +90,7 @@ pub fn get_storage_proof(
         starknet.resolve_block_view(block_id)?.into_confirmed().context("View cannot be preconfirmed here")?;
 
     let Some(latest) = starknet.backend.latest_confirmed_block_n() else {
-        return Err(StarknetRpcApiError::NoBlocks);
+        return Err(StarknetRpcApiError::BlockNotFound);
     };
 
     if latest.saturating_sub(block_view.block_number()) > starknet.storage_proof_config.max_distance {

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/get_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/get_events.rs
@@ -40,14 +40,13 @@ pub fn get_events(starknet: &Starknet, filter: EventFilterWithPageRequest) -> St
         return Err(StarknetRpcApiError::PageSizeTooBig);
     }
 
-    // Get the block numbers for the requested range
-
+    // Get the block numbers for the requested range.
     let from_block_n = match filter.from_block {
-        Some(block_id) => starknet.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0),
+        Some(block_id) => starknet.resolve_event_from_block_bound(block_id)?,
         None => 0,
     };
     let to_block_n = match filter.to_block {
-        Some(block_id) => starknet.resolve_view_on(block_id)?.latest_block_n().unwrap_or(0),
+        Some(block_id) => starknet.resolve_event_to_block_bound(block_id)?,
         None => view.latest_block_n().unwrap_or(0),
     };
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/get_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/get_transaction_status.rs
@@ -28,9 +28,9 @@ pub async fn get_transaction_status(
     if let Some(res) = view.find_transaction_by_hash(&transaction_hash)? {
         let transaction = res.get_transaction()?;
 
-        let execution_status = match transaction.receipt.execution_result() {
-            ExecutionResult::Reverted { .. } => Some(TxnExecutionStatus::Reverted),
-            ExecutionResult::Succeeded => Some(TxnExecutionStatus::Succeeded),
+        let (execution_status, failure_reason) = match transaction.receipt.execution_result() {
+            ExecutionResult::Reverted { reason } => (Some(TxnExecutionStatus::Reverted), Some(reason.clone())),
+            ExecutionResult::Succeeded => (Some(TxnExecutionStatus::Succeeded), None),
         };
 
         let finality_status = if res.block.is_on_l1() {
@@ -41,9 +41,13 @@ pub async fn get_transaction_status(
             TxnStatus::PreConfirmed
         };
 
-        Ok(TxnFinalityAndExecutionStatus { finality_status, execution_status })
+        Ok(TxnFinalityAndExecutionStatus { finality_status, execution_status, failure_reason })
     } else if starknet.transaction_lookup.received_transaction(transaction_hash).await.is_some_and(|b| b) {
-        Ok(TxnFinalityAndExecutionStatus { finality_status: TxnStatus::Received, execution_status: None })
+        Ok(TxnFinalityAndExecutionStatus {
+            finality_status: TxnStatus::Received,
+            execution_status: None,
+            failure_reason: None,
+        })
     } else {
         Err(StarknetRpcApiError::TxnHashNotFound)
     }
@@ -151,7 +155,11 @@ mod tests {
 
         assert_eq!(
             status,
-            TxnFinalityAndExecutionStatus { finality_status: TxnStatus::Received, execution_status: None }
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::Received,
+                execution_status: None,
+                failure_reason: None
+            }
         );
     }
 
@@ -172,6 +180,7 @@ mod tests {
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL2,
                 execution_status: Some(mp_rpc::v0_9_0::TxnExecutionStatus::Succeeded),
+                failure_reason: None
             }
         );
     }
@@ -204,6 +213,7 @@ mod tests {
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::PreConfirmed,
                 execution_status: Some(mp_rpc::v0_9_0::TxnExecutionStatus::Succeeded),
+                failure_reason: None
             }
         );
     }
@@ -226,6 +236,7 @@ mod tests {
             TxnFinalityAndExecutionStatus {
                 finality_status: TxnStatus::AcceptedOnL1,
                 execution_status: Some(mp_rpc::v0_9_0::TxnExecutionStatus::Succeeded),
+                failure_reason: None
             }
         );
     }
@@ -234,5 +245,41 @@ mod tests {
     #[rstest::rstest]
     async fn get_transaction_status_err_not_found(_logs: (), starknet: Starknet) {
         assert_eq!(get_transaction_status(&starknet, TX_HASH).await, Err(StarknetRpcApiError::TxnHashNotFound));
+    }
+
+    /// Reverted transactions must carry the failure reason in the status result.
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn get_transaction_status_reverted_includes_failure_reason(
+        _logs: (),
+        starknet: Starknet,
+        tx: mp_rpc::v0_9_0::BroadcastedInvokeTxn,
+    ) {
+        let block = mp_block::FullBlockWithoutCommitments {
+            header: Default::default(),
+            state_diff: Default::default(),
+            transactions: vec![mp_block::TransactionWithReceipt {
+                transaction: mp_transactions::Transaction::Invoke(tx.into()),
+                receipt: mp_receipt::TransactionReceipt::Invoke(mp_receipt::InvokeTransactionReceipt {
+                    transaction_hash: TX_HASH,
+                    execution_result: mp_receipt::ExecutionResult::Reverted { reason: "Insufficient fee".into() },
+                    ..Default::default()
+                }),
+            }],
+            events: Default::default(),
+        };
+        let backend = std::sync::Arc::clone(&starknet.backend);
+        backend.write_access().add_full_block_with_classes(&block, &[], true).expect("Failed to store block");
+
+        let status = get_transaction_status(&starknet, TX_HASH).await.expect("Failed to retrieve transaction status");
+
+        assert_eq!(
+            status,
+            TxnFinalityAndExecutionStatus {
+                finality_status: TxnStatus::AcceptedOnL2,
+                execution_status: Some(mp_rpc::v0_9_0::TxnExecutionStatus::Reverted),
+                failure_reason: Some("Insufficient fee".into())
+            }
+        );
     }
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/mod.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/read/mod.rs
@@ -148,7 +148,7 @@ impl StarknetReadRpcApiV0_9_0Server for Starknet {
         V0_8_1Impl::get_storage_proof(
             self,
             mp_rpc::v0_8_1::BlockId::Number(
-                block_view.latest_confirmed_block_n().ok_or(StarknetRpcApiError::NoBlocks)?,
+                block_view.latest_confirmed_block_n().ok_or(StarknetRpcApiError::BlockNotFound)?,
             ),
             class_hashes,
             contract_addresses,

--- a/madara/crates/primitives/rpc/src/v0_10_0/starknet_api_openrpc.rs
+++ b/madara/crates/primitives/rpc/src/v0_10_0/starknet_api_openrpc.rs
@@ -113,7 +113,7 @@ pub struct EmittedEvent {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EventsChunk {
     /// Use this token in a subsequent query to obtain the next page. Should not appear if there are no more pages.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
     /// The events matching the filter
     pub events: Vec<EmittedEvent>,

--- a/madara/crates/primitives/rpc/src/v0_7_1/starknet_api_openrpc.rs
+++ b/madara/crates/primitives/rpc/src/v0_7_1/starknet_api_openrpc.rs
@@ -635,7 +635,7 @@ pub struct EventContent {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EventsChunk {
     /// Use this token in a subsequent query to obtain the next page. Should not appear if there are no more pages.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
     pub events: Vec<EmittedEvent>,
 }

--- a/madara/crates/primitives/rpc/src/v0_9_0/starknet_api_openrpc.rs
+++ b/madara/crates/primitives/rpc/src/v0_9_0/starknet_api_openrpc.rs
@@ -330,6 +330,9 @@ pub struct TxnFinalityAndExecutionStatus {
     #[serde(default)]
     pub execution_status: Option<TxnExecutionStatus>,
     pub finality_status: TxnStatus,
+    /// The failure reason, only appears if execution_status is REVERTED.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
 }
 
 #[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Clone, Copy, Debug, Default)]

--- a/tests/js_tests/fixtures/v0_10_0/error_assertions.json
+++ b/tests/js_tests/fixtures/v0_10_0/error_assertions.json
@@ -5,28 +5,42 @@
       "id": "unknown_method_returns_32601",
       "method": "starknet_thisMethodDoesNotExist",
       "params": {},
-      "expected_error": { "code": -32601 },
+      "expected_error": {
+        "code": -32601
+      },
       "description": "Unknown method must return JSON-RPC Method not found"
     },
     {
       "id": "invalid_params_getBlockWithTxs",
       "method": "starknet_getBlockWithTxs",
-      "params": { "bad": "payload" },
-      "expected_error": { "code": -32602 },
+      "params": {
+        "bad": "payload"
+      },
+      "expected_error": {
+        "code": -32602
+      },
       "description": "Known method with invalid params must return Invalid params"
     },
     {
       "id": "invalid_params_getTransactionByHash",
       "method": "starknet_getTransactionByHash",
       "params": {},
-      "expected_error": { "code": -32602 },
+      "expected_error": {
+        "code": -32602
+      },
       "description": "Missing required transaction_hash param"
     },
     {
       "id": "block_not_found",
       "method": "starknet_getBlockWithTxHashes",
-      "params": { "block_id": { "block_number": 999999 } },
-      "expected_error": { "code": 24 },
+      "params": {
+        "block_id": {
+          "block_number": 999999
+        }
+      },
+      "expected_error": {
+        "code": 24
+      },
       "description": "Non-existent block number returns BLOCK_NOT_FOUND (code 24)"
     },
     {
@@ -35,7 +49,9 @@
       "params": {
         "transaction_hash": "0x0000000000000000000000000000000000000000000000000000000000dead"
       },
-      "expected_error": { "code": 29 },
+      "expected_error": {
+        "code": 29
+      },
       "description": "Non-existent tx hash returns TXN_HASH_NOT_FOUND (code 29)"
     },
     {
@@ -45,7 +61,9 @@
         "block_id": "latest",
         "contract_address": "0x0000000000000000000000000000000000000000000000000000000000dead"
       },
-      "expected_error": { "code": 20 },
+      "expected_error": {
+        "code": 20
+      },
       "description": "Non-existent contract returns CONTRACT_NOT_FOUND (code 20)"
     },
     {
@@ -55,17 +73,23 @@
         "block_id": "latest",
         "class_hash": "0x0000000000000000000000000000000000000000000000000000000000dead"
       },
-      "expected_error": { "code": 28 },
+      "expected_error": {
+        "code": 28
+      },
       "description": "Non-existent class hash returns CLASS_HASH_NOT_FOUND (code 28)"
     },
     {
       "id": "invalid_tx_index",
       "method": "starknet_getTransactionByBlockIdAndIndex",
       "params": {
-        "block_id": { "block_number": 0 },
+        "block_id": {
+          "block_number": 0
+        },
         "index": 999
       },
-      "expected_error": { "code": 27 },
+      "expected_error": {
+        "code": 27
+      },
       "description": "Out-of-range tx index returns INVALID_TXN_INDEX (code 27)"
     },
     {
@@ -74,7 +98,9 @@
       "params": {
         "transaction_hash": "0x0000000000000000000000000000000000000000000000000000000000000001"
       },
-      "expected_error": { "code": 29 },
+      "expected_error": {
+        "code": 29
+      },
       "description": "Unknown L1 tx hash returns TXN_HASH_NOT_FOUND (code 29)"
     },
     {
@@ -91,6 +117,115 @@
       },
       "expected_error": { "code": 40 },
       "description": "Reverted L1 handler fee estimation returns CONTRACT_ERROR (code 40)"
+    },
+    {
+      "id": "call_non_existent_entrypoint",
+      "method": "starknet_call",
+      "params": {
+        "request": {
+          "contract_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+          "entry_point_selector": "$computed:sn_keccak:definitely_not_an_entrypoint",
+          "calldata": []
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 21
+      },
+      "description": "Calling a non-existent selector returns ENTRYPOINT_NOT_FOUND (21). Regression: blockifier >= 0.13.4 reports this as a successful execution with ENTRYPOINT_NOT_FOUND retdata, which used to be returned as a successful call result."
+    },
+    {
+      "id": "call_non_existent_contract",
+      "method": "starknet_call",
+      "params": {
+        "request": {
+          "contract_address": "0x0000000000000000000000000000000000000000000000000000000000dead",
+          "entry_point_selector": "$computed:sn_keccak:get_balance",
+          "calldata": []
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 20
+      },
+      "description": "Calling a non-existent contract returns CONTRACT_NOT_FOUND (20)."
+    },
+    {
+      "id": "call_reverted_structured_error",
+      "method": "starknet_call",
+      "params": {
+        "request": {
+          "contract_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+          "entry_point_selector": "$computed:sn_keccak:transfer",
+          "calldata": [
+            "0x055be462e718c4166d656d11f89e341115b8bc82389c3762a10eade04fcb225d",
+            "0x1",
+            "0x0"
+          ]
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 40,
+        "data": {
+          "revert_error": {
+            "contract_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+            "selector": "$computed:sn_keccak:transfer",
+            "error": "$exists"
+          }
+        }
+      },
+      "description": "A reverted call (caller of starknet_call is 0, so the ERC20 panics with ERC20: transfer from 0) returns CONTRACT_ERROR (40) with the structured CONTRACT_EXECUTION_ERROR object as data, not a successful result with the panic retdata."
+    },
+    {
+      "id": "estimate_message_fee_reverted_handler",
+      "method": "starknet_estimateMessageFee",
+      "params": {
+        "message": {
+          "from_address": "0x000000000000000000000000000000000000beef",
+          "to_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+          "entry_point_selector": "$computed:sn_keccak:l1_handler_entrypoint",
+          "payload": ["0x1", "0x2"]
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 40
+      },
+      "description": "A message whose handler fails (the fee token has no l1 handler) returns CONTRACT_ERROR (40). Regression: blockifier reports a failed L1 handler as a successful execution with revert_error set, which used to be priced as a fee estimate."
+    },
+    {
+      "id": "estimate_message_fee_contract_not_found",
+      "method": "starknet_estimateMessageFee",
+      "params": {
+        "message": {
+          "from_address": "0x000000000000000000000000000000000000beef",
+          "to_address": "0x0000000000000000000000000000000000000000000000000000000000dead",
+          "entry_point_selector": "$computed:sn_keccak:l1_handler_entrypoint",
+          "payload": ["0x1", "0x2"]
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 20
+      },
+      "description": "A message to a non-existent contract returns CONTRACT_NOT_FOUND (20) on v0.10+."
+    },
+    {
+      "id": "get_events_unknown_hash_bound",
+      "method": "starknet_getEvents",
+      "params": {
+        "filter": {
+          "from_block": {
+            "block_hash": "0x0000000000000000000000000000000000000000000000000000000000dead"
+          },
+          "chunk_size": 10
+        }
+      },
+      "expected_error": {
+        "code": 24
+      },
+      "description": "Hash range bounds must resolve through the backend: an unknown block hash is BLOCK_NOT_FOUND (24). Only numeric bounds are exempt from existence checks."
     }
   ]
 }

--- a/tests/js_tests/fixtures/v0_10_0/read_assertions.json
+++ b/tests/js_tests/fixtures/v0_10_0/read_assertions.json
@@ -40,7 +40,9 @@
       "id": "get_block_tx_hashes_single",
       "method": "starknet_getBlockWithTxHashes",
       "params": {
-        "block_id": { "block_number": "$ref:declare_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:declare_hello.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -52,9 +54,18 @@
         "starknet_version": "$any",
         "timestamp": "$gt:0",
         "l1_da_mode": "$any",
-        "l1_gas_price": { "price_in_fri": "$any", "price_in_wei": "$any" },
-        "l1_data_gas_price": { "price_in_fri": "$any", "price_in_wei": "$any" },
-        "l2_gas_price": { "price_in_fri": "$any", "price_in_wei": "$any" },
+        "l1_gas_price": {
+          "price_in_fri": "$any",
+          "price_in_wei": "$any"
+        },
+        "l1_data_gas_price": {
+          "price_in_fri": "$any",
+          "price_in_wei": "$any"
+        },
+        "l2_gas_price": {
+          "price_in_fri": "$any",
+          "price_in_wei": "$any"
+        },
         "transaction_commitment": "$any",
         "event_commitment": "$any",
         "receipt_commitment": "$any",
@@ -70,7 +81,9 @@
       "id": "get_block_tx_hashes_multi",
       "method": "starknet_getBlockWithTxHashes",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -87,7 +100,9 @@
       "id": "get_block_tx_hashes_by_hash",
       "method": "starknet_getBlockWithTxHashes",
       "params": {
-        "block_id": { "block_hash": "$ref:declare_hello.block_hash" }
+        "block_id": {
+          "block_hash": "$ref:declare_hello.block_hash"
+        }
       },
       "expected": {
         "block_hash": "$ref:declare_hello.block_hash",
@@ -99,7 +114,9 @@
       "id": "get_block_with_txs",
       "method": "starknet_getBlockWithTxs",
       "params": {
-        "block_id": { "block_number": "$ref:declare_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:declare_hello.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -123,7 +140,9 @@
       "id": "get_block_with_txs_deploy_account",
       "method": "starknet_getBlockWithTxs",
       "params": {
-        "block_id": { "block_number": "$ref:deploy_new_account.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_new_account.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -135,26 +154,35 @@
       "id": "get_block_with_receipts",
       "method": "starknet_getBlockWithReceipts",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
         "transactions": [
           {
-            "transaction": { "type": "INVOKE" },
+            "transaction": {
+              "type": "INVOKE"
+            },
             "receipt": {
               "type": "INVOKE",
               "transaction_hash": "$ref:invoke_increase_42.transaction_hash",
               "execution_status": "SUCCEEDED",
               "finality_status": "ACCEPTED_ON_L2",
-              "actual_fee": { "amount": "$any", "unit": "FRI" },
+              "actual_fee": {
+                "amount": "$any",
+                "unit": "FRI"
+              },
               "execution_resources": "$any",
               "events": "$any",
               "messages_sent": "$any"
             }
           },
           {
-            "transaction": { "type": "INVOKE" },
+            "transaction": {
+              "type": "INVOKE"
+            },
             "receipt": {
               "type": "INVOKE",
               "transaction_hash": "$ref:invoke_increase_100.transaction_hash",
@@ -169,7 +197,9 @@
       "id": "get_block_tx_count_multi",
       "method": "starknet_getBlockTransactionCount",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": 2
     },
@@ -177,7 +207,9 @@
       "id": "get_block_tx_count_empty",
       "method": "starknet_getBlockTransactionCount",
       "params": {
-        "block_id": { "block_number": "$ref:empty_block.block_number" }
+        "block_id": {
+          "block_number": "$ref:empty_block.block_number"
+        }
       },
       "expected": 0,
       "description": "Empty block must return 0, not error"
@@ -185,7 +217,9 @@
     {
       "id": "get_tx_by_hash_declare",
       "method": "starknet_getTransactionByHash",
-      "params": { "transaction_hash": "$ref:declare_hello.transaction_hash" },
+      "params": {
+        "transaction_hash": "$ref:declare_hello.transaction_hash"
+      },
       "expected": {
         "transaction_hash": "$ref:declare_hello.transaction_hash",
         "type": "DECLARE",
@@ -232,7 +266,9 @@
       "id": "get_tx_by_block_and_index_0",
       "method": "starknet_getTransactionByBlockIdAndIndex",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" },
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        },
         "index": 0
       },
       "expected": {
@@ -245,7 +281,9 @@
       "id": "get_tx_by_block_and_index_1",
       "method": "starknet_getTransactionByBlockIdAndIndex",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" },
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        },
         "index": 1
       },
       "expected": {
@@ -257,7 +295,9 @@
     {
       "id": "get_tx_receipt_declare",
       "method": "starknet_getTransactionReceipt",
-      "params": { "transaction_hash": "$ref:declare_hello.transaction_hash" },
+      "params": {
+        "transaction_hash": "$ref:declare_hello.transaction_hash"
+      },
       "expected": {
         "type": "DECLARE",
         "transaction_hash": "$ref:declare_hello.transaction_hash",
@@ -265,7 +305,10 @@
         "block_number": "$ref:declare_hello.block_number",
         "execution_status": "SUCCEEDED",
         "finality_status": "ACCEPTED_ON_L2",
-        "actual_fee": { "amount": "$any", "unit": "FRI" },
+        "actual_fee": {
+          "amount": "$any",
+          "unit": "FRI"
+        },
         "execution_resources": {
           "l1_gas": "$exists",
           "l2_gas": "$exists",
@@ -288,7 +331,10 @@
         "block_number": "$ref:invoke_increase_100.block_number",
         "execution_status": "SUCCEEDED",
         "finality_status": "ACCEPTED_ON_L2",
-        "actual_fee": { "amount": "$any", "unit": "FRI" }
+        "actual_fee": {
+          "amount": "$any",
+          "unit": "FRI"
+        }
       },
       "description": "invoke_increase_42 is in same block as invoke_increase_100"
     },
@@ -310,7 +356,9 @@
     {
       "id": "get_tx_receipt_l1_handler",
       "method": "starknet_getTransactionReceipt",
-      "params": { "transaction_hash": "$ref:l1_handler_call.transaction_hash" },
+      "params": {
+        "transaction_hash": "$ref:l1_handler_call.transaction_hash"
+      },
       "expected": {
         "type": "L1_HANDLER",
         "execution_status": "SUCCEEDED",
@@ -334,7 +382,9 @@
       "id": "get_state_update_declare",
       "method": "starknet_getStateUpdate",
       "params": {
-        "block_id": { "block_number": "$ref:declare_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:declare_hello.block_number"
+        }
       },
       "expected": {
         "block_hash": "$ref:declare_hello.block_hash",
@@ -356,7 +406,9 @@
       "id": "get_state_update_deploy",
       "method": "starknet_getStateUpdate",
       "params": {
-        "block_id": { "block_number": "$ref:deploy_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_hello.block_number"
+        }
       },
       "expected": {
         "state_diff": {
@@ -370,7 +422,9 @@
       "id": "get_state_update_invoke",
       "method": "starknet_getStateUpdate",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": {
         "state_diff": {
@@ -386,7 +440,9 @@
       "params": {
         "contract_address": "$ref:deploy_hello.contract_address",
         "key": "$computed:sn_keccak:balance",
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": "0x8e",
       "description": "HelloStarknet.balance = 0x2a + 0x64 = 0x8e (142). Key computed by runner via sn_keccak('balance')."
@@ -397,7 +453,9 @@
       "params": {
         "contract_address": "$ref:deploy_hello.contract_address",
         "key": "$computed:sn_keccak:balance",
-        "block_id": { "block_number": "$ref:deploy_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_hello.block_number"
+        }
       },
       "expected": "0x0",
       "description": "Balance is 0 right after deploy, before any invoke. Catches: block_id ignored."
@@ -416,7 +474,9 @@
       "id": "get_nonce_at_genesis",
       "method": "starknet_getNonce",
       "params": {
-        "block_id": { "block_number": 0 },
+        "block_id": {
+          "block_number": 0
+        },
         "contract_address": "0x055be462e718c4166d656d11f89e341115b8bc82389c3762a10eade04fcb225d"
       },
       "expected": "0x0",
@@ -469,7 +529,9 @@
     {
       "id": "get_compiled_casm",
       "method": "starknet_getCompiledCasm",
-      "params": { "class_hash": "$ref:declare_hello.class_hash" },
+      "params": {
+        "class_hash": "$ref:declare_hello.class_hash"
+      },
       "expected": {
         "prime": "$any",
         "compiler_version": "$any",
@@ -515,7 +577,9 @@
           "entry_point_selector": "$computed:sn_keccak:get_balance",
           "calldata": []
         },
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": ["0x8e"],
       "description": "get_balance() returns 142. Cross-validates with getStorageAt."
@@ -529,7 +593,9 @@
           "entry_point_selector": "$computed:sn_keccak:get_balance",
           "calldata": []
         },
-        "block_id": { "block_number": "$ref:deploy_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_hello.block_number"
+        }
       },
       "expected": ["0x0"],
       "description": "Balance is 0 after deploy, before invoke. Catches: call ignores block_id."
@@ -553,6 +619,26 @@
         "resourceBounds": "$any"
       },
       "description": "Fee estimate via starknet.js Account. Returns overall_fee, unit, resourceBounds."
+    },
+    {
+      "id": "estimate_message_fee",
+      "method": "starknet_estimateMessageFee",
+      "params": {
+        "message": {
+          "from_address": "0x00000000000000000000000000000000deadbeef",
+          "to_address": "$ref:deploy_new_account.contract_address",
+          "entry_point_selector": "$computed:sn_keccak:l1_handler_entrypoint",
+          "payload": ["0x1", "0x2"]
+        },
+        "block_id": "latest"
+      },
+      "expected": {
+        "overall_fee": "$gt:0",
+        "unit": "WEI",
+        "l1_gas_consumed": "$exists",
+        "l2_gas_consumed": "$exists"
+      },
+      "description": "Estimate fee for a message whose L1 handler executes successfully. Regression: the handler used to be built with paid_fee_on_l1=0, which blockifier rejects on the success path, so every valid message errored (and reverted handlers were priced instead)."
     },
     {
       "id": "simulate_transactions",
@@ -587,7 +673,9 @@
       "id": "trace_block_transactions",
       "method": "starknet_traceBlockTransactions",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": "$length:2",
       "description": "Multi-tx block must produce 2 traces"
@@ -597,8 +685,12 @@
       "method": "starknet_getEvents",
       "params": {
         "filter": {
-          "from_block": { "block_number": "$ref:transfer_strk.block_number" },
-          "to_block": { "block_number": "$ref:transfer_strk.block_number" },
+          "from_block": {
+            "block_number": "$ref:transfer_strk.block_number"
+          },
+          "to_block": {
+            "block_number": "$ref:transfer_strk.block_number"
+          },
           "address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
           "keys": [["$computed:sn_keccak:Transfer"]],
           "chunk_size": 100
@@ -610,6 +702,45 @@
       "description": "ERC20 Transfer events in transfer block"
     },
     {
+      "id": "get_events_beyond_tip_numeric",
+      "method": "starknet_getEvents",
+      "params": {
+        "filter": {
+          "from_block": {
+            "block_number": 100000
+          },
+          "to_block": {
+            "block_number": 200000
+          },
+          "chunk_size": 10
+        }
+      },
+      "expected": {
+        "events": "$length:0",
+        "continuation_token": null
+      },
+      "description": "Numeric range bounds past the tip return an empty page, not BLOCK_NOT_FOUND, like pathfinder and juno."
+    },
+    {
+      "id": "get_events_to_block_beyond_tip",
+      "method": "starknet_getEvents",
+      "params": {
+        "filter": {
+          "from_block": {
+            "block_number": 0
+          },
+          "to_block": {
+            "block_number": 100000
+          },
+          "chunk_size": 5
+        }
+      },
+      "expected": {
+        "events": "$length_gte:1"
+      },
+      "description": "An out-of-range numeric to_block scans up to the tip and still returns events."
+    },
+    {
       "id": "get_events_messaging",
       "method": "starknet_getEvents",
       "params": {
@@ -617,7 +748,9 @@
           "from_block": {
             "block_number": "$ref:invoke_fire_event.block_number"
           },
-          "to_block": { "block_number": "$ref:invoke_fire_event.block_number" },
+          "to_block": {
+            "block_number": "$ref:invoke_fire_event.block_number"
+          },
           "address": "$ref:deploy_messaging.contract_address",
           "keys": [],
           "chunk_size": 100
@@ -664,8 +797,12 @@
       "method": "starknet_getEvents",
       "params": {
         "filter": {
-          "from_block": { "block_number": "$ref:l1_handler_call.block_number" },
-          "to_block": { "block_number": "$ref:l1_handler_call.block_number" },
+          "from_block": {
+            "block_number": "$ref:l1_handler_call.block_number"
+          },
+          "to_block": {
+            "block_number": "$ref:l1_handler_call.block_number"
+          },
           "address": "$ref:deploy_new_account.contract_address",
           "keys": [],
           "chunk_size": 100

--- a/tests/js_tests/fixtures/v0_10_2/error_assertions.json
+++ b/tests/js_tests/fixtures/v0_10_2/error_assertions.json
@@ -5,28 +5,42 @@
       "id": "unknown_method_returns_32601",
       "method": "starknet_thisMethodDoesNotExist",
       "params": {},
-      "expected_error": { "code": -32601 },
+      "expected_error": {
+        "code": -32601
+      },
       "description": "Unknown method must return JSON-RPC Method not found"
     },
     {
       "id": "invalid_params_getBlockWithTxs",
       "method": "starknet_getBlockWithTxs",
-      "params": { "bad": "payload" },
-      "expected_error": { "code": -32602 },
+      "params": {
+        "bad": "payload"
+      },
+      "expected_error": {
+        "code": -32602
+      },
       "description": "Known method with invalid params must return Invalid params"
     },
     {
       "id": "invalid_params_getTransactionByHash",
       "method": "starknet_getTransactionByHash",
       "params": {},
-      "expected_error": { "code": -32602 },
+      "expected_error": {
+        "code": -32602
+      },
       "description": "Missing required transaction_hash param"
     },
     {
       "id": "block_not_found",
       "method": "starknet_getBlockWithTxHashes",
-      "params": { "block_id": { "block_number": 999999 } },
-      "expected_error": { "code": 24 },
+      "params": {
+        "block_id": {
+          "block_number": 999999
+        }
+      },
+      "expected_error": {
+        "code": 24
+      },
       "description": "Non-existent block number returns BLOCK_NOT_FOUND (code 24)"
     },
     {
@@ -35,7 +49,9 @@
       "params": {
         "transaction_hash": "0x0000000000000000000000000000000000000000000000000000000000dead"
       },
-      "expected_error": { "code": 29 },
+      "expected_error": {
+        "code": 29
+      },
       "description": "Non-existent tx hash returns TXN_HASH_NOT_FOUND (code 29)"
     },
     {
@@ -45,7 +61,9 @@
         "block_id": "latest",
         "contract_address": "0x0000000000000000000000000000000000000000000000000000000000dead"
       },
-      "expected_error": { "code": 20 },
+      "expected_error": {
+        "code": 20
+      },
       "description": "Non-existent contract returns CONTRACT_NOT_FOUND (code 20)"
     },
     {
@@ -55,17 +73,23 @@
         "block_id": "latest",
         "class_hash": "0x0000000000000000000000000000000000000000000000000000000000dead"
       },
-      "expected_error": { "code": 28 },
+      "expected_error": {
+        "code": 28
+      },
       "description": "Non-existent class hash returns CLASS_HASH_NOT_FOUND (code 28)"
     },
     {
       "id": "invalid_tx_index",
       "method": "starknet_getTransactionByBlockIdAndIndex",
       "params": {
-        "block_id": { "block_number": 0 },
+        "block_id": {
+          "block_number": 0
+        },
         "index": 999
       },
-      "expected_error": { "code": 27 },
+      "expected_error": {
+        "code": 27
+      },
       "description": "Out-of-range tx index returns INVALID_TXN_INDEX (code 27)"
     },
     {
@@ -74,7 +98,9 @@
       "params": {
         "transaction_hash": "0x0000000000000000000000000000000000000000000000000000000000000001"
       },
-      "expected_error": { "code": 29 },
+      "expected_error": {
+        "code": 29
+      },
       "description": "Unknown L1 tx hash returns TXN_HASH_NOT_FOUND (code 29)"
     },
     {
@@ -91,6 +117,115 @@
       },
       "expected_error": { "code": 40 },
       "description": "Reverted L1 handler fee estimation returns CONTRACT_ERROR (code 40)"
+    },
+    {
+      "id": "call_non_existent_entrypoint",
+      "method": "starknet_call",
+      "params": {
+        "request": {
+          "contract_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+          "entry_point_selector": "$computed:sn_keccak:definitely_not_an_entrypoint",
+          "calldata": []
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 21
+      },
+      "description": "Calling a non-existent selector returns ENTRYPOINT_NOT_FOUND (21). Regression: blockifier >= 0.13.4 reports this as a successful execution with ENTRYPOINT_NOT_FOUND retdata, which used to be returned as a successful call result."
+    },
+    {
+      "id": "call_non_existent_contract",
+      "method": "starknet_call",
+      "params": {
+        "request": {
+          "contract_address": "0x0000000000000000000000000000000000000000000000000000000000dead",
+          "entry_point_selector": "$computed:sn_keccak:get_balance",
+          "calldata": []
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 20
+      },
+      "description": "Calling a non-existent contract returns CONTRACT_NOT_FOUND (20)."
+    },
+    {
+      "id": "call_reverted_structured_error",
+      "method": "starknet_call",
+      "params": {
+        "request": {
+          "contract_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+          "entry_point_selector": "$computed:sn_keccak:transfer",
+          "calldata": [
+            "0x055be462e718c4166d656d11f89e341115b8bc82389c3762a10eade04fcb225d",
+            "0x1",
+            "0x0"
+          ]
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 40,
+        "data": {
+          "revert_error": {
+            "contract_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+            "selector": "$computed:sn_keccak:transfer",
+            "error": "$exists"
+          }
+        }
+      },
+      "description": "A reverted call (caller of starknet_call is 0, so the ERC20 panics with ERC20: transfer from 0) returns CONTRACT_ERROR (40) with the structured CONTRACT_EXECUTION_ERROR object as data, not a successful result with the panic retdata."
+    },
+    {
+      "id": "estimate_message_fee_reverted_handler",
+      "method": "starknet_estimateMessageFee",
+      "params": {
+        "message": {
+          "from_address": "0x000000000000000000000000000000000000beef",
+          "to_address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+          "entry_point_selector": "$computed:sn_keccak:l1_handler_entrypoint",
+          "payload": ["0x1", "0x2"]
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 40
+      },
+      "description": "A message whose handler fails (the fee token has no l1 handler) returns CONTRACT_ERROR (40). Regression: blockifier reports a failed L1 handler as a successful execution with revert_error set, which used to be priced as a fee estimate."
+    },
+    {
+      "id": "estimate_message_fee_contract_not_found",
+      "method": "starknet_estimateMessageFee",
+      "params": {
+        "message": {
+          "from_address": "0x000000000000000000000000000000000000beef",
+          "to_address": "0x0000000000000000000000000000000000000000000000000000000000dead",
+          "entry_point_selector": "$computed:sn_keccak:l1_handler_entrypoint",
+          "payload": ["0x1", "0x2"]
+        },
+        "block_id": "latest"
+      },
+      "expected_error": {
+        "code": 20
+      },
+      "description": "A message to a non-existent contract returns CONTRACT_NOT_FOUND (20) on v0.10+."
+    },
+    {
+      "id": "get_events_unknown_hash_bound",
+      "method": "starknet_getEvents",
+      "params": {
+        "filter": {
+          "from_block": {
+            "block_hash": "0x0000000000000000000000000000000000000000000000000000000000dead"
+          },
+          "chunk_size": 10
+        }
+      },
+      "expected_error": {
+        "code": 24
+      },
+      "description": "Hash range bounds must resolve through the backend: an unknown block hash is BLOCK_NOT_FOUND (24). Only numeric bounds are exempt from existence checks."
     }
   ]
 }

--- a/tests/js_tests/fixtures/v0_10_2/read_assertions.json
+++ b/tests/js_tests/fixtures/v0_10_2/read_assertions.json
@@ -40,7 +40,9 @@
       "id": "get_block_tx_hashes_single",
       "method": "starknet_getBlockWithTxHashes",
       "params": {
-        "block_id": { "block_number": "$ref:declare_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:declare_hello.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -52,9 +54,18 @@
         "starknet_version": "$any",
         "timestamp": "$gt:0",
         "l1_da_mode": "$any",
-        "l1_gas_price": { "price_in_fri": "$any", "price_in_wei": "$any" },
-        "l1_data_gas_price": { "price_in_fri": "$any", "price_in_wei": "$any" },
-        "l2_gas_price": { "price_in_fri": "$any", "price_in_wei": "$any" },
+        "l1_gas_price": {
+          "price_in_fri": "$any",
+          "price_in_wei": "$any"
+        },
+        "l1_data_gas_price": {
+          "price_in_fri": "$any",
+          "price_in_wei": "$any"
+        },
+        "l2_gas_price": {
+          "price_in_fri": "$any",
+          "price_in_wei": "$any"
+        },
         "transaction_commitment": "$any",
         "event_commitment": "$any",
         "receipt_commitment": "$any",
@@ -70,7 +81,9 @@
       "id": "get_block_tx_hashes_multi",
       "method": "starknet_getBlockWithTxHashes",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -87,7 +100,9 @@
       "id": "get_block_tx_hashes_by_hash",
       "method": "starknet_getBlockWithTxHashes",
       "params": {
-        "block_id": { "block_hash": "$ref:declare_hello.block_hash" }
+        "block_id": {
+          "block_hash": "$ref:declare_hello.block_hash"
+        }
       },
       "expected": {
         "block_hash": "$ref:declare_hello.block_hash",
@@ -99,7 +114,9 @@
       "id": "get_block_with_txs",
       "method": "starknet_getBlockWithTxs",
       "params": {
-        "block_id": { "block_number": "$ref:declare_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:declare_hello.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -123,7 +140,9 @@
       "id": "get_block_with_txs_deploy_account",
       "method": "starknet_getBlockWithTxs",
       "params": {
-        "block_id": { "block_number": "$ref:deploy_new_account.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_new_account.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
@@ -135,26 +154,35 @@
       "id": "get_block_with_receipts",
       "method": "starknet_getBlockWithReceipts",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": {
         "status": "ACCEPTED_ON_L2",
         "transactions": [
           {
-            "transaction": { "type": "INVOKE" },
+            "transaction": {
+              "type": "INVOKE"
+            },
             "receipt": {
               "type": "INVOKE",
               "transaction_hash": "$ref:invoke_increase_42.transaction_hash",
               "execution_status": "SUCCEEDED",
               "finality_status": "ACCEPTED_ON_L2",
-              "actual_fee": { "amount": "$any", "unit": "FRI" },
+              "actual_fee": {
+                "amount": "$any",
+                "unit": "FRI"
+              },
               "execution_resources": "$any",
               "events": "$any",
               "messages_sent": "$any"
             }
           },
           {
-            "transaction": { "type": "INVOKE" },
+            "transaction": {
+              "type": "INVOKE"
+            },
             "receipt": {
               "type": "INVOKE",
               "transaction_hash": "$ref:invoke_increase_100.transaction_hash",
@@ -169,7 +197,9 @@
       "id": "get_block_tx_count_multi",
       "method": "starknet_getBlockTransactionCount",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": 2
     },
@@ -177,7 +207,9 @@
       "id": "get_block_tx_count_empty",
       "method": "starknet_getBlockTransactionCount",
       "params": {
-        "block_id": { "block_number": "$ref:empty_block.block_number" }
+        "block_id": {
+          "block_number": "$ref:empty_block.block_number"
+        }
       },
       "expected": 0,
       "description": "Empty block must return 0, not error"
@@ -185,7 +217,9 @@
     {
       "id": "get_tx_by_hash_declare",
       "method": "starknet_getTransactionByHash",
-      "params": { "transaction_hash": "$ref:declare_hello.transaction_hash" },
+      "params": {
+        "transaction_hash": "$ref:declare_hello.transaction_hash"
+      },
       "expected": {
         "transaction_hash": "$ref:declare_hello.transaction_hash",
         "type": "DECLARE",
@@ -232,7 +266,9 @@
       "id": "get_tx_by_block_and_index_0",
       "method": "starknet_getTransactionByBlockIdAndIndex",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" },
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        },
         "index": 0
       },
       "expected": {
@@ -245,7 +281,9 @@
       "id": "get_tx_by_block_and_index_1",
       "method": "starknet_getTransactionByBlockIdAndIndex",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" },
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        },
         "index": 1
       },
       "expected": {
@@ -257,7 +295,9 @@
     {
       "id": "get_tx_receipt_declare",
       "method": "starknet_getTransactionReceipt",
-      "params": { "transaction_hash": "$ref:declare_hello.transaction_hash" },
+      "params": {
+        "transaction_hash": "$ref:declare_hello.transaction_hash"
+      },
       "expected": {
         "type": "DECLARE",
         "transaction_hash": "$ref:declare_hello.transaction_hash",
@@ -265,7 +305,10 @@
         "block_number": "$ref:declare_hello.block_number",
         "execution_status": "SUCCEEDED",
         "finality_status": "ACCEPTED_ON_L2",
-        "actual_fee": { "amount": "$any", "unit": "FRI" },
+        "actual_fee": {
+          "amount": "$any",
+          "unit": "FRI"
+        },
         "execution_resources": {
           "l1_gas": "$exists",
           "l2_gas": "$exists",
@@ -288,7 +331,10 @@
         "block_number": "$ref:invoke_increase_100.block_number",
         "execution_status": "SUCCEEDED",
         "finality_status": "ACCEPTED_ON_L2",
-        "actual_fee": { "amount": "$any", "unit": "FRI" }
+        "actual_fee": {
+          "amount": "$any",
+          "unit": "FRI"
+        }
       },
       "description": "invoke_increase_42 is in same block as invoke_increase_100"
     },
@@ -310,7 +356,9 @@
     {
       "id": "get_tx_receipt_l1_handler",
       "method": "starknet_getTransactionReceipt",
-      "params": { "transaction_hash": "$ref:l1_handler_call.transaction_hash" },
+      "params": {
+        "transaction_hash": "$ref:l1_handler_call.transaction_hash"
+      },
       "expected": {
         "type": "L1_HANDLER",
         "execution_status": "SUCCEEDED",
@@ -334,7 +382,9 @@
       "id": "get_state_update_declare",
       "method": "starknet_getStateUpdate",
       "params": {
-        "block_id": { "block_number": "$ref:declare_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:declare_hello.block_number"
+        }
       },
       "expected": {
         "block_hash": "$ref:declare_hello.block_hash",
@@ -356,7 +406,9 @@
       "id": "get_state_update_deploy",
       "method": "starknet_getStateUpdate",
       "params": {
-        "block_id": { "block_number": "$ref:deploy_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_hello.block_number"
+        }
       },
       "expected": {
         "state_diff": {
@@ -370,7 +422,9 @@
       "id": "get_state_update_invoke",
       "method": "starknet_getStateUpdate",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": {
         "state_diff": {
@@ -386,7 +440,9 @@
       "params": {
         "contract_address": "$ref:deploy_hello.contract_address",
         "key": "$computed:sn_keccak:balance",
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": "0x8e",
       "description": "HelloStarknet.balance = 0x2a + 0x64 = 0x8e (142). Key computed by runner via sn_keccak('balance')."
@@ -397,7 +453,9 @@
       "params": {
         "contract_address": "$ref:deploy_hello.contract_address",
         "key": "$computed:sn_keccak:balance",
-        "block_id": { "block_number": "$ref:deploy_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_hello.block_number"
+        }
       },
       "expected": "0x0",
       "description": "Balance is 0 right after deploy, before any invoke. Catches: block_id ignored."
@@ -416,7 +474,9 @@
       "id": "get_nonce_at_genesis",
       "method": "starknet_getNonce",
       "params": {
-        "block_id": { "block_number": 0 },
+        "block_id": {
+          "block_number": 0
+        },
         "contract_address": "0x055be462e718c4166d656d11f89e341115b8bc82389c3762a10eade04fcb225d"
       },
       "expected": "0x0",
@@ -469,7 +529,9 @@
     {
       "id": "get_compiled_casm",
       "method": "starknet_getCompiledCasm",
-      "params": { "class_hash": "$ref:declare_hello.class_hash" },
+      "params": {
+        "class_hash": "$ref:declare_hello.class_hash"
+      },
       "expected": {
         "prime": "$any",
         "compiler_version": "$any",
@@ -515,7 +577,9 @@
           "entry_point_selector": "$computed:sn_keccak:get_balance",
           "calldata": []
         },
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": ["0x8e"],
       "description": "get_balance() returns 142. Cross-validates with getStorageAt."
@@ -529,7 +593,9 @@
           "entry_point_selector": "$computed:sn_keccak:get_balance",
           "calldata": []
         },
-        "block_id": { "block_number": "$ref:deploy_hello.block_number" }
+        "block_id": {
+          "block_number": "$ref:deploy_hello.block_number"
+        }
       },
       "expected": ["0x0"],
       "description": "Balance is 0 after deploy, before invoke. Catches: call ignores block_id."
@@ -553,6 +619,26 @@
         "resourceBounds": "$any"
       },
       "description": "Fee estimate via starknet.js Account. Returns overall_fee, unit, resourceBounds."
+    },
+    {
+      "id": "estimate_message_fee",
+      "method": "starknet_estimateMessageFee",
+      "params": {
+        "message": {
+          "from_address": "0x00000000000000000000000000000000deadbeef",
+          "to_address": "$ref:deploy_new_account.contract_address",
+          "entry_point_selector": "$computed:sn_keccak:l1_handler_entrypoint",
+          "payload": ["0x1", "0x2"]
+        },
+        "block_id": "latest"
+      },
+      "expected": {
+        "overall_fee": "$gt:0",
+        "unit": "WEI",
+        "l1_gas_consumed": "$exists",
+        "l2_gas_consumed": "$exists"
+      },
+      "description": "Estimate fee for a message whose L1 handler executes successfully. Regression: the handler used to be built with paid_fee_on_l1=0, which blockifier rejects on the success path, so every valid message errored (and reverted handlers were priced instead)."
     },
     {
       "id": "simulate_transactions",
@@ -587,7 +673,9 @@
       "id": "trace_block_transactions",
       "method": "starknet_traceBlockTransactions",
       "params": {
-        "block_id": { "block_number": "$ref:invoke_increase_100.block_number" }
+        "block_id": {
+          "block_number": "$ref:invoke_increase_100.block_number"
+        }
       },
       "expected": "$length:2",
       "description": "Multi-tx block must produce 2 traces"
@@ -597,8 +685,12 @@
       "method": "starknet_getEvents",
       "params": {
         "filter": {
-          "from_block": { "block_number": "$ref:transfer_strk.block_number" },
-          "to_block": { "block_number": "$ref:transfer_strk.block_number" },
+          "from_block": {
+            "block_number": "$ref:transfer_strk.block_number"
+          },
+          "to_block": {
+            "block_number": "$ref:transfer_strk.block_number"
+          },
           "address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
           "keys": [["$computed:sn_keccak:Transfer"]],
           "chunk_size": 100
@@ -610,6 +702,45 @@
       "description": "ERC20 Transfer events in transfer block"
     },
     {
+      "id": "get_events_beyond_tip_numeric",
+      "method": "starknet_getEvents",
+      "params": {
+        "filter": {
+          "from_block": {
+            "block_number": 100000
+          },
+          "to_block": {
+            "block_number": 200000
+          },
+          "chunk_size": 10
+        }
+      },
+      "expected": {
+        "events": "$length:0",
+        "continuation_token": null
+      },
+      "description": "Numeric range bounds past the tip return an empty page, not BLOCK_NOT_FOUND, like pathfinder and juno."
+    },
+    {
+      "id": "get_events_to_block_beyond_tip",
+      "method": "starknet_getEvents",
+      "params": {
+        "filter": {
+          "from_block": {
+            "block_number": 0
+          },
+          "to_block": {
+            "block_number": 100000
+          },
+          "chunk_size": 5
+        }
+      },
+      "expected": {
+        "events": "$length_gte:1"
+      },
+      "description": "An out-of-range numeric to_block scans up to the tip and still returns events."
+    },
+    {
       "id": "get_events_messaging",
       "method": "starknet_getEvents",
       "params": {
@@ -617,7 +748,9 @@
           "from_block": {
             "block_number": "$ref:invoke_fire_event.block_number"
           },
-          "to_block": { "block_number": "$ref:invoke_fire_event.block_number" },
+          "to_block": {
+            "block_number": "$ref:invoke_fire_event.block_number"
+          },
           "address": "$ref:deploy_messaging.contract_address",
           "keys": [],
           "chunk_size": 100
@@ -664,8 +797,12 @@
       "method": "starknet_getEvents",
       "params": {
         "filter": {
-          "from_block": { "block_number": "$ref:l1_handler_call.block_number" },
-          "to_block": { "block_number": "$ref:l1_handler_call.block_number" },
+          "from_block": {
+            "block_number": "$ref:l1_handler_call.block_number"
+          },
+          "to_block": {
+            "block_number": "$ref:l1_handler_call.block_number"
+          },
           "address": "$ref:deploy_new_account.contract_address",
           "keys": [],
           "chunk_size": 100

--- a/tests/js_tests/src/types.ts
+++ b/tests/js_tests/src/types.ts
@@ -107,7 +107,10 @@ export interface ErrorAssertion {
   id: string;
   method: string;
   params: any;
-  expected_error: { code: number };
+  /// `data`, when present, is partially matched against the error's data field
+  /// with the same matcher vocabulary as read assertions ($ref/$computed are
+  /// resolved first).
+  expected_error: { code: number; data?: any };
   description?: string;
 }
 

--- a/tests/js_tests/tests/rpc.test.ts
+++ b/tests/js_tests/tests/rpc.test.ts
@@ -1,8 +1,16 @@
 import * as fs from "fs";
 import * as path from "path";
-import { getRpcUrl, getAdminUrl } from "../src/config";
+import { hash as snHash } from "starknet";
+import {
+  getRpcUrl,
+  getAdminUrl,
+  DEFAULT_ACCOUNT_ADDRESS,
+  DEFAULT_PRIVATE_KEY,
+  ERC20_STRK_ADDRESS,
+} from "../src/config";
 import { executeStateSetup } from "../src/state-executor";
-import { runAssertion } from "../src/assertion-runner";
+import { runAssertion, matchValue } from "../src/assertion-runner";
+import { resolveValue } from "../src/ref-resolver";
 import { RpcCaller } from "../src/rpc-caller";
 import { AdminClient } from "../src/admin-client";
 import {
@@ -365,12 +373,41 @@ describe("Starknet RPC multi-version", () => {
             const rpcCaller = new RpcCaller(ctx.rpcUrl);
             const envelope = await rpcCaller.rawCall(
               assertion.method,
-              assertion.params,
+              resolveValue(assertion.params, ctx.results),
             );
 
             expect(envelope.error).toBeDefined();
             expect(envelope.error!.code).toBe(assertion.expected_error.code);
             expect(envelope.result).toBeUndefined();
+
+            // Optional partial match on the error data, with the same matcher
+            // vocabulary as read assertions.
+            if (assertion.expected_error.data !== undefined) {
+              const expectedData = resolveValue(
+                assertion.expected_error.data,
+                ctx.results,
+              );
+              const errors = matchValue(
+                expectedData,
+                envelope.error!.data,
+                "$.error.data",
+              );
+              if (errors.length > 0) {
+                const errorMsg = errors
+                  .map(
+                    (e) =>
+                      `  ${e.path}: expected ${e.expected}, got ${e.actual}`,
+                  )
+                  .join("\n");
+                throw new Error(
+                  `Error data assertion "${assertion.id}" failed (${
+                    assertion.method
+                  }):\n${errorMsg}\nfull data: ${JSON.stringify(
+                    envelope.error!.data,
+                  )}`,
+                );
+              }
+            }
           });
         }
 
@@ -439,7 +476,9 @@ describe("Starknet RPC multi-version", () => {
 
           if (missing.length > 0) {
             console.warn(
-              `[method-surface] v${fixture.stateSetup.version} methods in spec but not exposed: ${missing.join(", ")}`,
+              `[method-surface] v${
+                fixture.stateSetup.version
+              } methods in spec but not exposed: ${missing.join(", ")}`,
             );
           }
           expect(missing).toEqual([]);
@@ -463,7 +502,9 @@ describe("Starknet RPC multi-version", () => {
 
           if (untested.length > 0) {
             console.warn(
-              `[coverage] v${fixture.stateSetup.version} spec methods without test assertions: ${untested.join(", ")}`,
+              `[coverage] v${
+                fixture.stateSetup.version
+              } spec methods without test assertions: ${untested.join(", ")}`,
             );
           }
           expect(untested.length).toBe(0);
@@ -591,4 +632,455 @@ describe("Starknet RPC multi-version", () => {
       });
     });
   }
+
+  // ---- Phase 6: Spec failure-path regressions ----
+  // The v0.10.x failure paths are covered by the fixture error/read assertions
+  // (the original format, with $ref/$computed resolution and OpenRPC spec
+  // validation). This phase only covers what the fixtures cannot express,
+  // scoped to the specs we track (v0.9 and above; older endpoints are kept
+  // as-is and not spec-pinned here):
+  //  - the same wire semantics on v0.9.0, the spec-relevant endpoint with no
+  //    fixture directory;
+  //  - estimateFee/simulateTransactions semantics that need a live nonce or
+  //    generated batches (SKIP_VALIDATE nonce relaxation, the failing
+  //    transaction_index, the -32602 batch cap);
+  //  - submitting a transaction that reverts on execution, to assert
+  //    failure_reason in getTransactionStatus.
+  describe("Spec failure-path regressions", () => {
+    // Spec-relevant (v0.9+) endpoints with no fixture directory: covered here.
+    const NON_FIXTURE_VERSIONS = ["0.9.0"];
+
+    const ENTRYPOINT_NOT_FOUND_FELT =
+      "0x454e545259504f494e545f4e4f545f464f554e44"; // 'ENTRYPOINT_NOT_FOUND'
+    const FROM_L1_ADDRESS = "0x000000000000000000000000000000000000beef";
+    const NON_EXISTENT_CONTRACT =
+      "0x000000000000000000000000000000000000000000000000000000000000dead";
+
+    const callerFor = (version: string) => new RpcCaller(getRpcUrl(version));
+    const toHex = (n: bigint) => "0x" + n.toString(16);
+
+    async function fetchNonce(caller: RpcCaller): Promise<bigint> {
+      const nonce = await caller.call("starknet_getNonce", {
+        block_id: "latest",
+        contract_address: DEFAULT_ACCOUNT_ADDRESS,
+      });
+      return BigInt(nonce);
+    }
+
+    /// A fee-token transfer of amount (low, high) to self, as a raw
+    /// broadcasted invoke v3 with a dummy signature (only usable with
+    /// SKIP_VALIDATE or where validation is expected to fail).
+    function transferTx(
+      nonce: string,
+      amountLow: string,
+      amountHigh: string,
+    ): any {
+      const resource_bounds = {
+        l1_gas: { max_amount: "0x186a0", max_price_per_unit: "0x100000000000" },
+        l2_gas: {
+          max_amount: "0x1000000000",
+          max_price_per_unit: "0x100000000",
+        },
+        l1_data_gas: {
+          max_amount: "0x186a0",
+          max_price_per_unit: "0x100000000000",
+        },
+      };
+      return {
+        type: "INVOKE",
+        version: "0x3",
+        sender_address: DEFAULT_ACCOUNT_ADDRESS,
+        // OZ cairo1 __execute__ calldata: [n_calls, to, selector, len, ...]
+        calldata: [
+          "0x1",
+          ERC20_STRK_ADDRESS,
+          snHash.getSelectorFromName("transfer"),
+          "0x3",
+          DEFAULT_ACCOUNT_ADDRESS,
+          amountLow,
+          amountHigh,
+        ],
+        signature: ["0x1", "0x2"],
+        nonce,
+        resource_bounds,
+        tip: "0x0",
+        paymaster_data: [],
+        account_deployment_data: [],
+        nonce_data_availability_mode: "L1",
+        fee_data_availability_mode: "L1",
+      };
+    }
+
+    describe("starknet_call failure surfacing (non-fixture versions)", () => {
+      for (const version of NON_FIXTURE_VERSIONS) {
+        it(`v${version}: non-existent selector returns ENTRYPOINT_NOT_FOUND (21), not retdata`, async () => {
+          const envelope = await callerFor(version).rawCall("starknet_call", {
+            request: {
+              contract_address: ERC20_STRK_ADDRESS,
+              entry_point_selector: snHash.getSelectorFromName(
+                "definitely_not_an_entrypoint",
+              ),
+              calldata: [],
+            },
+            block_id: "latest",
+          });
+
+          // Regression guard: this used to be a *successful* response whose
+          // result was ["0x454e...44"] ('ENTRYPOINT_NOT_FOUND').
+          if (envelope.result !== undefined) {
+            expect(envelope.result).not.toEqual([ENTRYPOINT_NOT_FOUND_FELT]);
+          }
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(21);
+        });
+
+        it(`v${version}: non-existent contract returns CONTRACT_NOT_FOUND (20)`, async () => {
+          const envelope = await callerFor(version).rawCall("starknet_call", {
+            request: {
+              contract_address: NON_EXISTENT_CONTRACT,
+              entry_point_selector: snHash.getSelectorFromName("get_balance"),
+              calldata: [],
+            },
+            block_id: "latest",
+          });
+
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(20);
+        });
+
+        it(`v${version}: reverted call returns CONTRACT_ERROR (40) with structured revert_error`, async () => {
+          // The caller address of starknet_call is 0, so the ERC20 panics
+          // with 'ERC20: transfer from 0'. This used to be a successful call
+          // result containing the panic felts.
+          const envelope = await callerFor(version).rawCall("starknet_call", {
+            request: {
+              contract_address: ERC20_STRK_ADDRESS,
+              entry_point_selector: snHash.getSelectorFromName("transfer"),
+              calldata: [DEFAULT_ACCOUNT_ADDRESS, "0x1", "0x0"],
+            },
+            block_id: "latest",
+          });
+
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(40);
+          const revertError = envelope.error!.data?.revert_error;
+          expect(revertError).toBeDefined();
+          expect(typeof revertError).toBe("object");
+          expect(normHex(revertError.contract_address)).toBe(
+            normHex(ERC20_STRK_ADDRESS),
+          );
+          expect(normHex(revertError.selector)).toBe(
+            normHex(snHash.getSelectorFromName("transfer")),
+          );
+          expect(JSON.stringify(revertError)).toContain(
+            "ERC20: transfer from 0",
+          );
+        });
+      }
+    });
+
+    describe("estimateMessageFee semantics (non-fixture versions)", () => {
+      for (const version of NON_FIXTURE_VERSIONS) {
+        it(`v${version}: valid message returns a non-zero fee estimate`, async () => {
+          // TestContract (deployed as the extra account) has
+          // #[l1_handler] l1_handler_entrypoint(from_address, arg1, arg2).
+          const target =
+            sharedResults.get("deploy_new_account")?.contract_address;
+          expect(target).toBeDefined();
+
+          // Regression guard: the handler used to be built with
+          // paid_fee_on_l1=0, which blockifier rejects on the *success* path,
+          // so every valid message errored.
+          const result = await callerFor(version).call(
+            "starknet_estimateMessageFee",
+            {
+              message: {
+                from_address: FROM_L1_ADDRESS,
+                to_address: target,
+                entry_point_selector: snHash.getSelectorFromName(
+                  "l1_handler_entrypoint",
+                ),
+                payload: ["0x1", "0x2"],
+              },
+              block_id: "latest",
+            },
+          );
+
+          expect(result.overall_fee).toBeDefined();
+          expect(BigInt(result.overall_fee)).toBeGreaterThan(0n);
+        });
+
+        it(`v${version}: message whose handler fails returns CONTRACT_ERROR (40), not a fee`, async () => {
+          // The fee token ERC20 has no l1 handler: executing the message
+          // fails. Blockifier reports this as a successful execution with
+          // revert_error set, which used to be priced as a fee estimate.
+          const envelope = await callerFor(version).rawCall(
+            "starknet_estimateMessageFee",
+            {
+              message: {
+                from_address: FROM_L1_ADDRESS,
+                to_address: ERC20_STRK_ADDRESS,
+                entry_point_selector: snHash.getSelectorFromName(
+                  "l1_handler_entrypoint",
+                ),
+                payload: ["0x1", "0x2"],
+              },
+              block_id: "latest",
+            },
+          );
+
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(40);
+        });
+      }
+    });
+
+    describe("estimateFee error semantics", () => {
+      for (const version of ["0.9.0", "0.10.2"]) {
+        it(`v${version}: SKIP_VALIDATE allows estimating with a future nonce`, async () => {
+          const caller = callerFor(version);
+          const nonce = await fetchNonce(caller);
+
+          const result = await caller.call("starknet_estimateFee", {
+            request: [transferTx(toHex(nonce + 5n), "0x1", "0x0")],
+            simulation_flags: ["SKIP_VALIDATE"],
+            block_id: "latest",
+          });
+
+          expect(result).toHaveLength(1);
+          expect(BigInt(result[0].overall_fee)).toBeGreaterThan(0n);
+        });
+
+        it(`v${version}: future nonce without SKIP_VALIDATE fails with error 41`, async () => {
+          const caller = callerFor(version);
+          const nonce = await fetchNonce(caller);
+
+          const envelope = await caller.rawCall("starknet_estimateFee", {
+            request: [transferTx(toHex(nonce + 5n), "0x1", "0x0")],
+            simulation_flags: [],
+            block_id: "latest",
+          });
+
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(41);
+          expect(envelope.error!.data?.transaction_index).toBe(0);
+        });
+
+        it(`v${version}: error 41 blames the failing transaction with structured execution_error`, async () => {
+          const caller = callerFor(version);
+          const nonce = await fetchNonce(caller);
+
+          // tx0 transfers 1 wei (fine), tx1 transfers more STRK than the
+          // account holds and reverts. The error data must blame index 1,
+          // not default to 0.
+          const envelope = await caller.rawCall("starknet_estimateFee", {
+            request: [
+              transferTx(toHex(nonce), "0x1", "0x0"),
+              transferTx(toHex(nonce + 1n), "0x0", "0xffffffffffffffff"),
+            ],
+            simulation_flags: ["SKIP_VALIDATE"],
+            block_id: "latest",
+          });
+
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(41);
+          expect(envelope.error!.data?.transaction_index).toBe(1);
+          const executionError = envelope.error!.data?.execution_error;
+          // Structured CONTRACT_EXECUTION_ERROR rooted at the sender account.
+          expect(typeof executionError).toBe("object");
+          expect(normHex(executionError.contract_address)).toBe(
+            normHex(DEFAULT_ACCOUNT_ADDRESS),
+          );
+        });
+      }
+
+      for (const version of ["0.9.0", "0.10.2"]) {
+        it(`v${version}: oversized estimateFee batch is rejected with -32602`, async () => {
+          const tx = transferTx("0x0", "0x1", "0x0");
+          const envelope = await callerFor(version).rawCall(
+            "starknet_estimateFee",
+            {
+              request: Array(101).fill(tx),
+              simulation_flags: ["SKIP_VALIDATE"],
+              block_id: "latest",
+            },
+          );
+
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(-32602);
+        });
+      }
+
+      it("v0.10.2: oversized simulateTransactions batch is rejected with -32602", async () => {
+        const tx = transferTx("0x0", "0x1", "0x0");
+        const envelope = await callerFor("0.10.2").rawCall(
+          "starknet_simulateTransactions",
+          {
+            block_id: "latest",
+            transactions: Array(101).fill(tx),
+            simulation_flags: ["SKIP_VALIDATE"],
+          },
+        );
+
+        expect(envelope.error).toBeDefined();
+        expect(envelope.error!.code).toBe(-32602);
+      });
+
+      it("v0.10.2: simulateTransactions with SKIP_VALIDATE allows a future nonce", async () => {
+        const caller = callerFor("0.10.2");
+        const nonce = await fetchNonce(caller);
+
+        const result = await caller.call("starknet_simulateTransactions", {
+          block_id: "latest",
+          transactions: [transferTx(toHex(nonce + 5n), "0x1", "0x0")],
+          simulation_flags: ["SKIP_VALIDATE", "SKIP_FEE_CHARGE"],
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].transaction_trace).toBeDefined();
+      });
+    });
+
+    describe("getEvents numeric range bounds (v0.9.0 has its own implementation and no fixture)", () => {
+      for (const version of ["0.9.0"]) {
+        it(`v${version}: numeric bounds beyond the tip return an empty page, not BLOCK_NOT_FOUND`, async () => {
+          const caller = callerFor(version);
+          const latest = await caller.call("starknet_blockNumber", []);
+
+          const result = await caller.call("starknet_getEvents", {
+            filter: {
+              from_block: { block_number: latest + 1000 },
+              to_block: { block_number: latest + 2000 },
+              chunk_size: 10,
+            },
+          });
+
+          expect(result.events).toEqual([]);
+          // The spec says the token "should not appear if there are no more
+          // pages"; pathfinder omits it.
+          expect(result.continuation_token).toBeUndefined();
+        });
+
+        it(`v${version}: numeric to_block beyond the tip scans up to the tip`, async () => {
+          const caller = callerFor(version);
+          const latest = await caller.call("starknet_blockNumber", []);
+
+          const result = await caller.call("starknet_getEvents", {
+            filter: {
+              from_block: { block_number: 0 },
+              to_block: { block_number: latest + 1000 },
+              chunk_size: 5,
+            },
+          });
+
+          // The chain has events from state setup: an out-of-range to_block
+          // must not error, and must still return them.
+          expect(result.events.length).toBeGreaterThan(0);
+        });
+
+        it(`v${version}: hash bounds must still resolve (unknown hash is BLOCK_NOT_FOUND)`, async () => {
+          const envelope = await callerFor(version).rawCall(
+            "starknet_getEvents",
+            {
+              filter: {
+                from_block: { block_hash: NON_EXISTENT_CONTRACT },
+                chunk_size: 10,
+              },
+            },
+          );
+
+          expect(envelope.error).toBeDefined();
+          expect(envelope.error!.code).toBe(24);
+        });
+      }
+    });
+
+    describe("getTransactionStatus failure_reason", () => {
+      let revertedTxHash: string | undefined;
+
+      it("submits a transaction that reverts on execution", async () => {
+        const { Account, RpcProvider } = await import("starknet");
+
+        const rpcUrl = getRpcUrl("0.10.2");
+        const provider = new RpcProvider({ nodeUrl: rpcUrl });
+        const account = new Account({
+          provider,
+          address: DEFAULT_ACCOUNT_ADDRESS,
+          signer: DEFAULT_PRIVATE_KEY,
+        });
+
+        const admin = new AdminClient(adminUrl);
+        try {
+          await admin.closeBlock();
+          await sleep(1000);
+        } catch {
+          // No pending block to close
+        }
+
+        const nonce = await provider.getNonceForAddress(
+          DEFAULT_ACCOUNT_ADDRESS,
+          "latest",
+        );
+        // Transfer far more STRK than the account holds: validation passes
+        // (real signature, fee is affordable) but execution reverts, so the
+        // transaction is included with execution_status REVERTED.
+        const response = await account.execute(
+          {
+            contractAddress: ERC20_STRK_ADDRESS,
+            entrypoint: "transfer",
+            calldata: [DEFAULT_ACCOUNT_ADDRESS, "0x0", "0xffffffffffffffff"],
+          },
+          {
+            nonce,
+            resourceBounds: {
+              l2_gas: { max_amount: 0x1000000n, max_price_per_unit: 0x100000n },
+              l1_gas: { max_amount: 0x1000n, max_price_per_unit: 0x100000000n },
+              l1_data_gas: {
+                max_amount: 0x1000n,
+                max_price_per_unit: 0x100000000n,
+              },
+            },
+          },
+        );
+
+        revertedTxHash = response.transaction_hash;
+
+        // The shared waiter treats REVERTED as a failure, so poll the status
+        // directly until the node reports one for this transaction.
+        const caller = callerFor("0.10.2");
+        const deadline = Date.now() + 30_000;
+        let included = false;
+        while (Date.now() < deadline) {
+          const envelope = await caller.rawCall(
+            "starknet_getTransactionStatus",
+            { transaction_hash: revertedTxHash },
+          );
+          if (envelope.result !== undefined) {
+            included = true;
+            break;
+          }
+          await sleep(500);
+        }
+        expect(included).toBe(true);
+
+        await admin.closeBlock();
+        await sleep(1000);
+      });
+
+      for (const version of ["0.9.0", "0.10.2"]) {
+        it(`v${version}: reverted transaction carries failure_reason`, async () => {
+          expect(revertedTxHash).toBeDefined();
+
+          const status = await callerFor(version).call(
+            "starknet_getTransactionStatus",
+            { transaction_hash: revertedTxHash },
+          );
+
+          expect(status.execution_status).toBe("REVERTED");
+          expect(typeof status.failure_reason).toBe("string");
+          expect(status.failure_reason.length).toBeGreaterThan(0);
+        });
+      }
+    });
+  });
 });


### PR DESCRIPTION
Three read-method divergences from pathfinder v0.22.5 and juno v0.16.2:

```mermaid
flowchart LR
    subgraph before [" before "]
        A3["status of reverted tx"] --> B3["no failure_reason"]
        A4["getEvents(to_block > tip)"] --> B4[⛔ 24]
        A5["latest / l1_accepted, none yet"] --> B5[⛔ 32 NO_BLOCKS]
    end
    subgraph after [" after "]
        C3["✅ failure_reason: '…'"]
        C4[✅ empty page / scan to tip]
        C5[⛔ 24 BLOCK_NOT_FOUND]
    end
    B3 -.-> C3
    B4 -.-> C4
    B5 -.-> C5
```

- `failure_reason` (spec field, "only appears if execution_status is REVERTED") added to `TxnFinalityAndExecutionStatus`.
- `getEvents` numeric range bounds are no longer required to exist — clients paginating by block number at the chain tip got errors where both references succeed; this also lets a bound reference the pre-confirmed block number.
- `NO_BLOCKS` (32) stays only where the spec defines it (`blockNumber`/`blockHashAndNumber`); tag resolution failures are `BLOCK_NOT_FOUND` (24).

Candidate-transaction visibility was dropped from this PR (candidate status is slated for deprecation).

**Tests:** focused mc-rpc regressions pass locally; full PR CI runs after ready-for-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
