### PR TITLE
[codex] Optimize manual docker image builds

### DIFF
--- a/.docker-base-images.yml
+++ b/.docker-base-images.yml
@@ -1,0 +1,8 @@
+builder:
+  madara: ghcr.io/madara-alliance/madara-rust-builder-base:rust-1.89-bookworm-llvm19-python3.9.16-sccache0.10.0-chef0.1.71-v1
+  orchestrator: ghcr.io/madara-alliance/orchestrator-rust-builder-base:rust-1.89-bookworm-llvm19-python3.9.16-sccache0.10.0-chef0.1.71-blst0.3.15-v1
+  bootstrapper-v2: ghcr.io/madara-alliance/bootstrapper-v2-rust-builder-base:rust-1.89-bookworm-llvm19-python3.9.16-sccache0.10.0-chef0.1.71-v1
+runtime:
+  madara: ghcr.io/madara-alliance/madara-runtime-base:bookworm-llvm19-tini0.19-v1
+  orchestrator: ghcr.io/madara-alliance/orchestrator-runtime-base:bookworm-node18-tini0.19-v1
+  bootstrapper-v2: ghcr.io/madara-alliance/bootstrapper-v2-runtime-base:bookworm-tini0.19-v1

--- a/.github/workflows/manual-build-docker-images.yml
+++ b/.github/workflows/manual-build-docker-images.yml
@@ -27,12 +27,30 @@ on:
         default: true
 
 jobs:
+  build_madara_binary:
+    if: ${{ inputs.build-madara }}
+    uses: ./.github/workflows/task-build-madara.yml
+    secrets: inherit
+
+  build_orchestrator_binary:
+    if: ${{ inputs.build-orchestrator }}
+    uses: ./.github/workflows/task-build-orchestrator.yml
+    secrets: inherit
+
+  build_bootstrapper_v2_binary:
+    if: ${{ inputs.build-bootstrapper-v2 }}
+    uses: ./.github/workflows/task-build-bootstrapper-v2.yml
+    secrets: inherit
+
   build-and-publish-madara:
     if: ${{ inputs.build-madara }}
-    uses: ./.github/workflows/task-build-manual-and-publish.yml
+    needs: build_madara_binary
+    uses: ./.github/workflows/task-package-manual-and-publish.yml
     with:
       image-name: madara
-      image-file: ./madara/Dockerfile
+      image-file: ./madara/Dockerfile.manual
+      binary-name: madara
+      binary-artifact-name: madara-binary-${{ needs.build_madara_binary.outputs['madara-binary-hash'] }}
     permissions:
       contents: read
       packages: write
@@ -42,10 +60,13 @@ jobs:
 
   build-and-publish-orchestrator:
     if: ${{ inputs.build-orchestrator }}
-    uses: ./.github/workflows/task-build-manual-and-publish.yml
+    needs: build_orchestrator_binary
+    uses: ./.github/workflows/task-package-manual-and-publish.yml
     with:
       image-name: orchestrator
-      image-file: ./orchestrator/Dockerfile
+      image-file: ./orchestrator/Dockerfile.manual
+      binary-name: orchestrator
+      binary-artifact-name: orchestrator-binary-${{ needs.build_orchestrator_binary.outputs['orchestrator-binary-hash'] }}
     permissions:
       contents: read
       packages: write
@@ -68,10 +89,14 @@ jobs:
 
   build-and-publish-bootstrapper-v2:
     if: ${{ inputs.build-bootstrapper-v2 }}
-    uses: ./.github/workflows/task-build-manual-and-publish.yml
+    needs: build_bootstrapper_v2_binary
+    uses: ./.github/workflows/task-package-manual-and-publish.yml
     with:
       image-name: bootstrapper-v2
-      image-file: ./bootstrapper-v2/Dockerfile
+      image-file: ./bootstrapper-v2/Dockerfile.manual
+      binary-name: bootstrapper-v2
+      binary-artifact-name: bootstrapper-v2-binary-${{ needs.build_bootstrapper_v2_binary.outputs['bootstrapper-v2-binary-hash'] }}
+      include-build-artifacts: true
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/task-build-binary.yml
+++ b/.github/workflows/task-build-binary.yml
@@ -20,6 +20,16 @@ on:
         required: false
         type: boolean
         default: false
+      needs-cairo-native:
+        description: "Whether to install Cairo Native/LLVM setup even for standalone binaries"
+        required: false
+        type: boolean
+        default: false
+      needs-python-cairo:
+        description: "Whether to install Python Cairo setup even for standalone binaries"
+        required: false
+        type: boolean
+        default: false
     outputs:
       binary-hash:
         description: "Hash of the built binary"
@@ -54,11 +64,11 @@ jobs:
           cache-workspaces: ${{ inputs.binary-name }} -> ${{ inputs.binary-name }}/target
 
       - name: Cairo Native setup
-        if: inputs.is-standalone == false
+        if: inputs.is-standalone == false || inputs.needs-cairo-native == true
         uses: ./.github/actions/setup-cairo-native
 
       - name: Python Cairo setup (for apollo_starknet_os_program dependencies)
-        if: inputs.is-standalone == false
+        if: inputs.is-standalone == false || inputs.needs-python-cairo == true
         uses: ./.github/actions/setup-python-cairo
         with:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}

