### PR TITLE
[codex] Retry transient SNOS failures via SQS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
+source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13010,7 +13010,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
+source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14436,7 +14436,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=v0.14.2-rc.4#fef6c4bf2da5c3d2941e5be24b87f876087a05db"
+source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2783,7 +2783,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2803,7 +2803,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5298,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5307,7 +5307,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6515,7 +6515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.5#7da559392a1ea3ec9048cc62d8c5a75ebc0aad1d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8374,7 +8374,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10790,7 +10790,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12395,7 +12395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12408,7 +12408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12497,7 +12497,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13010,7 +13010,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.5#7da559392a1ea3ec9048cc62d8c5a75ebc0aad1d"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -13280,7 +13280,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13421,7 +13421,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14436,7 +14436,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/karnotxyz/snos.git?rev=02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e#02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e"
+source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.5#7da559392a1ea3ec9048cc62d8c5a75ebc0aad1d"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",
@@ -15188,7 +15188,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15208,7 +15208,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16610,7 +16610,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,8 +314,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-# Temporary fork revision while https://github.com/keep-starknet-strange/snos/pull/525 is under review.
-generate-pie = { git = "https://github.com/karnotxyz/snos.git", rev = "02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.5" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,8 +314,8 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-# This rev fixes SNOS to fetch the revert reason from RPC itself instead of filtering the reason got from trace
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "v0.14.2-rc.4" }
+# Temporary fork revision while https://github.com/keep-starknet-strange/snos/pull/525 is under review.
+generate-pie = { git = "https://github.com/karnotxyz/snos.git", rev = "02de4a7d0aaf5f3a3eeabb3f1635012b3d72918e" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/orchestrator/src/error/job/mod.rs
+++ b/orchestrator/src/error/job/mod.rs
@@ -116,10 +116,7 @@ pub enum JobError {
 }
 
 impl JobError {
-    pub fn is_retryable_processing_failure(&self) -> bool {
-        match self {
-            Self::SnosJobError(error) => error.is_retryable(),
-            _ => false,
-        }
+    pub fn is_fail_fast_snos_processing_failure(&self) -> bool {
+        matches!(self, Self::SnosJobError(error) if !error.is_retryable())
     }
 }

--- a/orchestrator/src/error/job/mod.rs
+++ b/orchestrator/src/error/job/mod.rs
@@ -114,3 +114,12 @@ pub enum JobError {
     #[error("Orchestrator Error: {0}")]
     AnyHowError(#[from] anyhow::Error),
 }
+
+impl JobError {
+    pub fn is_retryable_processing_failure(&self) -> bool {
+        match self {
+            Self::SnosJobError(error) => error.is_retryable(),
+            _ => false,
+        }
+    }
+}

--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -74,10 +74,11 @@ fn is_retryable_pie_generation_error(error: &PieGenerationError) -> bool {
         PieGenerationError::RpcClient(message)
         | PieGenerationError::StateProcessing(message)
         | PieGenerationError::ContractClassProcessing(message) => is_retryable_remote_message(message),
-        PieGenerationError::TaskJoin(_)
-        | PieGenerationError::OsExecution(_)
-        | PieGenerationError::Io(_)
-        | PieGenerationError::InvalidConfig(_) => false,
+        // A tokio JoinError means an internal SNOS task panicked or was cancelled. At this
+        // boundary we cannot safely distinguish a deterministic bug from a transient RPC path
+        // that panicked internally, so align it with the service-level panic policy and retry.
+        PieGenerationError::TaskJoin(_) => true,
+        PieGenerationError::OsExecution(_) | PieGenerationError::Io(_) | PieGenerationError::InvalidConfig(_) => false,
     }
 }
 
@@ -215,6 +216,19 @@ mod tests {
         };
 
         assert!(!error.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn snos_task_join_errors_are_retryable() {
+        let join_error = tokio::spawn(async {
+            panic!("simulated inner snos task panic");
+        })
+        .await
+        .unwrap_err();
+
+        let error = SnosError::SnosExecutionError { internal_id: 7, source: PieGenerationError::TaskJoin(join_error) };
+
+        assert!(error.is_retryable());
     }
 
     #[test]

--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -70,9 +70,9 @@ impl SnosError {
 
 fn is_retryable_pie_generation_error(error: &PieGenerationError) -> bool {
     match error {
-        PieGenerationError::BlockProcessing { source, .. } => {
-            source.downcast_ref::<BlockProcessingError>().is_some_and(is_retryable_block_processing_error)
-        }
+        PieGenerationError::BlockProcessing { source, .. } => source
+            .downcast_ref::<BlockProcessingError>()
+            .map_or_else(|| error_chain_is_retryable(source.as_ref()), is_retryable_block_processing_error),
         PieGenerationError::RpcClient(message)
         | PieGenerationError::StateProcessing(message)
         | PieGenerationError::ContractClassProcessing(message) => is_retryable_remote_message(message),
@@ -85,7 +85,7 @@ fn is_retryable_pie_generation_error(error: &PieGenerationError) -> bool {
 
 fn is_retryable_block_processing_error(error: &BlockProcessingError) -> bool {
     match error {
-        BlockProcessingError::RpcClient(_) => true,
+        BlockProcessingError::RpcClient(source) => error_chain_is_retryable(source.as_ref()),
         BlockProcessingError::TransactionConversion { source, .. } => error_chain_is_retryable(source.as_ref()),
         BlockProcessingError::StateUpdate(source) => error_chain_is_retryable(source),
         BlockProcessingError::StorageProof(source) | BlockProcessingError::ClassProof(source) => {
@@ -93,10 +93,7 @@ fn is_retryable_block_processing_error(error: &BlockProcessingError) -> bool {
         }
         BlockProcessingError::StateUpdateProcessing(message)
         | BlockProcessingError::ContractClassConversion(message) => is_retryable_remote_message(message),
-        BlockProcessingError::InvalidBlockState(message) => {
-            let lower = message.to_ascii_lowercase();
-            lower.contains("pending")
-        }
+        BlockProcessingError::InvalidBlockState(message) => is_retryable_pending_block_state(message),
         BlockProcessingError::InitialReadsExtension { source }
         | BlockProcessingError::InitialReadsSnapshot { source, .. }
         | BlockProcessingError::InitialReadClassHashHydration { source, .. }
@@ -135,6 +132,16 @@ fn error_chain_is_retryable(error: &(dyn std::error::Error + 'static)) -> bool {
     false
 }
 
+fn is_retryable_pending_block_state(message: &str) -> bool {
+    matches!(
+        message.to_ascii_lowercase().as_str(),
+        "block is still pending"
+            | "block receipts are still pending"
+            | "previous block is still pending"
+            | "older block is still pending"
+    )
+}
+
 fn is_retryable_remote_message(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
 
@@ -162,8 +169,14 @@ fn is_retryable_remote_message(message: &str) -> bool {
         "timeout",
         "timed out",
         "request error",
-        "transport",
-        "connection",
+        "transport error",
+        "transporterror",
+        "connection reset",
+        "connection refused",
+        "connection aborted",
+        "connection timed out",
+        "error trying to connect",
+        "dns error",
         "temporarily unavailable",
         "503",
         "429",
@@ -180,7 +193,16 @@ fn is_retryable_remote_message(message: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use starknet::core::types::StarknetError;
     use starknet::providers::ProviderError;
+    use thiserror::Error;
+
+    #[derive(Debug, Error)]
+    #[error("wrapped block processing error: {source}")]
+    struct WrappedBlockProcessingError {
+        #[source]
+        source: BlockProcessingError,
+    }
 
     #[test]
     fn snos_rpc_errors_are_retryable() {
@@ -203,5 +225,49 @@ mod tests {
         };
 
         assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn wrapped_block_processing_rpc_errors_stay_retryable() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(WrappedBlockProcessingError {
+                    source: BlockProcessingError::RpcClient(Box::new(ProviderError::RateLimited)),
+                }),
+            },
+        };
+
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn permanent_rpc_errors_fail_fast() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::StarknetError(
+                    StarknetError::ContractNotFound,
+                )))),
+            },
+        };
+
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn only_known_pending_block_state_errors_are_retryable() {
+        assert!(is_retryable_pending_block_state("Block is still pending"));
+        assert!(is_retryable_pending_block_state("Block receipts are still pending"));
+        assert!(!is_retryable_pending_block_state("Cannot convert pending block: missing header"));
+    }
+
+    #[test]
+    fn broad_connection_substrings_no_longer_trigger_retries() {
+        assert!(!is_retryable_remote_message("No active connection for contract"));
+        assert!(is_retryable_remote_message("Encountered a request error: connection reset by peer"));
+        assert!(is_retryable_remote_message("Provider error: transport error"));
     }
 }

--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -70,9 +70,7 @@ impl SnosError {
 
 fn is_retryable_pie_generation_error(error: &PieGenerationError) -> bool {
     match error {
-        PieGenerationError::BlockProcessing { source, .. } => source
-            .downcast_ref::<BlockProcessingError>()
-            .map_or_else(|| error_chain_is_retryable(source.as_ref()), is_retryable_block_processing_error),
+        PieGenerationError::BlockProcessing { source, .. } => is_retryable_block_processing_error(source),
         PieGenerationError::RpcClient(message)
         | PieGenerationError::StateProcessing(message)
         | PieGenerationError::ContractClassProcessing(message) => is_retryable_remote_message(message),
@@ -195,14 +193,6 @@ mod tests {
     use super::*;
     use starknet::core::types::StarknetError;
     use starknet::providers::ProviderError;
-    use thiserror::Error;
-
-    #[derive(Debug, Error)]
-    #[error("wrapped block processing error: {source}")]
-    struct WrappedBlockProcessingError {
-        #[source]
-        source: BlockProcessingError,
-    }
 
     #[test]
     fn snos_rpc_errors_are_retryable() {
@@ -225,21 +215,6 @@ mod tests {
         };
 
         assert!(!error.is_retryable());
-    }
-
-    #[test]
-    fn wrapped_block_processing_rpc_errors_stay_retryable() {
-        let error = SnosError::SnosExecutionError {
-            internal_id: 7,
-            source: PieGenerationError::BlockProcessing {
-                block_number: 12,
-                source: Box::new(WrappedBlockProcessingError {
-                    source: BlockProcessingError::RpcClient(Box::new(ProviderError::RateLimited)),
-                }),
-            },
-        };
-
-        assert!(error.is_retryable());
     }
 
     #[test]

--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -1,8 +1,9 @@
 use crate::error::job::fact::FactError;
 use crate::error::other::OtherError;
+use generate_pie::error::{BlockProcessingError, PieGenerationError};
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum SnosError {
     #[error("Block numbers to run must be specified (snos job #{internal_id:?})")]
     UnspecifiedBlockNumber { internal_id: u64 },
@@ -25,10 +26,12 @@ pub enum SnosError {
     #[error("Could not store the Program output (snos job #{internal_id:?}): {message}")]
     ProgramOutputUnstorable { internal_id: u64, message: String },
 
-    // ProveBlockError from Snos is not usable with #[from] since it does not implement PartialEq.
-    // Instead, we convert it to string & pass it into the [SnosExecutionError] error.
-    #[error("Error while running SNOS (snos job #{internal_id:?}): {message}")]
-    SnosExecutionError { internal_id: u64, message: String },
+    #[error("Error while running SNOS (snos job #{internal_id:?}): {source}")]
+    SnosExecutionError {
+        internal_id: u64,
+        #[source]
+        source: PieGenerationError,
+    },
 
     #[error("Error when calculating fact info: {0}")]
     FactCalculationError(#[from] FactError),
@@ -41,4 +44,164 @@ pub enum SnosError {
     OnChainDataUnstorable { internal_id: u64, message: String },
     #[error("Un-supported KZG flag")]
     UnsupportedKZGFlag,
+}
+
+impl SnosError {
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::CairoPieUnstorable { .. }
+            | Self::SnosOutputUnstorable { .. }
+            | Self::ProgramOutputUnstorable { .. }
+            | Self::OnChainDataUnstorable { .. } => true,
+            Self::SnosExecutionError { source, .. } => is_retryable_pie_generation_error(source),
+            Self::UnspecifiedBlockNumber { .. }
+            | Self::BlockNumberNotFound { .. }
+            | Self::InvalidBlockNumber { .. }
+            | Self::CairoPieUnserializable { .. }
+            | Self::SnosOutputUnserializable { .. }
+            | Self::ProgramOutputUnserializable { .. }
+            | Self::FactCalculationError(_)
+            | Self::Other(_)
+            | Self::OnChainDataUnserializable { .. }
+            | Self::UnsupportedKZGFlag => false,
+        }
+    }
+}
+
+fn is_retryable_pie_generation_error(error: &PieGenerationError) -> bool {
+    match error {
+        PieGenerationError::BlockProcessing { source, .. } => {
+            source.downcast_ref::<BlockProcessingError>().is_some_and(is_retryable_block_processing_error)
+        }
+        PieGenerationError::RpcClient(message)
+        | PieGenerationError::StateProcessing(message)
+        | PieGenerationError::ContractClassProcessing(message) => is_retryable_remote_message(message),
+        PieGenerationError::TaskJoin(_)
+        | PieGenerationError::OsExecution(_)
+        | PieGenerationError::Io(_)
+        | PieGenerationError::InvalidConfig(_) => false,
+    }
+}
+
+fn is_retryable_block_processing_error(error: &BlockProcessingError) -> bool {
+    match error {
+        BlockProcessingError::RpcClient(_) => true,
+        BlockProcessingError::TransactionConversion { source, .. } => error_chain_is_retryable(source.as_ref()),
+        BlockProcessingError::StateUpdate(source) => error_chain_is_retryable(source),
+        BlockProcessingError::StorageProof(source) | BlockProcessingError::ClassProof(source) => {
+            error_chain_is_retryable(source)
+        }
+        BlockProcessingError::StateUpdateProcessing(message)
+        | BlockProcessingError::ContractClassConversion(message) => is_retryable_remote_message(message),
+        BlockProcessingError::InvalidBlockState(message) => {
+            let lower = message.to_ascii_lowercase();
+            lower.contains("pending")
+        }
+        BlockProcessingError::InitialReadsExtension { source }
+        | BlockProcessingError::InitialReadsSnapshot { source, .. }
+        | BlockProcessingError::InitialReadClassHashHydration { source, .. }
+        | BlockProcessingError::InitialReadNonceHydration { source, .. }
+        | BlockProcessingError::InitialReadCompiledClassHashHydration { source, .. } => {
+            error_chain_is_retryable(source)
+        }
+        BlockProcessingError::TransactionExecution(_)
+        | BlockProcessingError::ContextBuilding(_)
+        | BlockProcessingError::TransactionExecutorCreation { .. }
+        | BlockProcessingError::StarknetVersion(_)
+        | BlockProcessingError::MissingBlockStateAfterExecution
+        | BlockProcessingError::InvalidContractAddress { .. }
+        | BlockProcessingError::MissingProofField { .. }
+        | BlockProcessingError::MissingProofFieldForContract { .. }
+        | BlockProcessingError::InvalidOldBlockNumber { .. }
+        | BlockProcessingError::Io(_)
+        | BlockProcessingError::Serialization(_)
+        | BlockProcessingError::Custom(_) => false,
+    }
+}
+
+fn error_chain_is_retryable(error: &(dyn std::error::Error + 'static)) -> bool {
+    if is_retryable_remote_message(&error.to_string()) {
+        return true;
+    }
+
+    let mut source = error.source();
+    while let Some(next) = source {
+        if is_retryable_remote_message(&next.to_string()) {
+            return true;
+        }
+        source = next.source();
+    }
+
+    false
+}
+
+fn is_retryable_remote_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+
+    let non_retryable_markers = [
+        "contractnotfound",
+        "classhashnotfound",
+        "undeclaredclasshash",
+        "missing proof field",
+        "invalid proof structure",
+        "invalidtreeheight",
+        "emptyproof",
+        "invalidchildnodehash",
+        "non-existence proof",
+    ];
+    if non_retryable_markers.iter().any(|marker| lower.contains(marker)) {
+        return false;
+    }
+
+    let retryable_markers = [
+        "rpcerror",
+        "rpc error",
+        "providererror",
+        "ratelimited",
+        "rate limited",
+        "timeout",
+        "timed out",
+        "request error",
+        "transport",
+        "connection",
+        "temporarily unavailable",
+        "503",
+        "429",
+        "pendingblock",
+        "still pending",
+        "invalid response format",
+        "proofconversionerror",
+        "failed to convert rpc response",
+    ];
+
+    retryable_markers.iter().any(|marker| lower.contains(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use starknet::providers::ProviderError;
+
+    #[test]
+    fn snos_rpc_errors_are_retryable() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::RateLimited))),
+            },
+        };
+
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn snos_os_execution_errors_fail_fast() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::OsExecution("cairo execution failed".to_string()),
+        };
+
+        assert!(!error.is_retryable());
+    }
 }

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -32,12 +32,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use generate_pie::error::{BlockProcessingError, PieGenerationError};
 use mockall::predicate::eq;
 use mongodb::bson::doc;
 use rstest::rstest;
+use starknet::providers::ProviderError;
 use tokio::time::sleep;
 
 use crate::core::client::alert::MockAlertClient;
+use crate::error::job::snos::SnosError;
 use crate::tests::common::MessagePayloadType;
 use crate::tests::config::{ConfigType, MockType, TestConfigBuilder};
 use crate::tests::utils::build_job_item;
@@ -626,6 +629,117 @@ async fn process_job_job_handler_returns_error_works() {
     );
 }
 
+/// Tests that retryable SNOS execution errors restore the original job status and rely on SQS/DLQ retries.
+#[rstest]
+#[case::created(JobStatus::Created)]
+#[case::verification_failed(JobStatus::VerificationFailed)]
+#[case::pending_retry(JobStatus::PendingRetry)]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_retryable_snos_error_restores_original_status_for_sqs_retry(#[case] initial_status: JobStatus) {
+    let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(0);
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler.expect_process_job().times(1).returning(|_, _| {
+        Err(JobError::from(SnosError::SnosExecutionError {
+            internal_id: 1,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 42,
+                source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::RateLimited))),
+            },
+        }))
+    });
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::SnosRun, initial_status.clone(), 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_err(), "retryable SNOS errors should bubble up so the message is not ACKed");
+
+    let retriable_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(retriable_job.status, initial_status);
+    assert_eq!(retriable_job.metadata.common.process_attempt_no, 1);
+    assert_eq!(retriable_job.metadata.common.process_retry_attempt_no, 1);
+    assert!(retriable_job.metadata.common.process_started_at.is_none());
+
+    let failure_reason = retriable_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("Processing attempt 1 failed"),
+        "failure_reason should record the retryable processing failure. Got: {}",
+        failure_reason
+    );
+    assert!(
+        failure_reason.contains("RPC client error"),
+        "failure_reason should include the underlying RPC error. Got: {}",
+        failure_reason
+    );
+}
+
+/// Tests that Cairo/OS execution failures still fail fast so alerting can stop the sequencer quickly.
+#[rstest]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_cairo_execution_failure_still_fails_fast() {
+    let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(1).returning(|_| Ok(()));
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler.expect_process_job().times(1).returning(|_, _| {
+        Err(JobError::from(SnosError::SnosExecutionError {
+            internal_id: 1,
+            source: PieGenerationError::OsExecution("cairo vm execution failed".to_string()),
+        }))
+    });
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::SnosRun, JobStatus::Created, 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_ok(), "non-retryable Cairo execution failures should still ACK after marking failed");
+
+    let failed_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(failed_job.status, JobStatus::Failed);
+    assert_eq!(failed_job.metadata.common.process_retry_attempt_no, 0);
+
+    let failure_reason = failed_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("cairo vm execution failed"),
+        "failure_reason should contain the Cairo execution error. Got: {}",
+        failure_reason
+    );
+}
+
 /// Tests `verify_job` function when job is having expected status
 /// and returns a `Verified` verification status.
 #[rstest]
