### PR TITLE
fix(deps): combine compatible cargo dependency bumps

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,5 +1,5 @@
 **/lib/**/*.md
-node_modules/**/*.md
+**/node_modules/**
 **/target/**/*.md
 docs/**/*.md
 AI_docs/**/*.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -411,7 +420,7 @@ dependencies = [
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
- "sha3",
+ "sha3 0.10.8",
  "tiny-keccak",
 ]
 
@@ -438,7 +447,7 @@ dependencies = [
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
- "sha3",
+ "sha3 0.10.8",
  "tiny-keccak",
 ]
 
@@ -2763,7 +2772,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2783,7 +2792,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2803,7 +2812,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2946,7 +2955,7 @@ dependencies = [
  "derive_more 2.1.1",
  "indexmap 2.13.1",
  "itertools 0.12.1",
- "keccak",
+ "keccak 0.1.5",
  "log",
  "mockall 0.12.1",
  "num-bigint",
@@ -4107,7 +4116,7 @@ dependencies = [
  "cairo-vm",
  "clap",
  "itertools 0.14.0",
- "keccak",
+ "keccak 0.1.5",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -4212,7 +4221,7 @@ dependencies = [
  "postcard",
  "salsa 0.26.0",
  "serde",
- "sha3",
+ "sha3 0.10.8",
  "starknet-types-core 0.2.4",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -4235,7 +4244,7 @@ dependencies = [
  "regex",
  "salsa 0.16.1",
  "serde",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.1.24",
  "thiserror 1.0.69",
 ]
@@ -4257,7 +4266,7 @@ dependencies = [
  "regex",
  "salsa 0.16.1",
  "serde",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.2.2",
  "thiserror 1.0.69",
 ]
@@ -4280,7 +4289,7 @@ dependencies = [
  "regex",
  "salsa 0.16.1",
  "serde",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.2.2",
  "thiserror 1.0.69",
 ]
@@ -4305,7 +4314,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.3.4",
  "starknet-types-core 0.2.4",
  "thiserror 2.0.17",
@@ -4650,7 +4659,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.1.24",
  "thiserror 1.0.69",
 ]
@@ -4690,7 +4699,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.2.2",
  "thiserror 1.0.69",
 ]
@@ -4731,7 +4740,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.2.2",
  "thiserror 1.0.69",
 ]
@@ -4787,7 +4796,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "smol_str 0.3.4",
  "starknet-types-core 0.2.4",
  "thiserror 2.0.17",
