### PR TITLE
[codex] Resolve code-scanning alerts

### DIFF
--- a/.github/workflows/nightly-run.yml
+++ b/.github/workflows/nightly-run.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   # ========================================================================= #
   #                               SCHEDULE GATE                               #

--- a/.github/workflows/pull-request-merge.yml
+++ b/.github/workflows/pull-request-merge.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   # ========================================================================= #
   #                              NIGHTLY RELEASE                              #

--- a/.github/workflows/schedule-daily-maintenance-issues.yml
+++ b/.github/workflows/schedule-daily-maintenance-issues.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale_issues:
     name: 🧹 Clean up stale issues and PRs

--- a/.github/workflows/schedule-daily-security-audit.yml
+++ b/.github/workflows/schedule-daily-security-audit.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   security_audit:
     name: Security - Audit check

--- a/.github/workflows/task-build-binary.yml
+++ b/.github/workflows/task-build-binary.yml
@@ -25,6 +25,9 @@ on:
         description: "Hash of the built binary"
         value: ${{ jobs.build-binary.outputs.binary-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-binary:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-build-bootstrapper.yml
+++ b/.github/workflows/task-build-bootstrapper.yml
@@ -10,6 +10,9 @@ on:
         description: "Hash of the built bootstrapper binary"
         value: ${{ jobs.build-bootstrapper.outputs.binary-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-bootstrapper:
     uses: ./.github/workflows/task-build-binary.yml

--- a/.github/workflows/task-build-cairo-artifacts.yml
+++ b/.github/workflows/task-build-cairo-artifacts.yml
@@ -15,6 +15,9 @@ on:
         description: "Hash of the built cairo artifacts"
         value: ${{ jobs.build-cairo-artifacts.outputs.cairo-artifacts-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-cairo-artifacts:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-build-madara-tests.yml
+++ b/.github/workflows/task-build-madara-tests.yml
@@ -14,6 +14,9 @@ on:
         description: "Hash of the archived Madara test binaries"
         value: ${{ jobs.build-madara-tests.outputs.madara-tests-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-madara-tests:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-build-madara.yml
+++ b/.github/workflows/task-build-madara.yml
@@ -17,6 +17,9 @@ on:
         description: "Hash of the built madara binary"
         value: ${{ jobs.build-binaries.outputs.madara-binary-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-binaries:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-build-migration-tests.yml
+++ b/.github/workflows/task-build-migration-tests.yml
@@ -13,6 +13,9 @@ on:
         description: "Hash of the archived migration test binaries"
         value: ${{ jobs.build-migration-tests.outputs.migration-tests-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-migration-tests:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-build-orchestrator-tests.yml
+++ b/.github/workflows/task-build-orchestrator-tests.yml
@@ -10,6 +10,9 @@ on:
         description: "Hash of the archived orchestrator test binaries"
         value: ${{ jobs.build-orchestrator-tests.outputs.orchestrator-tests-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-orchestrator-tests:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-build-orchestrator.yml
+++ b/.github/workflows/task-build-orchestrator.yml
@@ -12,6 +12,9 @@ on:
         description: "Hash of the built orchestrator binary"
         value: ${{ jobs.build-orchestrator.outputs.binary-hash }}
 
+permissions:
+  contents: read
+
 jobs:
   build-orchestrator:
     uses: ./.github/workflows/task-build-binary.yml

--- a/.github/workflows/task-ci-version-file.yml
+++ b/.github/workflows/task-ci-version-file.yml
@@ -30,6 +30,9 @@ on:
         description: "Whether the matching container image tag already exists"
         value: ${{ jobs.update-version-file.outputs.tag-exists }}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-build-nightly-and-publish.yml
+++ b/.github/workflows/task-do-nothing-build-nightly-and-publish.yml
@@ -5,6 +5,9 @@ name: Task - Build And Publish Nightly Docker Image
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build-nightly-and-publish:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-check-bootstrapper.yml
+++ b/.github/workflows/task-do-nothing-check-bootstrapper.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check-binaries:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-test-bootstrapper.yml
+++ b/.github/workflows/task-do-nothing-test-bootstrapper.yml
@@ -5,6 +5,9 @@ name: Task - Integration Tests and Coverage (Bootstrapper)
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-bootstrapper:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-test-cli.yml
+++ b/.github/workflows/task-do-nothing-test-cli.yml
@@ -5,6 +5,9 @@ name: Task - Run CLI tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-cli:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-test-end-to-end.yml
+++ b/.github/workflows/task-do-nothing-test-end-to-end.yml
@@ -4,6 +4,9 @@ name: Task - Test E2E
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-end-to-end:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-test-js.yml
+++ b/.github/workflows/task-do-nothing-test-js.yml
@@ -5,6 +5,9 @@ name: Task - Test JavaScript
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-js:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-test-madara.yml
+++ b/.github/workflows/task-do-nothing-test-madara.yml
@@ -5,6 +5,9 @@ name: Task - Integration Tests and Coverage (Madara)
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-madara:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-do-nothing-test-migration.yml
+++ b/.github/workflows/task-do-nothing-test-migration.yml
@@ -5,6 +5,9 @@ name: Task - Test Migration
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-migration:
     runs-on: ubuntu-latest

--- a/.github/workflows/task-do-nothing-test-orchestrator.yml
+++ b/.github/workflows/task-do-nothing-test-orchestrator.yml
@@ -5,6 +5,9 @@ name: Task - Integration Tests and Coverage (Orchestrator)
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-orchestrator:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-e2e-orchestrator.yml
+++ b/.github/workflows/task-e2e-orchestrator.yml
@@ -18,6 +18,9 @@ on:
       RPC_FOR_SNOS:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   e2e-orchestrator:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-lint-cargo.yml
+++ b/.github/workflows/task-lint-cargo.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   cargo-lint:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/.github/workflows/task-lint-code-style.yml
+++ b/.github/workflows/task-lint-code-style.yml
@@ -13,6 +13,9 @@ env:
   TAPLO_VERSION: "0.9.3"
   TAPLO_CONFIG: "./taplo/taplo.toml"
 
+permissions:
+  contents: read
+
 jobs:
   # Run prettier for code formatting
   prettier:

--- a/.github/workflows/task-test-cli.yml
+++ b/.github/workflows/task-test-cli.yml
@@ -14,6 +14,9 @@ on:
         description: "Hash used to retrieve the madara binary artifact"
         required: true
         type: string
+permissions:
+  contents: read
+
 jobs:
   test-cli:
     runs-on: blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/task-test-end-to-end.yml
+++ b/.github/workflows/task-test-end-to-end.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   workflow_call: {}
 
+permissions:
+  contents: read
+
 jobs:
   test-end-to-end:
     runs-on: blacksmith-8vcpu-ubuntu-2404

--- a/.github/workflows/task-test-js.yml
+++ b/.github/workflows/task-test-js.yml
@@ -17,6 +17,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test-js:
     runs-on: blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/task-test-migration.yml
+++ b/.github/workflows/task-test-migration.yml
@@ -22,6 +22,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   migration-test:
     name: Test Migration

--- a/.github/workflows/task-test-orchestrator.yml
+++ b/.github/workflows/task-test-orchestrator.yml
@@ -25,6 +25,9 @@ on:
       RPC_FOR_SNOS:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   test-orchestrator:
     runs-on: blacksmith-8vcpu-ubuntu-2204

--- a/bootstrapper/src/contract_clients/utils.rs
+++ b/bootstrapper/src/contract_clients/utils.rs
@@ -200,7 +200,6 @@ pub(crate) async fn deploy_account_using_priv_key(
     let chain_id = provider.chain_id().await.unwrap();
 
     let signer = LocalWallet::from(SigningKey::from_secret_scalar(Felt::from_hex(&priv_key).unwrap()));
-    log::debug!("signer : {:?}", signer);
     let mut oz_account_factory =
         OpenZeppelinAccountFactory::new(oz_account_class_hash, chain_id, signer, provider).await.unwrap();
     oz_account_factory.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));


### PR DESCRIPTION
## Summary
- Sets explicit least-privilege GitHub token permissions for workflows flagged by code scanning.
- Removes a debug log that exposed signer material derived from a private key.
- Dismisses deterministic test-only hard-coded-value alerts with the GitHub `used in tests` reason.

## Validation
- Formatting and whitespace checks passed.
- Workflow YAML parses successfully.
- GitHub Actions semantic lint was attempted, but existing unrelated workflow issues remain in the repo.
- The focused Rust validation is blocked locally because generated Starkgate artifacts are missing and Docker is not running to fetch them.

## Notes
The valid alerts will close after this change is merged and code scanning re-runs on the protected branch.