@@ -974,8 +1088,11 @@ async fn handle_job_failure_with_failed_job_status_works(#[case] job_type: JobTy
 }
 
 #[rstest]
+#[case::created(JobType::SnosRun, JobStatus::Created)]
+#[case::verification_failed(JobType::SnosRun, JobStatus::VerificationFailed)]
 #[case::pending_verification(JobType::SnosRun, JobStatus::PendingVerification)]
 #[case::verification_timeout(JobType::SnosRun, JobStatus::VerificationTimeout)]
+#[case::pending_retry(JobType::SnosRun, JobStatus::PendingRetry)]
 #[tokio::test]
 async fn handle_job_failure_with_correct_job_status_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
     let mut mock_alert_client = MockAlertClient::new();

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -583,12 +583,14 @@ async fn process_job_job_handler_returns_error_works() {
     let mut job_handler = MockJobHandlerTrait::new();
     // Expecting check_ready_to_process to return Ok (dependencies are ready)
     job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
-    // Expecting process job function in job processor to return an error.
-    let failure_reason = "Failed to process job";
-    job_handler
-        .expect_process_job()
-        .times(1)
-        .returning(move |_, _| Err(JobError::Other(failure_reason.to_string().into())));
+    // Expecting process job function in job processor to return a non-retryable SNOS error.
+    let failure_reason = "cairo vm execution failed";
+    job_handler.expect_process_job().times(1).returning(move |_, _| {
+        Err(JobError::from(SnosError::SnosExecutionError {
+            internal_id: 1,
+            source: PieGenerationError::OsExecution(failure_reason.to_string()),
+        }))
+    });
 
     // building config
     let services = TestConfigBuilder::new()
@@ -624,6 +626,63 @@ async fn process_job_job_handler_returns_error_works() {
     );
     assert!(
         recorded_reason.contains(failure_reason),
+        "failure_reason should contain the original error. Got: {}",
+        recorded_reason
+    );
+}
+
+/// Tests that unclassified SNOS processing errors restore the original job status and rely on SQS/DLQ retries.
+#[rstest]
+#[case::created(JobStatus::Created)]
+#[case::verification_failed(JobStatus::VerificationFailed)]
+#[case::pending_retry(JobStatus::PendingRetry)]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_unclassified_snos_error_restores_original_status_for_sqs_retry(#[case] initial_status: JobStatus) {
+    let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(0);
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler
+        .expect_process_job()
+        .times(1)
+        .returning(|_, _| Err(JobError::Other("simulated generic snos processing failure".to_string().into())));
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::SnosRun, initial_status.clone(), 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
+
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_err(), "generic SNOS processing errors should bubble up so the message is not ACKed");
+
+    let retriable_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(retriable_job.status, initial_status);
+    assert_eq!(retriable_job.metadata.common.process_attempt_no, 1);
+    assert_eq!(retriable_job.metadata.common.process_retry_attempt_no, 1);
+    assert!(retriable_job.metadata.common.process_started_at.is_none());
+
+    let recorded_reason = retriable_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        recorded_reason.contains("Processing attempt 1 failed"),
+        "failure_reason should contain attempt info. Got: {}",
+        recorded_reason
+    );
+    assert!(
+        recorded_reason.contains("simulated generic snos processing failure"),
         "failure_reason should contain the original error. Got: {}",
         recorded_reason
     );

