### PR TITLE
[codex] add feeder gateway optimizations

### DIFF
--- a/.github/workflows/task-test-js.yml
+++ b/.github/workflows/task-test-js.yml
@@ -74,6 +74,9 @@ jobs:
             --rpc-cors "*" \
             --rpc-external \
             --rpc-admin \
+            --gateway-enable \
+            --gateway-external \
+            --feeder-gateway-enable \
             --devnet \
             --preset devnet \
             --l1-gas-price 0 \

--- a/.github/workflows/task-test-js.yml
+++ b/.github/workflows/task-test-js.yml
@@ -88,6 +88,7 @@ jobs:
           MADARA_PID=$!
 
           while ! echo exit | nc localhost 9944; do sleep 1; done
+          while ! echo exit | nc localhost 8080; do sleep 1; done
           cd tests/js_tests
           ANVIL_PORT=${{ env.ANVIL_PORT }} CORE_CONTRACT=${{ env.CORE_CONTRACT }} npm test
 

--- a/madara/crates/client/gateway/client/src/methods.rs
+++ b/madara/crates/client/gateway/client/src/methods.rs
@@ -1,7 +1,7 @@
 use super::{builder::GatewayProvider, request_builder::RequestBuilder};
 use blockifier::bouncer::BouncerWeights;
 use mp_class::{ContractClass, FlattenedSierraClass, LegacyContractClass};
-use mp_gateway::block::ProviderBlockPreConfirmed;
+use mp_gateway::block::{ProviderBlockPreConfirmed, ProviderBlockPreConfirmedUpdate};
 use mp_gateway::error::{SequencerError, StarknetError};
 use mp_gateway::feeder::{ProviderTransactionResponse, ProviderTransactionStatus};
 use mp_gateway::user_transaction::{
@@ -9,7 +9,7 @@ use mp_gateway::user_transaction::{
 };
 use mp_gateway::{
     block::{ProviderBlock, ProviderBlockHeader, ProviderBlockSignature},
-    state_update::{ProviderStateUpdate, ProviderStateUpdateWithBlock},
+    state_update::{ProviderStateUpdate, ProviderStateUpdateWithBlock, ProviderStateUpdateWithBlockAndSignature},
     user_transaction::{
         UserDeclareTransaction, UserDeployAccountTransaction, UserInvokeFunctionTransaction, UserTransaction,
     },
@@ -78,6 +78,34 @@ impl GatewayProvider {
                 .with_block_id(&BlockId::Number(block_number));
 
             request.send_get::<ProviderBlockPreConfirmed>().await
+        })
+        .await
+    }
+
+    pub async fn get_preconfirmed_block_optimized(
+        &self,
+        block_id: BlockId,
+        block_identifier: Option<&str>,
+        known_transaction_count: Option<usize>,
+        include_receipts: bool,
+        include_state_diffs: bool,
+    ) -> Result<ProviderBlockPreConfirmedUpdate, SequencerError> {
+        self.retry_get(|| async {
+            let mut request = RequestBuilder::new(&self.client, self.feeder_gateway_url.clone(), self.headers.clone())
+                .add_uri_segment("get_preconfirmed_block")
+                .expect("Failed to add URI segment. This should not fail in prod.")
+                .with_block_id(&block_id)
+                .add_param(Cow::from("includeReceipts"), include_receipts.to_string())
+                .add_param(Cow::from("includeStateDiffs"), include_state_diffs.to_string());
+
+            if let Some(block_identifier) = block_identifier {
+                request = request.add_param(Cow::from("blockIdentifier"), block_identifier.to_owned());
+            }
+            if let Some(known_transaction_count) = known_transaction_count {
+                request = request.add_param(Cow::from("knownTransactionCount"), known_transaction_count.to_string());
+            }
+
+            request.send_get::<ProviderBlockPreConfirmedUpdate>().await
         })
         .await
     }
@@ -183,6 +211,23 @@ impl GatewayProvider {
                 .add_param(Cow::from("includeBlock"), "true");
 
             request.send_get::<ProviderStateUpdateWithBlock>().await
+        })
+        .await
+    }
+
+    pub async fn get_state_update_with_block_and_signature(
+        &self,
+        block_id: BlockId,
+    ) -> Result<ProviderStateUpdateWithBlockAndSignature, SequencerError> {
+        self.retry_get(|| async {
+            let request = RequestBuilder::new(&self.client, self.feeder_gateway_url.clone(), self.headers.clone())
+                .add_uri_segment("get_state_update")
+                .expect("Failed to add URI segment. This should not fail in prod")
+                .with_block_id(&block_id)
+                .add_param(Cow::from("includeBlock"), "true")
+                .add_param(Cow::from("includeSignature"), "true");
+
+            request.send_get::<ProviderStateUpdateWithBlockAndSignature>().await
         })
         .await
     }

--- a/madara/crates/client/gateway/server/src/handler.rs
+++ b/madara/crates/client/gateway/server/src/handler.rs
@@ -22,16 +22,16 @@ use mc_submit_tx::{
 use mp_block::MadaraMaybePreconfirmedBlockInfo;
 use mp_class::{convert::ReadSizeLimiter, ClassInfo, ContractClass};
 use mp_gateway::{
-    block::ProviderBlockPreConfirmed,
+    block::{BlockStatus, ProviderBlock, ProviderBlockSignature},
+    state_update::ProviderStateUpdate,
+};
+use mp_gateway::{
+    block::{ProviderBlockPreConfirmed, ProviderBlockPreConfirmedUnchanged, ProviderBlockPreConfirmedWithInfo},
     feeder::{ProviderTransactionResponse, ProviderTransactionStatus},
     user_transaction::{
         AddTransactionResult, UserDeclareTransaction, UserDeployAccountTransaction, UserInvokeFunctionTransaction,
         UserTransaction,
     },
-};
-use mp_gateway::{
-    block::{BlockStatus, ProviderBlock, ProviderBlockSignature},
-    state_update::ProviderStateUpdate,
 };
 use mp_gateway::{
     error::{StarknetError, StarknetErrorCode},
@@ -42,7 +42,7 @@ use mp_transactions::validated::ValidatedTransaction;
 use serde::Serialize;
 use serde_json::json;
 use starknet_types_core::felt::Felt;
-use std::{borrow::Cow, io::Read, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, io::Read, sync::Arc};
 
 #[cfg(test)]
 use mp_gateway::feeder::{TransactionExecutionStatus, TransactionStatus};
@@ -153,6 +153,58 @@ fn parse_block_id(params: &std::collections::HashMap<String, String>) -> Result<
     })
 }
 
+fn parse_bool_param(params: &HashMap<String, String>, name: &str, default: bool) -> Result<bool, GatewayError> {
+    match params.get(name).map(|value| value.as_str()) {
+        None => Ok(default),
+        Some("true") => Ok(true),
+        Some("false") => Ok(false),
+        Some(value) => Err(StarknetError::new(
+            StarknetErrorCode::MalformedRequest,
+            format!("Invalid boolean value for {name}: {value}"),
+        )
+        .into()),
+    }
+}
+
+fn preconfirmed_block_identifier(header: &mp_block::header::PreconfirmedHeader) -> String {
+    format!(
+        "madara-preconfirmed:{}:{}:{}:{:?}:{:#x}:{:#x}:{:#x}:{:#x}:{:#x}:{:#x}:{:#x}",
+        header.block_number,
+        header.block_timestamp.0,
+        header.protocol_version,
+        header.l1_da_mode,
+        header.sequencer_address,
+        header.gas_prices.eth_l1_gas_price,
+        header.gas_prices.strk_l1_gas_price,
+        header.gas_prices.eth_l1_data_gas_price,
+        header.gas_prices.strk_l1_data_gas_price,
+        header.gas_prices.eth_l2_gas_price,
+        header.gas_prices.strk_l2_gas_price,
+    )
+}
+
+fn slice_preconfirmed_block(block: ProviderBlockPreConfirmed, skip_first_n: usize) -> ProviderBlockPreConfirmed {
+    ProviderBlockPreConfirmed {
+        status: block.status,
+        starknet_version: block.starknet_version,
+        l1_da_mode: block.l1_da_mode,
+        l1_gas_price: block.l1_gas_price,
+        l1_data_gas_price: block.l1_data_gas_price,
+        l2_gas_price: block.l2_gas_price,
+        timestamp: block.timestamp,
+        sequencer_address: block.sequencer_address,
+        transactions: block.transactions.into_iter().skip(skip_first_n).collect(),
+        transaction_receipts: block.transaction_receipts.into_iter().skip(skip_first_n).collect(),
+        transaction_state_diffs: block.transaction_state_diffs.into_iter().skip(skip_first_n).collect(),
+    }
+}
+
+fn block_signature(backend: &Arc<MadaraBackend>, block_hash: Felt) -> Result<Vec<Felt>, GatewayError> {
+    let private_key = backend.chain_config().private_key.as_ref().context("Private key not available for signing")?;
+    let signature = private_key.sign(&block_hash).context("Failed to sign block hash")?;
+    Ok(vec![signature.r, signature.s])
+}
+
 async fn transaction_status_response(
     transaction_hash: Felt,
     backend: &Arc<MadaraBackend>,
@@ -231,14 +283,18 @@ pub async fn handle_get_preconfirmed_block(
         StarknetError::new(StarknetErrorCode::MalformedRequest, "Field blockNumber is required.".into())
     })?;
 
-    let block_number: u64 = block_number
-        .parse()
-        .map_err(|e: std::num::ParseIntError| StarknetError::new(StarknetErrorCode::MalformedRequest, e.to_string()))?;
-
     // Use block_view_on_preconfirmed_or_fake() - this always returns a block
     let mut block = backend
         .block_view_on_preconfirmed_or_fake()
         .map_err(|e| StarknetError::new(StarknetErrorCode::BlockNotFound, e.to_string()))?;
