### PR TITLE
[codex] Retry SNOS state-read BlockNotFound failures

### DIFF
--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -87,7 +87,9 @@ fn is_retryable_pie_generation_error(error: &PieGenerationError) -> bool {
 
 fn is_retryable_block_processing_error(error: &BlockProcessingError) -> bool {
     match error {
-        BlockProcessingError::RpcClient(source) => error_chain_is_retryable(source.as_ref()),
+        BlockProcessingError::RpcClient(source) => {
+            error_chain_contains_block_not_found(source.as_ref()) || error_chain_is_retryable(source.as_ref())
+        }
         BlockProcessingError::TransactionConversion { source, .. } => error_chain_is_retryable(source.as_ref()),
         BlockProcessingError::StateUpdate(source) => error_chain_is_retryable(source),
         BlockProcessingError::StorageProof(source) | BlockProcessingError::ClassProof(source) => {
@@ -126,6 +128,22 @@ fn error_chain_is_retryable(error: &(dyn std::error::Error + 'static)) -> bool {
     let mut source = error.source();
     while let Some(next) = source {
         if is_retryable_remote_message(&next.to_string()) {
+            return true;
+        }
+        source = next.source();
+    }
+
+    false
+}
+
+fn error_chain_contains_block_not_found(error: &(dyn std::error::Error + 'static)) -> bool {
+    if is_block_not_found_message(&error.to_string()) {
+        return true;
+    }
+
+    let mut source = error.source();
+    while let Some(next) = source {
+        if is_block_not_found_message(&next.to_string()) {
             return true;
         }
         source = next.source();
@@ -176,13 +194,13 @@ fn is_retryable_state_error(error: &StateError) -> bool {
 }
 
 fn is_retryable_state_read_message(message: &str) -> bool {
+    is_block_not_found_message(message)
+}
+
+fn is_block_not_found_message(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
 
-    if lower.contains("blocknotfound") || lower.contains("block not found") {
-        return true;
-    }
-
-    is_retryable_remote_message(message)
+    lower.contains("blocknotfound") || lower.contains("block not found")
 }
 
 fn is_retryable_pending_block_state(message: &str) -> bool {
@@ -316,6 +334,61 @@ mod tests {
     }
 
     #[test]
+    fn rpc_client_block_not_found_is_retryable() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::StarknetError(
+                    StarknetError::BlockNotFound,
+                )))),
+            },
+        };
+
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn exact_rpc_client_block_not_found_error_string_is_retryable() {
+        let error = crate::error::job::JobError::from(SnosError::SnosExecutionError {
+            internal_id: 646856,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 2222689,
+                source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::StarknetError(
+                    StarknetError::BlockNotFound,
+                )))),
+            },
+        });
+
+        assert_eq!(
+            error.to_string(),
+            "Snos Error: Error while running SNOS (snos job #646856): Block processing failed for block 2222689: \
+             RPC client error: BlockNotFound"
+        );
+        assert!(!error.is_fail_fast_snos_processing_failure());
+    }
+
+    #[test]
+    fn exact_block_not_found_error_string_is_retryable() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 645003,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 2216682,
+                source: Box::new(BlockProcessingError::TransactionExecution(TransactionExecutorError::StateError(
+                    StateError::StateReadError("BlockNotFound".to_string()),
+                ))),
+            },
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "Error while running SNOS (snos job #645003): Block processing failed for block 2216682: \
+             Transaction execution error: Failed to read from state: BlockNotFound."
+        );
+        assert!(error.is_retryable());
+    }
+
+    #[test]
     fn transaction_execution_non_block_not_found_state_reads_fail_fast() {
         let error = SnosError::SnosExecutionError {
             internal_id: 7,
@@ -323,6 +396,21 @@ mod tests {
                 block_number: 12,
                 source: Box::new(BlockProcessingError::TransactionExecution(TransactionExecutorError::StateError(
                     StateError::StateReadError("Failed to decompress legacy contract class".to_string()),
+                ))),
+            },
+        };
+
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn transaction_execution_state_read_rpc_errors_do_not_retry_via_block_not_found_rule() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(BlockProcessingError::TransactionExecution(TransactionExecutorError::StateError(
+                    StateError::StateReadError("RPC error: timeout".to_string()),
                 ))),
             },
         };

--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -1,5 +1,8 @@
 use crate::error::job::fact::FactError;
 use crate::error::other::OtherError;
+use blockifier::blockifier::transaction_executor::TransactionExecutorError;
+use blockifier::state::errors::StateError;
+use blockifier::transaction::errors::{TransactionExecutionError, TransactionFeeError, TransactionPreValidationError};
 use generate_pie::error::{BlockProcessingError, PieGenerationError};
 use thiserror::Error;
 
