### PR TITLE
feat(orchestrator): record SNOS batch block count

### DIFF
--- a/orchestrator/src/utils/metrics.rs
+++ b/orchestrator/src/utils/metrics.rs
@@ -33,6 +33,7 @@ pub struct OrchestratorMetrics {
     pub job_e2e_latency: Gauge<f64>,
     pub proof_generation_time: Gauge<f64>,
     pub snos_job_processing_time: Histogram<f64>,
+    pub snos_batch_blocks: Histogram<f64>,
     pub snos_rpc_fallback_total: Counter<f64>,
     pub settlement_time: Gauge<f64>,
     // Throughput Metrics
@@ -215,6 +216,13 @@ impl Metrics for OrchestratorMetrics {
             "snos_job_processing_time".to_string(),
             "Time to process SNOS jobs".to_string(),
             "s".to_string(),
+        );
+
+        let snos_batch_blocks = register_histogram_metric_instrument(
+            &orchestrator_meter,
+            "snos_batch_blocks".to_string(),
+            "Number of blocks included in closed SNOS batches".to_string(),
+            "blocks".to_string(),
         );
 
         let snos_rpc_fallback_total = register_counter_metric_instrument(
@@ -494,6 +502,7 @@ impl Metrics for OrchestratorMetrics {
             job_e2e_latency,
             proof_generation_time,
             snos_job_processing_time,
+            snos_batch_blocks,
             snos_rpc_fallback_total,
             settlement_time,
             jobs_per_minute,

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -5,6 +5,7 @@ use opentelemetry::metrics::{Meter, ObservableGauge};
 use opentelemetry::KeyValue;
 use std::time::Instant;
 
+use crate::core::config::StarknetVersion;
 use crate::types::jobs::job_item::JobItem;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::types::jobs::WorkerTriggerType;
@@ -464,6 +465,14 @@ impl MetricsRecorder {
     pub fn record_snos_job_processing_time(duration_seconds: f64) {
         let attributes = [KeyValue::new("operation_job_type", format!("{:?}", JobType::SnosRun))];
         ORCHESTRATOR_METRICS.snos_job_processing_time.record(duration_seconds, &attributes);
+    }
+
+    pub fn record_snos_batch_blocks(num_blocks: u64, starknet_version: StarknetVersion) {
+        let attributes = [
+            KeyValue::new("operation_job_type", format!("{:?}", JobType::SnosRun)),
+            KeyValue::new("starknet_version", starknet_version.to_string()),
+        ];
+        ORCHESTRATOR_METRICS.snos_batch_blocks.record(num_blocks as f64, &attributes);
     }
 
     pub fn record_snos_rpc_fallback(job: &JobItem) {

--- a/orchestrator/src/worker/event_handler/triggers/batching/snos.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching/snos.rs
@@ -3,6 +3,7 @@ use crate::error::job::JobError;
 use crate::error::other::OtherError;
 use crate::types::batch::{SnosBatch, SnosBatchStatus, SnosBatchUpdates};
 use crate::types::constant::ORCHESTRATOR_VERSION;
+use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::triggers::batching::utils::{get_block_builtin_weights, get_block_version};
 use crate::worker::event_handler::triggers::batching::BlockProcessingResult;
 use blockifier::bouncer::BouncerWeights;
@@ -405,6 +406,9 @@ impl NonEmptySnosState {
     ///
     /// Returns a new state with the batch status set to Closed
     pub fn close(&mut self) {
+        if !self.batch.status.is_closed() {
+            MetricsRecorder::record_snos_batch_blocks(self.batch.num_blocks, self.batch.starknet_version);
+        }
         self.batch.status = SnosBatchStatus::Closed;
     }
 }


### PR DESCRIPTION
## Summary
- add an orchestrator histogram metric `snos_batch_blocks` for the number of blocks in each closed SNOS batch
- emit the metric when a non-empty SNOS batch transitions to `Closed`
- label the datapoint with `operation_job_type=SnosRun` and `starknet_version`

Linear: MDR-1609

## Validation
- `cargo fmt --check` passed
- `git diff --check` passed
- `cargo check` was run locally, but failed while building `librocksdb-sys` because the machine ran out of disk space writing `librocksdb.a` (`errno=28`). CI should validate the compile.