+
+    let current_block_number = block.block_number();
+    let block_number: u64 = match block_number.as_str() {
+        "latest" => current_block_number,
+        value => value.parse().map_err(|e: std::num::ParseIntError| {
+            StarknetError::new(StarknetErrorCode::MalformedRequest, e.to_string())
+        })?,
+    };
 
     // Check if the requested block number matches the pre-confirmed block number
     if block.block_number() != block_number {
@@ -250,6 +306,7 @@ pub async fn handle_get_preconfirmed_block(
     }
 
     block.refresh_with_candidates(); // We want candidates too :)
+    let block_identifier = preconfirmed_block_identifier(block.header());
     let block = {
         let content = block.borrow_content();
         ProviderBlockPreConfirmed::new(
@@ -260,7 +317,54 @@ pub async fn handle_get_preconfirmed_block(
         )
     };
 
-    Ok(create_json_response(hyper::StatusCode::OK, &block))
+    let wants_optimized_response = params.contains_key("blockIdentifier")
+        || params.contains_key("knownTransactionCount")
+        || params.contains_key("includeReceipts")
+        || params.contains_key("includeStateDiffs")
+        || params.get("blockNumber").is_some_and(|value| value == "latest");
+
+    if !wants_optimized_response {
+        return Ok(create_json_response(hyper::StatusCode::OK, &block));
+    }
+
+    let known_block_identifier = params.get("blockIdentifier");
+    let known_transaction_count = params
+        .get("knownTransactionCount")
+        .map(|count| {
+            count.parse().map_err(|e: std::num::ParseIntError| {
+                StarknetError::new(StarknetErrorCode::MalformedRequest, e.to_string())
+            })
+        })
+        .transpose()?
+        .unwrap_or(0);
+    let include_receipts = parse_bool_param(&params, "includeReceipts", true)?;
+    let include_state_diffs = parse_bool_param(&params, "includeStateDiffs", true)?;
+    let transaction_count = block.transactions.len();
+
+    if known_block_identifier.is_some_and(|identifier| identifier == &block_identifier)
+        && known_transaction_count == transaction_count
+    {
+        return Ok(create_json_response(hyper::StatusCode::OK, &ProviderBlockPreConfirmedUnchanged { changed: false }));
+    }
+
+    let skip_first_n = if known_block_identifier.is_some_and(|identifier| identifier == &block_identifier)
+        && known_transaction_count < transaction_count
+    {
+        known_transaction_count
+    } else {
+        0
+    };
+    let block = slice_preconfirmed_block(block, skip_first_n);
+    let response = ProviderBlockPreConfirmedWithInfo::new(
+        block,
+        block_number,
+        block_identifier,
+        true,
+        include_receipts,
+        include_state_diffs,
+    );
+
+    Ok(create_json_response(hyper::StatusCode::OK, &response))
 }
 
 pub async fn handle_get_transaction(
@@ -391,10 +495,10 @@ pub async fn handle_get_signature(
 
     let block_info = confirmed.get_block_info()?;
 
-    let private_key = backend.chain_config().private_key.as_ref().context("Private key not available for signing")?;
-    let signature = private_key.sign(&block_info.block_hash).context("Failed to sign block hash")?;
-    let signature =
-        ProviderBlockSignature { block_hash: block_info.block_hash, signature: vec![signature.r, signature.s] };
+    let signature = ProviderBlockSignature {
+        block_hash: block_info.block_hash,
+        signature: block_signature(&backend, block_info.block_hash)?,
+    };
     Ok(create_json_response(hyper::StatusCode::OK, &signature))
 }
 
@@ -422,12 +526,33 @@ pub async fn handle_get_state_update(
         state_diff: block.get_state_diff()?.into(),
     };
 
+    let include_signature = parse_bool_param(&params, "includeSignature", false)?;
+
     let json_response = if include_block_params(&params) {
         let status = if block.is_on_l1() { BlockStatus::AcceptedOnL1 } else { BlockStatus::AcceptedOnL2 };
         let block_provider =
             ProviderBlock::new(block_info.block_hash, block_info.header, block.get_executed_transactions(..)?, status);
 
-        create_json_response(hyper::StatusCode::OK, &json!({"block": block_provider, "state_update": state_update}))
+        if include_signature {
+            create_json_response(
+                hyper::StatusCode::OK,
+                &json!({
+                    "block": block_provider,
+                    "state_update": state_update,
+                    "signature": block_signature(&backend, block_info.block_hash)?,
+                }),
+            )
+        } else {
+            create_json_response(hyper::StatusCode::OK, &json!({"block": block_provider, "state_update": state_update}))
+        }
+    } else if include_signature {
+        create_json_response(
+            hyper::StatusCode::OK,
+            &json!({
+                "state_update": state_update,
+                "signature": block_signature(&backend, block_info.block_hash)?,
+            }),
+        )
     } else {
         create_json_response(hyper::StatusCode::OK, &state_update)
     };
@@ -865,6 +990,57 @@ mod tests {
             transactions: vec![tx_with_receipt()],
             events: Default::default(),
         }
+    }
+
+    fn preconfirmed_provider_block(tx_count: usize) -> ProviderBlockPreConfirmed {
+        let header = mp_block::header::PreconfirmedHeader { block_number: 7, ..Default::default() };
+        let transactions = std::iter::repeat_with(preconfirmed_tx).take(tx_count).collect::<Vec<_>>();
+
+        ProviderBlockPreConfirmed::new(
+            &header,
+            transactions.iter().map(|tx| (&tx.transaction, &tx.state_diff)),
+            std::iter::empty::<&ValidatedTransaction>(),
+            BlockStatus::PreConfirmed,
+        )
+    }
+
+    #[test]
+    fn preconfirmed_block_identifier_is_stable_and_header_sensitive() {
+        let header = mp_block::header::PreconfirmedHeader { block_number: 7, ..Default::default() };
+        let same_header = mp_block::header::PreconfirmedHeader { block_number: 7, ..Default::default() };
+        let next_header = mp_block::header::PreconfirmedHeader { block_number: 8, ..Default::default() };
+
+        assert_eq!(preconfirmed_block_identifier(&header), preconfirmed_block_identifier(&same_header));
+        assert_ne!(preconfirmed_block_identifier(&header), preconfirmed_block_identifier(&next_header));
+    }
+
+    #[test]
+    fn slice_preconfirmed_block_keeps_transactions_receipts_and_diffs_aligned() {
+        let block = preconfirmed_provider_block(2);
+
+        let block = slice_preconfirmed_block(block, 1);
+
+        assert_eq!(block.transactions.len(), 1);
+        assert_eq!(block.transaction_receipts.len(), 1);
+        assert_eq!(block.transaction_state_diffs.len(), 1);
+        assert_eq!(
+            block.transactions[0].transaction_hash(),
+            &block.transaction_receipts[0].as_ref().unwrap().transaction_hash
+        );
+    }
+
+    #[test]
+    fn preconfirmed_block_with_info_omits_receipts_and_state_diffs_when_disabled() {
+        let block = preconfirmed_provider_block(1);
+
+        let response =
+            ProviderBlockPreConfirmedWithInfo::new(block, 7, "madara-preconfirmed:test".to_owned(), true, false, false);
+        let value = serde_json::to_value(response).expect("serializes response");
+
+        assert_eq!(value["changed"], true);
+        assert!(value.get("transactions").is_some());
+        assert!(value.get("transaction_receipts").is_none());
+        assert!(value.get("transaction_state_diffs").is_none());
     }
 
     #[tokio::test]

--- a/madara/crates/client/sync/src/gateway/blocks.rs
+++ b/madara/crates/client/sync/src/gateway/blocks.rs
@@ -8,10 +8,14 @@ use mc_db::{
     preconfirmed::{PreconfirmedBlock, PreconfirmedExecutedTransaction},
     MadaraBackend, MadaraStorageRead, MadaraStorageWrite,
 };
-use mc_gateway_client::{BlockId, GatewayProvider};
-use mp_block::{BlockHeaderWithSignatures, FullBlock, Header};
+use mc_gateway_client::{BlockId, BlockTag, GatewayProvider};
+use mp_block::{BlockHeaderWithSignatures, ConsensusSignature, FullBlock, Header};
 use mp_convert::Felt;
-use mp_gateway::error::{SequencerError, StarknetErrorCode};
+use mp_gateway::state_update::ProviderStateUpdateWithBlock;
+use mp_gateway::{
+    block::ProviderBlockPreConfirmedUpdate,
+    error::{SequencerError, StarknetErrorCode},
+};
 use mp_state_update::StateDiff;
 use mp_transactions::validated::{TxTimestamp, ValidatedTransaction};
 use mp_utils::AbortOnDrop;
@@ -53,6 +57,31 @@ pub struct GatewaySyncSteps {
     keep_pre_v0_13_2_hashes: bool,
     sync_bouncer_config: bool,
     disable_reorg: bool,
+}
+
+struct PreconfirmedSyncCursor {
+    optimized_supported: bool,
+    block_identifier: Option<String>,
+    transaction_count: usize,
+}
+
+impl Default for PreconfirmedSyncCursor {
+    fn default() -> Self {
+        Self { optimized_supported: true, block_identifier: None, transaction_count: 0 }
+    }
+}
+
+struct OptimizedPreconfirmedMeta {
+    block_identifier: String,
+    is_delta: bool,
+    known_transaction_count: usize,
+}
+
+fn consensus_signatures(signature: Vec<Felt>) -> Vec<ConsensusSignature> {
+    match signature.as_slice() {
+        [r, s] => vec![ConsensusSignature { r: *r, s: *s }],
+        _ => vec![],
+    }
 }
 
 impl GatewaySyncSteps {
@@ -242,11 +271,36 @@ impl PipelineSteps for GatewaySyncSteps {
 
             for block_n in block_range {
                 tracing::debug!("📥 Fetching block #{} from gateway", block_n);
-                let block = self
+                let (block, block_signatures) = match self
                     .client
-                    .get_state_update_with_block(BlockId::Number(block_n))
+                    .get_state_update_with_block_and_signature(BlockId::Number(block_n))
                     .await
-                    .with_context(|| format!("Getting state update with block_n={block_n}"))?;
+                {
+                    Ok(response) => (
+                        ProviderStateUpdateWithBlock { state_update: response.state_update, block: response.block },
+                        consensus_signatures(response.signature),
+                    ),
+                    Err(combined_error) => {
+                        tracing::debug!(
+                            "Gateway get_state_update includeSignature failed for block #{block_n}, falling back: {combined_error:#}"
+                        );
+                        let block = self
+                            .client
+                            .get_state_update_with_block(BlockId::Number(block_n))
+                            .await
+                            .with_context(|| format!("Getting state update with block_n={block_n}"))?;
+                        let block_signatures = match self.client.get_signature(BlockId::Number(block_n)).await {
+                            Ok(signature) => consensus_signatures(signature.signature),
+                            Err(signature_error) => {
+                                tracing::debug!(
+                                    "Gateway get_signature failed for block #{block_n}, importing without consensus signatures: {signature_error:#}"
+                                );
+                                vec![]
+                            }
+                        };
+                        (block, block_signatures)
+                    }
+                };
 
                 let bouncer_weights = if self.sync_bouncer_config {
                     Some(
@@ -398,7 +452,7 @@ impl PipelineSteps for GatewaySyncSteps {
                         let mut signed_header = BlockHeaderWithSignatures {
                             header: gateway_block.header,
                             block_hash: gateway_block.block_hash,
-                            consensus_signatures: vec![],
+                            consensus_signatures: block_signatures,
                         };
 
                         // Allow the gateway format, which has legacy commitments.
@@ -470,14 +524,16 @@ pub fn gateway_preconfirmed_block_sync(
     _importer: Arc<BlockImporter>,
     backend: Arc<MadaraBackend>,
 ) -> ThrottledRepeatedFuture<()> {
+    let optimized_cursor = Arc::new(tokio::sync::Mutex::new(PreconfirmedSyncCursor::default()));
     ThrottledRepeatedFuture::new(
         move |_| {
             let client = client.clone();
             let backend = backend.clone();
+            let optimized_cursor = optimized_cursor.clone();
             async move {
                 // We do some shenanigans to abort the request if a new block has been imported.
                 let mut subscription = backend.watch_chain_tip();
-                let (block, block_number) = loop {
+                let (block, block_number, optimized_meta) = loop {
                     let block_number = subscription
                         .current()
                         .latest_confirmed_block_n()
@@ -487,8 +543,70 @@ pub fn gateway_preconfirmed_block_sync(
                     tokio::select! {
                         biased;
                         _ = subscription.recv() => continue, // Abort request and restart
-                        preconfirmed = client.get_preconfirmed_block(block_number) => {
-                            break (preconfirmed, block_number)
+                        preconfirmed = async {
+                            let (optimized_supported, known_block_identifier, known_transaction_count) = {
+                                let cursor = optimized_cursor.lock().await;
+                                (cursor.optimized_supported, cursor.block_identifier.clone(), cursor.transaction_count)
+                            };
+
+                            if optimized_supported {
+                                let block_identifier_param = known_block_identifier.as_deref().unwrap_or("junk");
+                                match client
+                                    .get_preconfirmed_block_optimized(
+                                        BlockId::Tag(BlockTag::Latest),
+                                        Some(block_identifier_param),
+                                        Some(known_transaction_count),
+                                        true,
+                                        true,
+                                    )
+                                    .await
+                                {
+                                    Ok(ProviderBlockPreConfirmedUpdate::Unchanged(_)) => return Ok(None),
+                                    Ok(ProviderBlockPreConfirmedUpdate::Changed(response)) => {
+                                        let response_block_number = response.block_number;
+                                        let response_block_identifier = response.block_identifier.clone();
+                                        let is_delta = known_block_identifier.as_deref() == Some(response_block_identifier.as_str());
+                                        let Some(block) = response.into_preconfirmed_block() else {
+                                            let mut cursor = optimized_cursor.lock().await;
+                                            cursor.optimized_supported = false;
+                                            return client.get_preconfirmed_block(block_number).await.map(|block| {
+                                                Some((block, block_number, None))
+                                            });
+                                        };
+                                        return Ok(Some((
+                                            block,
+                                            response_block_number,
+                                            Some(OptimizedPreconfirmedMeta {
+                                                block_identifier: response_block_identifier,
+                                                is_delta,
+                                                known_transaction_count,
+                                            }),
+                                        )));
+                                    }
+                                    Ok(ProviderBlockPreConfirmedUpdate::Legacy(block)) => {
+                                        let mut cursor = optimized_cursor.lock().await;
+                                        cursor.optimized_supported = false;
+                                        return Ok(Some((block, block_number, None)));
+                                    }
+                                    Err(error) => {
+                                        tracing::debug!(
+                                            "Optimized preconfirmed gateway polling failed, falling back to legacy polling: {error:#}"
+                                        );
+                                        let mut cursor = optimized_cursor.lock().await;
+                                        cursor.optimized_supported = false;
+                                    }
+                                }
+                            }
+
+                            client.get_preconfirmed_block(block_number).await.map(|block| Some((block, block_number, None)))
+                        } => {
+                            match preconfirmed {
+                                Ok(Some((block, block_number, optimized_meta))) => {
+                                    break (Ok(block), block_number, optimized_meta)
+                                }
+                                Ok(None) => return Ok(None),
+                                Err(error) => break (Err(error), block_number, None),
+                            }
                         }
                     }
                 };
@@ -511,19 +629,33 @@ pub fn gateway_preconfirmed_block_sync(
 
                 let n_executed = block.num_executed_transactions();
                 let header = block.header(block_number)?;
+                let optimized_is_delta = optimized_meta.as_ref().is_some_and(|meta| meta.is_delta);
 
                 // How many of these transactions do we already have? When None, we need to make a new pre-confirmed block.
-                let mut common_prefix = None;
+                let mut common_prefix = optimized_is_delta.then_some(0);
 
                 if let Some(mut in_backend) = backend.block_view_on_preconfirmed() {
                     in_backend.refresh_with_candidates(); // we want to compare candidates too.
 
                     if in_backend.block_number() != block_number {
+                        if optimized_is_delta {
+                            let mut cursor = optimized_cursor.lock().await;
+                            cursor.block_identifier = None;
+                            cursor.transaction_count = 0;
+                        }
                         return Ok(None);
                     }
 
-                    // True if this gateway block should be considered as a new pre-confirmed block entirely.
-                    let new_preconfirmed = in_backend.header() != &header
+                    if optimized_is_delta {
+                        if in_backend.header() != &header {
+                            let mut cursor = optimized_cursor.lock().await;
+                            cursor.block_identifier = None;
+                            cursor.transaction_count = 0;
+                            return Ok(None);
+                        }
+                    } else {
+                        // True if this gateway block should be considered as a new pre-confirmed block entirely.
+                        let new_preconfirmed = in_backend.header() != &header
                         || in_backend.num_executed_transactions() > n_executed
                         ||
                         // Compare hashes
@@ -533,21 +665,33 @@ pub fn gateway_preconfirmed_block_sync(
                             block.transactions[..n_executed].iter().map(|tx| tx.transaction_hash()),
                         );
 
-                    if !new_preconfirmed {
-                        common_prefix = Some(in_backend.num_executed_transactions());
-                    }
+                        if !new_preconfirmed {
+                            common_prefix = Some(in_backend.num_executed_transactions());
+                        }
 
-                    // Whether there was no change at all (no need to update the backend)
-                    let has_not_changed = !new_preconfirmed
+                        // Whether there was no change at all (no need to update the backend)
+                        let has_not_changed = !new_preconfirmed
                         && in_backend.num_executed_transactions() == n_executed
                         // Compare candidate hashes.
                         && Iterator::eq(
                         in_backend.candidate_transactions().iter().map(|tx| &tx.hash),
                         block.transactions[n_executed..].iter().map(|tx| tx.transaction_hash()),
                     );
-                    if has_not_changed {
-                        return Ok(None);
+                        if has_not_changed {
+                            if let Some(meta) = &optimized_meta {
+                                let mut cursor = optimized_cursor.lock().await;
+                                cursor.optimized_supported = true;
+                                cursor.block_identifier = Some(meta.block_identifier.clone());
+                                cursor.transaction_count = n_executed;
+                            }
+                            return Ok(None);
+                        }
                     }
+                } else if optimized_is_delta {
+                    let mut cursor = optimized_cursor.lock().await;
+                    cursor.block_identifier = None;
+                    cursor.transaction_count = 0;
+                    return Ok(None);
                 }
 
                 let arrived_at = TxTimestamp::now();
@@ -599,6 +743,14 @@ pub fn gateway_preconfirmed_block_sync(
                     backend
                         .write_access()
                         .append_to_preconfirmed(&executed, /* replace_candidates */ candidates)?;
+                }
+
+                if let Some(meta) = optimized_meta {
+                    let mut cursor = optimized_cursor.lock().await;
+                    cursor.optimized_supported = true;
+                    cursor.block_identifier = Some(meta.block_identifier);
+                    cursor.transaction_count =
+                        if meta.is_delta { meta.known_transaction_count + n_executed } else { n_executed };
                 }
 
                 Ok(Some(()))

--- a/madara/crates/primitives/gateway/src/block.rs
+++ b/madara/crates/primitives/gateway/src/block.rs
@@ -202,6 +202,44 @@ pub struct ProviderBlockPreConfirmed {
     pub transaction_state_diffs: Vec<Option<StateDiff>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[cfg_attr(test, derive(Eq))]
+pub struct ProviderBlockPreConfirmedWithInfo {
+    pub status: BlockStatus,
+    pub starknet_version: String,
+    pub l1_da_mode: L1DataAvailabilityMode,
+    pub l1_gas_price: ResourcePrice,
+    pub l1_data_gas_price: ResourcePrice,
+    pub l2_gas_price: ResourcePrice,
+    pub timestamp: u64,
+    pub sequencer_address: Felt,
+    pub transactions: Vec<Transaction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_receipts: Option<Vec<Option<ConfirmedReceipt>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_state_diffs: Option<Vec<Option<StateDiff>>>,
+    pub block_number: u64,
+    pub block_identifier: String,
+    pub changed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(Eq))]
+pub struct ProviderBlockPreConfirmedUnchanged {
+    pub changed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+#[cfg_attr(test, derive(Eq))]
+pub enum ProviderBlockPreConfirmedUpdate {
+    Unchanged(ProviderBlockPreConfirmedUnchanged),
+    Changed(ProviderBlockPreConfirmedWithInfo),
+    Legacy(ProviderBlockPreConfirmed),
+}
+
 impl ProviderBlockPreConfirmed {
     pub fn new<'a>(
         header: &PreconfirmedHeader,
@@ -325,6 +363,50 @@ impl ProviderBlockPreConfirmed {
             .collect();
 
         (executed, candidates)
+    }
+}
+
+impl ProviderBlockPreConfirmedWithInfo {
+    pub fn new(
+        block: ProviderBlockPreConfirmed,
+        block_number: u64,
+        block_identifier: String,
+        changed: bool,
+        include_receipts: bool,
+        include_state_diffs: bool,
+    ) -> Self {
+        Self {
+            status: block.status,
+            starknet_version: block.starknet_version,
+            l1_da_mode: block.l1_da_mode,
+            l1_gas_price: block.l1_gas_price,
+            l1_data_gas_price: block.l1_data_gas_price,
+            l2_gas_price: block.l2_gas_price,
+            timestamp: block.timestamp,
+            sequencer_address: block.sequencer_address,
+            transactions: block.transactions,
+            transaction_receipts: include_receipts.then_some(block.transaction_receipts),
+            transaction_state_diffs: include_state_diffs.then_some(block.transaction_state_diffs),
+            block_number,
+            block_identifier,
+            changed,
+        }
+    }
+
+    pub fn into_preconfirmed_block(self) -> Option<ProviderBlockPreConfirmed> {
+        Some(ProviderBlockPreConfirmed {
+            status: self.status,
+            starknet_version: self.starknet_version,
+            l1_da_mode: self.l1_da_mode,
+            l1_gas_price: self.l1_gas_price,
+            l1_data_gas_price: self.l1_data_gas_price,
+            l2_gas_price: self.l2_gas_price,
+            timestamp: self.timestamp,
+            sequencer_address: self.sequencer_address,
+            transactions: self.transactions,
+            transaction_receipts: self.transaction_receipts?,
+            transaction_state_diffs: self.transaction_state_diffs?,
+        })
     }
 }
 

--- a/madara/crates/primitives/gateway/src/state_update.rs
+++ b/madara/crates/primitives/gateway/src/state_update.rs
@@ -119,7 +119,21 @@ pub struct ProviderStateUpdateWithBlock {
     pub block: ProviderBlock,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(test, derive(Eq))]
+pub struct ProviderStateUpdateWithBlockAndSignature {
+    pub state_update: ProviderStateUpdate,
+    pub block: ProviderBlock,
+    pub signature: Vec<Felt>,
+}
+
 impl ProviderStateUpdateWithBlock {
+    pub fn into_full_block(self) -> Result<FullBlock, FromGatewayError> {
+        self.block.into_full_block(self.state_update.state_diff.into())
+    }
+}
+
+impl ProviderStateUpdateWithBlockAndSignature {
     pub fn into_full_block(self) -> Result<FullBlock, FromGatewayError> {
         self.block.into_full_block(self.state_update.state_diff.into())
     }

--- a/tests/js_tests/src/config.ts
+++ b/tests/js_tests/src/config.ts
@@ -11,6 +11,7 @@ export const UDC_ADDRESS =
 
 export const RPC_PORT = 9944;
 export const ADMIN_PORT = 9943;
+export const GATEWAY_PORT = 8080;
 
 export function getRpcUrl(version: string): string {
   const versionPath = version.replace(/\./g, "_");
@@ -19,6 +20,14 @@ export function getRpcUrl(version: string): string {
 
 export function getAdminUrl(): string {
   return `http://127.0.0.1:${ADMIN_PORT}/`;
+}
+
+export function getGatewayUrl(): string {
+  return `http://127.0.0.1:${GATEWAY_PORT}/gateway/`;
+}
+
+export function getFeederGatewayUrl(): string {
+  return `http://127.0.0.1:${GATEWAY_PORT}/feeder_gateway/`;
 }
 
 export const BLOCK_POLL_INTERVAL_MS = 500;

--- a/tests/js_tests/tests/rpc.test.ts
+++ b/tests/js_tests/tests/rpc.test.ts
@@ -165,25 +165,30 @@ async function waitForTransactionInPreconfirmedBlock(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   let lastTransactions: string[] = [];
+  let lastError: unknown;
 
   while (Date.now() < deadline) {
-    const preconfirmedBlock = await feederGet("get_preconfirmed_block", {
-      blockNumber,
-    });
-    const preconfirmedTxHashes = (preconfirmedBlock.transactions || []).map(
-      (tx: any) => tx.transaction_hash
-    );
-    if (preconfirmedTxHashes.includes(txHash)) {
-      return;
+    try {
+      const preconfirmedBlock = await feederGet("get_preconfirmed_block", {
+        blockNumber,
+      });
+      const preconfirmedTxHashes = (preconfirmedBlock.transactions || []).map(
+        (tx: any) => tx.transaction_hash
+      );
+      if (preconfirmedTxHashes.includes(txHash)) {
+        return;
+      }
+      lastTransactions = preconfirmedTxHashes;
+    } catch (error) {
+      lastError = error;
     }
-    lastTransactions = preconfirmedTxHashes;
     await sleep(500);
   }
 
   throw new Error(
     `Timed out waiting for ${txHash} in preconfirmed block ${blockNumber}. Last seen transactions: ${lastTransactions.join(
       ", "
-    )}`
+    )}. Last error: ${String(lastError)}`
   );
 }
 

--- a/tests/js_tests/tests/rpc.test.ts
+++ b/tests/js_tests/tests/rpc.test.ts
@@ -1,6 +1,12 @@
 import * as fs from "fs";
 import * as path from "path";
-import { getRpcUrl, getAdminUrl } from "../src/config";
+import { gzipSync } from "zlib";
+import {
+  getRpcUrl,
+  getAdminUrl,
+  getGatewayUrl,
+  getFeederGatewayUrl,
+} from "../src/config";
 import { executeStateSetup } from "../src/state-executor";
 import { runAssertion } from "../src/assertion-runner";
 import { RpcCaller } from "../src/rpc-caller";
@@ -61,6 +67,9 @@ const contexts = new Map(
 );
 const setupFixture = fixtures[0];
 const setupContext = contexts.get(setupFixture.stateSetup.version)!;
+const latestRpcContext = contexts.get("0.10.2")!;
+const gatewayUrl = getGatewayUrl();
+const feederGatewayUrl = getFeederGatewayUrl();
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -70,6 +79,124 @@ function normHex(s: string): string {
   if (!s.startsWith("0x")) return s.toLowerCase();
   const stripped = s.slice(2).replace(/^0+/, "") || "0";
   return "0x" + stripped.toLowerCase();
+}
+
+function buildUrl(
+  baseUrl: string,
+  relativePath: string,
+  query: Record<string, string | number | boolean> = {},
+): string {
+  const url = new URL(relativePath, baseUrl);
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+async function readJsonResponse(response: Response): Promise<any> {
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText}: ${bodyText}`,
+    );
+  }
+  return JSON.parse(bodyText);
+}
+
+async function feederGet(
+  relativePath: string,
+  query: Record<string, string | number | boolean> = {},
+): Promise<any> {
+  const response = await fetch(buildUrl(feederGatewayUrl, relativePath, query));
+  return readJsonResponse(response);
+}
+
+async function gatewayPostJson(body: any, gzipBody = false): Promise<any> {
+  const payload = JSON.stringify(body);
+  const response = await fetch(buildUrl(gatewayUrl, "add_transaction"), {
+    method: "POST",
+    headers: gzipBody
+      ? {
+          "content-type": "application/json",
+          "content-encoding": "gzip",
+        }
+      : {
+          "content-type": "application/json",
+        },
+    body: gzipBody ? gzipSync(Buffer.from(payload, "utf8")) : payload,
+  });
+  return readJsonResponse(response);
+}
+
+function mapGatewayResourceBounds(resourceBounds: any) {
+  return {
+    L1_GAS: resourceBounds.l1_gas,
+    L2_GAS: resourceBounds.l2_gas,
+    L1_DATA_GAS: resourceBounds.l1_data_gas,
+  };
+}
+
+async function buildGatewayInvokePayload(calls: any[]): Promise<any> {
+  const {
+    Account,
+    RpcProvider,
+    Deployer,
+    TransactionType,
+    stark,
+  } = await import("starknet");
+  const {
+    DEFAULT_ACCOUNT_ADDRESS,
+    DEFAULT_PRIVATE_KEY,
+    UDC_ADDRESS,
+  } = await import("../src/config");
+
+  const provider = new RpcProvider({ nodeUrl: latestRpcContext.rpcUrl });
+  const account = new Account({
+    provider,
+    address: DEFAULT_ACCOUNT_ADDRESS,
+    signer: DEFAULT_PRIVATE_KEY,
+    deployer: new Deployer(UDC_ADDRESS, "deployContract"),
+  });
+
+  const [invocation] = await (account as any).accountInvocationsFactory(
+    [{ type: TransactionType.INVOKE, payload: calls }],
+    {
+      versions: ["0x3"],
+      nonce: await provider.getNonceForAddress(DEFAULT_ACCOUNT_ADDRESS, "latest"),
+      tip: 0n,
+      paymasterData: [],
+      accountDeploymentData: [],
+      nonceDataAvailabilityMode: "L1",
+      feeDataAvailabilityMode: "L1",
+      resourceBounds: {
+        l1_gas: { max_amount: 0xf4240n, max_price_per_unit: 0x2540be400n },
+        l2_gas: { max_amount: 0x3b9aca00n, max_price_per_unit: 0x2540be400n },
+        l1_data_gas: { max_amount: 0x989680n, max_price_per_unit: 0x2540be400n },
+      },
+      skipValidate: false,
+    },
+  );
+
+  return {
+    type: "INVOKE_FUNCTION",
+    sender_address: invocation.contractAddress,
+    calldata: invocation.calldata,
+    signature: invocation.signature,
+    nonce: invocation.nonce,
+    resource_bounds: mapGatewayResourceBounds(
+      stark.resourceBoundsToHexString(invocation.resourceBounds),
+    ),
+    tip: invocation.tip,
+    paymaster_data: invocation.paymasterData,
+    account_deployment_data: invocation.accountDeploymentData,
+    nonce_data_availability_mode: stark.intDAM(
+      invocation.nonceDataAvailabilityMode,
+    ),
+    fee_data_availability_mode: stark.intDAM(
+      invocation.feeDataAvailabilityMode,
+    ),
+    version: invocation.version,
+  };
 }
 
 describe("Starknet RPC multi-version", () => {
@@ -591,4 +718,194 @@ describe("Starknet RPC multi-version", () => {
       });
     });
   }
+
+  describe("Gateway Endpoints", () => {
+    const gatewayResults: Record<string, any> = {};
+
+    it("submits a plain gateway invoke transaction and exposes it through the feeder gateway", async () => {
+      const { ERC20_ETH_ADDRESS } = await import("../src/config");
+
+      const payload = await buildGatewayInvokePayload([
+        {
+          contractAddress: ERC20_ETH_ADDRESS,
+          entrypoint: "transfer",
+          calldata: [
+            "0x008a1719e7ca19f3d91e8ef50a48fc456575f645497a1d55f30e3781f786afe4",
+            "0x1",
+            "0x0",
+          ],
+        },
+      ]);
+
+      const gatewayResponse = await gatewayPostJson(payload);
+      expect(gatewayResponse.code).toBe("TRANSACTION_RECEIVED");
+      expect(gatewayResponse.transaction_hash).toMatch(/^0x[0-9a-f]+$/i);
+      gatewayResults.smallTxHash = gatewayResponse.transaction_hash;
+
+      const preconfirmedBlock = await feederGet("get_preconfirmed_block", {
+        blockNumber: "latest",
+      });
+      const preconfirmedTxHashes = (preconfirmedBlock.transactions || []).map(
+        (tx: any) => tx.transaction_hash,
+      );
+      expect(preconfirmedTxHashes).toContain(gatewayResults.smallTxHash);
+
+      const admin = new AdminClient(adminUrl);
+      await admin.closeBlock();
+      await sleep(1000);
+
+      const status = await feederGet("get_transaction_status", {
+        transactionHash: gatewayResults.smallTxHash,
+      });
+      expect(status.tx_status).toBe("ACCEPTED_ON_L2");
+      expect(status.finality_status).toBe("ACCEPTED_ON_L2");
+      expect(status.execution_status).toBe("SUCCEEDED");
+      gatewayResults.smallStatus = status;
+
+      const transaction = await feederGet("get_transaction", {
+        transactionHash: gatewayResults.smallTxHash,
+      });
+      expect(transaction.status).toBe("ACCEPTED_ON_L2");
+      expect(transaction.finality_status).toBe("ACCEPTED_ON_L2");
+      expect(transaction.execution_status).toBe("SUCCEEDED");
+      expect(transaction.transaction.type).toBe("INVOKE_FUNCTION");
+      gatewayResults.smallTransaction = transaction;
+    });
+
+    it("accepts a gzipped oversized gateway invoke transaction", async () => {
+      const { ERC20_ETH_ADDRESS } = await import("../src/config");
+      const repeatedCall = {
+        contractAddress: ERC20_ETH_ADDRESS,
+        entrypoint: "transfer",
+        calldata: [
+          "0x008a1719e7ca19f3d91e8ef50a48fc456575f645497a1d55f30e3781f786afe4",
+          "0x1",
+          "0x0",
+        ],
+      };
+
+      const payload = await buildGatewayInvokePayload(
+        Array.from({ length: 10 }, () => repeatedCall),
+      );
+
+      const rawPayloadSize = Buffer.byteLength(JSON.stringify(payload), "utf8");
+      expect(rawPayloadSize).toBeGreaterThan(1024);
+
+      const gatewayResponse = await gatewayPostJson(payload, true);
+      expect(gatewayResponse.code).toBe("TRANSACTION_RECEIVED");
+      expect(gatewayResponse.transaction_hash).toMatch(/^0x[0-9a-f]+$/i);
+      gatewayResults.largeTxHash = gatewayResponse.transaction_hash;
+
+      const admin = new AdminClient(adminUrl);
+      await admin.closeBlock();
+      await sleep(1000);
+
+      const status = await feederGet("get_transaction_status", {
+        transactionHash: gatewayResults.largeTxHash,
+      });
+      expect(status.tx_status).toBe("ACCEPTED_ON_L2");
+      expect(status.execution_status).toBe("SUCCEEDED");
+
+      const rpcCaller = new RpcCaller(latestRpcContext.rpcUrl);
+      const receipt = await rpcCaller.call("starknet_getTransactionReceipt", [
+        gatewayResults.largeTxHash,
+      ]);
+      expect(receipt.execution_status).toBe("SUCCEEDED");
+      gatewayResults.largeReceipt = receipt;
+    });
+
+    it("serves the historical feeder block, state update, traces, and signature endpoints", async () => {
+      const historicalBlockNumber = sharedResults.get("invoke_increase_100")
+        ?.block_number;
+      const historicalBlockHash = sharedResults.get("invoke_increase_100")
+        ?.block_hash;
+      expect(historicalBlockNumber).toBeDefined();
+      expect(historicalBlockHash).toBeDefined();
+
+      const block = await feederGet("get_block", {
+        blockNumber: historicalBlockNumber!,
+      });
+      expect(block.block_number).toBe(historicalBlockNumber);
+      expect(normHex(block.block_hash)).toBe(normHex(historicalBlockHash!));
+
+      const stateUpdate = await feederGet("get_state_update", {
+        blockNumber: historicalBlockNumber!,
+        includeBlock: true,
+      });
+      expect(normHex(stateUpdate.block.block_hash)).toBe(
+        normHex(historicalBlockHash!),
+      );
+      expect(stateUpdate.state_diff).toBeDefined();
+
+      const traces = await feederGet("get_block_traces", {
+        blockNumber: historicalBlockNumber!,
+      });
+      expect(Array.isArray(traces.traces)).toBe(true);
+      expect(traces.traces.length).toBeGreaterThan(0);
+
+      const signature = await feederGet("get_signature", {
+        blockNumber: historicalBlockNumber!,
+      });
+      expect(Array.isArray(signature.signature)).toBe(true);
+      expect(signature.signature).toHaveLength(2);
+    });
+
+    it("round-trips the block hash/id feeder endpoints on the local chain", async () => {
+      const historicalBlockNumber = sharedResults.get("invoke_increase_100")
+        ?.block_number;
+      const historicalBlockHash = sharedResults.get("invoke_increase_100")
+        ?.block_hash;
+      expect(historicalBlockNumber).toBeDefined();
+      expect(historicalBlockHash).toBeDefined();
+
+      const blockHashById = await feederGet("get_block_hash_by_id", {
+        blockId: historicalBlockNumber!,
+      });
+      expect(normHex(blockHashById.block_hash)).toBe(
+        normHex(historicalBlockHash!),
+      );
+
+      const blockIdByHash = await feederGet("get_block_id_by_hash", {
+        blockHash: historicalBlockHash!,
+      });
+      expect(blockIdByHash.block_id).toBe(historicalBlockNumber);
+    });
+
+    it("serves class and chain metadata feeder endpoints", async () => {
+      const helloClassHash = sharedResults.get("declare_hello")?.class_hash;
+      expect(helloClassHash).toBeDefined();
+
+      const classByHash = await feederGet("get_class_by_hash", {
+        classHash: helloClassHash!,
+      });
+      expect(classByHash.entry_points_by_type).toBeDefined();
+
+      const compiledClass = await feederGet(
+        "get_compiled_class_by_class_hash",
+        {
+          classHash: helloClassHash!,
+        },
+      );
+      expect(compiledClass.bytecode).toBeDefined();
+
+      const contractAddresses = await feederGet("get_contract_addresses");
+      expect(contractAddresses.Starknet).toBeDefined();
+      expect(contractAddresses.GpsStatementVerifier).toBeDefined();
+
+      const publicKey = await feederGet("get_public_key");
+      expect(publicKey).toMatch(/^0x[0-9a-f]+$/i);
+    });
+
+    it("returns bouncer weights for a historical block", async () => {
+      const historicalBlockNumber = sharedResults.get("invoke_increase_100")
+        ?.block_number;
+      expect(historicalBlockNumber).toBeDefined();
+
+      const bouncerWeights = await feederGet("get_block_bouncer_weights", {
+        blockNumber: historicalBlockNumber!,
+      });
+      expect(bouncerWeights).toBeDefined();
+      expect(Object.keys(bouncerWeights).length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/tests/js_tests/tests/rpc.test.ts
+++ b/tests/js_tests/tests/rpc.test.ts
@@ -814,10 +814,66 @@ describe("Starknet RPC multi-version", () => {
         "starknet_blockNumber",
         []
       );
+      const preconfirmedBlockNumber = Number(latestConfirmedBlockNumber) + 1;
       await waitForTransactionInPreconfirmedBlock(
         gatewayResults.smallTxHash,
-        Number(latestConfirmedBlockNumber) + 1
+        preconfirmedBlockNumber
       );
+
+      const legacyPreconfirmedBlock = await feederGet("get_preconfirmed_block", {
+        blockNumber: preconfirmedBlockNumber,
+      });
+      expect(legacyPreconfirmedBlock.status).toBe("PRE_CONFIRMED");
+      expect(legacyPreconfirmedBlock.block_number).toBeUndefined();
+      expect(legacyPreconfirmedBlock.block_identifier).toBeUndefined();
+      expect(legacyPreconfirmedBlock.changed).toBeUndefined();
+      expect(
+        legacyPreconfirmedBlock.transactions.some(
+          (tx: any) => normHex(tx.transaction_hash) === normHex(gatewayResults.smallTxHash)
+        )
+      ).toBe(true);
+      expect(Array.isArray(legacyPreconfirmedBlock.transaction_receipts)).toBe(true);
+      expect(Array.isArray(legacyPreconfirmedBlock.transaction_state_diffs)).toBe(true);
+
+      const optimizedPreconfirmedBlock = await feederGet("get_preconfirmed_block", {
+        blockNumber: "latest",
+        blockIdentifier: "unknown",
+        knownTransactionCount: 0,
+        includeReceipts: true,
+        includeStateDiffs: true,
+      });
+      expect(optimizedPreconfirmedBlock.status).toBe("PRE_CONFIRMED");
+      expect(optimizedPreconfirmedBlock.changed).toBe(true);
+      expect(optimizedPreconfirmedBlock.block_number).toBe(preconfirmedBlockNumber);
+      expect(typeof optimizedPreconfirmedBlock.block_identifier).toBe("string");
+      expect(optimizedPreconfirmedBlock.block_identifier.length).toBeGreaterThan(0);
+      expect(
+        optimizedPreconfirmedBlock.transactions.some(
+          (tx: any) => normHex(tx.transaction_hash) === normHex(gatewayResults.smallTxHash)
+        )
+      ).toBe(true);
+      expect(Array.isArray(optimizedPreconfirmedBlock.transaction_receipts)).toBe(true);
+      expect(Array.isArray(optimizedPreconfirmedBlock.transaction_state_diffs)).toBe(true);
+
+      const optimizedWithoutOptionalPayloads = await feederGet("get_preconfirmed_block", {
+        blockNumber: "latest",
+        blockIdentifier: optimizedPreconfirmedBlock.block_identifier,
+        knownTransactionCount: 0,
+        includeReceipts: false,
+        includeStateDiffs: false,
+      });
+      expect(optimizedWithoutOptionalPayloads.changed).toBe(true);
+      expect(optimizedWithoutOptionalPayloads.transaction_receipts).toBeUndefined();
+      expect(optimizedWithoutOptionalPayloads.transaction_state_diffs).toBeUndefined();
+
+      const optimizedUnchanged = await feederGet("get_preconfirmed_block", {
+        blockNumber: "latest",
+        blockIdentifier: optimizedPreconfirmedBlock.block_identifier,
+        knownTransactionCount: optimizedPreconfirmedBlock.transactions.length,
+        includeReceipts: true,
+        includeStateDiffs: true,
+      });
+      expect(optimizedUnchanged).toEqual({ changed: false });
 
       const admin = new AdminClient(adminUrl);
       await admin.closeBlock();
@@ -905,6 +961,18 @@ describe("Starknet RPC multi-version", () => {
         normHex(historicalBlockHash!)
       );
       expect(stateUpdate.state_update.state_diff).toBeDefined();
+
+      const optimizedStateUpdate = await feederGet("get_state_update", {
+        blockNumber: historicalBlockNumber!,
+        includeBlock: true,
+        includeSignature: true,
+      });
+      expect(normHex(optimizedStateUpdate.block.block_hash)).toBe(
+        normHex(historicalBlockHash!)
+      );
+      expect(optimizedStateUpdate.state_update.state_diff).toBeDefined();
+      expect(Array.isArray(optimizedStateUpdate.signature)).toBe(true);
+      expect(optimizedStateUpdate.signature).toHaveLength(2);
 
       const traces = await feederGet("get_block_traces", {
         blockNumber: historicalBlockNumber!,

--- a/tests/js_tests/tests/rpc.test.ts
+++ b/tests/js_tests/tests/rpc.test.ts
@@ -128,6 +128,32 @@ async function gatewayPostJson(body: any, gzipBody = false): Promise<any> {
   return readJsonResponse(response);
 }
 
+async function waitForFeederTransactionStatus(
+  txHash: string,
+  timeoutMs = 30_000,
+): Promise<any> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const status = await feederGet("get_transaction_status", {
+        transactionHash: txHash,
+      });
+      if (status.tx_status === "ACCEPTED_ON_L2") {
+        return status;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(500);
+  }
+
+  throw new Error(
+    `Timed out waiting for feeder transaction status for ${txHash}: ${String(lastError)}`,
+  );
+}
+
 function mapGatewayResourceBounds(resourceBounds: any) {
   return {
     L1_GAS: resourceBounds.l1_gas,
@@ -141,7 +167,7 @@ async function buildGatewayInvokePayload(calls: any[]): Promise<any> {
     Account,
     RpcProvider,
     Deployer,
-    TransactionType,
+    transaction,
     stark,
   } = await import("starknet");
   const {
@@ -158,44 +184,49 @@ async function buildGatewayInvokePayload(calls: any[]): Promise<any> {
     deployer: new Deployer(UDC_ADDRESS, "deployContract"),
   });
 
-  const [invocation] = await (account as any).accountInvocationsFactory(
-    [{ type: TransactionType.INVOKE, payload: calls }],
-    {
-      versions: ["0x3"],
-      nonce: await provider.getNonceForAddress(DEFAULT_ACCOUNT_ADDRESS, "latest"),
-      tip: 0n,
-      paymasterData: [],
-      accountDeploymentData: [],
-      nonceDataAvailabilityMode: "L1",
-      feeDataAvailabilityMode: "L1",
-      resourceBounds: {
-        l1_gas: { max_amount: 0xf4240n, max_price_per_unit: 0x2540be400n },
-        l2_gas: { max_amount: 0x3b9aca00n, max_price_per_unit: 0x2540be400n },
-        l1_data_gas: { max_amount: 0x989680n, max_price_per_unit: 0x2540be400n },
-      },
-      skipValidate: false,
-    },
-  );
+  const cairoVersion = await account.getCairoVersion();
+  const chainId = await provider.getChainId();
+  const nonce = await provider.getNonceForAddress(DEFAULT_ACCOUNT_ADDRESS, "latest");
+  const resourceBounds = {
+    l1_gas: { max_amount: 0xf4240n, max_price_per_unit: 0x2540be400n },
+    l2_gas: { max_amount: 0x3b9aca00n, max_price_per_unit: 0x2540be400n },
+    l1_data_gas: { max_amount: 0x989680n, max_price_per_unit: 0x2540be400n },
+  };
+  const details = {
+    walletAddress: DEFAULT_ACCOUNT_ADDRESS,
+    cairoVersion,
+    chainId,
+    version: "0x3" as const,
+    nonce: BigInt(nonce),
+    tip: 0n,
+    paymasterData: [],
+    accountDeploymentData: [],
+    nonceDataAvailabilityMode: "L1" as any,
+    feeDataAvailabilityMode: "L1" as any,
+    resourceBounds,
+  };
+  const calldata = transaction.getExecuteCalldata(calls, cairoVersion);
+  const signature = await account.signer.signTransaction(calls, details as any);
 
   return {
     type: "INVOKE_FUNCTION",
-    sender_address: invocation.contractAddress,
-    calldata: invocation.calldata,
-    signature: invocation.signature,
-    nonce: invocation.nonce,
+    sender_address: DEFAULT_ACCOUNT_ADDRESS,
+    calldata,
+    signature,
+    nonce,
     resource_bounds: mapGatewayResourceBounds(
-      stark.resourceBoundsToHexString(invocation.resourceBounds),
+      stark.resourceBoundsToHexString(resourceBounds),
     ),
-    tip: invocation.tip,
-    paymaster_data: invocation.paymasterData,
-    account_deployment_data: invocation.accountDeploymentData,
+    tip: "0x0",
+    paymaster_data: [],
+    account_deployment_data: [],
     nonce_data_availability_mode: stark.intDAM(
-      invocation.nonceDataAvailabilityMode,
+      details.nonceDataAvailabilityMode,
     ),
     fee_data_availability_mode: stark.intDAM(
-      invocation.feeDataAvailabilityMode,
+      details.feeDataAvailabilityMode,
     ),
-    version: invocation.version,
+    version: details.version,
   };
 }
 
@@ -742,8 +773,13 @@ describe("Starknet RPC multi-version", () => {
       expect(gatewayResponse.transaction_hash).toMatch(/^0x[0-9a-f]+$/i);
       gatewayResults.smallTxHash = gatewayResponse.transaction_hash;
 
+      const rpcCaller = new RpcCaller(latestRpcContext.rpcUrl);
+      const latestConfirmedBlockNumber = await rpcCaller.call(
+        "starknet_blockNumber",
+        [],
+      );
       const preconfirmedBlock = await feederGet("get_preconfirmed_block", {
-        blockNumber: "latest",
+        blockNumber: Number(latestConfirmedBlockNumber) + 1,
       });
       const preconfirmedTxHashes = (preconfirmedBlock.transactions || []).map(
         (tx: any) => tx.transaction_hash,
@@ -752,11 +788,10 @@ describe("Starknet RPC multi-version", () => {
 
       const admin = new AdminClient(adminUrl);
       await admin.closeBlock();
-      await sleep(1000);
 
-      const status = await feederGet("get_transaction_status", {
-        transactionHash: gatewayResults.smallTxHash,
-      });
+      const status = await waitForFeederTransactionStatus(
+        gatewayResults.smallTxHash,
+      );
       expect(status.tx_status).toBe("ACCEPTED_ON_L2");
       expect(status.finality_status).toBe("ACCEPTED_ON_L2");
       expect(status.execution_status).toBe("SUCCEEDED");
@@ -798,11 +833,10 @@ describe("Starknet RPC multi-version", () => {
 
       const admin = new AdminClient(adminUrl);
       await admin.closeBlock();
-      await sleep(1000);
 
-      const status = await feederGet("get_transaction_status", {
-        transactionHash: gatewayResults.largeTxHash,
-      });
+      const status = await waitForFeederTransactionStatus(
+        gatewayResults.largeTxHash,
+      );
       expect(status.tx_status).toBe("ACCEPTED_ON_L2");
       expect(status.execution_status).toBe("SUCCEEDED");
 

--- a/tests/js_tests/tests/rpc.test.ts
+++ b/tests/js_tests/tests/rpc.test.ts
@@ -34,13 +34,13 @@ function loadFixture(fixtureDirName: string): RpcFixture {
   return {
     fixtureDirName,
     stateSetup: JSON.parse(
-      fs.readFileSync(path.join(fixtureDir, "state_setup.json"), "utf-8"),
+      fs.readFileSync(path.join(fixtureDir, "state_setup.json"), "utf-8")
     ),
     readAssertions: JSON.parse(
-      fs.readFileSync(path.join(fixtureDir, "read_assertions.json"), "utf-8"),
+      fs.readFileSync(path.join(fixtureDir, "read_assertions.json"), "utf-8")
     ),
     errorAssertions: JSON.parse(
-      fs.readFileSync(path.join(fixtureDir, "error_assertions.json"), "utf-8"),
+      fs.readFileSync(path.join(fixtureDir, "error_assertions.json"), "utf-8")
     ),
   };
 }
@@ -63,7 +63,7 @@ const contexts = new Map(
   fixtures.map((fixture) => [
     fixture.stateSetup.version,
     createContext(fixture.stateSetup.version),
-  ]),
+  ])
 );
 const setupFixture = fixtures[0];
 const setupContext = contexts.get(setupFixture.stateSetup.version)!;
@@ -84,7 +84,7 @@ function normHex(s: string): string {
 function buildUrl(
   baseUrl: string,
   relativePath: string,
-  query: Record<string, string | number | boolean> = {},
+  query: Record<string, string | number | boolean> = {}
 ): string {
   const url = new URL(relativePath, baseUrl);
   for (const [key, value] of Object.entries(query)) {
@@ -97,7 +97,7 @@ async function readJsonResponse(response: Response): Promise<any> {
   const bodyText = await response.text();
   if (!response.ok) {
     throw new Error(
-      `HTTP ${response.status} ${response.statusText}: ${bodyText}`,
+      `HTTP ${response.status} ${response.statusText}: ${bodyText}`
     );
   }
   return JSON.parse(bodyText);
@@ -105,14 +105,16 @@ async function readJsonResponse(response: Response): Promise<any> {
 
 async function feederGet(
   relativePath: string,
-  query: Record<string, string | number | boolean> = {},
+  query: Record<string, string | number | boolean> = {}
 ): Promise<any> {
   const response = await fetch(buildUrl(feederGatewayUrl, relativePath, query));
   return readJsonResponse(response);
 }
 
 async function gatewayPostJson(body: any, gzipBody = false): Promise<any> {
-  const payload = JSON.stringify(body);
+  const payload = JSON.stringify(body, (_, value) =>
+    typeof value === "bigint" ? `0x${value.toString(16)}` : value
+  );
   const response = await fetch(buildUrl(gatewayUrl, "add_transaction"), {
     method: "POST",
     headers: gzipBody
@@ -130,7 +132,7 @@ async function gatewayPostJson(body: any, gzipBody = false): Promise<any> {
 
 async function waitForFeederTransactionStatus(
   txHash: string,
-  timeoutMs = 30_000,
+  timeoutMs = 30_000
 ): Promise<any> {
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
@@ -150,7 +152,9 @@ async function waitForFeederTransactionStatus(
   }
 
   throw new Error(
-    `Timed out waiting for feeder transaction status for ${txHash}: ${String(lastError)}`,
+    `Timed out waiting for feeder transaction status for ${txHash}: ${String(
+      lastError
+    )}`
   );
 }
 
@@ -163,18 +167,11 @@ function mapGatewayResourceBounds(resourceBounds: any) {
 }
 
 async function buildGatewayInvokePayload(calls: any[]): Promise<any> {
-  const {
-    Account,
-    RpcProvider,
-    Deployer,
-    transaction,
-    stark,
-  } = await import("starknet");
-  const {
-    DEFAULT_ACCOUNT_ADDRESS,
-    DEFAULT_PRIVATE_KEY,
-    UDC_ADDRESS,
-  } = await import("../src/config");
+  const { Account, RpcProvider, Deployer, transaction, stark } = await import(
+    "starknet"
+  );
+  const { DEFAULT_ACCOUNT_ADDRESS, DEFAULT_PRIVATE_KEY, UDC_ADDRESS } =
+    await import("../src/config");
 
   const provider = new RpcProvider({ nodeUrl: latestRpcContext.rpcUrl });
   const account = new Account({
@@ -186,7 +183,10 @@ async function buildGatewayInvokePayload(calls: any[]): Promise<any> {
 
   const cairoVersion = await account.getCairoVersion();
   const chainId = await provider.getChainId();
-  const nonce = await provider.getNonceForAddress(DEFAULT_ACCOUNT_ADDRESS, "latest");
+  const nonce = await provider.getNonceForAddress(
+    DEFAULT_ACCOUNT_ADDRESS,
+    "latest"
+  );
   const resourceBounds = {
     l1_gas: { max_amount: 0xf4240n, max_price_per_unit: 0x2540be400n },
     l2_gas: { max_amount: 0x3b9aca00n, max_price_per_unit: 0x2540be400n },
@@ -215,17 +215,15 @@ async function buildGatewayInvokePayload(calls: any[]): Promise<any> {
     signature,
     nonce,
     resource_bounds: mapGatewayResourceBounds(
-      stark.resourceBoundsToHexString(resourceBounds),
+      stark.resourceBoundsToHexString(resourceBounds)
     ),
     tip: "0x0",
     paymaster_data: [],
     account_deployment_data: [],
     nonce_data_availability_mode: stark.intDAM(
-      details.nonceDataAvailabilityMode,
+      details.nonceDataAvailabilityMode
     ),
-    fee_data_availability_mode: stark.intDAM(
-      details.feeDataAvailabilityMode,
-    ),
+    fee_data_availability_mode: stark.intDAM(details.feeDataAvailabilityMode),
     version: details.version,
   };
 }
@@ -262,7 +260,7 @@ describe("Starknet RPC multi-version", () => {
       const anvilPort = process.env.ANVIL_PORT;
       if (!anvilPort) {
         console.log(
-          "[l1-messaging] ANVIL_PORT not set, skipping L1 messaging setup",
+          "[l1-messaging] ANVIL_PORT not set, skipping L1 messaging setup"
         );
         return;
       }
@@ -320,7 +318,7 @@ describe("Starknet RPC multi-version", () => {
         hash: fireHash,
       });
       console.log(
-        `[l1-messaging] LogMessageToL2 fired in L1 tx ${fireReceipt.transactionHash} at block ${fireReceipt.blockNumber}`,
+        `[l1-messaging] LogMessageToL2 fired in L1 tx ${fireReceipt.transactionHash} at block ${fireReceipt.blockNumber}`
       );
 
       expect(fireReceipt.status).toBe("success");
@@ -342,7 +340,7 @@ describe("Starknet RPC multi-version", () => {
         try {
           const envelope = await rpcCaller.rawCall(
             "starknet_getMessagesStatus",
-            { transaction_hash: l1TxHash },
+            { transaction_hash: l1TxHash }
           );
           if (!envelope.error) {
             synced = true;
@@ -371,10 +369,10 @@ describe("Starknet RPC multi-version", () => {
       "add_deploy_account_transaction",
     ]);
     const readOnly = fixture.readAssertions.assertions.filter(
-      (a) => !writeMethodIds.has(a.id),
+      (a) => !writeMethodIds.has(a.id)
     );
     const writeOnly = fixture.readAssertions.assertions.filter((a) =>
-      writeMethodIds.has(a.id),
+      writeMethodIds.has(a.id)
     );
 
     describe(`Starknet RPC v${fixture.stateSetup.version}`, () => {
@@ -393,7 +391,7 @@ describe("Starknet RPC multi-version", () => {
           it(`${assertion.id} (${assertion.method})`, async () => {
             if (ctx.results.size === 0) {
               throw new Error(
-                "State setup did not complete - cannot run read assertions",
+                "State setup did not complete - cannot run read assertions"
               );
             }
 
@@ -440,14 +438,14 @@ describe("Starknet RPC multi-version", () => {
               {
                 transaction_hash: invoke!.transaction_hash,
                 response_flags: ["INCLUDE_PROOF_FACTS"],
-              },
+              }
             );
 
             expect(result.type).toBe("INVOKE");
             expect(result.version).toBe("0x3");
             expect(
               result.proof_facts === undefined ||
-                Array.isArray(result.proof_facts),
+                Array.isArray(result.proof_facts)
             ).toBe(true);
           });
 
@@ -467,7 +465,7 @@ describe("Starknet RPC multi-version", () => {
               expect(tx.type).toBe("INVOKE");
               expect(tx.version).toBe("0x3");
               expect(
-                tx.proof_facts === undefined || Array.isArray(tx.proof_facts),
+                tx.proof_facts === undefined || Array.isArray(tx.proof_facts)
               ).toBe(true);
             }
           });
@@ -482,7 +480,7 @@ describe("Starknet RPC multi-version", () => {
               {
                 block_id: { block_number: invokeBlock!.block_number },
                 response_flags: ["INCLUDE_PROOF_FACTS"],
-              },
+              }
             );
 
             expect(Array.isArray(result.transactions)).toBe(true);
@@ -492,7 +490,7 @@ describe("Starknet RPC multi-version", () => {
               expect(item.transaction.version).toBe("0x3");
               expect(
                 item.transaction.proof_facts === undefined ||
-                  Array.isArray(item.transaction.proof_facts),
+                  Array.isArray(item.transaction.proof_facts)
               ).toBe(true);
             }
           });
@@ -507,7 +505,7 @@ describe("Starknet RPC multi-version", () => {
               {
                 transaction_hash: invoke!.transaction_hash,
                 response_flags: ["UNKNOWN_FLAG"],
-              },
+              }
             );
 
             expect(envelope.error).toBeDefined();
@@ -523,7 +521,7 @@ describe("Starknet RPC multi-version", () => {
             const rpcCaller = new RpcCaller(ctx.rpcUrl);
             const envelope = await rpcCaller.rawCall(
               assertion.method,
-              assertion.params,
+              assertion.params
             );
 
             expect(envelope.error).toBeDefined();
@@ -559,12 +557,12 @@ describe("Starknet RPC multi-version", () => {
           try {
             await account.declare({ contract: sierra, casm });
             throw new Error(
-              "Expected error when re-declaring already-declared class",
+              "Expected error when re-declaring already-declared class"
             );
           } catch (err: any) {
             const code = err.baseError?.code ?? err.code;
             const data = JSON.stringify(
-              err.baseError?.data ?? err.data ?? err.message ?? "",
+              err.baseError?.data ?? err.data ?? err.message ?? ""
             );
             expect([41, 51]).toContain(code);
             expect(data).toContain("already declared");
@@ -597,7 +595,9 @@ describe("Starknet RPC multi-version", () => {
 
           if (missing.length > 0) {
             console.warn(
-              `[method-surface] v${fixture.stateSetup.version} methods in spec but not exposed: ${missing.join(", ")}`,
+              `[method-surface] v${
+                fixture.stateSetup.version
+              } methods in spec but not exposed: ${missing.join(", ")}`
             );
           }
           expect(missing).toEqual([]);
@@ -621,7 +621,9 @@ describe("Starknet RPC multi-version", () => {
 
           if (untested.length > 0) {
             console.warn(
-              `[coverage] v${fixture.stateSetup.version} spec methods without test assertions: ${untested.join(", ")}`,
+              `[coverage] v${
+                fixture.stateSetup.version
+              } spec methods without test assertions: ${untested.join(", ")}`
             );
           }
           expect(untested.length).toBe(0);
@@ -644,7 +646,7 @@ describe("Starknet RPC multi-version", () => {
         it("tx count consistency: getBlockTransactionCount matches getBlockWithTxHashes.transactions.length", async () => {
           const txCount = ctx.assertionResults.get("get_block_tx_count_multi");
           const blockTxHashes = ctx.assertionResults.get(
-            "get_block_tx_hashes_multi",
+            "get_block_tx_hashes_multi"
           );
           expect(txCount).toBeDefined();
           expect(blockTxHashes).toBeDefined();
@@ -659,10 +661,10 @@ describe("Starknet RPC multi-version", () => {
           expect(byAddr).toBeDefined();
 
           expect(byHash.entry_points_by_type.EXTERNAL.length).toBe(
-            byAddr.entry_points_by_type.EXTERNAL.length,
+            byAddr.entry_points_by_type.EXTERNAL.length
           );
           expect(byHash.contract_class_version).toBe(
-            byAddr.contract_class_version,
+            byAddr.contract_class_version
           );
         });
 
@@ -673,13 +675,13 @@ describe("Starknet RPC multi-version", () => {
           expect(declareResult).toBeDefined();
 
           expect(normHex(String(classHashAt))).toBe(
-            normHex(declareResult!.class_hash!),
+            normHex(declareResult!.class_hash!)
           );
         });
 
         it("storage vs call consistency: getStorageAt matches call(get_balance)", async () => {
           const storageResult = ctx.assertionResults.get(
-            "get_storage_at_balance",
+            "get_storage_at_balance"
           );
           const callResult = ctx.assertionResults.get("call_get_balance");
           expect(storageResult).toBeDefined();
@@ -687,21 +689,21 @@ describe("Starknet RPC multi-version", () => {
 
           const storageHex = normHex(String(storageResult));
           const callHex = normHex(
-            String(Array.isArray(callResult) ? callResult[0] : callResult),
+            String(Array.isArray(callResult) ? callResult[0] : callResult)
           );
           expect(storageHex).toBe(callHex);
         });
 
         it("receipt block info consistency: receipt block_hash matches block from write phase", async () => {
           const receiptInvoke = ctx.assertionResults.get(
-            "get_tx_receipt_invoke",
+            "get_tx_receipt_invoke"
           );
           const invokeStep = ctx.results.get("invoke_increase_100");
           expect(receiptInvoke).toBeDefined();
           expect(invokeStep).toBeDefined();
 
           expect(normHex(receiptInvoke.block_hash)).toBe(
-            normHex(invokeStep!.block_hash!),
+            normHex(invokeStep!.block_hash!)
           );
         });
 
@@ -716,10 +718,10 @@ describe("Starknet RPC multi-version", () => {
 
         it("tx by index matches tx by hash in multi-tx block", async () => {
           const byIndex0 = ctx.assertionResults.get(
-            "get_tx_by_block_and_index_0",
+            "get_tx_by_block_and_index_0"
           );
           const byIndex1 = ctx.assertionResults.get(
-            "get_tx_by_block_and_index_1",
+            "get_tx_by_block_and_index_1"
           );
           expect(byIndex0).toBeDefined();
           expect(byIndex1).toBeDefined();
@@ -729,7 +731,7 @@ describe("Starknet RPC multi-version", () => {
 
         it("empty block has zero transactions", async () => {
           const emptyCount = ctx.assertionResults.get(
-            "get_block_tx_count_empty",
+            "get_block_tx_count_empty"
           );
           expect(emptyCount).toBeDefined();
 
@@ -776,13 +778,13 @@ describe("Starknet RPC multi-version", () => {
       const rpcCaller = new RpcCaller(latestRpcContext.rpcUrl);
       const latestConfirmedBlockNumber = await rpcCaller.call(
         "starknet_blockNumber",
-        [],
+        []
       );
       const preconfirmedBlock = await feederGet("get_preconfirmed_block", {
         blockNumber: Number(latestConfirmedBlockNumber) + 1,
       });
       const preconfirmedTxHashes = (preconfirmedBlock.transactions || []).map(
-        (tx: any) => tx.transaction_hash,
+        (tx: any) => tx.transaction_hash
       );
       expect(preconfirmedTxHashes).toContain(gatewayResults.smallTxHash);
 
@@ -790,7 +792,7 @@ describe("Starknet RPC multi-version", () => {
       await admin.closeBlock();
 
       const status = await waitForFeederTransactionStatus(
-        gatewayResults.smallTxHash,
+        gatewayResults.smallTxHash
       );
       expect(status.tx_status).toBe("ACCEPTED_ON_L2");
       expect(status.finality_status).toBe("ACCEPTED_ON_L2");
@@ -820,7 +822,7 @@ describe("Starknet RPC multi-version", () => {
       };
 
       const payload = await buildGatewayInvokePayload(
-        Array.from({ length: 10 }, () => repeatedCall),
+        Array.from({ length: 10 }, () => repeatedCall)
       );
 
       const rawPayloadSize = Buffer.byteLength(JSON.stringify(payload), "utf8");
@@ -835,7 +837,7 @@ describe("Starknet RPC multi-version", () => {
       await admin.closeBlock();
 
       const status = await waitForFeederTransactionStatus(
-        gatewayResults.largeTxHash,
+        gatewayResults.largeTxHash
       );
       expect(status.tx_status).toBe("ACCEPTED_ON_L2");
       expect(status.execution_status).toBe("SUCCEEDED");
@@ -849,10 +851,12 @@ describe("Starknet RPC multi-version", () => {
     });
 
     it("serves the historical feeder block, state update, traces, and signature endpoints", async () => {
-      const historicalBlockNumber = sharedResults.get("invoke_increase_100")
-        ?.block_number;
-      const historicalBlockHash = sharedResults.get("invoke_increase_100")
-        ?.block_hash;
+      const historicalBlockNumber = sharedResults.get(
+        "invoke_increase_100"
+      )?.block_number;
+      const historicalBlockHash = sharedResults.get(
+        "invoke_increase_100"
+      )?.block_hash;
       expect(historicalBlockNumber).toBeDefined();
       expect(historicalBlockHash).toBeDefined();
 
@@ -867,9 +871,9 @@ describe("Starknet RPC multi-version", () => {
         includeBlock: true,
       });
       expect(normHex(stateUpdate.block.block_hash)).toBe(
-        normHex(historicalBlockHash!),
+        normHex(historicalBlockHash!)
       );
-      expect(stateUpdate.state_diff).toBeDefined();
+      expect(stateUpdate.state_update.state_diff).toBeDefined();
 
       const traces = await feederGet("get_block_traces", {
         blockNumber: historicalBlockNumber!,
@@ -885,24 +889,26 @@ describe("Starknet RPC multi-version", () => {
     });
 
     it("round-trips the block hash/id feeder endpoints on the local chain", async () => {
-      const historicalBlockNumber = sharedResults.get("invoke_increase_100")
-        ?.block_number;
-      const historicalBlockHash = sharedResults.get("invoke_increase_100")
-        ?.block_hash;
+      const historicalBlockNumber = sharedResults.get(
+        "invoke_increase_100"
+      )?.block_number;
+      const historicalBlockHash = sharedResults.get(
+        "invoke_increase_100"
+      )?.block_hash;
       expect(historicalBlockNumber).toBeDefined();
       expect(historicalBlockHash).toBeDefined();
 
       const blockHashById = await feederGet("get_block_hash_by_id", {
         blockId: historicalBlockNumber!,
       });
-      expect(normHex(blockHashById.block_hash)).toBe(
-        normHex(historicalBlockHash!),
+      expect(normHex(String(blockHashById))).toBe(
+        normHex(historicalBlockHash!)
       );
 
       const blockIdByHash = await feederGet("get_block_id_by_hash", {
         blockHash: historicalBlockHash!,
       });
-      expect(blockIdByHash.block_id).toBe(historicalBlockNumber);
+      expect(blockIdByHash).toBe(historicalBlockNumber);
     });
 
     it("serves class and chain metadata feeder endpoints", async () => {
@@ -918,7 +924,7 @@ describe("Starknet RPC multi-version", () => {
         "get_compiled_class_by_class_hash",
         {
           classHash: helloClassHash!,
-        },
+        }
       );
       expect(compiledClass.bytecode).toBeDefined();
 
@@ -931,8 +937,9 @@ describe("Starknet RPC multi-version", () => {
     });
 
     it("returns bouncer weights for a historical block", async () => {
-      const historicalBlockNumber = sharedResults.get("invoke_increase_100")
-        ?.block_number;
+      const historicalBlockNumber = sharedResults.get(
+        "invoke_increase_100"
+      )?.block_number;
       expect(historicalBlockNumber).toBeDefined();
 
       const bouncerWeights = await feederGet("get_block_bouncer_weights", {

--- a/tests/js_tests/tests/rpc.test.ts
+++ b/tests/js_tests/tests/rpc.test.ts
@@ -158,6 +158,35 @@ async function waitForFeederTransactionStatus(
   );
 }
 
+async function waitForTransactionInPreconfirmedBlock(
+  txHash: string,
+  blockNumber: number,
+  timeoutMs = 15_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastTransactions: string[] = [];
+
+  while (Date.now() < deadline) {
+    const preconfirmedBlock = await feederGet("get_preconfirmed_block", {
+      blockNumber,
+    });
+    const preconfirmedTxHashes = (preconfirmedBlock.transactions || []).map(
+      (tx: any) => tx.transaction_hash
+    );
+    if (preconfirmedTxHashes.includes(txHash)) {
+      return;
+    }
+    lastTransactions = preconfirmedTxHashes;
+    await sleep(500);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${txHash} in preconfirmed block ${blockNumber}. Last seen transactions: ${lastTransactions.join(
+      ", "
+    )}`
+  );
+}
+
 function mapGatewayResourceBounds(resourceBounds: any) {
   return {
     L1_GAS: resourceBounds.l1_gas,
@@ -780,13 +809,10 @@ describe("Starknet RPC multi-version", () => {
         "starknet_blockNumber",
         []
       );
-      const preconfirmedBlock = await feederGet("get_preconfirmed_block", {
-        blockNumber: Number(latestConfirmedBlockNumber) + 1,
-      });
-      const preconfirmedTxHashes = (preconfirmedBlock.transactions || []).map(
-        (tx: any) => tx.transaction_hash
+      await waitForTransactionInPreconfirmedBlock(
+        gatewayResults.smallTxHash,
+        Number(latestConfirmedBlockNumber) + 1
       );
-      expect(preconfirmedTxHashes).toContain(gatewayResults.smallTxHash);
 
       const admin = new AdminClient(adminUrl);
       await admin.closeBlock();


### PR DESCRIPTION
## Summary

This adds support for the feeder gateway optimizations observed on live Starknet feeder gateways and wires Madara full-node sync to use them opportunistically.

This branch also includes the JS gateway/feeder endpoint coverage from #1112, extended to cover both the pre-optimization feeder response shape and the new optimized feeder response shape.

## Changes

- Add gateway response types for optimized preconfirmed block updates and combined state-update/block/signature responses.
- Extend Madara feeder gateway `get_preconfirmed_block` with `blockNumber=latest`, `blockIdentifier`, `knownTransactionCount`, `includeReceipts`, and `includeStateDiffs` while preserving legacy numeric responses.
- Extend `get_state_update` with `includeSignature=true` and reuse the existing signature generation logic.
- Add gateway client helpers for optimized preconfirmed polling and combined state-update/signature fetches.
- Update full-node gateway sync to try optimized paths first and fall back to current unoptimized flows if unavailable or incomplete.
- Merge #1112's JS gateway/feeder endpoint tests and add assertions for legacy numeric preconfirmed responses, optimized latest/cursor responses, optional payload omission, unchanged responses, and `includeSignature` state updates.

## Validation

- `cargo fmt --package mp-gateway --package mc-gateway-server --package mc-gateway-client --package mc-sync`
- `cargo check -p mp-gateway -p mc-gateway-server -p mc-gateway-client -p mc-sync`
- `cargo test -p mc-gateway-server`
- `cargo test -p mp-gateway`
- `cd tests/js_tests && npm install --no-package-lock && npx tsc --noEmit`

Note: local Rust test execution needed gitignored Cairo test artifacts. The Docker daemon was not reachable, so the missing artifacts were copied from another local Madara worktree before rerunning tests.