--- a/.github/workflows/task-build-bootstrapper-v2.yml
+++ b/.github/workflows/task-build-bootstrapper-v2.yml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Build Bootstrapper V2
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      bootstrapper-v2-binary-hash:
+        description: "Hash of the built bootstrapper-v2 binary"
+        value: ${{ jobs.build-bootstrapper-v2.outputs.binary-hash }}
+
+jobs:
+  build-bootstrapper-v2:
+    uses: ./.github/workflows/task-build-binary.yml
+    with:
+      binary-name: bootstrapper-v2
+      is-standalone: true
+      needs-cairo-native: true
+      needs-python-cairo: true
+    secrets: inherit

--- a/.github/workflows/task-build-docker-base-images.yml
+++ b/.github/workflows/task-build-docker-base-images.yml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Build Docker Base Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .docker-base-images.yml
+      - .github/workflows/task-build-docker-base-images.yml
+      - docker/base/**
+      - Makefile
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  build-base-images:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: madara-builder
+            tag-path: .builder.madara
+            dockerfile: docker/base/madara-builder.Dockerfile
+          - component: madara-runtime
+            tag-path: .runtime.madara
+            dockerfile: docker/base/madara-runtime.Dockerfile
+          - component: orchestrator-builder
+            tag-path: .builder.orchestrator
+            dockerfile: docker/base/orchestrator-builder.Dockerfile
+          - component: orchestrator-runtime
+            tag-path: .runtime.orchestrator
+            dockerfile: docker/base/orchestrator-runtime.Dockerfile
+          - component: bootstrapper-v2-builder
+            tag-path: '.builder["bootstrapper-v2"]'
+            dockerfile: docker/base/bootstrapper-v2-builder.Dockerfile
+          - component: bootstrapper-v2-runtime
+            tag-path: '.runtime["bootstrapper-v2"]'
+            dockerfile: docker/base/bootstrapper-v2-runtime.Dockerfile
+
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-base-${{ matrix.component }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          IMAGE=$(yq -e '${{ matrix.tag-path }}' .docker-base-images.yml)
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "Building $IMAGE"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+
+      - name: Build and publish base image
+        uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.tag.outputs.image }}

--- a/.github/workflows/task-package-manual-and-publish.yml
+++ b/.github/workflows/task-package-manual-and-publish.yml
@@ -1,0 +1,165 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+name: Task - Package And Publish Manual Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: Name of the Docker image
+        required: true
+        type: string
+      image-file:
+        description: Dockerfile used to package the image
+        required: true
+        type: string
+      binary-name:
+        description: Name of the prebuilt binary to copy into the image
+        required: true
+        type: string
+      binary-artifact-name:
+        description: GitHub Actions artifact containing the prebuilt binary
+        required: true
+        type: string
+      include-build-artifacts:
+        description: Whether to fetch build-artifacts from the published artifacts image
+        required: false
+        default: false
+        type: boolean
+      registry:
+        description: Container registry domain
+        required: false
+        default: ghcr.io
+        type: string
+    outputs:
+      manual-sha:
+        description: Manual image tag (with commit sha)
+        value: ${{ jobs.package-manual-and-publish.outputs.manual-sha }}
+      manual-latest:
+        description: Manual latest image tag (only set when built from main)
+        value: ${{ jobs.package-manual-and-publish.outputs.manual-latest }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  package-manual-and-publish:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    env:
+      BLACKSMITH_DOCKER_CACHE_KEY: ${{ github.repository }}-docker-manual-package-${{ inputs.image-name }}
+    outputs:
+      manual-sha: ${{ steps.tag.outputs.manual-sha }}
+      manual-latest: ${{ steps.tag.outputs.manual-latest }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download prebuilt binary
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.binary-artifact-name }}
+          path: ci-binaries
+
+      - name: Prepare prebuilt binary
+        run: chmod +x ci-binaries/${{ inputs.binary-name }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch build artifacts
+        if: ${{ inputs.include-build-artifacts }}
+        env:
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          VERSION=$(yq -e '.current_version' .artifact-versions.yml)
+          IMAGE="$REGISTRY/${{ github.repository_owner }}/artifacts:$VERSION"
+          echo "Fetching build artifacts from $IMAGE"
+          docker pull "$IMAGE"
+          CONTAINER_ID=$(docker create "$IMAGE" do-nothing)
+          trap 'docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true' EXIT
+          docker cp "$CONTAINER_ID:/artifacts.tar.gz" artifacts.tar.gz
+          tar -xzf artifacts.tar.gz
+
+      - name: Resolve base image pins
+        id: base
+        run: |
+          MADARA_RUNTIME_BASE=$(yq -e '.runtime.madara' .docker-base-images.yml)
+          ORCHESTRATOR_RUNTIME_BASE=$(yq -e '.runtime.orchestrator' .docker-base-images.yml)
+          BOOTSTRAPPER_V2_RUNTIME_BASE=$(yq -e '.runtime["bootstrapper-v2"]' .docker-base-images.yml)
+
+          case "${{ inputs.image-name }}" in
+            madara)
+              SELECTED_RUNTIME_BASE="$MADARA_RUNTIME_BASE"
+              ;;
+            orchestrator)
+              SELECTED_RUNTIME_BASE="$ORCHESTRATOR_RUNTIME_BASE"
+              ;;
+            bootstrapper-v2)
+              SELECTED_RUNTIME_BASE="$BOOTSTRAPPER_V2_RUNTIME_BASE"
+              ;;
+            *)
+              echo "Unsupported image-name: ${{ inputs.image-name }}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "madara-runtime-base=$MADARA_RUNTIME_BASE" >> "$GITHUB_OUTPUT"
+          echo "orchestrator-runtime-base=$ORCHESTRATOR_RUNTIME_BASE" >> "$GITHUB_OUTPUT"
+          echo "bootstrapper-v2-runtime-base=$BOOTSTRAPPER_V2_RUNTIME_BASE" >> "$GITHUB_OUTPUT"
+          echo "selected-runtime-base=$SELECTED_RUNTIME_BASE" >> "$GITHUB_OUTPUT"
+
+      - name: Check runtime base image
+        run: |
+          if ! docker buildx imagetools inspect "${{ steps.base.outputs.selected-runtime-base }}" >/dev/null; then
+            echo "Runtime base image is missing: ${{ steps.base.outputs.selected-runtime-base }}" >&2
+            echo "Run the 'Task - Build Docker Base Images' workflow before packaging manual images." >&2
+            exit 1
+          fi
+
+      - name: Tags
+        id: tag
+        run: |
+          IMAGE="${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}"
+          SHA=$(git rev-parse --short=7 "$GITHUB_SHA")
+          MANUAL_SHA="$IMAGE:manual-$SHA"
+          TAGS="$MANUAL_SHA"
+
+          echo "manual-sha=$MANUAL_SHA" >> "$GITHUB_OUTPUT"
+
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            MANUAL_LATEST="$IMAGE:manual-latest"
+            echo "manual-latest=$MANUAL_LATEST" >> "$GITHUB_OUTPUT"
+            TAGS="$TAGS"$'\n'"$MANUAL_LATEST"
+          fi
+
+          echo "tags<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$TAGS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+
+      - name: Build Docker Image and Publish
+        id: push
+        uses: useblacksmith/build-push-action@v2
+        env:
+          GITHUB_REPO_NAME: ${{ env.BLACKSMITH_DOCKER_CACHE_KEY }}
+        with:
+          context: .
+          push: true
+          file: ${{ inputs.image-file }}
+          tags: ${{ steps.tag.outputs.tags }}
+          build-args: |
+            MADARA_RUNTIME_BASE=${{ steps.base.outputs.madara-runtime-base }}
+            ORCHESTRATOR_RUNTIME_BASE=${{ steps.base.outputs.orchestrator-runtime-base }}
+            BOOTSTRAPPER_V2_RUNTIME_BASE=${{ steps.base.outputs.bootstrapper-v2-runtime-base }}

--- a/bootstrapper-v2/Dockerfile
+++ b/bootstrapper-v2/Dockerfile
@@ -1,84 +1,10 @@
-# Step 0: setup tooling (rust)
-FROM rust:1.89-bookworm AS base-rust
+ARG BOOTSTRAPPER_V2_BUILDER_BASE=ghcr.io/madara-alliance/bootstrapper-v2-rust-builder-base:rust-1.89-bookworm-llvm19-python3.9.16-sccache0.10.0-chef0.1.71-v1
+ARG BOOTSTRAPPER_V2_RUNTIME_BASE=ghcr.io/madara-alliance/bootstrapper-v2-runtime-base:bookworm-tini0.19-v1
+FROM ${BOOTSTRAPPER_V2_BUILDER_BASE} AS base-rust
+ARG SCCACHE_DIR=/sccache
 WORKDIR /app
 
-ENV SCCACHE_VERSION=v0.10.0
-ENV SCCACHE_URL=https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-ENV SCCACHE_TAR=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-ENV SCCACHE_BIN=/bin/sccache
-ENV SCCACHE_DIR=/sccache
-ENV SCCACHE=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache
-
-ENV CHEF_VERSION=v0.1.71
-ENV CHEF_URL=https://github.com/LukeMathWalker/cargo-chef/releases/download/${CHEF_VERSION}/cargo-chef-x86_64-unknown-linux-gnu.tar.gz
-ENV CHEF_TAR=cargo-chef-x86_64-unknown-linux-gnu.tar.gz
-
-ENV RUSTC_WRAPPER=/bin/sccache
-
-ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
-
-# Copy Makefile for LLVM installation
-COPY Makefile /tmp/Makefile
-
-# Install LLVM 19 for Cairo Native support (required by transitive workspace deps
-# pulled in during `cargo chef cook`, notably tblgen/llvm-sys/mlir-sys).
-RUN apt-get update -y && apt-get install -y \
-  bash \
-  build-essential \
-  ca-certificates \
-  clang \
-  curl \
-  git \
-  gnupg \
-  libgmp3-dev \
-  libssl-dev \
-  make \
-  openssl \
-  software-properties-common \
-  wget && \
-  cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Set LLVM environment variables for Cairo Native
-ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
-ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
-ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
-ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
-
-# Set explicit compilers for Cairo Native runtime compilation
-ENV CC=clang-19
-ENV CXX=clang++-19
-
-# Configure linker search paths for Cairo Native runtime compilation.
-# DEB_HOST_MULTIARCH resolves to the correct lib directory for the build runner architecture.
-RUN DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
-  printf '%s\n' \
-    "export LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
-    "export LD_LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
-    > /etc/profile.d/cairo-native-libs.sh
-# Use bash (non-login) so BASH_ENV is honored. A login shell would source
-# /etc/profile, which on Debian unconditionally resets PATH and would wipe
-# /usr/local/cargo/bin and /usr/lib/llvm-19/bin from PATH for every later RUN.
-ENV BASH_ENV=/etc/profile.d/cairo-native-libs.sh
 SHELL ["/bin/bash", "-c"]
-
-# Install Python 3.9
-RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
-    && tar xzf Python-3.9.16.tgz \
-    && cd Python-3.9.16 \
-    && ./configure --enable-optimizations \
-    && make altinstall \
-    && cd .. \
-    && rm -rf Python-3.9.16 Python-3.9.16.tgz
-
-# Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
-    && python3.9 get-pip.py \
-    && rm get-pip.py \
-    && python3.9 -m pip install virtualenv
-
-RUN wget $SCCACHE_URL && tar -xvpf $SCCACHE_TAR && mv $SCCACHE $SCCACHE_BIN && mkdir sccache
-RUN wget $CHEF_URL && tar -xvpf $CHEF_TAR && mv cargo-chef /bin
 
 # Step 1: Cache dependencies
 FROM base-rust AS planner
@@ -127,22 +53,13 @@ RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     CARGO_TARGET_DIR=target RUST_BUILD_DOCKER=1 cargo build --manifest-path bootstrapper-v2/Cargo.toml --release
 
 # Step 3: runner
-FROM debian:bookworm-slim AS runner
-
-RUN apt-get -y update && \
-    apt-get install -y openssl ca-certificates tini curl &&\
-    apt-get autoremove -y; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/*
+ARG BOOTSTRAPPER_V2_RUNTIME_BASE
+FROM ${BOOTSTRAPPER_V2_RUNTIME_BASE} AS runner
 
 WORKDIR /app
 
 COPY --from=builder-rust /app/target/release/bootstrapper-v2 /bin
 COPY --from=builder-rust /app/build-artifacts /app/build-artifacts
-
-ENV TINI_VERSION=v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
-RUN chmod +x /bin/tini
 
 # Set the entrypoint
 ENTRYPOINT ["tini", "--", "bootstrapper-v2"]

--- a/bootstrapper-v2/Dockerfile.manual
+++ b/bootstrapper-v2/Dockerfile.manual
@@ -1,0 +1,11 @@
+ARG BOOTSTRAPPER_V2_RUNTIME_BASE=ghcr.io/madara-alliance/bootstrapper-v2-runtime-base:bookworm-tini0.19-v1
+FROM ${BOOTSTRAPPER_V2_RUNTIME_BASE} AS runner
+
+WORKDIR /app
+
+COPY ci-binaries/bootstrapper-v2 /bin/bootstrapper-v2
+COPY build-artifacts /app/build-artifacts
+RUN chmod +x /bin/bootstrapper-v2
+
+ENTRYPOINT ["tini", "--", "bootstrapper-v2"]
+CMD ["--help"]

--- a/docker/base/bootstrapper-v2-builder.Dockerfile
+++ b/docker/base/bootstrapper-v2-builder.Dockerfile
@@ -1,0 +1,66 @@
+FROM rust:1.89-bookworm
+WORKDIR /app
+
+ENV SCCACHE_VERSION=v0.10.0
+ENV SCCACHE_URL=https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV SCCACHE_TAR=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV SCCACHE_BIN=/bin/sccache
+ENV SCCACHE_DIR=/sccache
+ENV SCCACHE=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache
+
+ENV CHEF_VERSION=v0.1.71
+ENV CHEF_URL=https://github.com/LukeMathWalker/cargo-chef/releases/download/${CHEF_VERSION}/cargo-chef-x86_64-unknown-linux-gnu.tar.gz
+ENV CHEF_TAR=cargo-chef-x86_64-unknown-linux-gnu.tar.gz
+
+ENV RUSTC_WRAPPER=/bin/sccache
+ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
+
+COPY Makefile /tmp/Makefile
+
+RUN apt-get update -y && apt-get install -y \
+  bash \
+  build-essential \
+  ca-certificates \
+  clang \
+  curl \
+  git \
+  gnupg \
+  libgmp3-dev \
+  libssl-dev \
+  make \
+  openssl \
+  software-properties-common \
+  wget && \
+  cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/Makefile
+
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+ENV CC=clang-19
+ENV CXX=clang++-19
+
+RUN DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
+  printf '%s\n' \
+    "export LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    "export LD_LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    > /etc/profile.d/cairo-native-libs.sh
+ENV BASH_ENV=/etc/profile.d/cairo-native-libs.sh
+SHELL ["/bin/bash", "-c"]
+
+RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
+    && tar xzf Python-3.9.16.tgz \
+    && cd Python-3.9.16 \
+    && ./configure \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-3.9.16 Python-3.9.16.tgz
+
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
+    && python3.9 get-pip.py \
+    && rm get-pip.py \
+    && python3.9 -m pip install virtualenv
+
+RUN wget $SCCACHE_URL && tar -xvpf $SCCACHE_TAR && mv $SCCACHE $SCCACHE_BIN && mkdir -p $SCCACHE_DIR
+RUN wget $CHEF_URL && tar -xvpf $CHEF_TAR && mv cargo-chef /bin

--- a/docker/base/bootstrapper-v2-runtime.Dockerfile
+++ b/docker/base/bootstrapper-v2-runtime.Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bookworm-slim
+
+RUN apt-get -y update && \
+    apt-get install -y openssl ca-certificates curl && \
+    apt-get autoremove -y; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
+RUN chmod +x /bin/tini

--- a/docker/base/madara-builder.Dockerfile
+++ b/docker/base/madara-builder.Dockerfile
@@ -1,0 +1,47 @@
+FROM rust:1.89-bookworm
+WORKDIR /app
+
+ENV SCCACHE_VERSION=v0.10.0
+ENV SCCACHE_URL=https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV SCCACHE_TAR=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV SCCACHE_BIN=/bin/sccache
+ENV SCCACHE_DIR=/sccache
+ENV SCCACHE=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache
+
+ENV CHEF_VERSION=v0.1.71
+ENV CHEF_URL=https://github.com/LukeMathWalker/cargo-chef/releases/download/${CHEF_VERSION}/cargo-chef-x86_64-unknown-linux-gnu.tar.gz
+ENV CHEF_TAR=cargo-chef-x86_64-unknown-linux-gnu.tar.gz
+
+ENV RUSTC_WRAPPER=/bin/sccache
+ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
+
+COPY Makefile /tmp/Makefile
+
+RUN apt-get update -y && apt-get install -y wget gnupg software-properties-common make && \
+    cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/Makefile
+
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+ENV CC=clang-19
+ENV CXX=clang-19
+ENV LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
+
+RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
+    && tar xzf Python-3.9.16.tgz \
+    && cd Python-3.9.16 \
+    && ./configure \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-3.9.16 Python-3.9.16.tgz
+
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
+    && python3.9 get-pip.py \
+    && rm get-pip.py \
+    && python3.9 -m pip install virtualenv
+
+RUN wget $SCCACHE_URL && tar -xvpf $SCCACHE_TAR && mv $SCCACHE $SCCACHE_BIN && mkdir -p $SCCACHE_DIR
+RUN wget $CHEF_URL && tar -xvpf $CHEF_TAR && mv cargo-chef /bin

--- a/docker/base/madara-runtime.Dockerfile
+++ b/docker/base/madara-runtime.Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:bookworm-slim
+
+COPY Makefile /tmp/Makefile
+
+RUN apt-get -y update && \
+    apt-get install -y openssl ca-certificates curl wget gnupg software-properties-common make && \
+    cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/Makefile
+
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+ENV CC=clang-19
+ENV CXX=clang-19
+ENV LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
+
+ENV TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
+RUN chmod +x /bin/tini

--- a/docker/base/orchestrator-builder.Dockerfile
+++ b/docker/base/orchestrator-builder.Dockerfile
@@ -1,0 +1,77 @@
+FROM rust:1.89-bookworm
+WORKDIR /app
+
+ENV SCCACHE_VERSION=v0.10.0
+ENV SCCACHE_URL=https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV SCCACHE_TAR=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+ENV SCCACHE_BIN=/bin/sccache
+ENV SCCACHE_DIR=/sccache
+ENV SCCACHE=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache
+
+ENV CHEF_VERSION=v0.1.71
+ENV CHEF_URL=https://github.com/LukeMathWalker/cargo-chef/releases/download/${CHEF_VERSION}/cargo-chef-x86_64-unknown-linux-gnu.tar.gz
+ENV CHEF_TAR=cargo-chef-x86_64-unknown-linux-gnu.tar.gz
+
+ENV RUSTC_WRAPPER=/bin/sccache
+ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
+
+COPY Makefile /tmp/Makefile
+
+RUN apt-get update -y && apt-get install -y \
+  bash \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  gnupg \
+  libgmp3-dev \
+  libssl-dev \
+  make \
+  openssl \
+  software-properties-common \
+  wget && \
+  cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/Makefile
+
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+ENV CC=clang-19
+ENV CXX=clang++-19
+
+RUN DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
+  printf '%s\n' \
+    "export LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    "export LD_LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
+    > /etc/profile.d/cairo-native-libs.sh
+ENV BASH_ENV=/etc/profile.d/cairo-native-libs.sh
+SHELL ["/bin/bash", "-c"]
+
+RUN git clone --depth 1 --branch v0.3.15 https://github.com/supranational/blst.git /tmp/blst && \
+  cd /tmp/blst && \
+  ./build.sh && \
+  mkdir -p /usr/local/lib /usr/local/include && \
+  cp libblst.a /usr/local/lib/ && \
+  cp bindings/blst.h /usr/local/include/ && \
+  cp bindings/blst_aux.h /usr/local/include/ && \
+  rm -rf /tmp/blst
+
+ENV RUSTFLAGS="-L /usr/local/lib -l blst"
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/blst.conf && ldconfig
+
+RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
+  && tar xzf Python-3.9.16.tgz \
+  && cd Python-3.9.16 \
+  && ./configure \
+  && make altinstall \
+  && cd .. \
+  && rm -rf Python-3.9.16 Python-3.9.16.tgz
+
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
+  && python3.9 get-pip.py \
+  && rm get-pip.py \
+  && python3.9 -m pip install virtualenv
+
+RUN wget $SCCACHE_URL && tar -xvpf $SCCACHE_TAR && mv $SCCACHE $SCCACHE_BIN && mkdir -p $SCCACHE_DIR
+RUN wget $CHEF_URL && tar -xvpf $CHEF_TAR && mv cargo-chef /bin

--- a/docker/base/orchestrator-runtime.Dockerfile
+++ b/docker/base/orchestrator-runtime.Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:bookworm-slim
+
+RUN apt-get -y update && \
+  apt-get install -y openssl ca-certificates curl jq && \
+  curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+  apt-get update && \
+  apt-get install -y nodejs && \
+  apt-get autoremove -y; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*
+
+ENV TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
+RUN chmod +x /bin/tini

--- a/madara/Dockerfile
+++ b/madara/Dockerfile
@@ -1,69 +1,8 @@
-# Step 0: setup tooling (rust)
-FROM rust:1.89-bookworm AS base-rust
+ARG MADARA_BUILDER_BASE=ghcr.io/madara-alliance/madara-rust-builder-base:rust-1.89-bookworm-llvm19-python3.9.16-sccache0.10.0-chef0.1.71-v1
+ARG MADARA_RUNTIME_BASE=ghcr.io/madara-alliance/madara-runtime-base:bookworm-llvm19-tini0.19-v1
+FROM ${MADARA_BUILDER_BASE} AS base-rust
+ARG SCCACHE_DIR=/sccache
 WORKDIR /app
-
-# Note that we do not install cargo chef and sccache through docker to avoid
-# having to compile them from source
-ENV SCCACHE_VERSION=v0.10.0
-ENV SCCACHE_URL=https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-ENV SCCACHE_TAR=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-ENV SCCACHE_BIN=/bin/sccache
-ENV SCCACHE_DIR=/sccache
-ENV SCCACHE=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache
-
-ENV CHEF_VERSION=v0.1.71
-ENV CHEF_URL=https://github.com/LukeMathWalker/cargo-chef/releases/download/${CHEF_VERSION}/cargo-chef-x86_64-unknown-linux-gnu.tar.gz
-ENV CHEF_TAR=cargo-chef-x86_64-unknown-linux-gnu.tar.gz
-
-ENV RUSTC_WRAPPER=/bin/sccache
-
-ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
-
-# Copy Makefile for LLVM installation
-COPY Makefile /tmp/Makefile
-
-# Install LLVM 19 for Cairo Native support using Makefile target
-RUN apt-get update -y && apt-get install -y wget gnupg software-properties-common make && \
-    cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Set LLVM environment variables for Cairo Native
-ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
-ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
-ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
-ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
-
-# Set explicit compilers for Cairo Native runtime compilation
-# Note: clang-19 handles both C and C++ compilation
-ENV CC=clang-19
-ENV CXX=clang-19
-
-# Configure linker search paths for Cairo Native runtime compilation
-ENV LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
-ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
-
-# Install Python 3.9
-# Note: --enable-optimizations (PGO) is intentionally omitted. Python here is
-# only used at build time to run cairo-compile for SNOS dependencies, so
-# runtime perf is irrelevant and skipping PGO halves this step's build time
-# (PGO builds Python twice). With CC=clang-19 below, PGO would also require
-# llvm-profdata which adds further fragility.
-RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
-    && tar xzf Python-3.9.16.tgz \
-    && cd Python-3.9.16 \
-    && ./configure \
-    && make altinstall \
-    && cd .. \
-    && rm -rf Python-3.9.16 Python-3.9.16.tgz
-
-# Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
-    && python3.9 get-pip.py \
-    && rm get-pip.py \
-    && python3.9 -m pip install virtualenv
-
-RUN wget $SCCACHE_URL && tar -xvpf $SCCACHE_TAR && mv $SCCACHE $SCCACHE_BIN && mkdir sccache
-RUN wget $CHEF_URL && tar -xvpf $CHEF_TAR && mv cargo-chef /bin
 
 # Step 1: Cache dependencies
 FROM base-rust AS planner
@@ -121,40 +60,12 @@ RUN --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     CARGO_TARGET_DIR=target RUST_BUILD_DOCKER=1 cargo build --release --bin madara
 
 # Step 3: runner
-FROM debian:bookworm-slim AS runner
-
-# Copy Makefile for LLVM installation
-COPY Makefile /tmp/Makefile
-
-# Install LLVM 19 for Cairo Native runtime compilation (compiles Sierra to native on-the-fly)
-RUN apt-get -y update && \
-    apt-get install -y openssl ca-certificates tini curl wget gnupg software-properties-common make && \
-    cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/Makefile
-
-# Set LLVM environment variables for Cairo Native runtime
-ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
-ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
-ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
-ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
-
-# Set compilers for Cairo Native runtime compilation
-ENV CC=clang-19
-ENV CXX=clang-19
-
-# Configure linker search paths for Cairo Native runtime compilation
-ENV LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
-ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib:/lib/x86_64-linux-gnu:/lib
+ARG MADARA_RUNTIME_BASE
+FROM ${MADARA_RUNTIME_BASE} AS runner
 
 WORKDIR /app
 
 COPY --from=builder-rust /app/target/release/madara /bin
-
-ENV TINI_VERSION=v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
-RUN chmod +x /bin/tini
 
 # Set the entrypoint
 ENTRYPOINT ["tini", "--", "madara"]

--- a/madara/Dockerfile.manual
+++ b/madara/Dockerfile.manual
@@ -1,0 +1,10 @@
+ARG MADARA_RUNTIME_BASE=ghcr.io/madara-alliance/madara-runtime-base:bookworm-llvm19-tini0.19-v1
+FROM ${MADARA_RUNTIME_BASE} AS runner
+
+WORKDIR /app
+
+COPY ci-binaries/madara /bin/madara
+RUN chmod +x /bin/madara
+
+ENTRYPOINT ["tini", "--", "madara"]
+CMD ["--help"]

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,104 +1,10 @@
-# Step 0: setup tooling (rust)
-FROM rust:1.89-bookworm AS base-rust
+ARG ORCHESTRATOR_BUILDER_BASE=ghcr.io/madara-alliance/orchestrator-rust-builder-base:rust-1.89-bookworm-llvm19-python3.9.16-sccache0.10.0-chef0.1.71-blst0.3.15-v1
+ARG ORCHESTRATOR_RUNTIME_BASE=ghcr.io/madara-alliance/orchestrator-runtime-base:bookworm-node18-tini0.19-v1
+FROM ${ORCHESTRATOR_BUILDER_BASE} AS base-rust
+ARG SCCACHE_DIR=/sccache
 WORKDIR /app
 
-# Note that we do not install cargo chef and sccache through docker to avoid
-# having to compile them from source
-ENV SCCACHE_VERSION=v0.10.0
-ENV SCCACHE_URL=https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-ENV SCCACHE_TAR=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-ENV SCCACHE_BIN=/bin/sccache
-ENV SCCACHE_DIR=/sccache
-ENV SCCACHE=sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache
-
-ENV CHEF_VERSION=v0.1.71
-ENV CHEF_URL=https://github.com/LukeMathWalker/cargo-chef/releases/download/${CHEF_VERSION}/cargo-chef-x86_64-unknown-linux-gnu.tar.gz
-ENV CHEF_TAR=cargo-chef-x86_64-unknown-linux-gnu.tar.gz
-
-ENV RUSTC_WRAPPER=/bin/sccache
-
-ENV WGET="-O- --timeout=10 --waitretry=3 --retry-connrefused --progress=dot:mega"
-
-# Copy Makefile for LLVM installation
-COPY Makefile /tmp/Makefile
-
-# Install LLVM 19 for Cairo Native support using Makefile target
-RUN apt-get update -y && apt-get install -y \
-  bash \
-  build-essential \
-  ca-certificates \
-  curl \
-  git \
-  gnupg \
-  libgmp3-dev \
-  libssl-dev \
-  make \
-  openssl \
-  software-properties-common \
-  wget && \
-  cd /tmp && make -f Makefile install-llvm19 CODENAME=bookworm && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Set LLVM environment variables for Cairo Native
-ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
-ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
-ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
-ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
-
-# Set explicit compilers for Cairo Native runtime compilation
-ENV CC=clang-19
-ENV CXX=clang++-19
-
-# Configure linker search paths for Cairo Native runtime compilation.
-# DEB_HOST_MULTIARCH resolves to the correct lib directory for the build runner architecture.
-RUN DEB_HOST_MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)" && \
-  printf '%s\n' \
-    "export LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
-    "export LD_LIBRARY_PATH=/usr/lib/${DEB_HOST_MULTIARCH}:/usr/lib:/lib/${DEB_HOST_MULTIARCH}:/lib" \
-    > /etc/profile.d/cairo-native-libs.sh
-# Use bash (non-login) so BASH_ENV is honored. A login shell would source
-# /etc/profile, which on Debian unconditionally resets PATH and would wipe
-# /usr/local/cargo/bin and /usr/lib/llvm-19/bin from PATH for every later RUN.
-ENV BASH_ENV=/etc/profile.d/cairo-native-libs.sh
 SHELL ["/bin/bash", "-c"]
-
-# Install BLST from source
-RUN git clone --depth 1 --branch v0.3.15 https://github.com/supranational/blst.git /tmp/blst && \
-  cd /tmp/blst && \
-  ./build.sh && \
-  mkdir -p /usr/local/lib /usr/local/include && \
-  cp libblst.a /usr/local/lib/ && \
-  cp bindings/blst.h /usr/local/include/ && \
-  cp bindings/blst_aux.h /usr/local/include/ && \
-  rm -rf /tmp/blst
-
-# ENV to link BLST dependency
-ENV RUSTFLAGS="-L /usr/local/lib -l blst"
-
-# Update linker cache
-RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/blst.conf && ldconfig
-
-# Install Python 3.9
-# Note: --enable-optimizations (PGO) is intentionally omitted. Python here is
-# only used at build time to run cairo-compile for SNOS dependencies, so
-# runtime perf is irrelevant and skipping PGO halves this step's build time
-# (PGO builds Python twice).
-RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
-  && tar xzf Python-3.9.16.tgz \
-  && cd Python-3.9.16 \
-  && ./configure \
-  && make altinstall \
-  && cd .. \
-  && rm -rf Python-3.9.16 Python-3.9.16.tgz
-
-# Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
-  && python3.9 get-pip.py \
-  && rm get-pip.py \
-  && python3.9 -m pip install virtualenv
-
-RUN wget $SCCACHE_URL && tar -xvpf $SCCACHE_TAR && mv $SCCACHE $SCCACHE_BIN && mkdir sccache
-RUN wget $CHEF_URL && tar -xvpf $CHEF_TAR && mv cargo-chef /bin
 
 # Step 1: Cache dependencies
 FROM base-rust AS planner
@@ -162,16 +68,8 @@ RUN mkdir -p /tmp && \
   touch /tmp/kzg_dirs.txt)
 
 # Step 3: runner
-FROM debian:bookworm-slim AS runner
-
-RUN apt-get -y update && \
-  apt-get install -y openssl ca-certificates tini curl jq && \
-  curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-  apt-get update && \
-  apt-get install -y nodejs && \
-  apt-get autoremove -y; \
-  apt-get clean; \
-  rm -rf /var/lib/apt/lists/*
+ARG ORCHESTRATOR_RUNTIME_BASE
+FROM ${ORCHESTRATOR_RUNTIME_BASE} AS runner
 
 WORKDIR /app
 
@@ -213,10 +111,6 @@ RUN echo '#!/bin/bash\n\
   ' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 EXPOSE 3000
-
-ENV TINI_VERSION=v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
-RUN chmod +x /bin/tini
 
 # Set the entrypoint
 ENTRYPOINT ["tini", "--", "/app/entrypoint.sh"]

--- a/orchestrator/Dockerfile.manual
+++ b/orchestrator/Dockerfile.manual
@@ -1,0 +1,34 @@
+ARG ORCHESTRATOR_RUNTIME_BASE=ghcr.io/madara-alliance/orchestrator-runtime-base:bookworm-node18-tini0.19-v1
+FROM ${ORCHESTRATOR_RUNTIME_BASE} AS runner
+
+WORKDIR /app
+
+COPY ci-binaries/orchestrator /bin/orchestrator
+RUN chmod +x /bin/orchestrator
+
+COPY orchestrator/crates/settlement-clients/ethereum/src/trusted_setup.txt \
+  /app/orchestrator/crates/settlement-clients/ethereum/src/trusted_setup.txt
+COPY orchestrator/crates/settlement-clients/ethereum/src/trusted_setup.txt /tmp/trusted_setup.txt
+
+COPY orchestrator/migrations /app/migrations
+COPY orchestrator/package.json /app/package.json
+COPY orchestrator/migrate-mongo-config.js /app/migrate-mongo-config.js
+
+RUN npm install --omit=dev
+
+RUN echo '#!/bin/bash\n\
+  set -e\n\
+  \n\
+  if [ -n "$MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL" ] && [ -n "$MADARA_ORCHESTRATOR_DATABASE_NAME" ]; then\n\
+  echo "Running database migrations..."\n\
+  cd /app && npx migrate-mongo up\n\
+  echo "Migrations complete"\n\
+  fi\n\
+  \n\
+  exec orchestrator "$@"\n\
+  ' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["tini", "--", "/app/entrypoint.sh"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary

Optimizes the Manual Docker Image Build workflow for Madara, Orchestrator, and Bootstrapper v2 by splitting Rust binary compilation from Docker image packaging and moving slow toolchain/runtime setup into reusable base images.

Linear: https://linear.app/karnot/issue/MDR-1568/optimize-madara-manual-docker-image-build-ci

## What changed

- Added pinned builder/runtime base image definitions in `.docker-base-images.yml`.
- Added Dockerfiles and a dispatchable workflow to build/publish those base images.
- Slimmed the existing service Dockerfiles so they start from prebuilt builder/runtime bases.
- Added manual packaging Dockerfiles that copy prebuilt CI binaries instead of compiling inside Docker.
- Updated `manual-build-docker-images.yml` to build binaries first, then package/publish manual images for Madara, Orchestrator, and Bootstrapper v2.
- Added a Bootstrapper v2 binary workflow and Cairo setup controls for standalone binary builds.

## Expected impact

The manual image workflow should stop paying the repeated Docker setup cost on every invocation. For warm binary caches, manual image jobs should mostly be binary download plus Docker packaging rather than full source rebuilds inside Docker. Bootstrapper v1 remains on the previous source-build path because it is deprecated and disabled by default.

## Operational note

Before the optimized manual packaging path can succeed, run `Task - Build Docker Base Images` once so the pinned GHCR base images exist. The packaging workflow now checks the selected runtime base image and fails with an explicit message if it has not been published yet.

## Validation

- Parsed changed workflow/YAML files with Ruby `YAML.load_file`.
- Ran `git diff --check` and staged `git diff --cached --check`.
- Ran `docker buildx build --check` for all six base Dockerfiles.
- Ran `docker buildx build --check` for the service/manual Dockerfiles with public stand-in bases to validate Dockerfile syntax and stage wiring before the pinned GHCR base images exist locally.

`actionlint` and `yq` are not installed in the local environment, so those checks were not run locally.