### PR TITLE
[codex] Retry transient SNOS failures via SQS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
+source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13010,7 +13010,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
+source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14436,7 +14436,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
+source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,8 +314,8 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-# This rev fixes SNOS to fetch the revert reason from RPC itself instead of filtering the reason got from trace
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "v0.14.2-rc.4" }
+# Temporary fork revision while https://github.com/keep-starknet-strange/snos/pull/525 is under review.
+generate-pie = { git = "https://github.com/karnotxyz/snos.git", rev = "02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/orchestrator/src/error/job/mod.rs
+++ b/orchestrator/src/error/job/mod.rs
@@ -114,3 +114,12 @@ pub enum JobError {
     #[error("Orchestrator Error: {0}")]
     AnyHowError(#[from] anyhow::Error),
 }
+
+impl JobError {
+    pub fn is_retryable_processing_failure(&self) -> bool {
+        match self {
+            Self::SnosJobError(error) => error.is_retryable(),
+            _ => false,
+        }
+    }
+}

--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -1,8 +1,9 @@
 use crate::error::job::fact::FactError;
 use crate::error::other::OtherError;
+use generate_pie::error::{BlockProcessingError, PieGenerationError};
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum SnosError {
     #[error("Block numbers to run must be specified (snos job #{internal_id:?})")]
     UnspecifiedBlockNumber { internal_id: u64 },
@@ -25,10 +26,12 @@ pub enum SnosError {
     #[error("Could not store the Program output (snos job #{internal_id:?}): {message}")]
     ProgramOutputUnstorable { internal_id: u64, message: String },
 
-    // ProveBlockError from Snos is not usable with #[from] since it does not implement PartialEq.
-    // Instead, we convert it to string & pass it into the [SnosExecutionError] error.
-    #[error("Error while running SNOS (snos job #{internal_id:?}): {message}")]
-    SnosExecutionError { internal_id: u64, message: String },
+    #[error("Error while running SNOS (snos job #{internal_id:?}): {source}")]
+    SnosExecutionError {
+        internal_id: u64,
+        #[source]
+        source: PieGenerationError,
+    },
 
     #[error("Error when calculating fact info: {0}")]
     FactCalculationError(#[from] FactError),
@@ -41,4 +44,164 @@ pub enum SnosError {
     OnChainDataUnstorable { internal_id: u64, message: String },
     #[error("Un-supported KZG flag")]
     UnsupportedKZGFlag,
+}
+
+impl SnosError {
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::CairoPieUnstorable { .. }
+            | Self::SnosOutputUnstorable { .. }
+            | Self::ProgramOutputUnstorable { .. }
+            | Self::OnChainDataUnstorable { .. } => true,
+            Self::SnosExecutionError { source, .. } => is_retryable_pie_generation_error(source),
+            Self::UnspecifiedBlockNumber { .. }
+            | Self::BlockNumberNotFound { .. }
+            | Self::InvalidBlockNumber { .. }
+            | Self::CairoPieUnserializable { .. }
+            | Self::SnosOutputUnserializable { .. }
+            | Self::ProgramOutputUnserializable { .. }
+            | Self::FactCalculationError(_)
+            | Self::Other(_)
+            | Self::OnChainDataUnserializable { .. }
+            | Self::UnsupportedKZGFlag => false,
+        }
+    }
+}
+
+fn is_retryable_pie_generation_error(error: &PieGenerationError) -> bool {
+    match error {
+        PieGenerationError::BlockProcessing { source, .. } => {
+            source.downcast_ref::<BlockProcessingError>().is_some_and(is_retryable_block_processing_error)
+        }
+        PieGenerationError::RpcClient(message)
+        | PieGenerationError::StateProcessing(message)
+        | PieGenerationError::ContractClassProcessing(message) => is_retryable_remote_message(message),
+        PieGenerationError::TaskJoin(_)
+        | PieGenerationError::OsExecution(_)
+        | PieGenerationError::Io(_)
+        | PieGenerationError::InvalidConfig(_) => false,
+    }
+}
+
+fn is_retryable_block_processing_error(error: &BlockProcessingError) -> bool {
+    match error {
+        BlockProcessingError::RpcClient(_) => true,
+        BlockProcessingError::TransactionConversion { source, .. } => error_chain_is_retryable(source.as_ref()),
+        BlockProcessingError::StateUpdate(source) => error_chain_is_retryable(source),
+        BlockProcessingError::StorageProof(source) | BlockProcessingError::ClassProof(source) => {
+            error_chain_is_retryable(source)
+        }
+        BlockProcessingError::StateUpdateProcessing(message)
+        | BlockProcessingError::ContractClassConversion(message) => is_retryable_remote_message(message),
+        BlockProcessingError::InvalidBlockState(message) => {
+            let lower = message.to_ascii_lowercase();
+            lower.contains("pending")
+        }
+        BlockProcessingError::InitialReadsExtension { source }
+        | BlockProcessingError::InitialReadsSnapshot { source, .. }
+        | BlockProcessingError::InitialReadClassHashHydration { source, .. }
+        | BlockProcessingError::InitialReadNonceHydration { source, .. }
+        | BlockProcessingError::InitialReadCompiledClassHashHydration { source, .. } => {
+            error_chain_is_retryable(source)
+        }
+        BlockProcessingError::TransactionExecution(_)
+        | BlockProcessingError::ContextBuilding(_)
+        | BlockProcessingError::TransactionExecutorCreation { .. }
+        | BlockProcessingError::StarknetVersion(_)
+        | BlockProcessingError::MissingBlockStateAfterExecution
+        | BlockProcessingError::InvalidContractAddress { .. }
+        | BlockProcessingError::MissingProofField { .. }
+        | BlockProcessingError::MissingProofFieldForContract { .. }
+        | BlockProcessingError::InvalidOldBlockNumber { .. }
+        | BlockProcessingError::Io(_)
+        | BlockProcessingError::Serialization(_)
+        | BlockProcessingError::Custom(_) => false,
+    }
+}
+
+fn error_chain_is_retryable(error: &(dyn std::error::Error + 'static)) -> bool {
+    if is_retryable_remote_message(&error.to_string()) {
+        return true;
+    }
+
+    let mut source = error.source();
+    while let Some(next) = source {
+        if is_retryable_remote_message(&next.to_string()) {
+            return true;
+        }
+        source = next.source();
+    }
+
+    false
+}
+
+fn is_retryable_remote_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+
+    let non_retryable_markers = [
+        "contractnotfound",
+        "classhashnotfound",
+        "undeclaredclasshash",
+        "missing proof field",
+        "invalid proof structure",
+        "invalidtreeheight",
+        "emptyproof",
+        "invalidchildnodehash",
+        "non-existence proof",
+    ];
+    if non_retryable_markers.iter().any(|marker| lower.contains(marker)) {
+        return false;
+    }
+
+    let retryable_markers = [
+        "rpcerror",
+        "rpc error",
+        "providererror",
+        "ratelimited",
+        "rate limited",
+        "timeout",
+        "timed out",
+        "request error",
+        "transport",
+        "connection",
+        "temporarily unavailable",
+        "503",
+        "429",
+        "pendingblock",
+        "still pending",
+        "invalid response format",
+        "proofconversionerror",
+        "failed to convert rpc response",
+    ];
+
+    retryable_markers.iter().any(|marker| lower.contains(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use starknet::providers::ProviderError;
+
+    #[test]
+    fn snos_rpc_errors_are_retryable() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::RateLimited))),
+            },
+        };
+
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn snos_os_execution_errors_fail_fast() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::OsExecution("cairo execution failed".to_string()),
+        };
+
+        assert!(!error.is_retryable());
+    }
 }

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -32,12 +32,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use generate_pie::error::{BlockProcessingError, PieGenerationError};
 use mockall::predicate::eq;
 use mongodb::bson::doc;
 use rstest::rstest;