@@ -100,8 +103,8 @@ fn is_retryable_block_processing_error(error: &BlockProcessingError) -> bool {
         | BlockProcessingError::InitialReadCompiledClassHashHydration { source, .. } => {
             error_chain_is_retryable(source)
         }
-        BlockProcessingError::TransactionExecution(_)
-        | BlockProcessingError::ContextBuilding(_)
+        BlockProcessingError::TransactionExecution(source) => is_retryable_transaction_executor_error(source),
+        BlockProcessingError::ContextBuilding(_)
         | BlockProcessingError::TransactionExecutorCreation { .. }
         | BlockProcessingError::StarknetVersion(_)
         | BlockProcessingError::MissingBlockStateAfterExecution
@@ -129,6 +132,57 @@ fn error_chain_is_retryable(error: &(dyn std::error::Error + 'static)) -> bool {
     }
 
     false
+}
+
+fn is_retryable_transaction_executor_error(error: &TransactionExecutorError) -> bool {
+    match error {
+        TransactionExecutorError::StateError(source) => is_retryable_state_error(source),
+        TransactionExecutorError::TransactionExecutionError(source) => is_retryable_transaction_execution_error(source),
+        TransactionExecutorError::BlockFull | TransactionExecutorError::CompressionError(_) => false,
+    }
+}
+
+fn is_retryable_transaction_execution_error(error: &TransactionExecutionError) -> bool {
+    match error {
+        TransactionExecutionError::StateError(source) => is_retryable_state_error(source),
+        TransactionExecutionError::TransactionFeeError(source) => is_retryable_transaction_fee_error(source),
+        TransactionExecutionError::TransactionPreValidationError(source) => {
+            is_retryable_transaction_pre_validation_error(source)
+        }
+        _ => false,
+    }
+}
+
+fn is_retryable_transaction_fee_error(error: &TransactionFeeError) -> bool {
+    match error {
+        TransactionFeeError::StateError(source) => is_retryable_state_error(source),
+        _ => false,
+    }
+}
+
+fn is_retryable_transaction_pre_validation_error(error: &TransactionPreValidationError) -> bool {
+    match error {
+        TransactionPreValidationError::StateError(source) => is_retryable_state_error(source),
+        TransactionPreValidationError::TransactionFeeError(source) => is_retryable_transaction_fee_error(source),
+        _ => false,
+    }
+}
+
+fn is_retryable_state_error(error: &StateError) -> bool {
+    match error {
+        StateError::StateReadError(message) => is_retryable_state_read_message(message),
+        _ => false,
+    }
+}
+
+fn is_retryable_state_read_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+
+    if lower.contains("blocknotfound") || lower.contains("block not found") {
+        return true;
+    }
+
+    is_retryable_remote_message(message)
 }
 
 fn is_retryable_pending_block_state(message: &str) -> bool {
@@ -240,6 +294,36 @@ mod tests {
                 source: Box::new(BlockProcessingError::RpcClient(Box::new(ProviderError::StarknetError(
                     StarknetError::ContractNotFound,
                 )))),
+            },
+        };
+
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn transaction_execution_state_read_block_not_found_is_retryable() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(BlockProcessingError::TransactionExecution(TransactionExecutorError::StateError(
+                    StateError::StateReadError("BlockNotFound".to_string()),
+                ))),
+            },
+        };
+
+        assert!(error.is_retryable());
+    }
+
+    #[test]
+    fn transaction_execution_non_block_not_found_state_reads_fail_fast() {
+        let error = SnosError::SnosExecutionError {
+            internal_id: 7,
+            source: PieGenerationError::BlockProcessing {
+                block_number: 12,
+                source: Box::new(BlockProcessingError::TransactionExecution(TransactionExecutorError::StateError(
+                    StateError::StateReadError("Failed to decompress legacy contract class".to_string()),
+                ))),
             },
         };
 


### PR DESCRIPTION
## What changed
- classify `BlockProcessingError::TransactionExecution` structurally instead of fail-fasting it unconditionally
- treat transaction execution failures as retryable when they come from `StateError::StateReadError` with `BlockNotFound` / `block not found`
- treat `BlockProcessingError::RpcClient(BlockNotFound)` as retryable as well
- keep other transaction execution failures and non-`BlockNotFound` RPC client failures on their existing paths
- add focused regression tests for both retryable `BlockNotFound` branches and non-retryable neighboring cases

## Why
We had two SNOS block-processing paths surfacing `BlockNotFound` from upstream RPC calls:
- `Transaction execution error: Failed to read from state: BlockNotFound.`
- `RPC client error: BlockNotFound`

Both come from external RPC/state availability conditions rather than deterministic Cairo/OS execution failures, so they should go back through SQS retry instead of failing fast.

## Impact
This keeps the retry policy narrow to the specific `BlockNotFound` cases we have observed without broadening retryability for unrelated transaction execution or RPC errors.

## Validation
- `cargo fmt --all --check`
- `cargo test -p orchestrator error::job::snos::tests -- --nocapture`
- `source /Users/prakhar/work/karnot/madara/sequencer_venv/bin/activate && cargo clippy -p orchestrator --all-features --tests --no-deps -- -D warnings`