@@ -5010,7 +5019,7 @@ dependencies = [
  "cairo-lang-utils 2.17.0",
  "educe 0.5.11",
  "itertools 0.14.0",
- "keccak",
+ "keccak 0.1.5",
  "lambdaworks-math 0.13.0",
  "lazy_static",
  "libc",
@@ -5043,7 +5052,7 @@ dependencies = [
  "bitvec",
  "generic-array",
  "indoc 2.0.7",
- "keccak",
+ "keccak 0.1.5",
  "lazy_static",
  "nom",
  "num-bigint",
@@ -5055,7 +5064,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "starknet-crypto 0.8.1",
  "starknet-types-core 0.2.4",
  "thiserror 2.0.17",
@@ -5173,7 +5182,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -5243,7 +5252,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "spki 0.7.3",
  "x509-cert",
@@ -5298,7 +5307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5307,7 +5316,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5373,7 +5382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -5383,6 +5392,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -5514,6 +5529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5558,25 +5582,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -5584,12 +5607,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -5677,7 +5700,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.2.3",
  "num-traits",
  "subtle",
  "zeroize",
@@ -5691,6 +5714,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array 0.4.10",
 ]
 
 [[package]]
@@ -5888,7 +5920,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -5898,7 +5930,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "pem-rfc7468",
@@ -6066,9 +6098,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -6210,7 +6252,7 @@ dependencies = [
  "lazy_static",
  "log",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust",
@@ -6255,7 +6297,7 @@ dependencies = [
  "orchestrator-ethereum-settlement-client",
  "orchestrator-utils",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust",
@@ -6535,7 +6577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 1.0.69",
  "uuid 0.8.2",
 ]
@@ -7769,6 +7811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7785,7 +7836,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8761,7 +8812,17 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -8842,7 +8903,7 @@ dependencies = [
  "pico-args",
  "regex",
  "regex-syntax 0.8.8",
- "sha3",
+ "sha3 0.10.8",
  "string_cache",
  "term 1.2.1",
  "unicode-xid",
@@ -8886,7 +8947,7 @@ dependencies = [
  "lambdaworks-math 0.10.0",
  "serde",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -8900,7 +8961,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -9282,7 +9343,7 @@ dependencies = [
  "hyper-util",
  "indoc 2.0.7",
  "ip_network",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jsonrpsee",
  "lazy_static",
  "librocksdb-sys",
@@ -9336,12 +9397,12 @@ dependencies = [
  "regex",
  "reqwest 0.12.26",
  "rocksdb",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "serde_with 3.16.1",
  "serde_yaml",
- "sha3",
+ "sha3 0.12.0",
  "starknet-rust",
  "starknet-rust-accounts",
  "starknet-rust-contract",
@@ -9474,7 +9535,7 @@ dependencies = [
  "opentelemetry_sdk",
  "proptest",
  "proptest-derive",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde_json",
  "starknet-rust-core 0.19.0-rc.2",
  "starknet-types-core 0.2.4",
@@ -9527,7 +9588,7 @@ dependencies = [
  "chrono",
  "dashmap 6.1.0",
  "futures",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "libc",
  "librocksdb-sys",
@@ -9556,7 +9617,7 @@ dependencies = [
  "rayon",
  "reqwest 0.12.26",
  "rocksdb",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -9609,7 +9670,7 @@ dependencies = [
  "opentelemetry_sdk",
  "proptest",
  "proptest-derive",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde_json",
  "starknet-rust-core 0.19.0-rc.2",
  "starknet-rust-signers",
@@ -9643,7 +9704,7 @@ dependencies = [
  "mp-transactions",
  "rand 0.8.5",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde_json",
  "starknet-rust",
  "starknet-rust-core 0.19.0-rc.2",
@@ -9664,7 +9725,7 @@ dependencies = [
  "anyhow",
  "blockifier",
  "cairo-vm",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "mc-class-exec",
  "mc-db",
  "mc-telemetry",
@@ -9682,7 +9743,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde_json",
  "starknet-types-core 0.2.4",
  "starknet_api",
@@ -9721,7 +9782,7 @@ dependencies = [
  "mp-utils",
  "opentelemetry",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust",
@@ -9759,7 +9820,7 @@ dependencies = [
  "mp-rpc",
  "mp-transactions",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust-core 0.19.0-rc.2",
@@ -9795,7 +9856,7 @@ dependencies = [
  "mp-rpc",
  "mp-transactions",
  "mp-utils",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-types-core 0.2.4",
@@ -9837,7 +9898,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "proptest-state-machine",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde_json",
  "smallvec",
  "starknet-types-core 0.2.4",
@@ -9881,7 +9942,7 @@ dependencies = [
  "mp-state-update",
  "mp-transactions",
  "mp-utils",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust-core 0.19.0-rc.2",
@@ -9931,7 +9992,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand 0.8.5",
  "regex",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust-accounts",
@@ -10013,7 +10074,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rayon",
  "regex",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde_json",
  "starknet-rust-core 0.19.0-rc.2",
  "starknet_api",
@@ -10268,7 +10329,7 @@ checksum = "7e0603425789b4a70fcc4ac4f5a46a566c116ee3e2a6b768dc623f7719c611de"
 dependencies = [
  "assert-json-diff",
  "bytes",
- "colored 2.2.0",
+ "colored 3.0.0",
  "futures-core",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -10452,7 +10513,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "rayon",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-types-core 0.2.4",
@@ -10475,7 +10536,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rayon",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -10494,7 +10555,7 @@ dependencies = [
  "lazy_static",
  "mp-rpc",
  "mp-utils",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -10527,7 +10588,7 @@ dependencies = [
  "mp-rpc",
  "num-bigint",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust-core 0.19.0-rc.2",
@@ -10546,7 +10607,7 @@ dependencies = [
  "alloy",
  "assert_matches",
  "primitive-types 0.12.2",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "serde_with 3.16.1",
@@ -10561,7 +10622,7 @@ name = "mp-gateway"
 version = "0.10.0"
 dependencies = [
  "hyper 1.8.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "mp-block",
  "mp-chain-config",
  "mp-class",
@@ -10570,7 +10631,7 @@ dependencies = [
  "mp-rpc",
  "mp-state-update",
  "mp-transactions",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "serde_with 3.16.1",
@@ -10604,10 +10665,10 @@ dependencies = [
  "mp-convert",
  "mp-rpc",
  "mp-transactions",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_with 3.16.1",
- "sha3",
+ "sha3 0.12.0",
  "starknet-rust-core 0.19.0-rc.2",
  "starknet-types-core 0.2.4",
  "starknet_api",
@@ -10619,7 +10680,7 @@ dependencies = [
 name = "mp-rpc"
 version = "0.10.0"
 dependencies = [
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-types-core 0.2.4",
@@ -10654,7 +10715,7 @@ dependencies = [
  "mp-convert",
  "mp-rpc",
  "num-bigint",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "serde_with 3.16.1",
@@ -10682,7 +10743,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rayon",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_yaml",
  "starknet-rust-core 0.19.0-rc.2",
@@ -11193,7 +11254,7 @@ dependencies = [
  "httpmock 0.8.2",
  "hyper 0.14.32",
  "indexmap 2.13.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "jemallocator",
  "lazy_static",
  "majin-blob-core",
@@ -11228,7 +11289,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust",
@@ -11330,7 +11391,7 @@ dependencies = [
  "orchestrator-da-client-interface",
  "orchestrator-utils",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "starknet-rust",
  "tokio",
@@ -11366,7 +11427,7 @@ dependencies = [
  "orchestrator-settlement-client-interface",
  "orchestrator-utils",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -11390,7 +11451,7 @@ dependencies = [
  "bincode",
  "cairo-vm",
  "dotenvy",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "num-bigint",
  "opentelemetry",
@@ -11423,7 +11484,7 @@ dependencies = [
  "orchestrator-gps-fact-checker",
  "orchestrator-prover-client-interface",
  "orchestrator-utils",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "tokio",
  "tracing",
  "url",
@@ -11440,7 +11501,7 @@ dependencies = [
  "mockall 0.13.1",
  "orchestrator-gps-fact-checker",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
@@ -11478,7 +11539,7 @@ dependencies = [
  "orchestrator-prover-client-interface",
  "orchestrator-utils",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -11528,7 +11589,7 @@ dependencies = [
  "orchestrator-settlement-client-interface",
  "orchestrator-utils",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "starknet-rust",
@@ -11565,7 +11626,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "reqwest 0.12.26",
- "rstest 0.18.2",
+ "rstest 0.26.1",
  "serde",
  "serde_json",
  "tar",
@@ -11623,6 +11684,16 @@ dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
  "sha2",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -11785,7 +11856,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.16.1",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -11810,7 +11881,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.16.1",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 2.0.17",
  "vergen",
 ]
@@ -12038,7 +12109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b3df3d3cc1015f12d70235e35b6b79befc5fa7a9b95b951eab1dd07c9efc2"
 dependencies = [
  "cms",
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "digest 0.10.7",
  "spki 0.7.3",
@@ -12331,9 +12402,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
@@ -12395,7 +12466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12408,7 +12479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14025,7 +14096,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -14037,7 +14108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -14048,7 +14119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -14065,7 +14136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -14076,7 +14147,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.5",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -14206,9 +14288,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -14326,6 +14408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
 name = "sprs"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14360,7 +14448,7 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with 3.16.1",
- "sha3",
+ "sha3 0.10.8",
  "starknet-core-derive",
  "starknet-crypto 0.8.1",
  "starknet-types-core 0.2.4",
@@ -14513,7 +14601,7 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with 3.16.1",
- "sha3",
+ "sha3 0.10.8",
  "starknet-rust-core-derive 0.1.0",
  "starknet-rust-crypto 0.8.1",
  "starknet-types-core 0.2.4",
@@ -14537,7 +14625,7 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with 3.16.1",
- "sha3",
+ "sha3 0.10.8",
  "starknet-rust-core-derive 0.19.0-rc.2",
  "starknet-rust-crypto 0.19.0-rc.2",
  "starknet-types-core 0.2.4",
@@ -14742,7 +14830,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "starknet-core",
  "starknet-crypto 0.8.1",
  "starknet-types-core 0.2.4",
@@ -14814,7 +14902,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.16.1",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "shared_execution_objects",
  "starknet-types-core 0.2.4",
  "starknet_api",
@@ -15145,9 +15233,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -15528,9 +15616,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -16610,7 +16698,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17164,7 +17252,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der 0.7.10",
  "spki 0.7.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,7 +234,7 @@ smallvec = { version = "1.15.1", features = ["write"] }
 # Std extensions
 lazy_static = { version = "1.4", default-features = false }
 once_cell = "1.21.3"
-itertools = "0.13.0"
+itertools = "0.14.0"
 bitvec = { version = "1.0", default-features = false, features = ["std"] }
 bytes = "1.6.0"
 derive_more = { version = "2.0.1", features = ["from_str"] }
@@ -247,7 +247,7 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Testing
-rstest = "0.18"
+rstest = "0.26"
 proptest = "1.5.0"
 proptest-derive = "0.5.0"
 proptest-state-machine = "0.3.1"
@@ -256,7 +256,7 @@ httpmock = "0.7.0"
 mockall = "0.13.0"
 fdlimit = "0.3.0"
 assert_matches = "1.5"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 # Macros
 indoc = "2"
@@ -273,7 +273,7 @@ figment = "0.10.19"
 # Misc
 flate2 = "1.0"
 regex = "1.10.5"
-sha3 = "0.10"
+sha3 = "0.12"
 tar = "0.4.44"
 inline_colorization = "0.1.6"
 subxt-lightclient = { version = "0.35.3", default-features = false }

--- a/orchestrator/src/worker/utils/fact_info.rs
+++ b/orchestrator/src/worker/utils/fact_info.rs
@@ -296,6 +296,7 @@ mod tests {
     #[rstest]
     #[case("fibonacci.zip", "0xca15503f02f8406b599cb220879e842394f5cf2cef753f3ee430647b5981b782", false)]
     #[case("sepolia_924016.zip", "0x033144ad6b132b1012f15e50aa53de1ed91b3b1af729014c3f1c00b702f972ea", false)]
+    #[tokio::test]
     async fn test_fact_info_local(
         #[case] cairo_pie_file: &str,
         #[case] expected_fact: &str,


### PR DESCRIPTION
## Summary
- Combine the compatible Cargo dependency updates from the closed Dependabot PRs into one rollup.
- Keep `bincode` on 1.3.x because the 3.0.0 crate release does not compile.
- Keep the direct `tower-http` dependency on 0.4.x because the current jsonrpsee/hyper server stack is still on the older HTTP type stack.
- Update the affected async rstest to the newer attribute requirement and keep nested generated node_modules markdown out of markdownlint.

## Validation
- Local formatting, linting, markdown, and workspace Rust checks passed via the repo pre-push gate.