+use starknet::providers::ProviderError;
 use tokio::time::sleep;
 
 use crate::core::client::alert::MockAlertClient;
+use crate::error::job::snos::SnosError;
 use crate::tests::common::MessagePayloadType;
 use crate::tests::config::{ConfigType, MockType, TestConfigBuilder};
 use crate::tests::utils::build_job_item;
@@ -626,6 +629,117 @@ async fn process_job_job_handler_returns_error_works() {
     );
 }
 
+/// Tests that retryable SNOS execution errors restore the original job status and rely on SQS/DLQ retries.
+#[rstest]
+#[case::created(JobStatus::Created)]
+#[case::verification_failed(JobStatus::VerificationFailed)]
+#[case::pending_retry(JobStatus::PendingRetry)]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_retryable_snos_error_restores_original_status_for_sqs_retry(#[case] initial_status: JobStatus) {
+    let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(0);
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler.expect_process_job().times(1).returning(|_, _| {
+        Err(JobError::from(SnosError::SnosExecutionError {
+            internal_id: 1,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 42,
+                source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::RateLimited))),
+            },
+        }))
+    });
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::SnosRun, initial_status.clone(), 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_err(), "retryable SNOS errors should bubble up so the message is not ACKed");
+
+    let retriable_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(retriable_job.status, initial_status);
+    assert_eq!(retriable_job.metadata.common.process_attempt_no, 1);
+    assert_eq!(retriable_job.metadata.common.process_retry_attempt_no, 1);
+    assert!(retriable_job.metadata.common.process_started_at.is_none());
+
+    let failure_reason = retriable_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("Processing attempt 1 failed"),
+        "failure_reason should record the retryable processing failure. Got: {}",
+        failure_reason
+    );
+    assert!(
+        failure_reason.contains("RPC client error"),
+        "failure_reason should include the underlying RPC error. Got: {}",
+        failure_reason
+    );
+}
+
+/// Tests that Cairo/OS execution failures still fail fast so alerting can stop the sequencer quickly.
+#[rstest]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_cairo_execution_failure_still_fails_fast() {
+    let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(1).returning(|_| Ok(()));
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler.expect_process_job().times(1).returning(|_, _| {
+        Err(JobError::from(SnosError::SnosExecutionError {
+            internal_id: 1,
+            source: PieGenerationError::OsExecution("cairo vm execution failed".to_string()),
+        }))
+    });
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::SnosRun, JobStatus::Created, 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_ok(), "non-retryable Cairo execution failures should still ACK after marking failed");
+
+    let failed_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(failed_job.status, JobStatus::Failed);
+    assert_eq!(failed_job.metadata.common.process_retry_attempt_no, 0);
+
+    let failure_reason = failed_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("cairo vm execution failed"),
+        "failure_reason should contain the Cairo execution error. Got: {}",
+        failure_reason
+    );
+}
+
 /// Tests `verify_job` function when job is having expected status
 /// and returns a `Verified` verification status.
 #[rstest]
