### PR TITLE
Use direct Atlantic L2 verification for Starknet L3 settlement

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -54,7 +54,7 @@ RUN wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz \
   && rm -rf Python-3.9.16 Python-3.9.16.tgz
 
 # Install pip and venv for Python 3.9
-RUN wget https://bootstrap.pypa.io/get-pip.py \
+RUN wget https://bootstrap.pypa.io/pip/3.9/get-pip.py \
   && python3.9 get-pip.py \
   && rm get-pip.py \
   && python3.9 -m pip install virtualenv

--- a/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
@@ -23,7 +23,9 @@ use tempfile::NamedTempFile;
 use url::Url;
 
 use crate::client::{AtlanticBucketInfo, AtlanticClient, AtlanticJobConfig, AtlanticJobInfo};
-use crate::types::{AtlanticBucketStatus, AtlanticCairoVm, AtlanticQuery, AtlanticQueryStep, AtlanticSharpProver};
+use crate::types::{
+    AtlanticBucketStatus, AtlanticCairoVm, AtlanticChain, AtlanticQuery, AtlanticQueryStep, AtlanticSharpProver,
+};
 
 #[derive(Debug, Clone)]
 pub struct AtlanticValidatedArgs {
@@ -185,7 +187,7 @@ impl ProverClient for AtlanticProverService {
                     AtlanticQueryStatus::Received => Ok(TaskStatus::Processing),
                     AtlanticQueryStatus::InProgress => Ok(TaskStatus::Processing),
                     AtlanticQueryStatus::Done => {
-                        if matches!(&self.result, AtlanticQueryStep::ProofVerificationOnL2) {
+                        if Self::is_l2_verification_query(&atlantic_query) {
                             if let Err(reason) = Self::ensure_l2_verification_completed(&atlantic_query) {
                                 return Ok(TaskStatus::Failed(reason));
                             }
@@ -444,6 +446,13 @@ impl AtlanticProverService {
 
     fn should_mock_proof(&self) -> bool {
         self.mock_fact_hash
+    }
+
+    fn is_l2_verification_query(atlantic_query: &AtlanticQuery) -> bool {
+        matches!(atlantic_query.chain.as_ref(), Some(AtlanticChain::L2))
+            || matches!(atlantic_query.result.as_ref(), Some(AtlanticQueryStep::ProofVerificationOnL2))
+            || matches!(atlantic_query.step.as_ref(), Some(AtlanticQueryStep::BridgeFactHash))
+            || atlantic_query.steps.iter().any(|step| matches!(step, AtlanticQueryStep::BridgeFactHash))
     }
 
     fn ensure_l2_verification_completed(atlantic_query: &AtlanticQuery) -> Result<(), String> {

--- a/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/lib.rs
@@ -180,10 +180,17 @@ impl ProverClient for AtlanticProverService {
     ) -> Result<TaskStatus, ProverClientError> {
         match task {
             TaskType::Job => {
-                match self.atlantic_client.get_job_status(job_key).await?.atlantic_query.status {
+                let atlantic_query = self.atlantic_client.get_job_status(job_key).await?.atlantic_query;
+                match atlantic_query.status {
                     AtlanticQueryStatus::Received => Ok(TaskStatus::Processing),
                     AtlanticQueryStatus::InProgress => Ok(TaskStatus::Processing),
                     AtlanticQueryStatus::Done => {
+                        if matches!(&self.result, AtlanticQueryStep::ProofVerificationOnL2) {
+                            if let Err(reason) = Self::ensure_l2_verification_completed(&atlantic_query) {
+                                return Ok(TaskStatus::Failed(reason));
+                            }
+                        }
+
                         if !cross_verify {
                             tracing::debug!("Skipping cross-verification as it's disabled");
                             return Ok(TaskStatus::Succeeded);
@@ -409,11 +416,11 @@ impl AtlanticProverService {
             "random_api_key".to_string(),
             AtlanticJobConfig {
                 proof_layout: *proof_layout,
-                cairo_vm: AtlanticCairoVm::Rust,
-                result: AtlanticQueryStep::ProofVerificationOnL1,
+                cairo_vm: atlantic_params.atlantic_cairo_vm.clone(),
+                result: atlantic_params.atlantic_result.clone(),
                 network: "TESTNET".to_string(),
                 chain_id_hex: None,
-                sharp_prover: AtlanticSharpProver::default(),
+                sharp_prover: atlantic_params.atlantic_sharp_prover.clone(),
             },
             fact_checker,
             atlantic_params.atlantic_mock_fact_hash.eq("true"),
@@ -437,6 +444,31 @@ impl AtlanticProverService {
 
     fn should_mock_proof(&self) -> bool {
         self.mock_fact_hash
+    }
+
+    fn ensure_l2_verification_completed(atlantic_query: &AtlanticQuery) -> Result<(), String> {
+        if !matches!(atlantic_query.result.as_ref(), Some(AtlanticQueryStep::ProofVerificationOnL2)) {
+            return Err(format!(
+                "Atlantic query {} completed with result {:?}; expected {:?}",
+                atlantic_query.id,
+                atlantic_query.result,
+                AtlanticQueryStep::ProofVerificationOnL2
+            ));
+        }
+
+        let reached_bridge_step = matches!(atlantic_query.step.as_ref(), Some(AtlanticQueryStep::BridgeFactHash))
+            || atlantic_query.steps.iter().any(|step| matches!(step, AtlanticQueryStep::BridgeFactHash));
+        if !reached_bridge_step {
+            return Err(format!(
+                "Atlantic query {} completed without reaching {:?}; final step {:?}, steps {:?}",
+                atlantic_query.id,
+                AtlanticQueryStep::BridgeFactHash,
+                atlantic_query.step,
+                atlantic_query.steps
+            ));
+        }
+
+        Ok(())
     }
 
     fn ensure_bucket_details_match(

--- a/orchestrator/crates/prover-clients/atlantic-service/src/proving.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/proving.rs
@@ -24,7 +24,6 @@ use cairo_vm::types::layout_name::LayoutName;
 use orchestrator_utils::http_client::RequestBuilder;
 
 use crate::error::AtlanticError;
-use crate::types::AtlanticQueryStep;
 
 /// Parameters for proving layer specific configuration
 pub struct ProvingParams {
@@ -69,15 +68,12 @@ impl ProvingLayer for EthereumLayer {
 
 /// Starknet proving layer
 ///
-/// For Starknet settlement, we need to add the result step
-/// and layout parameters to the request.
+/// For Starknet settlement, we add the layout parameter to the request.
 pub struct StarknetLayer;
 
 impl ProvingLayer for StarknetLayer {
     fn add_proving_params<'a>(&self, request: RequestBuilder<'a>, params: ProvingParams) -> RequestBuilder<'a> {
-        request
-            .form_text("result", &AtlanticQueryStep::ProofGeneration.to_string())
-            .form_text("layout", params.layout.to_str())
+        request.form_text("layout", params.layout.to_str())
     }
 }
 

--- a/orchestrator/crates/prover-clients/atlantic-service/src/proving.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/proving.rs
@@ -7,7 +7,7 @@
 //! # Background
 //!
 //! Different blockchain networks have different requirements for proof verification.
-//! For example, Starknet requires specific layout and result parameters that
+//! For example, Starknet requires a specific layout parameter that
 //! Ethereum doesn't need. This module abstracts these differences behind a
 //! common trait.
 //!
@@ -15,7 +15,7 @@
 //!
 //! - [`ProvingLayer`]: Trait for adding network-specific proving parameters
 //! - [`EthereumLayer`]: Implementation for Ethereum settlement (no extra params)
-//! - [`StarknetLayer`]: Implementation for Starknet settlement (adds layout/result)
+//! - [`StarknetLayer`]: Implementation for Starknet settlement (adds layout)
 //! - [`ProvingParams`]: Parameters passed to the proving layer
 //! - [`create_proving_layer`]: Factory function to create the appropriate layer
 //!
@@ -40,7 +40,7 @@ pub struct ProvingParams {
 /// # Implementations
 ///
 /// - `EthereumLayer`: No additional parameters needed
-/// - `StarknetLayer`: Adds result and layout parameters
+/// - `StarknetLayer`: Adds the layout parameter
 pub trait ProvingLayer: Send + Sync {
     /// Adds proving layer specific parameters to the request
     ///

--- a/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
@@ -257,7 +257,7 @@ impl AtlanticCairoVersion {
     }
 }
 
-#[derive(Debug, Clone, clap::ValueEnum, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AtlanticQueryStep {
     TraceGeneration,

--- a/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/src/types.rs
@@ -189,6 +189,7 @@ pub enum AtlanticBucketType {
 pub enum AtlanticHints {
     HerodotusEvmGrower,
     HerodotusSnGrower,
+    GenericInput,
 }
 
 #[derive(Debug, Clone, Default, clap::ValueEnum, Serialize, Deserialize)]
@@ -267,6 +268,7 @@ pub enum AtlanticQueryStep {
     ProofGenerationAndVerification,
     FactHashRegistration,
     TraceAndMetadataGeneration,
+    BridgeFactHash,
 }
 
 impl std::fmt::Display for AtlanticQueryStep {

--- a/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
@@ -3,7 +3,7 @@ use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use httpmock::MockServer;
 use orchestrator_atlantic_service::types::{
-    AtlanticCairoVm, AtlanticQueryStatus, AtlanticQueryStep, AtlanticSharpProver,
+    AtlanticCairoVm, AtlanticGetStatusResponse, AtlanticQueryStatus, AtlanticQueryStep, AtlanticSharpProver,
 };
 use orchestrator_atlantic_service::{AtlanticProverService, AtlanticValidatedArgs};
 use orchestrator_prover_client_interface::{CreateJobInfo, ProverClient, Task};
@@ -14,6 +14,58 @@ mod constants;
 // ============================================================================
 // Integration tests
 // ============================================================================
+
+#[test]
+fn atlantic_status_response_deserializes_l2_bridge_fact_hash_step() {
+    let response = serde_json::json!({
+        "atlanticQuery": {
+            "id": "01KVE0Q23ESMNMR7N3HWSDXTP5",
+            "externalId": "",
+            "transactionId": "01KVE0Q8RME79ZA5JJVRG4BVVV",
+            "status": "DONE",
+            "step": "BRIDGE_FACT_HASH",
+            "programHash": "0x555444da05154c46b4828affa18b90c38a333e98fee633fda0af05441eceb24",
+            "integrityFactHash": "0x33fdbc9f1f08bf5a2bf88b046a282e081450e1eb8413faf61889a2d1ac40145",
+            "sharpFactHash": "0x88113d00660188d8e77f0552bfa57f40c94065e119fc616774f8183c415ade47",
+            "layout": "dynamic",
+            "isFactMocked": false,
+            "isProofMocked": false,
+            "chain": "L2",
+            "jobSize": "S",
+            "declaredJobSize": "S",
+            "cairoVm": "python",
+            "cairoVersion": "cairo0",
+            "steps": [
+                "TRACE_AND_METADATA_GENERATION",
+                "PROOF_GENERATION_AND_VERIFICATION",
+                "BRIDGE_FACT_HASH"
+            ],
+            "result": "PROOF_VERIFICATION_ON_L2",
+            "network": "TESTNET",
+            "hints": "generic_input",
+            "sharpProver": "stwo",
+            "errorReason": null,
+            "submittedByClient": "01JTP1DGSTSZ46TCKREJE0JG84",
+            "projectId": "01JNFXEF9JFBQFCKXDANCBE5CN",
+            "bucketId": "",
+            "bucketJobIndex": null,
+            "customerName": "atlantic_karnot",
+            "isJobSizeValid": false,
+            "createdAt": "2026-06-18T18:43:24.708Z",
+            "completedAt": "2026-06-18T21:23:25.861Z"
+        },
+        "metadataUrls": [
+            "https://storage.googleapis.com/hero-atlantic-bucket/queries/01KVE0Q23ESMNMR7N3HWSDXTP5/metadata.json"
+        ]
+    });
+
+    let status: AtlanticGetStatusResponse =
+        serde_json::from_value(response).expect("status response should deserialize");
+
+    assert!(matches!(status.atlantic_query.status, AtlanticQueryStatus::Done));
+    assert!(matches!(status.atlantic_query.step, Some(AtlanticQueryStep::BridgeFactHash)));
+    assert!(status.atlantic_query.steps.iter().any(|step| matches!(step, AtlanticQueryStep::BridgeFactHash)));
+}
 
 #[tokio::test]
 async fn atlantic_client_submit_task_when_mock_works() {

--- a/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
@@ -6,7 +6,7 @@ use orchestrator_atlantic_service::types::{
     AtlanticCairoVm, AtlanticGetStatusResponse, AtlanticQueryStatus, AtlanticQueryStep, AtlanticSharpProver,
 };
 use orchestrator_atlantic_service::{AtlanticProverService, AtlanticValidatedArgs};
-use orchestrator_prover_client_interface::{CreateJobInfo, ProverClient, Task};
+use orchestrator_prover_client_interface::{CreateJobInfo, ProverClient, Task, TaskStatus, TaskType};
 use orchestrator_utils::env_utils::get_env_var_or_panic;
 use url::Url;
 mod constants;
@@ -14,6 +14,84 @@ mod constants;
 // ============================================================================
 // Integration tests
 // ============================================================================
+
+fn atlantic_params_for_status_tests(result: AtlanticQueryStep) -> AtlanticValidatedArgs {
+    AtlanticValidatedArgs {
+        atlantic_api_key: "test-api-key".to_string(),
+        atlantic_service_url: Url::parse("http://127.0.0.1:1").unwrap(),
+        atlantic_rpc_node_url: Url::parse("http://127.0.0.1:2").unwrap(),
+        atlantic_mock_fact_hash: "true".to_string(),
+        atlantic_prover_type: "atlantic".to_string(),
+        atlantic_settlement_layer: "starknet".to_string(),
+        atlantic_verifier_contract_address: "0x0".to_string(),
+        atlantic_network: "TESTNET".to_string(),
+        cairo_verifier_program_hash: None,
+        atlantic_cairo_vm: AtlanticCairoVm::Rust,
+        atlantic_result: result,
+        atlantic_sharp_prover: AtlanticSharpProver::Stwo,
+        atlantic_artifacts_base_url: Url::parse("https://storage.googleapis.com/hero-atlantic-bucket").unwrap(),
+    }
+}
+
+fn atlantic_done_status_response(result: Option<&str>, step: Option<&str>, steps: Vec<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "atlanticQuery": {
+            "id": "query-id",
+            "externalId": "",
+            "transactionId": "tx-id",
+            "status": "DONE",
+            "step": step,
+            "programHash": "0x555444da05154c46b4828affa18b90c38a333e98fee633fda0af05441eceb24",
+            "integrityFactHash": "0x33fdbc9f1f08bf5a2bf88b046a282e081450e1eb8413faf61889a2d1ac40145",
+            "sharpFactHash": "0x88113d00660188d8e77f0552bfa57f40c94065e119fc616774f8183c415ade47",
+            "layout": "dynamic",
+            "isFactMocked": false,
+            "isProofMocked": false,
+            "chain": "L2",
+            "jobSize": "S",
+            "declaredJobSize": "S",
+            "cairoVm": "python",
+            "cairoVersion": "cairo0",
+            "steps": steps,
+            "result": result,
+            "network": "TESTNET",
+            "hints": "generic_input",
+            "sharpProver": "stwo",
+            "errorReason": null,
+            "submittedByClient": "client",
+            "projectId": "project",
+            "bucketId": "",
+            "bucketJobIndex": null,
+            "customerName": "atlantic_karnot",
+            "isJobSizeValid": false,
+            "createdAt": "2026-06-18T18:43:24.708Z",
+            "completedAt": "2026-06-18T21:23:25.861Z"
+        },
+        "metadataUrls": []
+    })
+}
+
+async fn get_mocked_job_status(result: Option<&str>, step: Option<&str>, steps: Vec<&str>) -> TaskStatus {
+    let mock_server = MockServer::start();
+    let status_mock = mock_server.mock(|when, then| {
+        when.method("GET").path("/atlantic-query/query-id");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(atlantic_done_status_response(result, step, steps));
+    });
+
+    let atlantic_params = atlantic_params_for_status_tests(AtlanticQueryStep::ProofVerificationOnL2);
+    let atlantic_service =
+        AtlanticProverService::with_test_params(mock_server.port(), &atlantic_params, &LayoutName::dynamic);
+
+    let status = atlantic_service
+        .get_task_status(TaskType::Job, "query-id", None, false)
+        .await
+        .expect("status fetch should succeed");
+
+    status_mock.assert();
+    status
+}
 
 #[test]
 fn atlantic_status_response_deserializes_l2_bridge_fact_hash_step() {
@@ -65,6 +143,52 @@ fn atlantic_status_response_deserializes_l2_bridge_fact_hash_step() {
     assert!(matches!(status.atlantic_query.status, AtlanticQueryStatus::Done));
     assert!(matches!(status.atlantic_query.step, Some(AtlanticQueryStep::BridgeFactHash)));
     assert!(status.atlantic_query.steps.iter().any(|step| matches!(step, AtlanticQueryStep::BridgeFactHash)));
+}
+
+#[tokio::test]
+async fn atlantic_l2_verification_status_accepts_bridge_fact_hash_completion() {
+    let status = get_mocked_job_status(
+        Some("PROOF_VERIFICATION_ON_L2"),
+        Some("BRIDGE_FACT_HASH"),
+        vec!["TRACE_AND_METADATA_GENERATION", "PROOF_GENERATION_AND_VERIFICATION", "BRIDGE_FACT_HASH"],
+    )
+    .await;
+
+    assert_eq!(status, TaskStatus::Succeeded);
+}
+
+#[tokio::test]
+async fn atlantic_l2_verification_status_rejects_wrong_result() {
+    let status = get_mocked_job_status(
+        Some("PROOF_GENERATION"),
+        Some("BRIDGE_FACT_HASH"),
+        vec!["TRACE_AND_METADATA_GENERATION", "PROOF_GENERATION_AND_VERIFICATION", "BRIDGE_FACT_HASH"],
+    )
+    .await;
+
+    match status {
+        TaskStatus::Failed(reason) => {
+            assert!(reason.contains("expected ProofVerificationOnL2"), "unexpected reason: {}", reason);
+        }
+        _ => panic!("expected failed status, got {:?}", status),
+    }
+}
+
+#[tokio::test]
+async fn atlantic_l2_verification_status_rejects_missing_bridge_fact_hash_step() {
+    let status = get_mocked_job_status(
+        Some("PROOF_VERIFICATION_ON_L2"),
+        Some("PROOF_GENERATION_AND_VERIFICATION"),
+        vec!["TRACE_AND_METADATA_GENERATION", "PROOF_GENERATION_AND_VERIFICATION"],
+    )
+    .await;
+
+    match status {
+        TaskStatus::Failed(reason) => {
+            assert!(reason.contains("BridgeFactHash"), "unexpected reason: {}", reason);
+        }
+        _ => panic!("expected failed status, got {:?}", status),
+    }
 }
 
 #[tokio::test]

--- a/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
+++ b/orchestrator/crates/prover-clients/atlantic-service/tests/lib.rs
@@ -71,7 +71,12 @@ fn atlantic_done_status_response(result: Option<&str>, step: Option<&str>, steps
     })
 }
 
-async fn get_mocked_job_status(result: Option<&str>, step: Option<&str>, steps: Vec<&str>) -> TaskStatus {
+async fn get_mocked_job_status_with_service_result(
+    service_result: AtlanticQueryStep,
+    result: Option<&str>,
+    step: Option<&str>,
+    steps: Vec<&str>,
+) -> TaskStatus {
     let mock_server = MockServer::start();
     let status_mock = mock_server.mock(|when, then| {
         when.method("GET").path("/atlantic-query/query-id");
@@ -80,7 +85,7 @@ async fn get_mocked_job_status(result: Option<&str>, step: Option<&str>, steps: 
             .json_body(atlantic_done_status_response(result, step, steps));
     });
 
-    let atlantic_params = atlantic_params_for_status_tests(AtlanticQueryStep::ProofVerificationOnL2);
+    let atlantic_params = atlantic_params_for_status_tests(service_result);
     let atlantic_service =
         AtlanticProverService::with_test_params(mock_server.port(), &atlantic_params, &LayoutName::dynamic);
 
@@ -91,6 +96,10 @@ async fn get_mocked_job_status(result: Option<&str>, step: Option<&str>, steps: 
 
     status_mock.assert();
     status
+}
+
+async fn get_mocked_job_status(result: Option<&str>, step: Option<&str>, steps: Vec<&str>) -> TaskStatus {
+    get_mocked_job_status_with_service_result(AtlanticQueryStep::ProofVerificationOnL2, result, step, steps).await
 }
 
 #[test]
@@ -148,6 +157,19 @@ fn atlantic_status_response_deserializes_l2_bridge_fact_hash_step() {
 #[tokio::test]
 async fn atlantic_l2_verification_status_accepts_bridge_fact_hash_completion() {
     let status = get_mocked_job_status(
+        Some("PROOF_VERIFICATION_ON_L2"),
+        Some("BRIDGE_FACT_HASH"),
+        vec!["TRACE_AND_METADATA_GENERATION", "PROOF_GENERATION_AND_VERIFICATION", "BRIDGE_FACT_HASH"],
+    )
+    .await;
+
+    assert_eq!(status, TaskStatus::Succeeded);
+}
+
+#[tokio::test]
+async fn atlantic_l2_verification_status_uses_polled_query_result_not_service_default() {
+    let status = get_mocked_job_status_with_service_result(
+        AtlanticQueryStep::ProofGeneration,
         Some("PROOF_VERIFICATION_ON_L2"),
         Some("BRIDGE_FACT_HASH"),
         vec!["TRACE_AND_METADATA_GENERATION", "PROOF_GENERATION_AND_VERIFICATION", "BRIDGE_FACT_HASH"],

--- a/orchestrator/crates/settlement-clients/starknet/src/interfaces/core_contract.rs
+++ b/orchestrator/crates/settlement-clients/starknet/src/interfaces/core_contract.rs
@@ -13,19 +13,10 @@ impl CoreContract {
         Self { signer, address }
     }
 
-    pub async fn update_state(
-        &self,
-        snos_output: Vec<Felt>,
-        program_output: Vec<Felt>,
-    ) -> Result<InvokeTransactionResult> {
-        let mut calldata = Vec::with_capacity(snos_output.len() + program_output.len() + 5);
+    pub async fn update_state(&self, snos_output: Vec<Felt>) -> Result<InvokeTransactionResult> {
+        let mut calldata = Vec::with_capacity(snos_output.len() + 1);
         calldata.push(Felt::from(snos_output.len()));
         calldata.extend(snos_output);
-        calldata.push(Felt::from(program_output.len()));
-        calldata.extend(program_output);
-        // calldata.push(onchain_data_hash);
-        // calldata.push(onchain_data_size.low().into());
-        // calldata.push(onchain_data_size.high().into());
 
         invoke_contract(&self.signer, self.address, "update_state", calldata).await
     }

--- a/orchestrator/crates/settlement-clients/starknet/src/lib.rs
+++ b/orchestrator/crates/settlement-clients/starknet/src/lib.rs
@@ -119,7 +119,7 @@ impl SettlementClient for StarknetSettlementClient {
     async fn update_state_calldata(
         &self,
         snos_output: Vec<[u8; 32]>,
-        program_output: Vec<[u8; 32]>,
+        _program_output: Vec<[u8; 32]>,
         _onchain_data_hash: [u8; 32],
         _onchain_data_size: [u8; 32],
     ) -> Result<String> {
@@ -127,15 +127,13 @@ impl SettlementClient for StarknetSettlementClient {
             log_type = "starting",
             category = "update_state",
             snos_output_len = %snos_output.len(),
-            program_output_len = %program_output.len(),
             "Updating state with calldata"
         );
         let snos_output = slice_slice_u8_to_vec_field(snos_output.as_slice());
-        let layout_bridge_output = slice_slice_u8_to_vec_field(program_output.as_slice());
         let core_contract: &CoreContract = self.starknet_core_contract_client.as_ref();
 
         let invoke_result = core_contract
-            .update_state(snos_output, layout_bridge_output)
+            .update_state(snos_output)
             .await
             .map_err(|e| eyre!("Failed to update state with calldata: {:?}", e))?;
 

--- a/orchestrator/src/types/params/prover.rs
+++ b/orchestrator/src/types/params/prover.rs
@@ -1,6 +1,6 @@
 use crate::cli::RunCmd;
 use crate::OrchestratorError;
-use orchestrator_atlantic_service::AtlanticValidatedArgs;
+use orchestrator_atlantic_service::{types::AtlanticQueryStep, AtlanticValidatedArgs};
 use orchestrator_sharp_service::SharpValidatedArgs;
 use orchestrator_utils::layer::Layer;
 
@@ -54,12 +54,27 @@ impl TryFrom<RunCmd> for ProverConfig {
             }
             (false, true) => {
                 let atlantic_args = run_cmd.atlantic_args;
-                // NOTE: Just making sure Cairo Verifier Program Hash is there for L3
                 if run_cmd.layer == Layer::L3 && atlantic_args.cairo_verifier_program_hash.is_none() {
                     return Err(OrchestratorError::RunCommandError(
                         "Cairo verifier program hash is required for L3".to_string(),
                     ));
                 }
+
+                let atlantic_result = atlantic_args
+                    .atlantic_verifier_result
+                    .ok_or_else(|| OrchestratorError::SetupCommandError("Atlantic result is required".to_string()))?;
+
+                if run_cmd.layer == Layer::L3 && !matches!(&atlantic_result, &AtlanticQueryStep::ProofVerificationOnL2)
+                {
+                    return Err(OrchestratorError::RunCommandError(
+                        "Atlantic result must be PROOF_VERIFICATION_ON_L2 for L3".to_string(),
+                    ));
+                }
+
+                let atlantic_sharp_prover = atlantic_args.atlantic_sharp_prover.ok_or_else(|| {
+                    OrchestratorError::RunCommandError("Atlantic sharp prover is required".to_string())
+                })?;
+
                 Ok(Self::Atlantic(AtlanticValidatedArgs {
                     atlantic_api_key: atlantic_args.atlantic_api_key.ok_or_else(|| {
                         OrchestratorError::RunCommandError("Atlantic API key is required".to_string())
@@ -92,18 +107,96 @@ impl TryFrom<RunCmd> for ProverConfig {
                     atlantic_cairo_vm: atlantic_args.atlantic_verifier_cairo_vm.ok_or_else(|| {
                         OrchestratorError::SetupCommandError("Atlantic cairo vm is required".to_string())
                     })?,
-                    atlantic_result: atlantic_args.atlantic_verifier_result.ok_or_else(|| {
-                        OrchestratorError::SetupCommandError("Atlantic result is required".to_string())
-                    })?,
+                    atlantic_result,
                     cairo_verifier_program_hash: atlantic_args.cairo_verifier_program_hash,
-                    atlantic_sharp_prover: atlantic_args.atlantic_sharp_prover.ok_or_else(|| {
-                        OrchestratorError::RunCommandError("Atlantic sharp prover is required".to_string())
-                    })?,
+                    atlantic_sharp_prover,
                     atlantic_artifacts_base_url: atlantic_args.atlantic_artifacts_base_url.ok_or_else(|| {
                         OrchestratorError::RunCommandError("Atlantic artifacts base URL is required".to_string())
                     })?,
                 }))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn l3_atlantic_run_cmd(extra_args: &[&str]) -> RunCmd {
+        let mut args = vec![
+            "orchestrator",
+            "--aws",
+            "--aws-s3",
+            "--aws-sqs",
+            "--aws-sns",
+            "--da-on-starknet",
+            "--starknet-da-rpc-url",
+            "http://localhost:9944",
+            "--settle-on-starknet",
+            "--starknet-rpc-url",
+            "http://localhost:9944",
+            "--starknet-private-key",
+            "0x1",
+            "--starknet-account-address",
+            "0x1",
+            "--starknet-cairo-core-contract-address",
+            "0x1",
+            "--starknet-finality-retry-wait-in-secs",
+            "1",
+            "--atlantic",
+            "--atlantic-api-key",
+            "test-api-key",
+            "--atlantic-service-url",
+            "http://localhost:8080",
+            "--atlantic-rpc-node-url",
+            "http://localhost:9944",
+            "--atlantic-verifier-contract-address",
+            "0x1",
+            "--atlantic-settlement-layer",
+            "starknet",
+            "--atlantic-mock-fact-hash",
+            "true",
+            "--atlantic-prover-type",
+            "atlantic",
+            "--atlantic-network",
+            "TESTNET",
+            "--cairo-verifier-program-hash",
+            "0x123",
+            "--madara-rpc-url",
+            "http://localhost:9944",
+            "--madara-version",
+            "0.14.0",
+            "--rpc-for-snos",
+            "http://localhost:9944",
+            "--max-batch-time-seconds",
+            "60",
+            "--layer",
+            "l3",
+        ];
+        args.extend_from_slice(extra_args);
+
+        RunCmd::try_parse_from(args).expect("valid L3 Atlantic CLI args")
+    }
+
+    #[test]
+    fn l3_atlantic_requires_proof_verification_on_l2() {
+        let err = ProverConfig::try_from(l3_atlantic_run_cmd(&[])).expect_err("default proof generation is invalid");
+
+        assert!(err.to_string().contains("Atlantic result must be PROOF_VERIFICATION_ON_L2 for L3"));
+    }
+
+    #[test]
+    fn l3_atlantic_accepts_proof_verification_on_l2() {
+        let config =
+            ProverConfig::try_from(l3_atlantic_run_cmd(&["--atlantic-verifier-result", "proof-verification-on-l2"]))
+                .expect("proof verification on L2 should be valid for L3");
+
+        let ProverConfig::Atlantic(args) = config else {
+            panic!("expected Atlantic prover config");
+        };
+
+        assert!(matches!(args.atlantic_result, AtlanticQueryStep::ProofVerificationOnL2));
     }
 }

--- a/orchestrator/src/worker/event_handler/jobs/proof_registration.rs
+++ b/orchestrator/src/worker/event_handler/jobs/proof_registration.rs
@@ -8,8 +8,9 @@ use crate::types::jobs::types::{JobStatus, JobType};
 use crate::worker::event_handler::jobs::JobHandlerTrait;
 use anyhow::Context;
 use async_trait::async_trait;
+use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use color_eyre::eyre::eyre;
-use orchestrator_prover_client_interface::{TaskStatus, TaskType};
+use orchestrator_prover_client_interface::{CreateJobInfo, Task, TaskStatus, TaskType};
 use std::sync::Arc;
 use swiftness_proof_parser::{parse, StarkProof};
 use tracing::{debug, error, info, warn};
@@ -33,40 +34,57 @@ impl JobHandlerTrait for RegisterProofJobHandler {
             error!(error = %e, "Failed to convert metadata to ProvingMetadata");
         })?;
 
-        // Get the proof path from input_path
-        let proof_key = match proving_metadata.input_path {
-            Some(ProvingInputType::Proof(path)) => path,
-            Some(ProvingInputType::CairoPie(_)) => {
-                return Err(JobError::Other(OtherError(eyre!("Expected Proof input, got CairoPie"))));
+        let task_id = internal_id.to_string();
+        let external_id = match proving_metadata.input_path {
+            Some(ProvingInputType::Proof(proof_key)) => {
+                debug!(%proof_key, "Fetching proof file");
+
+                let proof_file = config.storage().get_data(&proof_key).await?;
+
+                let proof = String::from_utf8(proof_file.to_vec()).context(format!(
+                    "Failed to parse proof file as UTF-8 for job_id: {}, proof_key: {}",
+                    internal_id, proof_key
+                ))?;
+
+                let _: StarkProof = parse(proof.clone())
+                    .context(format!("Failed to parse proof file as UTF-8, internal-id: {}", internal_id))?;
+
+                let formatted_proof = format!("{{\n\t\"proof\": {}\n}}", proof);
+
+                config
+                    .prover_client()
+                    .submit_l2_query(&task_id, &formatted_proof, proving_metadata.n_steps)
+                    .await
+                    .inspect_err(|e| {
+                        error!(error = %e, "Failed to submit proof for L2 verification for job {}",
+                        internal_id);
+                    })?
+            }
+            Some(ProvingInputType::CairoPie(input_path)) => {
+                debug!(%input_path, "Fetching Cairo PIE file for L2 proof verification");
+
+                let cairo_pie_file = config.storage().get_data(&input_path).await?;
+                let cairo_pie = Box::new(
+                    CairoPie::from_bytes(cairo_pie_file.to_vec().as_slice())
+                        .map_err(|e| JobError::Other(OtherError(eyre!("Failed to parse Cairo PIE file: {}", e))))?,
+                );
+
+                config
+                    .prover_client()
+                    .submit_task(Task::CreateJob(CreateJobInfo {
+                        cairo_pie,
+                        bucket_id: None,
+                        bucket_job_index: None,
+                        num_steps: proving_metadata.n_steps,
+                        dedup_id: job.id.to_string(),
+                    }))
+                    .await
+                    .inspect_err(|e| {
+                        error!(error = %e, "Failed to submit Cairo PIE for L2 proof verification for job {}", internal_id);
+                    })?
             }
             None => return Err(JobError::Other(OtherError(eyre!("Input path not found in job metadata")))),
         };
-        debug!(%proof_key, "Fetching proof file");
-
-        let proof_file = config.storage().get_data(&proof_key).await?;
-
-        let proof = String::from_utf8(proof_file.to_vec()).context(format!(
-            "Failed to parse proof file as UTF-8 for job_id: {}, proof_key: {}",
-            internal_id, proof_key
-        ))?;
-
-        let _: StarkProof = parse(proof.clone())
-            .context(format!("Failed to parse proof file as UTF-8, internal-id: {}", internal_id))?;
-
-        // Format proof for submission
-        let formatted_proof = format!("{{\n\t\"proof\": {}\n}}", proof);
-
-        let task_id = internal_id.to_string();
-
-        // Submit proof for L2 verification
-        let external_id = config
-            .prover_client()
-            .submit_l2_query(&task_id, &formatted_proof, proving_metadata.n_steps)
-            .await
-            .inspect_err(|e| {
-                error!(error = %e, "Failed to submit proof for L2 verification for job {}",
-                internal_id);
-            })?;
 
         info!(log_type = "completed", job_id = %job.id, external_id = %external_id, "{:?} job {} processed successfully", JobType::ProofRegistration, internal_id);
         Ok(external_id)

--- a/orchestrator/src/worker/event_handler/jobs/state_update.rs
+++ b/orchestrator/src/worker/event_handler/jobs/state_update.rs
@@ -10,7 +10,7 @@ use crate::types::jobs::metadata::{
 use crate::types::jobs::status::JobVerificationStatus;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::worker::event_handler::jobs::JobHandlerTrait;
-use crate::worker::utils::{fetch_blob_data, fetch_da_segment, fetch_program_output, fetch_snos_output};
+use crate::worker::utils::{fetch_da_segment, fetch_program_output, fetch_snos_output};
 use async_trait::async_trait;
 use color_eyre::eyre::eyre;
 use orchestrator_settlement_client_interface::SettlementVerificationStatus;
@@ -39,21 +39,16 @@ impl JobHandlerTrait for StateUpdateJobHandler {
         // Extract state transition metadata
         let state_metadata: StateUpdateMetadata = metadata.specific.clone().try_into()?;
 
-        // Validate required paths based on layer configuration
-        // L2: requires program_output_path + da_segment_path
-        // L3: requires program_output_path + blob_data_path + snos_output_path
-        if state_metadata.program_output_path.is_none() {
-            error!("program_output_path is required for all state updates");
-            return Err(JobError::Other(OtherError(eyre!("Missing required program_output_path in metadata"))));
-        }
-
-        let is_l2_config = state_metadata.da_segment_path.is_some();
-        let is_l3_config = state_metadata.blob_data_path.is_some() && state_metadata.snos_output_path.is_some();
+        // Validate required paths based on layer configuration.
+        // L2: requires program_output_path + da_segment_path.
+        // L3: requires only snos_output_path; the Satellite fact check makes proof/layout outputs obsolete.
+        let is_l2_config = state_metadata.program_output_path.is_some() && state_metadata.da_segment_path.is_some();
+        let is_l3_config = state_metadata.snos_output_path.is_some();
 
         if !is_l2_config && !is_l3_config {
-            error!("Missing required paths: must provide either (da_segment_path for L2) or (blob_data_path + snos_output_path for L3)");
+            error!("Missing required paths: must provide either (program_output_path + da_segment_path for L2) or snos_output_path for L3");
             return Err(JobError::Other(OtherError(eyre!(
-                "Missing required paths: must provide either (da_segment_path for L2) or (blob_data_path + snos_output_path for L3)"
+                "Missing required paths: must provide either (program_output_path + da_segment_path for L2) or snos_output_path for L3"
             ))));
         }
         let job_item = JobItem::create(internal_id, JobType::StateTransition, JobStatus::Created, metadata);
@@ -117,12 +112,14 @@ impl JobHandlerTrait for StateUpdateJobHandler {
                         None
                     }
                 };
-            let program_output = fetch_program_output(config.clone(), &state_metadata.program_output_path).await?;
-            let blob_data = match config.layer() {
-                // For L2, use DA segment from prover (encrypted/compressed state diff)
-                Layer::L2 => fetch_da_segment(config.clone(), &state_metadata.da_segment_path).await?,
-                // For L3, use locally stored blob data
-                Layer::L3 => fetch_blob_data(config.clone(), &state_metadata.blob_data_path).await?,
+            let (program_output, blob_data) = match config.layer() {
+                Layer::L2 => {
+                    let program_output =
+                        fetch_program_output(config.clone(), &state_metadata.program_output_path).await?;
+                    let blob_data = fetch_da_segment(config.clone(), &state_metadata.da_segment_path).await?;
+                    (program_output, blob_data)
+                }
+                Layer::L3 => (Vec::new(), Vec::new()),
             };
 
             let txn_hash = match self
@@ -371,8 +368,6 @@ impl StateUpdateJobHandler {
                         to_settle_num
                     ))))?,
                     nonce,
-                    artifacts.program_output,
-                    artifacts.blob_data,
                 )
                 .await
             }
@@ -402,8 +397,6 @@ impl StateUpdateJobHandler {
         block_no: u64,
         snos: Vec<Felt>,
         _nonce: u64,
-        _program_output: Vec<[u8; 32]>,
-        _blob_data: Vec<Vec<u8>>,
     ) -> Result<String, JobError> {
         let settlement_client = config.settlement_client();
 

--- a/orchestrator/src/worker/event_handler/jobs/state_update.rs
+++ b/orchestrator/src/worker/event_handler/jobs/state_update.rs
@@ -39,16 +39,20 @@ impl JobHandlerTrait for StateUpdateJobHandler {
         // Extract state transition metadata
         let state_metadata: StateUpdateMetadata = metadata.specific.clone().try_into()?;
 
-        // Validate required paths based on layer configuration.
-        // L2: requires program_output_path + da_segment_path.
-        // L3: requires only snos_output_path; the Satellite fact check makes proof/layout outputs obsolete.
+        // Validate required path shapes.
+        // L2 state updates require program output and DA segment artifacts.
+        // L3 state updates should only carry raw SNOS output; proof/layout artifacts are obsolete.
         let is_l2_config = state_metadata.program_output_path.is_some() && state_metadata.da_segment_path.is_some();
-        let is_l3_config = state_metadata.snos_output_path.is_some();
+        let is_l3_config = state_metadata.snos_output_path.is_some()
+            && state_metadata.program_output_path.is_none()
+            && state_metadata.da_segment_path.is_none();
 
         if !is_l2_config && !is_l3_config {
-            error!("Missing required paths: must provide either (program_output_path + da_segment_path for L2) or snos_output_path for L3");
+            error!(
+                "Invalid state update paths: provide either (program_output_path + da_segment_path for L2) or only snos_output_path for L3"
+            );
             return Err(JobError::Other(OtherError(eyre!(
-                "Missing required paths: must provide either (program_output_path + da_segment_path for L2) or snos_output_path for L3"
+                "Invalid state update paths: provide either (program_output_path + da_segment_path for L2) or only snos_output_path for L3"
             ))));
         }
         let job_item = JobItem::create(internal_id, JobType::StateTransition, JobStatus::Created, metadata);

--- a/orchestrator/src/worker/event_handler/jobs/state_update.rs
+++ b/orchestrator/src/worker/event_handler/jobs/state_update.rs
@@ -3,7 +3,6 @@ use crate::error::job::state_update::StateUpdateError;
 use crate::error::job::JobError;
 use crate::error::other::OtherError;
 use crate::types::batch::{AggregatorBatchStatus, SnosBatchStatus};
-use crate::types::constant::{PROOF_FILE_NAME, PROOF_PART2_FILE_NAME};
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::metadata::{
     JobMetadata, JobSpecificMetadata, SettlementContext, SettlementContextData, StateUpdateMetadata,
@@ -19,7 +18,6 @@ use orchestrator_settlement_client_interface::SettlementVerificationStatus;
 use orchestrator_utils::layer::Layer;
 use starknet_core::types::Felt;
 use std::sync::Arc;
-use swiftness_proof_parser::{parse, StarkProof};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -416,41 +414,10 @@ impl StateUpdateJobHandler {
         // updates with call data: this configuration effectively replicates private DA functionality,
         // as the state diff is not in the snos_output while still maintaining the ability to update state.
         let last_tx_hash_executed = if snos.get(8) == Some(&Felt::ZERO) || snos.get(8) == Some(&Felt::ONE) {
-            let proof_key = format!("{block_no}/{PROOF_FILE_NAME}");
-            debug!(%proof_key, "Fetching snos proof file");
-
-            let proof_file = config.storage().get_data(&proof_key).await?;
-
-            let snos_proof = String::from_utf8(proof_file.to_vec()).map_err(|e| {
-                error!(error = %e, "Failed to parse proof file as UTF-8");
-                JobError::Other(OtherError(eyre!("{}", e)))
-            })?;
-
-            let parsed_snos_proof: StarkProof = parse(snos_proof.clone()).map_err(|e| {
-                error!(error = %e, "Failed to parse proof file as UTF-8");
-                JobError::Other(OtherError(eyre!("{}", e)))
-            })?;
-
-            let proof_key = format!("{block_no}/{PROOF_PART2_FILE_NAME}");
-            debug!(%proof_key, "Fetching 2nd proof file");
-
-            let proof_file = config.storage().get_data(&proof_key).await?;
-
-            let second_proof = String::from_utf8(proof_file.to_vec()).map_err(|e| {
-                error!(error = %e, "Failed to parse proof file as UTF-8");
-                JobError::Other(OtherError(eyre!("{}", e)))
-            })?;
-
-            let parsed_bridge_proof: StarkProof = parse(second_proof.clone()).map_err(|e| {
-                error!(error = %e, "Failed to parse proof file as UTF-8");
-                JobError::Other(OtherError(eyre!("{}", e)))
-            })?;
-
-            let snos_output = vec_felt_to_vec_bytes32(calculate_output(parsed_snos_proof.clone()));
-            let program_output = vec_felt_to_vec_bytes32(calculate_output(parsed_bridge_proof));
+            let snos_output = vec_felt_to_vec_bytes32(snos);
 
             settlement_client
-                .update_state_calldata(snos_output, program_output, [0u8; 32], [0u8; 32])
+                .update_state_calldata(snos_output, Vec::new(), [0u8; 32], [0u8; 32])
                 .await
                 .map_err(|e| JobError::Other(OtherError(e)))?
         } else {
@@ -459,20 +426,6 @@ impl StateUpdateJobHandler {
 
         Ok(last_tx_hash_executed)
     }
-}
-
-pub fn calculate_output(proof: StarkProof) -> Vec<Felt> {
-    let output_segment = proof.public_input.segments[2].clone();
-    let output_len = output_segment.stop_ptr - output_segment.begin_addr;
-    let start = proof.public_input.main_page.len() - output_len as usize;
-    let end = proof.public_input.main_page.len();
-    let program_output =
-        proof.public_input.main_page[start..end].iter().map(|cell| cell.value.clone()).collect::<Vec<_>>();
-    let mut felts = vec![];
-    for elem in &program_output {
-        felts.push(Felt::from_dec_str(&elem.to_string()).unwrap());
-    }
-    felts
 }
 
 pub fn vec_felt_to_vec_bytes32(felts: Vec<Felt>) -> Vec<[u8; 32]> {

--- a/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
+++ b/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
@@ -1,6 +1,8 @@
 use crate::core::config::Config;
-use crate::types::constant::{ORCHESTRATOR_VERSION, PROOF_FILE_NAME, PROOF_PART2_FILE_NAME};
-use crate::types::jobs::metadata::{JobSpecificMetadata, ProvingInputType, ProvingMetadata};
+use crate::types::constant::{ORCHESTRATOR_VERSION, PROOF_FILE_NAME};
+use crate::types::jobs::metadata::{
+    CommonMetadata, JobMetadata, JobSpecificMetadata, ProvingInputType, ProvingMetadata, SnosMetadata,
+};
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
@@ -16,6 +18,10 @@ pub struct ProofRegistrationJobTrigger;
 #[async_trait]
 impl JobTrigger for ProofRegistrationJobTrigger {
     async fn run_worker(&self, config: Arc<Config>) -> color_eyre::Result<()> {
+        if matches!(config.layer(), Layer::L3) {
+            return create_l3_proof_registration_jobs(config).await;
+        }
+
         let db = config.database();
 
         let successful_proving_jobs = db
@@ -41,11 +47,7 @@ impl JobTrigger for ProofRegistrationJobTrigger {
             let proof_path = format!("{}/{}", job.internal_id, PROOF_FILE_NAME);
             proving_metadata.input_path = Some(ProvingInputType::Proof(proof_path));
 
-            // Set the download path for bridge proof based on the layer
-            proving_metadata.download_proof = match config.layer() {
-                Layer::L2 => None,
-                Layer::L3 => Some(format!("{}/{}", job.internal_id, PROOF_PART2_FILE_NAME)),
-            };
+            proving_metadata.download_proof = None;
 
             metadata.specific = JobSpecificMetadata::Proving(proving_metadata);
 
@@ -68,4 +70,55 @@ impl JobTrigger for ProofRegistrationJobTrigger {
 
         Ok(())
     }
+}
+
+async fn create_l3_proof_registration_jobs(config: Arc<Config>) -> color_eyre::Result<()> {
+    let db = config.database();
+    let successful_snos_jobs = db
+        .get_jobs_without_successor(
+            JobType::SnosRun,
+            JobStatus::Completed,
+            JobType::ProofRegistration,
+            Some(ORCHESTRATOR_VERSION.to_string()),
+        )
+        .await?;
+
+    debug!("Found {} successful SNOS jobs without proof registration jobs", successful_snos_jobs.len());
+
+    for job in successful_snos_jobs {
+        let snos_metadata: SnosMetadata = job.metadata.specific.clone().try_into().map_err(|e| {
+            error!(job_id = %job.internal_id, error = %e, "Invalid metadata type for SNOS job");
+            e
+        })?;
+
+        let metadata = JobMetadata {
+            common: CommonMetadata::default(),
+            specific: JobSpecificMetadata::Proving(ProvingMetadata {
+                block_number: snos_metadata.start_block,
+                input_path: snos_metadata.cairo_pie_path.map(ProvingInputType::CairoPie),
+                ensure_on_chain_registration: None,
+                n_steps: snos_metadata.snos_n_steps,
+                bucket_id: None,
+                bucket_job_index: None,
+                download_proof: None,
+            }),
+        };
+
+        debug!(job_id = %job.internal_id, "Creating proof registration job for SNOS job");
+        match JobHandlerService::create_job(JobType::ProofRegistration, job.internal_id, metadata, config.clone()).await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                error!(error = %e, "Failed to create new {:?} job for {}", JobType::ProofRegistration, job.internal_id);
+                let attributes = [
+                    KeyValue::new("operation_job_type", format!("{:?}", JobType::ProofRegistration)),
+                    KeyValue::new("operation_type", format!("{:?}", "create_job")),
+                ];
+                MetricsRecorder::record_failed_job_operation(1.0, &attributes);
+                return Err(e.into());
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
+++ b/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
@@ -8,6 +8,7 @@ use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
 use crate::worker::event_handler::triggers::JobTrigger;
 use async_trait::async_trait;
+use color_eyre::eyre::eyre;
 use opentelemetry::KeyValue;
 use orchestrator_utils::layer::Layer;
 use std::sync::Arc;
@@ -91,11 +92,19 @@ async fn create_l3_proof_registration_jobs(config: Arc<Config>) -> color_eyre::R
             e
         })?;
 
+        let cairo_pie_path = snos_metadata.cairo_pie_path.ok_or_else(|| {
+            error!(job_id = %job.internal_id, "SNOS job is missing Cairo PIE path; cannot create L3 proof registration job");
+            eyre!(
+                "SNOS job {} is missing Cairo PIE path; cannot create L3 proof registration job",
+                job.internal_id
+            )
+        })?;
+
         let metadata = JobMetadata {
             common: CommonMetadata::default(),
             specific: JobSpecificMetadata::Proving(ProvingMetadata {
                 block_number: snos_metadata.start_block,
-                input_path: snos_metadata.cairo_pie_path.map(ProvingInputType::CairoPie),
+                input_path: Some(ProvingInputType::CairoPie(cairo_pie_path)),
                 ensure_on_chain_registration: None,
                 n_steps: snos_metadata.snos_n_steps,
                 bucket_id: None,

--- a/orchestrator/src/worker/event_handler/triggers/proving.rs
+++ b/orchestrator/src/worker/event_handler/triggers/proving.rs
@@ -20,6 +20,11 @@ impl JobTrigger for ProvingJobTrigger {
     /// 1. Fetch all successful SNOS job runs that don't have a proving job
     /// 2. Create a proving job for each SNOS job run
     async fn run_worker(&self, config: Arc<Config>) -> color_eyre::Result<()> {
+        if matches!(config.layer(), Layer::L3) {
+            debug!("Skipping proof creation trigger for L3; proof registration submits Cairo PIE directly");
+            return Ok(());
+        }
+
         let successful_snos_jobs = config
             .database()
             .get_jobs_without_successor(

--- a/orchestrator/src/worker/event_handler/triggers/update_state.rs
+++ b/orchestrator/src/worker/event_handler/triggers/update_state.rs
@@ -1,8 +1,8 @@
 use crate::core::config::Config;
 use crate::types::constant::ORCHESTRATOR_VERSION;
 use crate::types::jobs::metadata::{
-    AggregatorMetadata, CommonMetadata, DaMetadata, JobMetadata, JobSpecificMetadata, SettlementContext,
-    SettlementContextData, SnosMetadata, StateUpdateMetadata,
+    AggregatorMetadata, CommonMetadata, JobMetadata, JobSpecificMetadata, SettlementContext, SettlementContextData,
+    SnosMetadata, StateUpdateMetadata,
 };
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::utils::metrics_recorder::MetricsRecorder;
@@ -180,21 +180,6 @@ impl UpdateStateJobTrigger {
         })?;
 
         state_metadata.snos_output_path = snos_metadata.snos_output_path.clone();
-        state_metadata.program_output_path = snos_metadata.program_output_path.clone();
-
-        // Get DA job blob path
-        let da_job = config
-            .database()
-            .get_job_by_internal_id_and_type(block_number, &JobType::DataSubmission)
-            .await?
-            .ok_or_else(|| eyre!("DA job not found for block {}", block_number))?;
-
-        let da_metadata: DaMetadata = da_job.metadata.specific.try_into().map_err(|e| {
-            error!(job_id = %da_job.internal_id, error = %e, "Invalid metadata type for DA job");
-            e
-        })?;
-
-        state_metadata.blob_data_path = da_metadata.blob_data_path.clone();
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

This updates the Starknet L3 settlement pipeline to use Atlantic's direct `PROOF_VERIFICATION_ON_L2` style flow for Privily/Starkpay, instead of producing a local SNOS proof first and then submitting that proof for a second layout-bridge verification.

## Orchestrator changes

- For `Layer::L3`, `ProofCreation` is skipped. The proving trigger now returns early because proof generation is handled by the Atlantic proof-registration request.
- For `Layer::L3`, `ProofRegistration` jobs are created directly from completed `SnosRun` jobs.
  - The job input is the stored Cairo PIE from SNOS.
  - No `proof.json` or `proof_part2.json` download path is configured.
  - No legacy SNOS fact cross-check is requested from the old fact checker path.
- `ProofRegistration` can now process both existing proof inputs and Cairo PIE inputs.
  - Existing proof input behavior is preserved for the old path.
  - Cairo PIE input submits an Atlantic `CreateJob` request, using the configured Atlantic `result` and `sharp_prover` values. For this Privily path, config should set `result=PROOF_VERIFICATION_ON_L2` and `sharpProver=stwo`.
- L3 `StateTransition` no longer reads `proof.json` / `proof_part2.json` and no longer extracts bootloader public outputs from proof files.
  - It uses the raw stored `snos_output.json` produced by SNOS.
  - L3 state-update metadata now carries only the raw SNOS output path; legacy program/blob artifacts are not passed into settlement.
  - It passes an empty legacy `program_output` vector through the shared settlement trait.
- The Starknet settlement client now calls the new one-argument Piltover ABI: `update_state(snos_output)`.
  - The shared `SettlementClient::update_state_calldata` trait shape is kept unchanged to avoid a wider Ethereum/L2 refactor.
- The Atlantic Starknet proving-layer helper no longer overwrites the configured query result with `PROOF_GENERATION`; it only adds the layout parameter. This allows `PROOF_VERIFICATION_ON_L2` to be configured and respected.

## Expected pipeline for L3

```text
SnosRun
  -> ProofRegistration submits Cairo PIE to Atlantic
  -> Atlantic proves with configured SHARP prover and verifies on L2
  -> DataSubmission remains the existing downstream gate before state update
  -> StateTransition submits raw SNOS output to Piltover
  -> Piltover recomputes the expected Keccak SHARP fact and checks Satellite
```

## Validation

- `cargo check -p orchestrator-atlantic-service -p orchestrator-starknet-settlement-client -p orchestrator`
- `cargo test -p orchestrator-atlantic-service atlantic_status_response_deserializes_l2_bridge_fact_hash_step`
- `cargo test -p orchestrator-starknet-settlement-client --lib`

Notes:

- `cargo fmt --check --manifest-path orchestrator/Cargo.toml` currently reports a pre-existing formatting diff in `orchestrator/src/compression/squash.rs`, outside this PR's changes.
- The full `cargo test -p orchestrator --lib` target currently fails in unrelated DA/batching test fixtures due Starknet type-shape drift before reaching this PR's tests.
