### PR TITLE
fix(orchestrator): alert on aggregator batching failures

### DIFF
--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -1,6 +1,7 @@
 use crate::core::config::Config;
 use crate::error::other::OtherError;
 use crate::error::{event::EventSystemResult, ConsumptionError};
+use crate::types::jobs::WorkerTriggerType;
 use crate::types::priority_slot::{
     take_from_processing_slot_if_matches, take_from_verification_slot_if_matches, PriorityJobSlot,
 };
@@ -282,7 +283,7 @@ impl EventWorker {
         parsed_message: &ParsedMessage,
     ) -> EventSystemResult<()> {
         if let Err(ref error) = result {
-            let (_error_context, consumption_error) = match parsed_message {
+            let (error_context, consumption_error) = match parsed_message {
                 ParsedMessage::WorkerTrigger(msg) => {
                     let worker = &msg.worker;
                     tracing::error!("Failed to handle worker trigger {worker:?}. Error: {error:?}");
@@ -303,6 +304,16 @@ impl EventWorker {
                     )
                 }
             };
+
+            if let ParsedMessage::WorkerTrigger(msg) = parsed_message {
+                if msg.worker == WorkerTriggerType::AggregatorBatching {
+                    let alert_message = aggregator_batching_failure_alert_message(&error_context);
+                    match self.config.alerts().send_message(alert_message).await {
+                        Ok(()) => info!("SNS alert sent successfully for AggregatorBatching worker failure"),
+                        Err(e) => error!(error = ?e, "Failed to send SNS alert for AggregatorBatching worker failure"),
+                    }
+                }
+            }
 
             message.nack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
 
@@ -515,6 +526,15 @@ fn should_check_priority_slot(queue_type: &QueueType) -> bool {
     )
 }
 
+fn aggregator_batching_failure_alert_message(error_context: &str) -> String {
+    format!(
+        "[CRITICAL] AggregatorBatching worker failed\n\n\
+         {error_context}\n\n\
+         The AggregatorBatching worker failed while handling a worker trigger. \
+         Check orchestrator logs for the full spantrace and retry context."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -537,5 +557,13 @@ mod tests {
         // Job verification queues should check priority slot
         assert!(should_check_priority_slot(&QueueType::SnosJobVerification));
         assert!(should_check_priority_slot(&QueueType::ProvingJobVerification));
+    }
+
+    #[test]
+    fn aggregator_batching_failure_alert_message_contains_searchable_context() {
+        let message = aggregator_batching_failure_alert_message("Worker AggregatorBatching handling failed: boom");
+
+        assert!(message.contains("[CRITICAL] AggregatorBatching worker failed"));
+        assert!(message.contains("Worker AggregatorBatching handling failed: boom"));
     }
 }

--- a/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
@@ -553,6 +553,7 @@ mod tests {
     use crate::tests::config::TestConfigBuilder;
     use chrono::{DateTime, Duration, Utc};
     use starknet_core::types::StateDiff;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Helper to create a test batch with configurable parameters
     fn create_test_batch(
@@ -661,6 +662,52 @@ mod tests {
         let result = state_handler.save_batch_state(&state).await;
 
         assert!(result.is_err(), "storage failure should make save_batch_state fail");
+    }
+
+    #[tokio::test]
+    async fn test_save_batch_state_does_not_update_db_when_blob_upload_fails() {
+        let mut database = MockDatabaseClient::new();
+        database.expect_update_or_create_aggregator_batch().times(0);
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let storage_call_count = call_count.clone();
+        let mut storage = MockStorageClient::new();
+        storage.expect_put_data().times(2).returning(move |_, key| {
+            let call_index = storage_call_count.fetch_add(1, Ordering::SeqCst);
+            match call_index {
+                0 => {
+                    assert_eq!(key, "test/path.json");
+                    Ok(())
+                }
+                1 => {
+                    assert_eq!(key, AggregatorBatch::get_blob_file_path(1, 1));
+                    Err(StorageError::ObjectStreamError("blob upload failed".to_string()))
+                }
+                _ => unreachable!("save_batch_state should stop after the first blob upload failure"),
+            }
+        });
+
+        let services = TestConfigBuilder::new()
+            .configure_database(database.into())
+            .configure_storage_client(storage.into())
+            .configure_prover_kind(ProverKind::Mock)
+            .build()
+            .await;
+
+        let batch = create_test_batch(
+            1,
+            AggregatorBatchStatus::Open,
+            StarknetVersion::V0_13_2,
+            AggregatorBatchWeights::new(100, 100),
+            Utc::now(),
+        );
+        let state = NonEmptyAggregatorState::new(batch, create_test_state_update());
+        let state_handler = AggregatorStateHandler::from_config(&services.config);
+
+        let result = state_handler.save_batch_state(&state).await;
+
+        assert!(result.is_err(), "blob upload failure should make save_batch_state fail");
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
     }
 
     mod check_block_sync_tests {

--- a/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
@@ -62,15 +62,14 @@ impl AggregatorStateHandler {
         }
     }
 
-    /// Save the given state in Storage and DB
+    /// Save the given state in DB and Storage
     ///
-    /// 1. Update or Create the blob and other assets in Storage
-    /// 2. Update or Create doc in DB
+    /// 1. Update or Create doc in DB
+    /// 2. Update or Create the blob and other assets in Storage
     ///
     /// IMPORTANT:
     /// 1. Assuming all the details are already updated in state
-    /// 2. Not making database and storage updates atomically. Storage is written first so failures don't leave DB rows
-    ///    pointing at missing objects.
+    /// 2. Not making database and storage updates atomically. It might happen that one fails and the other passes
     pub async fn save_batch_state(&self, state: &NonEmptyAggregatorState) -> Result<(), JobError> {
         info!(batch=?state.batch, "Saving aggregator batch state");
         // Compressing the state update into vector of felts
@@ -83,6 +82,12 @@ impl AggregatorStateHandler {
             self.config.batch_rpc_client(),
         )
         .await?;
+
+        // Update batch status in the database
+        self.config
+            .database()
+            .update_or_create_aggregator_batch(&state.batch, &AggregatorBatchUpdates::default())
+            .await?;
 
         // Update state update and blob in storage
         self.config
@@ -99,12 +104,6 @@ impl AggregatorStateHandler {
                 )
                 .await?;
         }
-
-        // Update batch status in the database only after all required storage artifacts exist.
-        self.config
-            .database()
-            .update_or_create_aggregator_batch(&state.batch, &AggregatorBatchUpdates::default())
-            .await?;
 
         Ok(())
     }
@@ -548,12 +547,8 @@ async fn compress_state_update(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::client::database::MockDatabaseClient;
-    use crate::core::client::storage::{MockStorageClient, StorageError};
-    use crate::tests::config::TestConfigBuilder;
     use chrono::{DateTime, Duration, Utc};
     use starknet_core::types::StateDiff;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Helper to create a test batch with configurable parameters
     fn create_test_batch(
@@ -628,86 +623,6 @@ mod tests {
             3600,                                          // max_batch_time_seconds (1 hour)
             100,                                           // empty block's proving gas
         )
-    }
-
-    #[tokio::test]
-    async fn test_save_batch_state_does_not_update_db_when_state_update_upload_fails() {
-        let mut database = MockDatabaseClient::new();
-        database.expect_update_or_create_aggregator_batch().times(0);
-
-        let mut storage = MockStorageClient::new();
-        storage
-            .expect_put_data()
-            .times(1)
-            .withf(|_, key| key == "test/path.json")
-            .returning(|_, _| Err(StorageError::ObjectStreamError("upload failed".to_string())));
-
-        let services = TestConfigBuilder::new()
-            .configure_database(database.into())
-            .configure_storage_client(storage.into())
-            .configure_prover_kind(ProverKind::Mock)
-            .build()
-            .await;
-
-        let batch = create_test_batch(
-            1,
-            AggregatorBatchStatus::Open,
-            StarknetVersion::V0_13_2,
-            AggregatorBatchWeights::new(100, 100),
-            Utc::now(),
-        );
-        let state = NonEmptyAggregatorState::new(batch, create_test_state_update());
-        let state_handler = AggregatorStateHandler::from_config(&services.config);
-
-        let result = state_handler.save_batch_state(&state).await;
-
-        assert!(result.is_err(), "storage failure should make save_batch_state fail");
-    }
-
-    #[tokio::test]
-    async fn test_save_batch_state_does_not_update_db_when_blob_upload_fails() {
-        let mut database = MockDatabaseClient::new();
-        database.expect_update_or_create_aggregator_batch().times(0);
-
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let storage_call_count = call_count.clone();
-        let mut storage = MockStorageClient::new();
-        storage.expect_put_data().times(2).returning(move |_, key| {
-            let call_index = storage_call_count.fetch_add(1, Ordering::SeqCst);
-            match call_index {
-                0 => {
-                    assert_eq!(key, "test/path.json");
-                    Ok(())
-                }
-                1 => {
-                    assert_eq!(key, AggregatorBatch::get_blob_file_path(1, 1));
-                    Err(StorageError::ObjectStreamError("blob upload failed".to_string()))
-                }
-                _ => unreachable!("save_batch_state should stop after the first blob upload failure"),
-            }
-        });
-
-        let services = TestConfigBuilder::new()
-            .configure_database(database.into())
-            .configure_storage_client(storage.into())
-            .configure_prover_kind(ProverKind::Mock)
-            .build()
-            .await;
-
-        let batch = create_test_batch(
-            1,
-            AggregatorBatchStatus::Open,
-            StarknetVersion::V0_13_2,
-            AggregatorBatchWeights::new(100, 100),
-            Utc::now(),
-        );
-        let state = NonEmptyAggregatorState::new(batch, create_test_state_update());
-        let state_handler = AggregatorStateHandler::from_config(&services.config);
-
-        let result = state_handler.save_batch_state(&state).await;
-
-        assert!(result.is_err(), "blob upload failure should make save_batch_state fail");
-        assert_eq!(call_count.load(Ordering::SeqCst), 2);
     }
 
     mod check_block_sync_tests {

--- a/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
@@ -62,14 +62,15 @@ impl AggregatorStateHandler {
         }
     }
 
-    /// Save the given state in DB and Storage
+    /// Save the given state in Storage and DB
     ///
-    /// 1. Update or Create doc in DB
-    /// 2. Update or Create the blob and other assets in Storage
+    /// 1. Update or Create the blob and other assets in Storage
+    /// 2. Update or Create doc in DB
     ///
     /// IMPORTANT:
     /// 1. Assuming all the details are already updated in state
-    /// 2. Not making database and storage updates atomically. It might happen that one fails and the other passes
+    /// 2. Not making database and storage updates atomically. Storage is written first so failures don't leave DB rows
+    ///    pointing at missing objects.
     pub async fn save_batch_state(&self, state: &NonEmptyAggregatorState) -> Result<(), JobError> {
         info!(batch=?state.batch, "Saving aggregator batch state");
         // Compressing the state update into vector of felts
@@ -82,12 +83,6 @@ impl AggregatorStateHandler {
             self.config.batch_rpc_client(),
         )
         .await?;
-
-        // Update batch status in the database
-        self.config
-            .database()
-            .update_or_create_aggregator_batch(&state.batch, &AggregatorBatchUpdates::default())
-            .await?;
 
         // Update state update and blob in storage
         self.config
@@ -104,6 +99,12 @@ impl AggregatorStateHandler {
                 )
                 .await?;
         }
+
+        // Update batch status in the database only after all required storage artifacts exist.
+        self.config
+            .database()
+            .update_or_create_aggregator_batch(&state.batch, &AggregatorBatchUpdates::default())
+            .await?;
 
         Ok(())
     }
@@ -547,6 +548,9 @@ async fn compress_state_update(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::client::database::MockDatabaseClient;
+    use crate::core::client::storage::{MockStorageClient, StorageError};
+    use crate::tests::config::TestConfigBuilder;
     use chrono::{DateTime, Duration, Utc};
     use starknet_core::types::StateDiff;
 
@@ -623,6 +627,40 @@ mod tests {
             3600,                                          // max_batch_time_seconds (1 hour)
             100,                                           // empty block's proving gas
         )
+    }
+
+    #[tokio::test]
+    async fn test_save_batch_state_does_not_update_db_when_state_update_upload_fails() {
+        let mut database = MockDatabaseClient::new();
+        database.expect_update_or_create_aggregator_batch().times(0);
+
+        let mut storage = MockStorageClient::new();
+        storage
+            .expect_put_data()
+            .times(1)
+            .withf(|_, key| key == "test/path.json")
+            .returning(|_, _| Err(StorageError::ObjectStreamError("upload failed".to_string())));
+
+        let services = TestConfigBuilder::new()
+            .configure_database(database.into())
+            .configure_storage_client(storage.into())
+            .configure_prover_kind(ProverKind::Mock)
+            .build()
+            .await;
+
+        let batch = create_test_batch(
+            1,
+            AggregatorBatchStatus::Open,
+            StarknetVersion::V0_13_2,
+            AggregatorBatchWeights::new(100, 100),
+            Utc::now(),
+        );
+        let state = NonEmptyAggregatorState::new(batch, create_test_state_update());
+        let state_handler = AggregatorStateHandler::from_config(&services.config);
+
+        let result = state_handler.save_batch_state(&state).await;
+
+        assert!(result.is_err(), "storage failure should make save_batch_state fail");
     }
 
     mod check_block_sync_tests {


### PR DESCRIPTION
## Summary
- Revert the net AggregatorBatching storage-before-DB persistence change from this PR.
- Send an SNS alert whenever the `AggregatorBatching` worker trigger fails.
- Keep the existing worker failure behavior intact: the queue message is still nacked/retried, and SNS publish failures are logged without masking the original AggregatorBatching error.

## Why
During the PC mainnet incident, AggregatorBatching failures were only visible through logs. This change makes that failure mode page through the existing SNS alert path so operators get a direct signal when AggregatorBatching cannot progress.

This PR no longer attempts to change the persistence ordering for aggregator batch state. It only adds alerting around the worker-trigger failure path.

## Validation
- `cargo fmt --package orchestrator`
- `git diff --check`
- Attempted: `cargo test -p orchestrator aggregator_batching_failure_alert_message_contains_searchable_context`
  - Blocked locally because `cairo-compile` is missing and the machine also hit `No space left on device` while compiling dependencies.

## Grafana
Search for the new alert/log strings:
https://grafana.dime.karnot.xyz/explore?schemaVersion=1&orgId=1&panes=%7B%22logs%22%3A%7B%22datasource%22%3A%22PDE7443F775B589AD%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22PDE7443F775B589AD%22%7D%2C%22expr%22%3A%22%7Bnamespace%3D%5C%22mainnet-prod%5C%22%7D%20%7C~%20%5C%22AggregatorBatching%20worker%20failed%7CSNS%20alert%20sent%20successfully%20for%20AggregatorBatching%20worker%20failure%7CFailed%20to%20send%20SNS%20alert%20for%20AggregatorBatching%20worker%20failure%5C%22%22%2C%22queryType%22%3A%22range%22%2C%22editorMode%22%3A%22code%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-24h%22%2C%22to%22%3A%22now%22%7D%7D%7D