--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -568,7 +568,7 @@ async fn process_job_two_workers_process_same_job_works() {
     assert_eq!(final_job_in_db.status, JobStatus::PendingVerification);
 }
 
-/// Tests `process_job` function when the job handler returns an error.
+/// Tests `process_job` function when the SNOS job handler returns a non-retryable error.
 /// The job should be marked as Failed immediately and the message should be ACKed.
 #[rstest]
 #[tokio::test]
@@ -626,6 +626,63 @@ async fn process_job_job_handler_returns_error_works() {
         recorded_reason.contains(failure_reason),
         "failure_reason should contain the original error. Got: {}",
         recorded_reason
+    );
+}
+
+/// Tests that non-SNOS processing errors restore the original job status and rely on SQS/DLQ retries.
+#[rstest]
+#[case::created(JobStatus::Created)]
+#[case::verification_failed(JobStatus::VerificationFailed)]
+#[case::pending_retry(JobStatus::PendingRetry)]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_non_snos_error_restores_original_status_for_sqs_retry(#[case] initial_status: JobStatus) {
+    let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(0);
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler
+        .expect_process_job()
+        .times(1)
+        .returning(|_, _| Err(JobError::Other("simulated non-snos processing failure".to_string().into())));
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::DataSubmission, initial_status.clone(), 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::DataSubmission)).returning(move |_| Arc::clone(&job_handler));
+
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_err(), "non-SNOS processing errors should bubble up so the message is not ACKed");
+
+    let retriable_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(retriable_job.status, initial_status);
+    assert_eq!(retriable_job.metadata.common.process_attempt_no, 1);
+    assert_eq!(retriable_job.metadata.common.process_retry_attempt_no, 1);
+    assert!(retriable_job.metadata.common.process_started_at.is_none());
+
+    let failure_reason = retriable_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("Processing attempt 1 failed"),
+        "failure_reason should record the processing failure. Got: {}",
+        failure_reason
+    );
+    assert!(
+        failure_reason.contains("simulated non-snos processing failure"),
+        "failure_reason should include the underlying error. Got: {}",
+        failure_reason
     );
 }
 