@@ -974,8 +1088,11 @@ async fn handle_job_failure_with_failed_job_status_works(#[case] job_type: JobTy
 }
 
 #[rstest]
+#[case::created(JobType::SnosRun, JobStatus::Created)]
+#[case::verification_failed(JobType::SnosRun, JobStatus::VerificationFailed)]
 #[case::pending_verification(JobType::SnosRun, JobStatus::PendingVerification)]
 #[case::verification_timeout(JobType::SnosRun, JobStatus::VerificationTimeout)]
+#[case::pending_retry(JobType::SnosRun, JobStatus::PendingRetry)]
 #[tokio::test]
 async fn handle_job_failure_with_correct_job_status_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
     let mut mock_alert_client = MockAlertClient::new();

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -137,7 +137,7 @@ impl JobHandlerTrait for SnosJobHandler {
 
         let snos_output: PieGenerationResult = generate_pie(input).await.map_err(|e| {
             error!(error = %e, "SNOS execution failed");
-            SnosError::SnosExecutionError { internal_id, message: e.to_string() }
+            SnosError::SnosExecutionError { internal_id, source: e }
         })?;
         debug!("generate_pie function completed successfully");
 

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use crate::core::client::database::{AggregatorBatchDbQuery, SnosBatchDbQuery};
 use crate::core::config::Config;
 use crate::error::job::JobError;
+use crate::error::other::OtherError;
 use crate::types::jobs::external_id::ExternalId;
 use crate::types::jobs::job_updates::JobItemUpdates;
 use crate::types::jobs::metadata::JobMetadata;
@@ -137,7 +138,8 @@ impl JobHandlerService {
     /// * `Created` -> `LockedForProcessing` -> `PendingVerification`
     /// * `VerificationFailed` -> `LockedForProcessing` -> `PendingVerification`
     /// * `PendingRetry` -> `LockedForProcessing` -> `PendingVerification`
-    /// * `LockedForProcessing` -> `Failed` (on processing error or panic — message is ACKed, no SQS retry)
+    /// * `LockedForProcessing` -> `Failed` (on non-retryable processing error or panic)
+    /// * `LockedForProcessing` -> original status (on retryable SNOS processing error, message is NACKed)
     ///
     /// # Metrics
     /// * Updates block gauge
@@ -153,12 +155,10 @@ impl JobHandlerService {
     ///   timeout (stale), otherwise acks the message assuming it's a duplicate
     ///
     /// # Failure handling
-    /// Processing errors (including transient ones) immediately move the job to `Failed` and ACK the
-    /// SQS message. There are no SQS-level retries for explicit failures — job handlers that talk to
-    /// external APIs (SHARP, Atlantic, Ethereum, Starknet) implement their own internal retry logic
-    /// before surfacing an error. SQS `maxReceiveCount` only protects against implicit failures
-    /// (OOM, consumer crash) where the handler never reaches the error path.
-    /// Failed jobs can be retried via the `retry_job` endpoint.
+    /// Retryable SNOS processing errors restore the job to its pre-processing status and return an
+    /// error so SQS can retry the message until it reaches the DLQ. Non-retryable processing errors
+    /// and panics still fail fast by moving the job to `Failed` and ACKing the message so alerting
+    /// can stop the sequencer quickly. Failed jobs can be retried via the `retry_job` endpoint.
     ///
     /// # Important
     /// The queue visibility timeout MUST be greater than the job healing timeout configured via
@@ -285,6 +285,10 @@ impl JobHandlerService {
             return Ok(());
         }
 
+        // Save original status so retryable processing failures can restore the job to the
+        // pre-processing state and let SQS own the retry lifecycle.
+        let original_status = job.status.clone();
+
         // This updates the version of the job.
         // This ensures that if another thread was about to process the same job,
         // it would fail to update the job in the database because the version would be outdated
@@ -334,6 +338,28 @@ impl JobHandlerService {
                 external_id
             }
             Ok(Err(e)) => {
+                let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
+
+                if e.is_retryable_processing_failure() {
+                    warn!(
+                        job_id = ?id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        status = ?original_status,
+                        error = ?e,
+                        "Retryable SNOS processing failure detected, restoring job state for SQS retry"
+                    );
+                    workload.finish_error();
+                    return Err(Self::reset_job_for_retryable_processing_error(
+                        &mut job,
+                        config.clone(),
+                        original_status,
+                        reason,
+                        e,
+                    )
+                    .await);
+                }
+
                 error!(
                     job_id = ?id,
                     job_type = ?job.job_type,
@@ -342,12 +368,12 @@ impl JobHandlerService {
                     error = ?e,
                     "Failed to process job, marking as failed"
                 );
-                let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
                 MetricsRecorder::record_job_state_transition(
                     JobStatus::LockedForProcessing,
                     JobStatus::Failed,
                     &job.job_type,
                 );
+                workload.finish_error();
                 return JobService::move_job_to_failed(&job, config.clone(), reason).await;
             }
             Err(panic) => {
@@ -365,6 +391,7 @@ impl JobHandlerService {
                     JobStatus::Failed,
                     &job.job_type,
                 );
+                workload.finish_error();
                 return JobService::move_job_to_failed(&job, config.clone(), reason).await;
             }
         };
@@ -433,6 +460,52 @@ impl JobHandlerService {
         workload.finish_success();
 
         Ok(())
+    }
+
+    async fn reset_job_for_retryable_processing_error(
+        job: &mut crate::types::jobs::job_item::JobItem,
+        config: Arc<Config>,
+        original_status: JobStatus,
+        reason: String,
+        original_error: JobError,
+    ) -> JobError {
+        job.metadata.common.process_retry_attempt_no += 1;
+        job.metadata.common.process_started_at = None;
+        job.metadata.common.process_completed_at = None;
+
+        if let Some(previous_reason) = job.metadata.common.failure_reason.take() {
+            job.metadata.common.previous_failure_reasons.push(previous_reason);
+        }
+        job.metadata.common.failure_reason = Some(reason);
+
+        match config
+            .database()
+            .update_job(
+                job,
+                JobItemUpdates::new()
+                    .update_status(original_status.clone())
+                    .update_metadata(job.metadata.clone())
+                    .build(),
+            )
+            .await
+        {
+            Ok(_) => {
+                MetricsRecorder::record_job_state_transition(
+                    JobStatus::LockedForProcessing,
+                    original_status.clone(),
+                    &job.job_type,
+                );
+                MetricsRecorder::record_job_status(job, &original_status);
+                original_error
+            }
+            Err(db_err) => {
+                error!(job_id = ?job.id, error = ?db_err, "Failed to reset retryable job state for SQS retry");
+                JobError::Other(OtherError::from(format!(
+                    "Failed to reset job state: {}. Original error: {}",
+                    db_err, original_error
+                )))
+            }
+        }
     }
 
     /// Verify Job Function


### PR DESCRIPTION
## Summary
- classify retryable versus fail-fast SNOS failures from typed `generate-pie` errors
- restore the pre-fail-fast SQS retry flow for retryable SNOS processing failures while keeping Cairo/OS execution failures fail-fast
- point the Madara workspace at the SNOS revision from karnotxyz/snos that preserves structured error information
- expand orchestrator tests around retryable SNOS processing and DLQ failure handling

## Why
Recent fail-fast behavior marked every SNOS processing failure as `Failed` immediately. That is too aggressive for intermittent RPC and proof-fetch failures, which should be retried by SQS until DLQ. At the same time, deterministic Cairo/OS execution failures should still fail fast so alerting can stop the sequencer promptly.

## Impact
- transient SNOS processing failures are restored to their original job status and the SQS message is left unacked for redelivery
- `process_retry_attempt_no` still increments so backup SNOS RPC fallback can activate on retries
- deterministic execution/configuration/proof-shape failures continue to fail fast

## Validation
- `cargo fmt --all --check`
- `source /Users/prakhar/work/karnot/madara/sequencer_venv/bin/activate && cargo clippy -p orchestrator --all-features --tests --no-deps -- -D warnings`
