### PR TITLE
Record SNOS timing in job metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.5#7da559392a1ea3ec9048cc62d8c5a75ebc0aad1d"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=b284015497ee980b4129d1c72d622b94965ace98#b284015497ee980b4129d1c72d622b94965ace98"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13081,7 +13081,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.5#7da559392a1ea3ec9048cc62d8c5a75ebc0aad1d"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=b284015497ee980b4129d1c72d622b94965ace98#b284015497ee980b4129d1c72d622b94965ace98"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14524,7 +14524,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?tag=v0.14.2-rc.5#7da559392a1ea3ec9048cc62d8c5a75ebc0aad1d"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=b284015497ee980b4129d1c72d622b94965ace98#b284015497ee980b4129d1c72d622b94965ace98"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=bc2da64603ea6981555c7bebb4d30199317525ea#bc2da64603ea6981555c7bebb4d30199317525ea"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c3409c4c1d6fd2c701ed9df47f083249058fec35#c3409c4c1d6fd2c701ed9df47f083249058fec35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13081,7 +13081,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=bc2da64603ea6981555c7bebb4d30199317525ea#bc2da64603ea6981555c7bebb4d30199317525ea"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c3409c4c1d6fd2c701ed9df47f083249058fec35#c3409c4c1d6fd2c701ed9df47f083249058fec35"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14524,7 +14524,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=bc2da64603ea6981555c7bebb4d30199317525ea#bc2da64603ea6981555c7bebb4d30199317525ea"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=c3409c4c1d6fd2c701ed9df47f083249058fec35#c3409c4c1d6fd2c701ed9df47f083249058fec35"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "generate-pie"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=b284015497ee980b4129d1c72d622b94965ace98#b284015497ee980b4129d1c72d622b94965ace98"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=bc2da64603ea6981555c7bebb4d30199317525ea#bc2da64603ea6981555c7bebb4d30199317525ea"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13081,7 +13081,7 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 [[package]]
 name = "rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=b284015497ee980b4129d1c72d622b94965ace98#b284015497ee980b4129d1c72d622b94965ace98"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=bc2da64603ea6981555c7bebb4d30199317525ea#bc2da64603ea6981555c7bebb4d30199317525ea"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -14524,7 +14524,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/snos.git?rev=b284015497ee980b4129d1c72d622b94965ace98#b284015497ee980b4129d1c72d622b94965ace98"
+source = "git+https://github.com/keep-starknet-strange/snos.git?rev=bc2da64603ea6981555c7bebb4d30199317525ea#bc2da64603ea6981555c7bebb4d30199317525ea"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", tag = "v0.14.2-rc.5" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "b284015497ee980b4129d1c72d622b94965ace98" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "bc2da64603ea6981555c7bebb4d30199317525ea" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "c3409c4c1d6fd2c701ed9df47f083249058fec35" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ strum = "0.26.3"
 async-std = { version = "1.13.0", features = ["attributes"] }
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "b284015497ee980b4129d1c72d622b94965ace98" }
+generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev = "bc2da64603ea6981555c7bebb4d30199317525ea" }
 
 orchestrator-da-client-interface = { path = "orchestrator/crates/da-clients/da-client-interface" }
 orchestrator-ethereum-da-client = { path = "orchestrator/crates/da-clients/ethereum" }

--- a/orchestrator/src/types/jobs/metadata/mod.rs
+++ b/orchestrator/src/types/jobs/metadata/mod.rs
@@ -1,6 +1,7 @@
 use crate::types::error::TypeError;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Common metadata fields shared across all job types.
 ///
@@ -224,6 +225,9 @@ pub struct SnosMetadata {
     /// Wall-clock time SNOS spent on local execution/processing outside RPC waits.
     #[serde(default)]
     pub snos_execution_time_ms: Option<u64>,
+    /// RPC calls SNOS made grouped by method name, including a `total` entry.
+    #[serde(default)]
+    pub snos_rpc_calls_by_method: Option<HashMap<String, u64>>,
 }
 
 /// Metadata specific to state update jobs.

--- a/orchestrator/src/types/jobs/metadata/mod.rs
+++ b/orchestrator/src/types/jobs/metadata/mod.rs
@@ -187,7 +187,7 @@ pub struct ProvingMetadata {
 ///
 /// # Field Management
 /// - Worker-initialized fields: start_block, end_block, num_blocks, full_output, and path configurations
-/// - Job-populated fields: snos_fact (during processing)
+/// - Job-populated fields: snos_fact and timing fields (during processing)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SnosMetadata {
     // Worker-initialized fields
@@ -215,6 +215,15 @@ pub struct SnosMetadata {
     pub snos_fact: Option<String>,
     /// SNOS total steps taken
     pub snos_n_steps: Option<usize>,
+    /// Total wall-clock time SNOS spent processing this job.
+    #[serde(default)]
+    pub snos_total_processing_time_ms: Option<u64>,
+    /// Wall-clock time SNOS spent waiting for RPC calls while processing this job.
+    #[serde(default)]
+    pub snos_rpc_wait_time_ms: Option<u64>,
+    /// Wall-clock time SNOS spent on local execution/processing outside RPC waits.
+    #[serde(default)]
+    pub snos_execution_time_ms: Option<u64>,
 }
 
 /// Metadata specific to state update jobs.

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -141,6 +141,7 @@ impl JobHandlerTrait for SnosJobHandler {
         })?;
         debug!("generate_pie function completed successfully");
 
+        let snos_timing = snos_output.timing;
         let cairo_pie = snos_output.output.cairo_pie;
 
         // TODO: currently we are getting the Vec<Felt> but ideally we should get a struct, fix it once it available upstream
@@ -181,6 +182,9 @@ impl JobHandlerTrait for SnosJobHandler {
         if let JobSpecificMetadata::Snos(metadata) = &mut job.metadata.specific {
             metadata.snos_fact = Some(fact_hash.to_string());
             metadata.snos_n_steps = Some(cairo_pie.execution_resources.n_steps);
+            metadata.snos_total_processing_time_ms = Some(snos_timing.total_processing_time_ms);
+            metadata.snos_rpc_wait_time_ms = Some(snos_timing.rpc_wait_time_ms);
+            metadata.snos_execution_time_ms = Some(snos_timing.execution_time_ms);
         }
 
         debug!("Storing SNOS outputs");

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -185,6 +185,7 @@ impl JobHandlerTrait for SnosJobHandler {
             metadata.snos_total_processing_time_ms = Some(snos_timing.total_processing_time_ms);
             metadata.snos_rpc_wait_time_ms = Some(snos_timing.rpc_wait_time_ms);
             metadata.snos_execution_time_ms = Some(snos_timing.execution_time_ms);
+            metadata.snos_rpc_calls_by_method = Some(snos_timing.rpc_calls_by_method.clone());
         }
 
         debug!("Storing SNOS outputs");


### PR DESCRIPTION
## Summary
- pin SNOS/generate-pie to keep-starknet-strange/snos commit b284015497ee980b4129d1c72d622b94965ace98 from PR #527
- add optional SNOS timing fields to SnosMetadata
- persist total SNOS processing time, RPC wait time, and execution/local processing time after successful SNOS runs

## Notes
- These values are stored in SNOS job metadata, not emitted as metrics, to avoid high-cardinality telemetry.
- The SNOS timing source PR is https://github.com/keep-starknet-strange/snos/pull/527.

## Testing
- cargo fmt --all
- git diff --check
- Local cargo check was intentionally skipped per request; CI/manual image build will validate with the full Cairo toolchain.