@@ -736,6 +793,60 @@ async fn process_job_cairo_execution_failure_still_fails_fast() {
     assert!(
         failure_reason.contains("cairo vm execution failed"),
         "failure_reason should contain the Cairo execution error. Got: {}",
+        failure_reason
+    );
+}
+
+/// Tests that non-SNOS panics restore the original job status and rely on SQS/DLQ retries.
+#[rstest]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_non_snos_panic_restores_original_status_for_sqs_retry() {
+    let _test_lock = acquire_test_lock();
+
+    let mut mock_alert_client = MockAlertClient::new();
+    mock_alert_client.expect_send_message().times(0);
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler
+        .expect_process_job()
+        .times(1)
+        .returning(|_, _| -> Result<String, JobError> { panic!("Simulated non-SNOS panic in process_job") });
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .configure_alerts(ConfigType::Mock(MockType::Alerts(Box::new(mock_alert_client))))
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::DataSubmission, JobStatus::Created, 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::DataSubmission)).returning(move |_| Arc::clone(&job_handler));
+
+    let result = JobHandlerService::process_job(job_item.id, services.config.clone()).await;
+    assert!(result.is_err(), "non-SNOS panics should bubble up so the message is not ACKed");
+
+    let retriable_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(retriable_job.status, JobStatus::Created);
+    assert_eq!(retriable_job.metadata.common.process_attempt_no, 1);
+    assert_eq!(retriable_job.metadata.common.process_retry_attempt_no, 1);
+    assert!(retriable_job.metadata.common.process_started_at.is_none());
+
+    let failure_reason = retriable_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("Processing attempt 1 panicked"),
+        "failure_reason should record the panic attempt info. Got: {}",
+        failure_reason
+    );
+    assert!(
+        failure_reason.contains("Simulated non-SNOS panic in process_job"),
+        "failure_reason should contain the panic message. Got: {}",
         failure_reason
     );
 }

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -137,7 +137,7 @@ impl JobHandlerTrait for SnosJobHandler {
 
         let snos_output: PieGenerationResult = generate_pie(input).await.map_err(|e| {
             error!(error = %e, "SNOS execution failed");
-            SnosError::SnosExecutionError { internal_id, message: e.to_string() }
+            SnosError::SnosExecutionError { internal_id, source: e }
         })?;
         debug!("generate_pie function completed successfully");
 

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use crate::core::client::database::{AggregatorBatchDbQuery, SnosBatchDbQuery};
 use crate::core::config::Config;
 use crate::error::job::JobError;
+use crate::error::other::OtherError;
 use crate::types::jobs::external_id::ExternalId;
 use crate::types::jobs::job_updates::JobItemUpdates;
 use crate::types::jobs::metadata::JobMetadata;
@@ -137,7 +138,8 @@ impl JobHandlerService {
     /// * `Created` -> `LockedForProcessing` -> `PendingVerification`
     /// * `VerificationFailed` -> `LockedForProcessing` -> `PendingVerification`
     /// * `PendingRetry` -> `LockedForProcessing` -> `PendingVerification`
-    /// * `LockedForProcessing` -> `Failed` (on processing error or panic — message is ACKed, no SQS retry)
+    /// * `LockedForProcessing` -> `Failed` (on non-retryable processing error or panic)
+    /// * `LockedForProcessing` -> original status (on retryable SNOS processing error, message is NACKed)
     ///
     /// # Metrics
     /// * Updates block gauge
@@ -153,12 +155,10 @@ impl JobHandlerService {
     ///   timeout (stale), otherwise acks the message assuming it's a duplicate
     ///
     /// # Failure handling
-    /// Processing errors (including transient ones) immediately move the job to `Failed` and ACK the
-    /// SQS message. There are no SQS-level retries for explicit failures — job handlers that talk to
-    /// external APIs (SHARP, Atlantic, Ethereum, Starknet) implement their own internal retry logic
-    /// before surfacing an error. SQS `maxReceiveCount` only protects against implicit failures
-    /// (OOM, consumer crash) where the handler never reaches the error path.
-    /// Failed jobs can be retried via the `retry_job` endpoint.
+    /// Retryable SNOS processing errors restore the job to its pre-processing status and return an
+    /// error so SQS can retry the message until it reaches the DLQ. Non-retryable processing errors
+    /// and panics still fail fast by moving the job to `Failed` and ACKing the message so alerting
+    /// can stop the sequencer quickly. Failed jobs can be retried via the `retry_job` endpoint.
     ///
     /// # Important
     /// The queue visibility timeout MUST be greater than the job healing timeout configured via
@@ -285,6 +285,10 @@ impl JobHandlerService {
             return Ok(());
         }
 
+        // Save original status so retryable processing failures can restore the job to the
+        // pre-processing state and let SQS own the retry lifecycle.
+        let original_status = job.status.clone();
+
         // This updates the version of the job.
         // This ensures that if another thread was about to process the same job,
         // it would fail to update the job in the database because the version would be outdated
@@ -334,6 +338,28 @@ impl JobHandlerService {
                 external_id
             }
             Ok(Err(e)) => {
+                let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
+
+                if e.is_retryable_processing_failure() {
+                    warn!(
+                        job_id = ?id,
+                        job_type = ?job.job_type,
+                        internal_id = %job.internal_id,
+                        status = ?original_status,
+                        error = ?e,
+                        "Retryable SNOS processing failure detected, restoring job state for SQS retry"
+                    );
+                    workload.finish_error();
+                    return Err(Self::reset_job_for_retryable_processing_error(
+                        &mut job,
+                        config.clone(),
+                        original_status,
+                        reason,
+                        e,
+                    )
+                    .await);
+                }
+
                 error!(
                     job_id = ?id,
                     job_type = ?job.job_type,
@@ -342,12 +368,12 @@ impl JobHandlerService {
                     error = ?e,
                     "Failed to process job, marking as failed"
                 );
-                let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
                 MetricsRecorder::record_job_state_transition(
                     JobStatus::LockedForProcessing,
                     JobStatus::Failed,
                     &job.job_type,
                 );
+                workload.finish_error();
                 return JobService::move_job_to_failed(&job, config.clone(), reason).await;
             }
             Err(panic) => {
@@ -365,6 +391,7 @@ impl JobHandlerService {
                     JobStatus::Failed,
                     &job.job_type,
                 );
+                workload.finish_error();
                 return JobService::move_job_to_failed(&job, config.clone(), reason).await;
             }
         };
@@ -433,6 +460,52 @@ impl JobHandlerService {
         workload.finish_success();
 
         Ok(())
+    }
+
+    async fn reset_job_for_retryable_processing_error(
+        job: &mut crate::types::jobs::job_item::JobItem,
+        config: Arc<Config>,
+        original_status: JobStatus,
+        reason: String,
+        original_error: JobError,
+    ) -> JobError {
+        job.metadata.common.process_retry_attempt_no += 1;
+        job.metadata.common.process_started_at = None;
+        job.metadata.common.process_completed_at = None;
+
+        if let Some(previous_reason) = job.metadata.common.failure_reason.take() {
+            job.metadata.common.previous_failure_reasons.push(previous_reason);
+        }
+        job.metadata.common.failure_reason = Some(reason);
+
+        match config
+            .database()
+            .update_job(
+                job,
+                JobItemUpdates::new()
+                    .update_status(original_status.clone())
+                    .update_metadata(job.metadata.clone())
+                    .build(),
+            )
+            .await
+        {
+            Ok(_) => {
+                MetricsRecorder::record_job_state_transition(
+                    JobStatus::LockedForProcessing,
+                    original_status.clone(),
+                    &job.job_type,
+                );
+                MetricsRecorder::record_job_status(job, &original_status);
+                original_error
+            }
+            Err(db_err) => {
+                error!(job_id = ?job.id, error = ?db_err, "Failed to reset retryable job state for SQS retry");
+                JobError::Other(OtherError::from(format!(
+                    "Failed to reset job state: {}. Original error: {}",
+                    db_err, original_error
+                )))
+            }
+        }
     }
 
     /// Verify Job Function

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -138,8 +138,9 @@ impl JobHandlerService {
     /// * `Created` -> `LockedForProcessing` -> `PendingVerification`
     /// * `VerificationFailed` -> `LockedForProcessing` -> `PendingVerification`
     /// * `PendingRetry` -> `LockedForProcessing` -> `PendingVerification`
-    /// * `LockedForProcessing` -> `Failed` (on non-retryable processing error or panic)
-    /// * `LockedForProcessing` -> original status (on retryable SNOS processing error, message is NACKed)
+    /// * `LockedForProcessing` -> `Failed` (on non-retryable SNOS processing error or panic)
+    /// * `LockedForProcessing` -> original status (on retryable SNOS processing error, or any
+    ///   non-SNOS processing failure/panic; message is NACKed)
     ///
     /// # Metrics
     /// * Updates block gauge
@@ -156,9 +157,10 @@ impl JobHandlerService {
     ///
     /// # Failure handling
     /// Retryable SNOS processing errors restore the job to its pre-processing status and return an
-    /// error so SQS can retry the message until it reaches the DLQ. Non-retryable processing errors
-    /// and panics still fail fast by moving the job to `Failed` and ACKing the message so alerting
-    /// can stop the sequencer quickly. Failed jobs can be retried via the `retry_job` endpoint.
+    /// error so SQS can retry the message until it reaches the DLQ. All non-SNOS processing errors
+    /// and panics also defer to SQS/DLQ retries. Only non-retryable SNOS processing errors and panics
+    /// still fail fast by moving the job to `Failed` and ACKing the message so alerting can stop the
+    /// sequencer quickly. Failed jobs can be retried via the `retry_job` endpoint.
     ///
     /// # Important
     /// The queue visibility timeout MUST be greater than the job healing timeout configured via
@@ -340,24 +342,19 @@ impl JobHandlerService {
             Ok(Err(e)) => {
                 let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
 
-                if e.is_retryable_processing_failure() {
+                if job.job_type != JobType::SnosRun || e.is_retryable_processing_failure() {
                     warn!(
                         job_id = ?id,
                         job_type = ?job.job_type,
                         internal_id = %job.internal_id,
                         status = ?original_status,
                         error = ?e,
-                        "Retryable SNOS processing failure detected, restoring job state for SQS retry"
+                        "Processing failure detected, restoring job state for SQS retry"
                     );
                     workload.finish_error();
-                    return Err(Self::reset_job_for_retryable_processing_error(
-                        &mut job,
-                        config.clone(),
-                        original_status,
-                        reason,
-                        e,
-                    )
-                    .await);
+                    return Err(
+                        Self::reset_job_for_sqs_retry(&mut job, config.clone(), original_status, reason, e).await
+                    );
                 }
 
                 error!(
@@ -383,9 +380,30 @@ impl JobHandlerService {
                     .or_else(|| panic.downcast_ref::<&str>().copied())
                     .unwrap_or("Unknown panic message");
 
-                error!(job_id = ?id, panic_msg = %panic_msg, "Job handler panicked during processing, marking as failed");
+                let panic_error =
+                    JobError::Other(OtherError::from(format!("Job handler panicked with message: {}", panic_msg)));
                 let reason =
                     format!("Processing attempt {} panicked: {}", job.metadata.common.process_attempt_no, panic_msg);
+
+                if job.job_type != JobType::SnosRun {
+                    error!(
+                        job_id = ?id,
+                        job_type = ?job.job_type,
+                        panic_msg = %panic_msg,
+                        "Job handler panicked during processing, restoring job state for SQS retry"
+                    );
+                    workload.finish_error();
+                    return Err(Self::reset_job_for_sqs_retry(
+                        &mut job,
+                        config.clone(),
+                        original_status,
+                        reason,
+                        panic_error,
+                    )
+                    .await);
+                }
+
+                error!(job_id = ?id, panic_msg = %panic_msg, "Job handler panicked during processing, marking as failed");
                 MetricsRecorder::record_job_state_transition(
                     JobStatus::LockedForProcessing,
                     JobStatus::Failed,
@@ -462,7 +480,7 @@ impl JobHandlerService {
         Ok(())
     }
 
-    async fn reset_job_for_retryable_processing_error(
+    async fn reset_job_for_sqs_retry(
         job: &mut crate::types::jobs::job_item::JobItem,
         config: Arc<Config>,
         original_status: JobStatus,

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -342,7 +342,7 @@ impl JobHandlerService {
             Ok(Err(e)) => {
                 let reason = format!("Processing attempt {} failed: {}", job.metadata.common.process_attempt_no, e);
 
-                if job.job_type != JobType::SnosRun || e.is_retryable_processing_failure() {
+                if job.job_type != JobType::SnosRun || !e.is_fail_fast_snos_processing_failure() {
                     warn!(
                         job_id = ?id,
                         job_type = ?job.job_type,


### PR DESCRIPTION
## Summary
- classify retryable versus fail-fast SNOS failures from typed `generate-pie` errors
- keep fail-fast only for non-retryable SNOS processing failures such as Cairo/OS execution errors
- restore the SQS retry flow for every other job type during processing, and for all processing panics
- point the Madara workspace at the released SNOS tag `v0.14.2-rc.5` from `keep-starknet-strange/snos`
- expand orchestrator tests around SNOS retryability, generic SNOS failures, and panic retry behavior

## Why
Recent fail-fast behavior marked processing failures as `Failed` immediately. That is too aggressive for intermittent SNOS RPC and proof-fetch failures, and it is also too aggressive for non-SNOS jobs, which should continue using the original SQS retry lifecycle until DLQ. The only failures that should still fail fast are non-retryable SNOS execution failures, so alerting can stop the sequencer promptly.

Panics are also not safely classifiable at the service boundary: a `SnosRun` panic could come from transient RPC or transport paths just as easily as from a deterministic internal bug. This PR therefore treats all processing panics as SQS-retryable and reserves fail-fast for positively classified non-retryable SNOS errors.

## Impact
- retryable SNOS processing failures are restored to their original job status and the SQS message is left unacked for redelivery
- all processing panics now restore the original job status and rely on SQS/DLQ retries instead of being marked `Failed` immediately
- all non-SNOS processing failures continue to rely on SQS/DLQ retries instead of being marked `Failed` immediately
- `process_retry_attempt_no` still increments when the job is restored for SQS retry
- deterministic SNOS execution/configuration/proof-shape failures continue to fail fast

## Validation
- `cargo fmt --all --check`
- `source /Users/prakhar/work/karnot/madara/sequencer_venv/bin/activate && cargo clippy -p orchestrator --all-features --tests --no-deps -- -D warnings`
- `source /Users/prakhar/work/karnot/madara/sequencer_venv/bin/activate && cargo test -p orchestrator --lib --no-run`
