### PR TITLE
[codex] consolidate dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "f72cf87cda808e593381fb9f005ffa4d2475552b7a6c5ac33d087bf77d82abd0"
 dependencies = [
  "alloy-primitives 1.4.1",
  "alloy-sol-types 1.4.1",
- "http 1.4.0",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -515,7 +515,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "wasmtimer",
 ]
@@ -562,7 +562,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -887,7 +887,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -903,7 +903,7 @@ dependencies = [
  "alloy-transport",
  "reqwest 0.12.26",
  "serde_json",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -937,7 +937,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "rustls 0.23.35",
  "serde_json",
  "tokio",
@@ -1044,7 +1044,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -1063,6 +1078,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1991,7 +2015,7 @@ dependencies = [
  "bytes",
  "fastrand 2.3.0",
  "hex",
- "http 1.4.0",
+ "http 1.4.2",
  "ring",
  "time",
  "tokio",
@@ -2128,7 +2152,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "lru 0.12.5",
  "percent-encoding",
@@ -2289,7 +2313,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "p256",
  "percent-encoding",
  "ring",
@@ -2356,7 +2380,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "percent-encoding",
  "pin-project-lite",
@@ -2374,9 +2398,9 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.12",
+ "h2 0.4.15",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper 1.8.1",
@@ -2390,7 +2414,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -2437,7 +2461,7 @@ dependencies = [
  "bytes",
  "fastrand 2.3.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "pin-project-lite",
@@ -2456,7 +2480,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -2474,7 +2498,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -2551,7 +2575,7 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -2570,7 +2594,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2602,7 +2626,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -2724,15 +2748,6 @@ dependencies = [
  "async-trait",
  "bb8",
  "redis",
-]
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2902,15 +2917,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -3033,7 +3039,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-named-pipe",
@@ -3186,9 +3192,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -5199,9 +5205,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -5209,11 +5215,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -5221,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5233,9 +5239,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -6097,7 +6103,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
@@ -6526,7 +6532,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",
@@ -6557,7 +6563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7182,15 +7188,15 @@ dependencies = [
 
 [[package]]
 name = "gloo-net"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 0.2.12",
+ "http 1.4.2",
  "js-sys",
  "pin-project",
  "serde",
@@ -7293,7 +7299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8a478015d079296167e3f08e096dc99cffc2cb50fa203dd38aaa9dd37f8354"
 dependencies = [
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "tonic 0.10.2",
 ]
 
@@ -7320,7 +7326,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-googleapis",
  "google-cloud-token",
- "prost-types",
+ "prost-types 0.12.6",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -7399,16 +7405,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.13.1",
  "slab",
  "tokio",
@@ -7502,7 +7508,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http 1.4.2",
  "httpdate",
  "mime",
  "sha1",
@@ -7514,7 +7520,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -7671,9 +7677,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -7697,7 +7703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -7708,16 +7714,10 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -7775,7 +7775,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "headers",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
@@ -7853,8 +7853,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.4.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -7892,7 +7892,6 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -7904,7 +7903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "hyper 1.8.1",
  "hyper-util",
  "log",
@@ -7922,7 +7921,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper 1.8.1",
  "hyper-util",
  "log",
@@ -8000,14 +7999,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8425,7 +8424,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8481,9 +8480,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc-sys"
@@ -8617,9 +8616,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -8635,81 +8634,87 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
+checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
 dependencies = [
+ "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 0.2.12",
+ "http 1.4.2",
  "jsonrpsee-core",
  "pin-project",
- "rustls-native-certs 0.7.3",
+ "rustls 0.23.35",
  "rustls-pki-types",
+ "rustls-platform-verifier 0.5.3",
  "soketto",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
 dependencies = [
- "anyhow",
  "async-trait",
- "beef",
+ "bytes",
  "futures-timer",
  "futures-util",
- "hyper 0.14.32",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
  "jsonrpsee-types",
  "parking_lot 0.12.5",
  "pin-project",
- "rand 0.8.5",
- "rustc-hash 1.1.0",
+ "rand 0.9.2",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
+ "tower 0.5.3",
  "tracing",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
+checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
 dependencies = [
- "async-trait",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
+ "base64 0.22.1",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "rustls 0.23.35",
+ "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
- "tower 0.4.13",
- "tracing",
+ "tower 0.5.3",
  "url",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0bb047e79a143b32ea03974a6bf59b62c2a4c5f5d42a381c907a8bbb3f75c0"
+checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -8718,13 +8723,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
+checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
 dependencies = [
  "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "pin-project",
@@ -8732,48 +8740,49 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower 0.4.13",
+ "tower 0.5.3",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
- "anyhow",
- "beef",
+ "http 1.4.2",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448d8eacd945cc17b6c0b42c361531ca36a962ee186342a97cdb8fca679cd77"
+checksum = "7902885de4779f711a95d82c8da2d7e5f9f3a7c7cfa44d51c067fd1c29d72a3c"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "tower 0.5.3",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
+checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
- "http 0.2.12",
+ "http 1.4.2",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -9335,10 +9344,10 @@ dependencies = [
  "flate2",
  "futures",
  "governor",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "httpmock 0.7.0",
- "hyper 0.14.32",
+ "hyper 1.8.1",
  "hyper-tls 0.6.0",
  "hyper-util",
  "indoc 2.0.7",
@@ -9417,8 +9426,8 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
- "tower-http 0.4.4",
+ "tower 0.5.3",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-core",
  "tracing-opentelemetry",
@@ -9808,7 +9817,7 @@ dependencies = [
  "bytes",
  "flate2",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-tls 0.6.0",
@@ -10331,7 +10340,7 @@ dependencies = [
  "bytes",
  "colored 3.0.0",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -10412,7 +10421,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with 1.14.0",
- "sha-1 0.10.1",
+ "sha-1",
  "sha2",
  "socket2 0.4.10",
  "stringprep",
@@ -10768,7 +10777,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "memchr",
  "mime",
@@ -11058,12 +11067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11109,9 +11112,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -11123,9 +11126,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.30.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68f63eca5fad47e570e00e893094fc17be959c80c79a7d6ec1abdd5ae6ffc16"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -11135,59 +11138,60 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry",
- "reqwest 0.12.26",
+ "reqwest 0.13.2",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "reqwest 0.12.26",
+ "prost 0.14.4",
+ "reqwest 0.13.2",
  "thiserror 2.0.17",
  "tokio",
- "tonic 0.13.1",
- "tracing",
+ "tonic 0.14.6",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "tonic 0.13.1",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
+checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447191061af41c3943e082ea359ab8b64ff27d6d34d30d327df309ddef1eef6f"
+checksum = "a1b1c6a247d79091f0062a5f4bd058589525cf987a8d4c169440d9c1be72f0ad"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -11196,17 +11200,17 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic 1.11.1",
  "rand 0.9.2",
- "serde_json",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -11252,7 +11256,7 @@ dependencies = [
  "generate-pie",
  "hex",
  "httpmock 0.8.2",
- "hyper 0.14.32",
+ "hyper 1.8.1",
  "indexmap 2.13.1",
  "itertools 0.14.0",
  "jemallocator",
@@ -12421,9 +12425,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12451,12 +12455,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.13.5",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -12474,9 +12478,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -12492,6 +12496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -12528,7 +12541,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12566,9 +12579,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12915,9 +12928,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.15",
  "hickory-resolver",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -12943,7 +12956,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
@@ -12965,7 +12978,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -12978,13 +12991,13 @@ dependencies = [
  "quinn",
  "rustls 0.23.35",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
@@ -13351,7 +13364,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13411,18 +13424,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
@@ -13476,6 +13477,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.35",
+ "rustls-native-certs 0.8.2",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.8",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
@@ -13491,8 +13513,8 @@ dependencies = [
  "rustls-webpki 0.103.8",
  "security-framework 3.5.1",
  "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.59.0",
+ "webpki-root-certs 1.0.6",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13554,9 +13576,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa"
@@ -14090,19 +14112,6 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
@@ -14355,18 +14364,18 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes",
  "futures",
- "http 0.2.12",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha1",
 ]
 
 [[package]]
@@ -15276,7 +15285,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15485,9 +15494,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -15764,14 +15773,14 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -15779,13 +15788,35 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -15810,9 +15841,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -15829,24 +15860,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.10.0",
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
@@ -15854,11 +15867,26 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "http 1.4.2",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]
@@ -15877,9 +15905,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -15900,9 +15928,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -15931,14 +15959,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -16059,7 +16085,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -16639,6 +16665,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.6",
+]
+
+[[package]]
+name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
@@ -16698,7 +16733,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -17383,18 +17418,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,42 +142,42 @@ alloy = { version = "1.1.0", features = [
 ] }
 
 # Instrumentation
-opentelemetry = { version = "0.30.0", features = ["metrics", "logs"] }
-opentelemetry_sdk = { version = "0.30.0", features = [
+opentelemetry = { version = "0.32.0", features = ["metrics", "logs"] }
+opentelemetry_sdk = { version = "0.32.1", features = [
   "rt-tokio",
   "logs",
   "experimental_metrics_custom_reader",
 ] }
-opentelemetry-stdout = { version = "0.30.0" }
-opentelemetry-otlp = { version = "0.30.0", features = [
+opentelemetry-stdout = { version = "0.32.0" }
+opentelemetry-otlp = { version = "0.32.0", features = [
   "grpc-tonic",
   "metrics",
   "logs",
 ] }
-opentelemetry-semantic-conventions = { version = "0.30.0" }
-opentelemetry-appender-tracing = { version = "0.30.0", default-features = false }
-tracing = { version = "0.1.40", default-features = false }
-tracing-core = { version = "0.1.32", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.32.0" }
+opentelemetry-appender-tracing = { version = "0.32.0", default-features = false }
+tracing = { version = "0.1.44", default-features = false }
+tracing-core = { version = "0.1.36", default-features = false }
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",
   "registry",
   "std",
 ] }
 tracing-test = "0.2.5"
-tracing-opentelemetry = "0.31.0"
+tracing-opentelemetry = "0.33.0"
 
 # Networking
-jsonrpsee = { version = "0.22", default-features = false, features = [
+jsonrpsee = { version = "0.26", default-features = false, features = [
   "server",
   "client",
 ] }
-tower = { version = "0.4", features = ["util"] }
-tower-http = { version = "0.4", features = ["cors"] }
+tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.7", features = ["cors"] }
 governor = "0.6"
-hyper = { version = "1.5.0", features = ["full"] }
+hyper = { version = "=1.8.1", features = ["full"] }
 hyper-tls = "0.6"
 hyper-util = "0.1.9"
-http = "1.1.0"
+http = "1.4.2"
 http-body-util = "0.1.2"
 ip_network = "0.4"
 reqwest = { version = "0.12.7", features = [
@@ -223,7 +223,7 @@ num-bigint = "0.4"
 primitive-types = "0.12"
 rand = "0.8"
 crypto-bigint = "0.5.5"
-zeroize = "1.8"
+zeroize = "1.9"
 ahash = "0.8"
 twox-hash = "2.1"
 rustc-hash = "2.1"
@@ -249,7 +249,7 @@ anyhow = "1.0"
 # Testing
 rstest = "0.26"
 proptest = "1.5.0"
-proptest-derive = "0.5.0"
+proptest-derive = "0.8.0"
 proptest-state-machine = "0.3.1"
 tempfile = "3.10.1"
 httpmock = "0.7.0"
@@ -266,7 +266,7 @@ syn = { version = "2.0.39", features = ["full"] }
 paste = "1.0.15"
 
 # Setup
-clap = { version = "4.4", features = ["derive", "env"] }
+clap = { version = "4.6.1", features = ["derive", "env"] }
 dotenv = "0.15.0"
 figment = "0.10.19"
 

--- a/madara/Cargo.toml
+++ b/madara/Cargo.toml
@@ -85,7 +85,7 @@ futures = { workspace = true, features = ["thread-pool"] }
 governor.workspace = true
 http.workspace = true
 http-body-util.workspace = true
-hyper = { version = "0.14", features = ["server"] }
+hyper = { version = "=1.8.1", features = ["server"] }
 hyper-tls.workspace = true
 hyper-util.workspace = true
 ip_network.workspace = true

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/status.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/status.rs
@@ -26,7 +26,8 @@ impl MadaraStatusRpcApiV0_1_0Server for Starknet {
 
         while !self.ctx.is_cancelled() {
             let now = unix_now();
-            let msg = jsonrpsee::SubscriptionMessage::from_json(&now)
+            let msg = serde_json::value::to_raw_value(&now)
+                .map(jsonrpsee::SubscriptionMessage::from)
                 .or_else_internal_server_error(|| format!("Failed to create response message at unix time {now}"))?;
             sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_events.rs
@@ -69,7 +69,7 @@ async fn send_event(
 ) -> Result<(), StarknetWsApiError> {
     let event = EmittedEvent::from(event);
     let item = super::SubscriptionItem::new(sink.subscription_id(), event);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from)
         .or_internal_server_error("Failed to create response message")?;
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_new_heads.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_new_heads.rs
@@ -120,7 +120,7 @@ async fn send_block_header(
 ) -> Result<(), StarknetWsApiError> {
     let header = mp_rpc::v0_8_1::BlockHeader::from(block_info);
     let item = super::SubscriptionItem::new(sink.subscription_id(), header);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from)
         .or_else_internal_server_error(|| format!("Failed to create response message for block {block_n}"))?;
 
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")?;

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_pending_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_pending_transactions.rs
@@ -90,7 +90,7 @@ pub async fn subscribe_pending_transactions(
         };
 
         let item = super::SubscriptionItem::new(sink.subscription_id(), tx_info);
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
+        let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from).or_else_internal_server_error(|| {
             format!("SubscribePendingTransactions failed to create response message at tx {tx_hash:#x}")
         })?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_8_1/methods/ws/subscribe_transaction_status.rs
@@ -255,7 +255,7 @@ impl StateTransitionCommon<'_> {
     ) -> Result<(), crate::errors::StarknetWsApiError> {
         let txn_status = mp_rpc::v0_8_1::NewTxnStatus { transaction_hash: self.tx_hash, status };
         let item = super::SubscriptionItem::new(self.sink.subscription_id(), txn_status);
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
+        let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from).or_else_internal_server_error(|| {
             format!("SubscribeTransactionStatus failed to create response for tx hash {:#x}", self.tx_hash)
         })?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_events.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_events.rs
@@ -69,7 +69,7 @@ async fn send_event(
 ) -> Result<(), StarknetWsApiError> {
     let event = EmittedEvent::from(event);
     let item = super::SubscriptionItem::new(sink.subscription_id(), event);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from)
         .or_internal_server_error("Failed to create response message")?;
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")
 }

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_heads.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_new_heads.rs
@@ -118,7 +118,7 @@ async fn send_block_header(
 ) -> Result<(), StarknetWsApiError> {
     let header = mp_rpc::v0_8_1::BlockHeader::from(block_info);
     let item = super::SubscriptionItem::new(sink.subscription_id(), header);
-    let msg = jsonrpsee::SubscriptionMessage::from_json(&item)
+    let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from)
         .or_else_internal_server_error(|| format!("Failed to create response message for block {block_n}"))?;
 
     sink.send(msg).await.or_internal_server_error("Failed to respond to websocket request")?;

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_pending_transactions.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_pending_transactions.rs
@@ -90,7 +90,7 @@ pub async fn subscribe_pending_transactions(
         };
 
         let item = super::SubscriptionItem::new(sink.subscription_id(), tx_info);
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
+        let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from).or_else_internal_server_error(|| {
             format!("SubscribePendingTransactions failed to create response message at tx {tx_hash:#x}")
         })?;
 

--- a/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
+++ b/madara/crates/client/rpc/src/versions/user/v0_9_0/methods/ws/subscribe_transaction_status.rs
@@ -255,7 +255,7 @@ impl StateTransitionCommon<'_> {
     ) -> Result<(), crate::errors::StarknetWsApiError> {
         let txn_status = mp_rpc::v0_8_1::NewTxnStatus { transaction_hash: self.tx_hash, status };
         let item = super::SubscriptionItem::new(self.sink.subscription_id(), txn_status);
-        let msg = jsonrpsee::SubscriptionMessage::from_json(&item).or_else_internal_server_error(|| {
+        let msg = serde_json::value::to_raw_value(&item).map(jsonrpsee::SubscriptionMessage::from).or_else_internal_server_error(|| {
             format!("SubscribeTransactionStatus failed to create response for tx hash {:#x}", self.tx_hash)
         })?;
 

--- a/madara/node/src/service/rpc/metrics.rs
+++ b/madara/node/src/service/rpc/metrics.rs
@@ -39,6 +39,17 @@ impl RpcMetrics {
         [KeyValue::new("method", method.to_string()), KeyValue::new("success", success.to_string())]
     }
 
+    pub(crate) fn on_call_method(&self, method: &str) {
+        self.calls_started.add(1, &Self::call_started_labels(method));
+    }
+
+    pub(crate) fn on_response_method(&self, method: &str, success: bool, now: Instant) {
+        let millis = now.elapsed().as_millis();
+
+        self.calls_time.record(millis as f64, &Self::call_started_labels(method));
+        self.calls_finished.add(1, &Self::call_completed_labels(method, success));
+    }
+
     /// Create an instance of metrics
     pub fn register() -> anyhow::Result<Self> {
         let meter = global::meter_with_scope(
@@ -114,12 +125,12 @@ impl RpcMetrics {
             req.method_name(),
             req.params(),
         );
-        self.calls_started.add(1, &Self::call_started_labels(req.method_name()));
+        self.on_call_method(req.method_name());
     }
 
     pub(crate) fn on_response(&self, req: &Request, rp: &MethodResponse, transport_label: &'static str, now: Instant) {
         tracing::trace!(target: "rpc_metrics", "[{transport_label}] on_response started_at={:?}", now);
-        tracing::trace!(target: "rpc_metrics::extra", "[{transport_label}] result={}", rp.as_result());
+        tracing::trace!(target: "rpc_metrics::extra", "[{transport_label}] result={}", rp.as_json());
 
         let millis = now.elapsed().as_millis();
         tracing::debug!(
@@ -129,10 +140,7 @@ impl RpcMetrics {
             millis,
         );
 
-        let labels = Self::call_completed_labels(req.method_name(), rp.is_success());
-
-        self.calls_time.record(millis as f64, &Self::call_started_labels(req.method_name()));
-        self.calls_finished.add(1, &labels);
+        self.on_response_method(req.method_name(), rp.is_success(), now);
     }
 }
 

--- a/madara/node/src/service/rpc/middleware.rs
+++ b/madara/node/src/service/rpc/middleware.rs
@@ -1,9 +1,11 @@
 //! JSON-RPC specific middleware.
 
-use anyhow::Context;
-use futures::future::{BoxFuture, FutureExt};
-use jsonrpsee::server::middleware::rpc::RpcServiceT;
+use jsonrpsee::{
+    server::middleware::rpc::{Batch, BatchEntry, BatchEntryErr, Notification, RpcServiceT},
+    MethodResponse,
+};
 use mp_chain_config::RpcVersion;
+use std::future::Future;
 use std::time::Instant;
 
 pub use super::metrics::Metrics;
@@ -44,13 +46,22 @@ pub struct RpcMiddlewareServiceMetrics<S> {
     metrics: Metrics,
 }
 
-impl<'a, S> RpcServiceT<'a> for RpcMiddlewareServiceMetrics<S>
+impl<S> RpcServiceT for RpcMiddlewareServiceMetrics<S>
 where
-    S: Send + Sync + Clone + RpcServiceT<'a> + 'static,
+    S: Send
+        + Sync
+        + Clone
+        + RpcServiceT<
+            MethodResponse = MethodResponse,
+            NotificationResponse = MethodResponse,
+            BatchResponse = MethodResponse,
+        > + 'static,
 {
-    type Future = BoxFuture<'a, jsonrpsee::MethodResponse>;
+    type MethodResponse = MethodResponse;
+    type NotificationResponse = MethodResponse;
+    type BatchResponse = MethodResponse;
 
-    fn call(&self, req: jsonrpsee::types::Request<'a>) -> Self::Future {
+    fn call<'a>(&self, req: jsonrpsee::types::Request<'a>) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
         let inner = self.inner.clone();
         let metrics = self.metrics.clone();
 
@@ -68,7 +79,7 @@ where
 
             let method = req.method_name();
             let status = rp.as_error_code().unwrap_or(200) as i64;
-            let res_len = rp.as_result().len() as u64;
+            let res_len = rp.as_json().get().len() as u64;
             let response_time = now.elapsed().as_micros();
 
             tracing::info!(
@@ -83,14 +94,58 @@ where
             tracing::trace!(
                 target: "rpc_raw_response",
                 "{:?}",
-                rp.as_result()
+                rp.as_json()
             );
 
             metrics.on_response(&req, &rp, now);
 
             rp
         }
-        .boxed()
+    }
+
+    fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        let metrics = self.metrics.clone();
+
+        async move {
+            let now = std::time::Instant::now();
+            let methods = batch
+                .iter()
+                .filter_map(|entry| entry.as_ref().ok().map(BatchEntry::method_name))
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+
+            for method in &methods {
+                metrics.inner.on_call_method(method);
+            }
+
+            let rp = inner.batch(batch).await;
+
+            for method in &methods {
+                metrics.inner.on_response_method(method, rp.is_success(), now);
+            }
+
+            rp
+        }
+    }
+
+    fn notification<'a>(
+        &self,
+        notification: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        let metrics = self.metrics.clone();
+
+        async move {
+            let now = std::time::Instant::now();
+            let method = notification.method_name().to_owned();
+
+            metrics.inner.on_call_method(&method);
+            let rp = inner.notification(notification).await;
+            metrics.inner.on_response_method(&method, rp.is_success(), now);
+
+            rp
+        }
     }
 }
 
@@ -107,56 +162,109 @@ impl<S> RpcMiddlewareServiceVersion<S> {
     }
 }
 
-impl<'a, S> RpcServiceT<'a> for RpcMiddlewareServiceVersion<S>
+impl<S> RpcServiceT for RpcMiddlewareServiceVersion<S>
 where
-    S: Send + Sync + Clone + RpcServiceT<'a> + 'static,
+    S: Send
+        + Sync
+        + Clone
+        + RpcServiceT<
+            MethodResponse = MethodResponse,
+            NotificationResponse = MethodResponse,
+            BatchResponse = MethodResponse,
+        > + 'static,
 {
-    type Future = BoxFuture<'a, jsonrpsee::MethodResponse>;
+    type MethodResponse = MethodResponse;
+    type NotificationResponse = MethodResponse;
+    type BatchResponse = MethodResponse;
 
-    fn call(&self, mut req: jsonrpsee::types::Request<'a>) -> Self::Future {
+    fn call<'a>(
+        &self,
+        mut req: jsonrpsee::types::Request<'a>,
+    ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
         let inner = self.inner.clone();
         let path = self.path.clone();
         let version_default = self.version_default;
 
         async move {
-            if req.method == "rpc_methods" {
-                return inner.call(req).await;
+            if let Err(error) = rewrite_method(&mut req.method, &path, version_default) {
+                return MethodResponse::error(req.id(), error);
             }
-
-            let version = match RpcVersion::from_request_path(&path, version_default)
-                .map(|v| v.name())
-                .context("Failed to get request path")
-            {
-                Ok(version) => version,
-                Err(_) => {
-                    return jsonrpsee::MethodResponse::error(
-                        req.id,
-                        jsonrpsee::types::ErrorObject::owned(
-                            jsonrpsee::types::error::PARSE_ERROR_CODE,
-                            jsonrpsee::types::error::PARSE_ERROR_MSG,
-                            None::<()>,
-                        ),
-                    )
-                }
-            };
-
-            let Some((namespace, method)) = req.method.split_once('_') else {
-                return jsonrpsee::MethodResponse::error(
-                    req.id(),
-                    jsonrpsee::types::ErrorObject::owned(
-                        jsonrpsee::types::error::METHOD_NOT_FOUND_CODE,
-                        jsonrpsee::types::error::METHOD_NOT_FOUND_MSG,
-                        Some(req.method_name()),
-                    ),
-                );
-            };
-
-            let method = method.replacen(&format!("{version}_"), "", 1);
-            let method_new = format!("{namespace}_{version}_{method}");
-            req.method = jsonrpsee::core::Cow::from(method_new);
 
             inner.call(req).await
         }
-        .boxed()
     }
+
+    fn batch<'a>(&self, mut batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        let path = self.path.clone();
+        let version_default = self.version_default;
+
+        async move {
+            for batch_entry in batch.iter_mut() {
+                let error = match batch_entry {
+                    Ok(entry) => match entry {
+                        BatchEntry::Call(req) => {
+                            rewrite_method(&mut req.method, &path, version_default).err().map(|error| (req.id(), error))
+                        }
+                        BatchEntry::Notification(notification) => {
+                            let _ = rewrite_method(&mut notification.method, &path, version_default);
+                            None
+                        }
+                    },
+                    Err(_) => None,
+                };
+
+                if let Some((id, error)) = error {
+                    *batch_entry = Err(BatchEntryErr::new(id, error));
+                }
+            }
+
+            inner.batch(batch).await
+        }
+    }
+
+    fn notification<'a>(
+        &self,
+        mut notification: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        let path = self.path.clone();
+        let version_default = self.version_default;
+
+        async move {
+            let _ = rewrite_method(&mut notification.method, &path, version_default);
+            inner.notification(notification).await
+        }
+    }
+}
+
+fn rewrite_method(
+    method: &mut jsonrpsee::core::Cow<'_, str>,
+    path: &str,
+    version_default: RpcVersion,
+) -> Result<(), jsonrpsee::types::ErrorObject<'static>> {
+    if method.as_ref() == "rpc_methods" {
+        return Ok(());
+    }
+
+    let version = RpcVersion::from_request_path(path, version_default).map(|v| v.name()).map_err(|_| {
+        jsonrpsee::types::ErrorObject::owned(
+            jsonrpsee::types::error::PARSE_ERROR_CODE,
+            jsonrpsee::types::error::PARSE_ERROR_MSG,
+            None::<()>,
+        )
+    })?;
+
+    let Some((namespace, method_name)) = method.split_once('_') else {
+        return Err(jsonrpsee::types::ErrorObject::owned(
+            jsonrpsee::types::error::METHOD_NOT_FOUND_CODE,
+            jsonrpsee::types::error::METHOD_NOT_FOUND_MSG,
+            Some(method.to_string()),
+        ));
+    };
+
+    let method_name = method_name.replacen(&format!("{version}_"), "", 1);
+    *method = jsonrpsee::core::Cow::from(format!("{namespace}_{version}_{method_name}"));
+
+    Ok(())
 }

--- a/madara/node/src/service/rpc/server.rs
+++ b/madara/node/src/service/rpc/server.rs
@@ -5,6 +5,7 @@ use super::metrics::RpcMetrics;
 use super::middleware::{Metrics, RpcMiddlewareLayerMetrics};
 use crate::service::rpc::middleware::RpcMiddlewareServiceVersion;
 use anyhow::Context;
+use jsonrpsee::server::middleware::rpc::RpcServiceBuilder;
 use mc_rpc::versions::user::v0_7_1::methods::read::syncing::syncing;
 use mc_rpc::Starknet;
 use mp_chain_config::RpcVersion;
@@ -85,7 +86,7 @@ pub async fn start_server(
         .option_layer(host_filtering(cors.is_some(), local_addr))
         .layer(try_into_cors(cors.as_ref())?);
 
-    let builder = jsonrpsee::server::Server::builder()
+    let server_config = jsonrpsee::server::ServerConfig::builder()
         .max_request_body_size(max_payload_in_mib.saturating_mul(MiB))
         .max_response_body_size(max_payload_out_mib.saturating_mul(MiB))
         .max_connections(max_connections)
@@ -93,8 +94,10 @@ pub async fn start_server(
         .enable_ws_ping(ping_config)
         .set_message_buffer_capacity(message_buffer_capacity)
         .set_batch_request_config(batch_config)
-        .set_http_middleware(http_middleware)
-        .set_id_provider(jsonrpsee::server::RandomStringIdProvider::new(16));
+        .set_id_provider(jsonrpsee::server::RandomStringIdProvider::new(16))
+        .build();
+
+    let builder = jsonrpsee::server::Server::builder().set_config(server_config).set_http_middleware(http_middleware);
 
     let cfg = PerConnection {
         methods,
@@ -102,20 +105,28 @@ pub async fn start_server(
         metrics,
         service_builder: builder.to_service_builder(),
     };
-    let ctx1 = ctx.clone();
+    let mut connections = tokio::task::JoinSet::new();
 
-    let make_service = hyper::service::make_service_fn(move |_| {
+    tracing::info!(
+        "📱 Running {name} server at http://{}/rpc/v{}/ (allowed origins={}, supported versions={})",
+        local_addr.to_string(),
+        config.rpc_version_default,
+        format_cors(cors.as_ref()),
+        format_rpc_versions(&supported_versions),
+    );
+
+    while let Some(res) = ctx.run_until_cancelled(listener.accept()).await {
+        let (stream, _) = res.context("Accepting RPC connection")?;
         let cfg = cfg.clone();
-        let ctx1 = ctx1.clone();
+        let stop_handle_for_service = cfg.stop_handle.clone();
+        let ctx_for_service = ctx.clone();
+        let mut ctx_for_shutdown = ctx.clone();
         let starknet = Arc::clone(&starknet);
 
-        async move {
-            let cfg = cfg.clone();
-            let starknet = Arc::clone(&starknet);
-
-            Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
+        connections.spawn(async move {
+            let service = tower::service_fn(move |req| {
                 let PerConnection { service_builder, metrics, stop_handle, methods } = cfg.clone();
-                let ctx1 = ctx1.clone();
+                let ctx1 = ctx_for_service.clone();
                 let starknet = Arc::clone(&starknet);
 
                 let is_websocket = jsonrpsee::server::ws::is_upgrade_request(&req);
@@ -123,7 +134,7 @@ pub async fn start_server(
                 let path = req.uri().path().to_string();
                 let metrics_layer = RpcMiddlewareLayerMetrics::new(Metrics::new(metrics, transport_label));
 
-                let rpc_middleware = jsonrpsee::server::RpcServiceBuilder::new()
+                let rpc_middleware = RpcServiceBuilder::new()
                     .layer_fn(move |service| {
                         RpcMiddlewareServiceVersion::new(service, path.clone(), rpc_version_default)
                     })
@@ -133,25 +144,21 @@ pub async fn start_server(
 
                 async move {
                     if ctx1.is_cancelled() {
-                        Ok(hyper::Response::builder()
-                            .status(hyper::StatusCode::GONE)
-                            .body(hyper::Body::from("GONE"))?)
+                        Ok::<_, Infallible>(text_response(http::StatusCode::GONE, "GONE"))
                     } else if req.uri().path() == "/health" {
-                        Ok(hyper::Response::builder().status(hyper::StatusCode::OK).body(hyper::Body::from("OK"))?)
+                        Ok::<_, Infallible>(text_response(http::StatusCode::OK, "OK"))
                     } else if req.uri().path() == "/ready" {
                         let sync_status = syncing(&starknet);
                         match sync_status {
                             Ok(sync_status) => match sync_status {
-                                SyncingStatus::Syncing(_) => Ok(hyper::Response::builder()
-                                    .status(hyper::StatusCode::SERVICE_UNAVAILABLE)
-                                    .body(hyper::Body::from("SYNCING"))?),
-                                SyncingStatus::NotSyncing => Ok(hyper::Response::builder()
-                                    .status(hyper::StatusCode::OK)
-                                    .body(hyper::Body::from("OK"))?),
+                                SyncingStatus::Syncing(_) => {
+                                    Ok(text_response(http::StatusCode::SERVICE_UNAVAILABLE, "SYNCING"))
+                                }
+                                SyncingStatus::NotSyncing => Ok(text_response(http::StatusCode::OK, "OK")),
                             },
-                            Err(_) => Ok(hyper::Response::builder()
-                                .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-                                .body(hyper::Body::from("INTERNAL_SERVER_ERROR"))?),
+                            Err(_) => {
+                                Ok(text_response(http::StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"))
+                            }
                         }
                     } else {
                         if is_websocket {
@@ -168,31 +175,40 @@ pub async fn start_server(
                             });
                         }
 
-                        svc.call(req).await
+                        match svc.call(req).await {
+                            Ok(response) => Ok(response),
+                            Err(error) => {
+                                tracing::error!("Error handling RPC request: {error:#}");
+                                Ok(text_response(http::StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"))
+                            }
+                        }
                     }
                 }
-            }))
+            });
+
+            let stopped = async move {
+                ctx_for_shutdown.run_until_cancelled(stop_handle_for_service.shutdown()).await;
+            };
+
+            if let Err(err) = jsonrpsee::server::serve_with_graceful_shutdown(stream, service, stopped).await {
+                tracing::error!("Error serving RPC connection: {err:#}");
+            }
+        });
+    }
+
+    while let Some(res) = connections.join_next().await {
+        if let Err(error) = res {
+            tracing::error!("RPC connection task failed: {error:#}");
         }
-    });
+    }
 
-    let server = hyper::Server::from_tcp(listener.into_std()?)
-        .with_context(|| format!("Creating hyper server at: {addr}"))?
-        .serve(make_service);
+    Ok(())
+}
 
-    tracing::info!(
-        "📱 Running {name} server at http://{}/rpc/v{}/ (allowed origins={}, supported versions={})",
-        local_addr.to_string(),
-        config.rpc_version_default,
-        format_cors(cors.as_ref()),
-        format_rpc_versions(&supported_versions),
-    );
-
-    server
-        .with_graceful_shutdown(async {
-            ctx.run_until_cancelled(stop_handle.shutdown()).await;
-        })
-        .await
-        .context("Running rpc server")
+fn text_response(status: http::StatusCode, body: &'static str) -> jsonrpsee::server::HttpResponse {
+    let mut response = http::Response::new(jsonrpsee::server::HttpBody::from(body));
+    *response.status_mut() = status;
+    response
 }
 
 // Copied from https://github.com/paritytech/polkadot-sdk/blob/a0aefc6b233ace0a82a8631d67b6854e6aeb014b/substrate/client/rpc-servers/src/utils.rs#L192
@@ -252,7 +268,7 @@ pub(crate) fn rpc_api_build<M: Send + Sync + 'static>(
     available_methods.sort();
 
     rpc_api
-        .register_method("rpc_methods", move |_, _| {
+        .register_method("rpc_methods", move |_, _, _| {
             serde_json::json!({
                 "methods": available_methods,
             })
@@ -266,7 +282,7 @@ pub(crate) fn try_into_cors(maybe_cors: Option<&Vec<String>>) -> anyhow::Result<
     if let Some(cors) = maybe_cors {
         let mut list = Vec::new();
         for origin in cors {
-            list.push(hyper::header::HeaderValue::from_str(origin)?);
+            list.push(http::header::HeaderValue::from_str(origin)?);
         }
         Ok(tower_http::cors::CorsLayer::new().allow_origin(tower_http::cors::AllowOrigin::list(list)))
     } else {

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -121,7 +121,7 @@ tracing-subscriber = { workspace = true, features = [
 
 anyhow = { workspace = true }
 httpmock = { version = "0.8.0-alpha.1", features = ["proxy", "remote"] }
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "=1.8.1", features = ["full"] }
 indexmap = "2.6.0"
 jemallocator = "0.5.4"
 num-integer = "0.1.46"
@@ -137,7 +137,7 @@ with_sqs = ["omniqueue"]
 testing = ["orchestrator-ethereum-settlement-client/testing"]
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "=1.8.1", features = ["full"] }
 rstest = { workspace = true }
 httpmock = { version = "0.8.0-alpha.1", features = ["proxy", "remote"] }
 mockito = "1.6.1"

--- a/orchestrator/src/error/mod.rs
+++ b/orchestrator/src/error/mod.rs
@@ -10,7 +10,6 @@ use aws_sdk_s3::operation::list_buckets::ListBucketsError;
 use aws_sdk_sqs::operation::set_queue_attributes::SetQueueAttributesError;
 use mongodb::bson;
 use opentelemetry_otlp::ExporterBuildError;
-use opentelemetry_sdk::trace::TraceError;
 use starknet_core::types::FromStrError;
 use thiserror::Error;
 
@@ -69,8 +68,6 @@ pub enum OrchestratorError {
     ExporterBuildError(#[from] ExporterBuildError),
     #[error("OLT Metrics Error: {0}")]
     OTLMetricsError(String),
-    #[error("OLT Trace Error: {0}")]
-    OLTTraceError(#[from] TraceError),
     #[error("Invalid layout name: {0}")]
     InvalidLayoutError(String),
     /// Configuration error

--- a/orchestrator/src/server/middleware.rs
+++ b/orchestrator/src/server/middleware.rs
@@ -1,7 +1,7 @@
 use axum::{body::Body, http::HeaderValue, http::Request, middleware::Next, response::Response};
 use opentelemetry::{global, propagation::Extractor, trace::TraceContextExt, Context as OtelContext};
 use rand::RngCore;
-use tracing::info_span;
+use tracing::{info_span, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
@@ -56,7 +56,9 @@ pub async fn trace_context(mut req: Request<Body>, next: Next) -> Response {
         otel_trace_id = tracing::field::Empty,
         job_id = tracing::field::Empty
     );
-    span.set_parent(parent_cx);
+    if let Err(error) = span.set_parent(parent_cx) {
+        warn!("failed to set OpenTelemetry span parent: {error}");
+    }
 
     // Record ids for log visibility
     let otel_trace_id_str = span.context().span().span_context().trace_id().to_string();

--- a/orchestrator/src/tests/server/admin_routes.rs
+++ b/orchestrator/src/tests/server/admin_routes.rs
@@ -17,7 +17,6 @@ use crate::tests::utils::build_job_item;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::types::queue::QueueType;
 use crate::worker::event_handler::jobs::{JobHandlerTrait, MockJobHandlerTrait};
-use hyper::{Body, Request};
 use orchestrator_da_client_interface::MockDaClient;
 use orchestrator_prover_client_interface::MockProverClient;
 use orchestrator_settlement_client_interface::MockSettlementClient;
@@ -48,14 +47,9 @@ async fn build_test_config(db: MockDatabaseClient, queue: MockQueueClient) -> St
 }
 
 async fn call_endpoint(addr: &str, path: &str) -> ApiResponse<BulkJobResponse> {
-    let client = hyper::Client::new();
-    let response = client
-        .request(Request::builder().method("POST").uri(format!("http://{}{}", addr, path)).body(Body::empty()).unwrap())
-        .await
-        .unwrap();
+    let response = reqwest::Client::new().post(format!("http://{}{}", addr, path)).send().await.unwrap();
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    serde_json::from_slice(&body_bytes).unwrap()
+    response.json().await.unwrap()
 }
 
 #[tokio::test]

--- a/orchestrator/src/tests/server/batch_routes.rs
+++ b/orchestrator/src/tests/server/batch_routes.rs
@@ -4,7 +4,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use chrono::{Duration, SubsecRound, Utc};
-use hyper::{Body, Request};
 use rstest::*;
 use starknet_api::execution_resources::GasAmount;
 
@@ -57,20 +56,10 @@ async fn test_query_snos_batches_by_index(#[future] setup_batches_server: (Socke
     config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
     config.database().create_snos_batch(snos_batch.clone()).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/batches/snos?index={}", addr, snos_batch.index))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/batches/snos?index={}", addr, snos_batch.index)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<SnosBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<SnosBatchListResponse> = response.json().await.unwrap();
 
     assert!(response_body.success);
     let batches = response_body.data.expect("missing snos batches payload").batches;
@@ -111,17 +100,10 @@ async fn test_query_snos_batches_closed_filter_includes_closed_batches(
     config.database().create_snos_batch(completed_batch.clone()).await.unwrap();
     config.database().create_snos_batch(open_batch).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder().uri(format!("http://{}/batches/snos?status=closed", addr)).body(Body::empty()).unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/batches/snos?status=closed", addr)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<SnosBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<SnosBatchListResponse> = response.json().await.unwrap();
 
     let batches = response_body.data.expect("missing snos batches payload").batches;
     assert_eq!(batches.iter().map(|batch| batch.batch.index).collect::<Vec<_>>(), vec![31, 33, 34]);
@@ -151,20 +133,11 @@ async fn test_query_aggregator_batches_closed_filter_returns_latest_closed(
     config.database().create_aggregator_batch(latest_closed_batch.clone()).await.unwrap();
     config.database().create_aggregator_batch(open_batch.clone()).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/batches/aggregator?status=closed&limit=1&sort=desc", addr))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response =
+        reqwest::get(format!("http://{}/batches/aggregator?status=closed&limit=1&sort=desc", addr)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<AggregatorBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<AggregatorBatchListResponse> = response.json().await.unwrap();
 
     assert!(response_body.success);
     let batches = response_body.data.expect("missing aggregator batches payload").batches;
@@ -187,20 +160,10 @@ async fn test_query_snos_batches_sort_order(#[future] setup_batches_server: (Soc
     config.database().create_snos_batch(build_snos_batch(42, None, 410)).await.unwrap();
     config.database().create_snos_batch(build_snos_batch(43, None, 420)).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/batches/snos?limit=2&sort=desc", addr))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/batches/snos?limit=2&sort=desc", addr)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<SnosBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<SnosBatchListResponse> = response.json().await.unwrap();
 
     let batches = response_body.data.expect("missing snos batches payload").batches;
     assert_eq!(batches.iter().map(|batch| batch.batch.index).collect::<Vec<_>>(), vec![43, 42]);
@@ -216,15 +179,10 @@ async fn test_query_batches_rejects_invalid_status(
 ) {
     let (addr, _config) = setup_batches_server.await;
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(Request::builder().uri(format!("http://{}{}", addr, path)).body(Body::empty()).unwrap())
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}{}", addr, path)).await.unwrap();
 
     assert_eq!(response.status(), 400);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse = response.json().await.unwrap();
 
     assert!(!response_body.success);
     assert!(response_body.message.expect("missing error message").contains("unsupported"));
@@ -241,15 +199,10 @@ async fn test_query_batches_rejects_invalid_limit(
 ) {
     let (addr, _config) = setup_batches_server.await;
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(Request::builder().uri(format!("http://{}{}", addr, path)).body(Body::empty()).unwrap())
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}{}", addr, path)).await.unwrap();
 
     assert_eq!(response.status(), 400);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse = response.json().await.unwrap();
 
     assert!(!response_body.success);
     assert!(response_body.message.expect("missing error message").contains(expected_message));
@@ -262,20 +215,10 @@ async fn test_query_aggregator_batches_accepts_max_limit(#[future] setup_batches
 
     config.database().create_aggregator_batch(build_batch(51, 500, 509)).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/batches/aggregator?limit=500", addr))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/batches/aggregator?limit=500", addr)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<AggregatorBatchListResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<AggregatorBatchListResponse> = response.json().await.unwrap();
 
     assert!(response_body.success);
     assert_eq!(response_body.data.expect("missing aggregator batches payload").batches.len(), 1);

--- a/orchestrator/src/tests/server/block_routes.rs
+++ b/orchestrator/src/tests/server/block_routes.rs
@@ -4,7 +4,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use chrono::{Duration, SubsecRound, Utc};
-use hyper::{Body, Request};
 use rstest::*;
 use uuid::Uuid;
 
@@ -146,20 +145,10 @@ async fn test_get_block_settlement_status_for_batched_block(#[future] setup_bloc
     config.database().create_job(aggregator_job.clone()).await.unwrap();
     config.database().create_job(state_transition_job.clone()).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/blocks/settlement-status/{}", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/blocks/settlement-status/{}", addr, block_number)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BlockSettlementStatusResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<BlockSettlementStatusResponse> = response.json().await.unwrap();
 
     assert!(response_body.success);
     assert_eq!(
@@ -214,20 +203,10 @@ async fn test_get_block_batch_mapping_legacy_route(#[future] setup_blocks_server
     config.database().create_aggregator_batch(aggregator_batch.clone()).await.unwrap();
     config.database().create_snos_batch(snos_batch).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/blocks/batch-for-block/{}", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/blocks/batch-for-block/{}", addr, block_number)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BlockStatusResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<BlockStatusResponse> = response.json().await.unwrap();
 
     assert_eq!(response_body.data.expect("missing legacy batch mapping payload").batch_number, aggregator_batch.index);
 }
@@ -252,20 +231,10 @@ async fn test_get_block_settlement_status_without_aggregator_uses_job_status(
 
     config.database().create_job(snos_job.clone()).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/blocks/settlement-status/{}", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/blocks/settlement-status/{}", addr, block_number)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BlockSettlementStatusResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<BlockSettlementStatusResponse> = response.json().await.unwrap();
 
     let data = response_body.data.expect("missing settlement status payload");
     let snos_batch = data.snos_batch.expect("missing snos batch response");
@@ -309,20 +278,10 @@ async fn test_get_block_settlement_status_without_aggregator_prefers_snos_batch_
     config.database().create_snos_batch(snos_batch.clone()).await.unwrap();
     config.database().create_job(snos_job.clone()).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/blocks/settlement-status/{}", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/blocks/settlement-status/{}", addr, block_number)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<BlockSettlementStatusResponse> = serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<BlockSettlementStatusResponse> = response.json().await.unwrap();
 
     let data = response_body.data.expect("missing settlement status payload");
     let returned_snos_batch = data.snos_batch.expect("missing snos batch response");

--- a/orchestrator/src/tests/server/job_routes.rs
+++ b/orchestrator/src/tests/server/job_routes.rs
@@ -3,7 +3,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use hyper::{Body, Request};
 use mockall::predicate::eq;
 use orchestrator_utils::env_utils::get_env_var_or_panic;
 use rstest::*;
@@ -62,26 +61,18 @@ async fn test_trigger_process_job(#[case] is_priority: bool, #[future] setup_tri
     config.database().create_job(job_item.clone()).await.unwrap();
     let job_id = job_item.clone().id;
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!(
-                    "http://{}/jobs/{}/process{}",
-                    addr,
-                    job_id,
-                    if is_priority { "?priority=true" } else { "" }
-                ))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!(
+        "http://{}/jobs/{}/process{}",
+        addr,
+        job_id,
+        if is_priority { "?priority=true" } else { "" }
+    ))
+    .await
+    .unwrap();
 
     // Verify response status and message
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response: ApiResponse = serde_json::from_slice(&body_bytes).unwrap();
+    let response: ApiResponse = response.json().await.unwrap();
     assert!(response.success);
     assert_eq!(
         response.message,
@@ -143,25 +134,17 @@ async fn test_trigger_verify_job(#[case] is_priority: bool, #[future] setup_trig
     let ctx = get_job_handler_context_safe();
     ctx.expect().with(eq(job_type.clone())).times(1).returning(move |_| Arc::clone(&job_handler));
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!(
-                    "http://{}/jobs/{}/verify{}",
-                    addr,
-                    job_id,
-                    if is_priority { "?priority=true" } else { "" }
-                ))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!(
+        "http://{}/jobs/{}/verify{}",
+        addr,
+        job_id,
+        if is_priority { "?priority=true" } else { "" }
+    ))
+    .await
+    .unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response: ApiResponse = serde_json::from_slice(&body_bytes).unwrap();
+    let response: ApiResponse = response.json().await.unwrap();
     assert!(response.success);
     assert_eq!(
         response.message,
@@ -211,25 +194,17 @@ async fn test_trigger_retry_job_when_failed(
     config.database().create_job(job_item.clone()).await.unwrap();
     let job_id = job_item.clone().id;
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!(
-                    "http://{}/jobs/{}/retry{}",
-                    addr,
-                    job_id,
-                    if is_priority { "?priority=true" } else { "" }
-                ))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!(
+        "http://{}/jobs/{}/retry{}",
+        addr,
+        job_id,
+        if is_priority { "?priority=true" } else { "" }
+    ))
+    .await
+    .unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response: ApiResponse = serde_json::from_slice(&body_bytes).unwrap();
+    let response: ApiResponse = response.json().await.unwrap();
     assert!(response.success);
     assert_eq!(
         response.message,
@@ -271,11 +246,7 @@ async fn test_trigger_retry_job_not_allowed(
     config.database().create_job(job_item.clone()).await.unwrap();
     let job_id = job_item.clone().id;
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(Request::builder().uri(format!("http://{}/jobs/{}/retry", addr, job_id)).body(Body::empty()).unwrap())
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/jobs/{}/retry", addr, job_id)).await.unwrap();
 
     // Verify request was rejected
     assert_eq!(response.status(), 400);
@@ -328,21 +299,10 @@ async fn test_get_job_status_by_block_number_found(#[future] setup_trigger: (Soc
     let other_block_job = build_job_item(JobType::SnosRun, JobStatus::Completed, block_number + 10);
     config.database().create_job(other_block_job).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/jobs/block/{}/status", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/jobs/block/{}/status", addr, block_number)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<crate::server::types::JobStatusResponse> =
-        serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<crate::server::types::JobStatusResponse> = response.json().await.unwrap();
 
     assert!(response_body.success);
     assert_eq!(response_body.message, Some(format!("Successfully fetched job statuses for block {}", block_number)));
@@ -367,21 +327,10 @@ async fn test_get_job_status_by_block_number_not_found(#[future] setup_trigger: 
     let other_block_job = build_job_item(JobType::SnosRun, JobStatus::Completed, block_number + 10);
     config.database().create_job(other_block_job).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(
-            Request::builder()
-                .uri(format!("http://{}/jobs/block/{}/status", addr, block_number))
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/jobs/block/{}/status", addr, block_number)).await.unwrap();
 
     assert_eq!(response.status(), 200); // Endpoint itself is found, just no data for this block
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<crate::server::types::JobStatusResponse> =
-        serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<crate::server::types::JobStatusResponse> = response.json().await.unwrap();
 
     assert!(response_body.success);
     assert_eq!(response_body.message, Some(format!("Successfully fetched job statuses for block {}", block_number)));

--- a/orchestrator/src/tests/server/jobs_by_status.rs
+++ b/orchestrator/src/tests/server/jobs_by_status.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use hyper::{Body, Request};
 use orchestrator_utils::env_utils::get_env_var_or_panic;
 use rstest::*;
 use starknet::providers::jsonrpc::HttpTransport;
@@ -49,16 +48,10 @@ async fn test_get_failed_jobs(#[future] setup_trigger: (SocketAddr, Arc<Config>)
     let success_job = build_job_item(JobType::ProofCreation, JobStatus::Completed, 2);
     config.database().create_job(success_job.clone()).await.unwrap();
 
-    let client = hyper::Client::new();
-    let response = client
-        .request(Request::builder().uri(format!("http://{}/jobs?status=Failed", addr)).body(Body::empty()).unwrap())
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/jobs?status=Failed", addr)).await.unwrap();
 
     assert_eq!(response.status(), 200);
-    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let response_body: ApiResponse<crate::server::types::JobStatusResponse> =
-        serde_json::from_slice(&body_bytes).unwrap();
+    let response_body: ApiResponse<crate::server::types::JobStatusResponse> = response.json().await.unwrap();
 
     assert!(response_body.success);
     let failed_jobs_data = response_body.data.unwrap();

--- a/orchestrator/src/tests/server/mod.rs
+++ b/orchestrator/src/tests/server/mod.rs
@@ -5,11 +5,7 @@ pub mod job_routes;
 pub mod jobs_by_status;
 use crate::tests::config::{ConfigType, TestConfigBuilder};
 use crate::worker::initialize_worker;
-use axum::http::StatusCode;
-use hyper::body::Buf;
-use hyper::{Body, Request};
 use rstest::*;
-use std::io::Read;
 use tokio_util::sync::CancellationToken;
 
 #[rstest]
@@ -20,18 +16,11 @@ async fn test_health_endpoint() {
     let services = TestConfigBuilder::new().configure_api_server(ConfigType::Actual).build().await;
 
     let addr = services.api_server_address.unwrap();
-    let client = hyper::Client::new();
-    let response = client
-        .request(Request::builder().uri(format!("http://{}/health", addr)).body(Body::empty()).unwrap())
-        .await
-        .unwrap();
+    let response = reqwest::get(format!("http://{}/health", addr)).await.unwrap();
 
-    assert_eq!(response.status().as_str(), StatusCode::OK.as_str());
+    assert_eq!(response.status(), 200);
 
-    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    let mut buf = String::new();
-    let res = body.reader().read_to_string(&mut buf).unwrap();
-    assert_eq!(res, 2);
+    assert_eq!(response.text().await.unwrap().len(), 2);
 }
 
 /// This test case will make sure that the consumers are initialized correctly.


### PR DESCRIPTION
## Summary

Consolidates the Dependabot dependency bumps into one draft PR and updates the affected RPC and telemetry integration points for the newer dependency APIs.

This moves the direct Hyper usage to the current Hyper 1 line, refreshes the OpenTelemetry/tracing stack, and keeps Rust 1.89 compatibility where newer transitive releases require a newer compiler.

## Validation

Local formatting, metadata, focused package checks, and focused linting pass.