### PR TITLE
fix(orchestrator): restore active jobs on graceful shutdown

### DIFF
--- a/orchestrator/src/tests/jobs/mod.rs
+++ b/orchestrator/src/tests/jobs/mod.rs
@@ -32,18 +32,22 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use generate_pie::error::{BlockProcessingError, PieGenerationError};
 use mockall::predicate::eq;
 use mongodb::bson::doc;
 use rstest::rstest;
 use starknet::providers::ProviderError;
+use tokio::sync::{oneshot, Mutex as TokioMutex};
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 
 use crate::core::client::alert::MockAlertClient;
 use crate::error::job::snos::SnosError;
 use crate::tests::common::MessagePayloadType;
 use crate::tests::config::{ConfigType, MockType, TestConfigBuilder};
 use crate::tests::utils::build_job_item;
+use crate::types::jobs::job_item::JobItem;
 
 #[cfg(test)]
 pub mod da_job;
@@ -77,6 +81,54 @@ use crate::worker::event_handler::jobs::{JobHandlerTrait, MockJobHandlerTrait};
 use crate::worker::event_handler::service::JobHandlerService;
 use crate::worker::service::JobService;
 use assert_matches::assert_matches;
+
+struct ShutdownBlockingJobHandler {
+    started: TokioMutex<Option<oneshot::Sender<()>>>,
+    release: TokioMutex<Option<oneshot::Receiver<()>>>,
+}
+
+#[async_trait]
+impl JobHandlerTrait for ShutdownBlockingJobHandler {
+    async fn create_job(&self, _internal_id: u64, _metadata: JobMetadata) -> Result<JobItem, JobError> {
+        Err(JobError::Other("not implemented for test".to_string().into()))
+    }
+
+    async fn process_job(
+        &self,
+        _config: Arc<crate::core::config::Config>,
+        _job: &mut JobItem,
+    ) -> Result<String, JobError> {
+        if let Some(started) = self.started.lock().await.take() {
+            let _ = started.send(());
+        }
+
+        if let Some(release) = self.release.lock().await.take() {
+            let _ = release.await;
+        }
+
+        Ok("0xbeef".to_string())
+    }
+
+    async fn verify_job(
+        &self,
+        _config: Arc<crate::core::config::Config>,
+        _job: &mut JobItem,
+    ) -> Result<JobVerificationStatus, JobError> {
+        Ok(JobVerificationStatus::Verified)
+    }
+
+    fn max_process_attempts(&self) -> u64 {
+        1
+    }
+
+    fn max_verification_attempts(&self) -> u64 {
+        1
+    }
+
+    fn verification_polling_delay_seconds(&self) -> u64 {
+        1
+    }
+}
 
 /// Tests `create_job` function when job is not existing in the db.
 #[rstest]
@@ -307,6 +359,105 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
     .unwrap();
     let consumed_message_payload: MessagePayloadType = consumed_messages.payload_serde_json().unwrap().unwrap();
     assert_eq!(consumed_message_payload.id, job_item.id);
+}
+
+/// Tests that graceful shutdown restores an active processing job so SQS can retry it.
+#[rstest]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_shutdown_restores_locked_job_for_sqs_retry() {
+    let _test_lock = acquire_test_lock();
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::SnosRun, JobStatus::Created, 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let (started_tx, started_rx) = oneshot::channel();
+    let (_release_tx, release_rx) = oneshot::channel();
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(ShutdownBlockingJobHandler {
+        started: TokioMutex::new(Some(started_tx)),
+        release: TokioMutex::new(Some(release_rx)),
+    }));
+
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::SnosRun)).return_once(move |_| Arc::clone(&job_handler));
+
+    let shutdown_token = CancellationToken::new();
+    let process_handle = tokio::spawn(JobHandlerService::process_job_with_shutdown(
+        job_item.id,
+        services.config.clone(),
+        shutdown_token.clone(),
+    ));
+
+    started_rx.await.expect("handler should start after job is locked");
+
+    let locked_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(locked_job.status, JobStatus::LockedForProcessing);
+
+    shutdown_token.cancel();
+
+    let result = process_handle.await.unwrap();
+    assert!(result.is_err(), "shutdown during processing should return Err so the message is NACKed");
+
+    let restored_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(restored_job.status, JobStatus::Created);
+    assert_eq!(restored_job.metadata.common.process_attempt_no, 1);
+    assert_eq!(restored_job.metadata.common.process_retry_attempt_no, 1);
+    assert!(restored_job.metadata.common.process_started_at.is_none());
+    assert!(restored_job.metadata.common.process_completed_at.is_none());
+
+    let failure_reason = restored_job.metadata.common.failure_reason.as_ref().unwrap();
+    assert!(
+        failure_reason.contains("interrupted by orchestrator shutdown"),
+        "failure_reason should record shutdown restore. Got: {}",
+        failure_reason
+    );
+}
+
+/// Tests that successful processing is not restored by a later shutdown signal.
+#[rstest]
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn process_job_shutdown_does_not_restore_completed_processing() {
+    let _test_lock = acquire_test_lock();
+
+    let services = TestConfigBuilder::new()
+        .configure_database(ConfigType::Actual)
+        .configure_queue_client(ConfigType::Actual)
+        .build()
+        .await;
+    let db_client = services.config.database();
+
+    let job_item = build_job_item(JobType::SnosRun, JobStatus::Created, 1);
+    db_client.create_job(job_item.clone()).await.unwrap();
+
+    let mut job_handler = MockJobHandlerTrait::new();
+    job_handler.expect_check_ready_to_process().times(1).returning(|_, _| Ok(()));
+    job_handler.expect_process_job().times(1).returning(move |_, _| Ok("0xbeef".to_string()));
+    job_handler.expect_verification_polling_delay_seconds().return_const(1u64);
+
+    let job_handler: Arc<Box<dyn JobHandlerTrait>> = Arc::new(Box::new(job_handler));
+    let ctx = get_job_handler_context_safe();
+    ctx.expect().times(1).with(eq(JobType::SnosRun)).return_once(move |_| Arc::clone(&job_handler));
+
+    let shutdown_token = CancellationToken::new();
+    let result =
+        JobHandlerService::process_job_with_shutdown(job_item.id, services.config.clone(), shutdown_token.clone())
+            .await;
+    assert!(result.is_ok());
+
+    shutdown_token.cancel();
+
+    let completed_processing_job = db_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
+    assert_eq!(completed_processing_job.status, JobStatus::PendingVerification);
+    assert_eq!(completed_processing_job.external_id, ExternalId::String(Box::from("0xbeef")));
+    assert_eq!(completed_processing_job.metadata.common.process_retry_attempt_no, 0);
 }
 
 /// Tests that SNOS panics restore the original job status and rely on SQS/DLQ retries.

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -213,9 +213,13 @@ impl EventWorker {
     async fn handle_job_queue(&self, queue_message: &JobQueueMessage, job_state: JobState) -> EventSystemResult<()> {
         match job_state {
             JobState::Processing => {
-                JobHandlerService::process_job(queue_message.id, self.config.clone())
-                    .await
-                    .map_err(|e| ConsumptionError::Other(OtherError::from(e.to_string())))?;
+                JobHandlerService::process_job_with_shutdown(
+                    queue_message.id,
+                    self.config.clone(),
+                    self.cancellation_token.clone(),
+                )
+                .await
+                .map_err(|e| ConsumptionError::Other(OtherError::from(e.to_string())))?;
             }
             JobState::Verification => {
                 JobHandlerService::verify_job(queue_message.id, self.config.clone())

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -5,6 +5,7 @@ use opentelemetry::KeyValue;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::core::client::database::{AggregatorBatchDbQuery, SnosBatchDbQuery};
@@ -168,6 +169,14 @@ impl JobHandlerService {
     /// timeout is shorter, messages may become visible again before the healing timeout expires,
     /// leading to duplicate processing attempts that get incorrectly treated as stale jobs.
     pub async fn process_job(id: Uuid, config: Arc<Config>) -> Result<(), JobError> {
+        Self::process_job_with_shutdown(id, config, CancellationToken::new()).await
+    }
+
+    pub async fn process_job_with_shutdown(
+        id: Uuid,
+        config: Arc<Config>,
+        shutdown_token: CancellationToken,
+    ) -> Result<(), JobError> {
         let start = Instant::now();
         let mut job = JobService::get_job(id, config.clone()).await?;
         let internal_id = job.internal_id;
@@ -287,6 +296,11 @@ impl JobHandlerService {
             return Ok(());
         }
 
+        if shutdown_token.is_cancelled() {
+            warn!(job_id = ?id, job_type = ?job.job_type, "Shutdown requested before processing lock was acquired");
+            return Err(Self::shutdown_processing_error(id));
+        }
+
         // Save original status so retryable processing failures can restore the job to the
         // pre-processing state and let SQS own the retry lifecycle.
         let original_status = job.status.clone();
@@ -330,8 +344,50 @@ impl JobHandlerService {
         // Increment process attempt counter
         job.metadata.common.process_attempt_no += 1;
 
-        let external_id = match AssertUnwindSafe(job_handler.process_job(config.clone(), &mut job)).catch_unwind().await
-        {
+        enum ProcessingOutcome<T> {
+            Completed(T),
+            Shutdown,
+        }
+
+        let processing_result = {
+            let processing = AssertUnwindSafe(job_handler.process_job(config.clone(), &mut job)).catch_unwind();
+            tokio::pin!(processing);
+
+            tokio::select! {
+                result = &mut processing => ProcessingOutcome::Completed(result),
+                _ = shutdown_token.cancelled() => ProcessingOutcome::Shutdown,
+            }
+        };
+
+        let processing_result = match processing_result {
+            ProcessingOutcome::Completed(result) => result,
+            ProcessingOutcome::Shutdown => {
+                let reason = format!(
+                    "Processing attempt {} interrupted by orchestrator shutdown",
+                    job.metadata.common.process_attempt_no
+                );
+                let shutdown_error = Self::shutdown_processing_error(id);
+
+                warn!(
+                    job_id = ?id,
+                    job_type = ?job.job_type,
+                    internal_id = %job.internal_id,
+                    status = ?original_status,
+                    "Shutdown requested while processing job, restoring job state for SQS retry"
+                );
+                workload.finish_error();
+                return Err(Self::reset_job_for_sqs_retry(
+                    &mut job,
+                    config.clone(),
+                    original_status,
+                    reason,
+                    shutdown_error,
+                )
+                .await);
+            }
+        };
+
+        let external_id = match processing_result {
             Ok(Ok(external_id)) => {
                 Span::current().record("external_id", format!("{:?}", external_id).as_str());
                 // Add the time of processing to the metadata.
@@ -467,6 +523,10 @@ impl JobHandlerService {
         workload.finish_success();
 
         Ok(())
+    }
+
+    fn shutdown_processing_error(id: Uuid) -> JobError {
+        JobError::Other(OtherError::from(format!("Job {id} processing interrupted by orchestrator shutdown")))
     }
 
     async fn reset_job_for_sqs_retry(

--- a/orchestrator/src/worker/event_handler/service.rs
+++ b/orchestrator/src/worker/event_handler/service.rs
@@ -354,6 +354,8 @@ impl JobHandlerService {
             tokio::pin!(processing);
 
             tokio::select! {
+                biased;
+
                 result = &mut processing => ProcessingOutcome::Completed(result),
                 _ = shutdown_token.cancelled() => ProcessingOutcome::Shutdown,
             }


### PR DESCRIPTION
## Summary
- pass the worker cancellation token into job processing
- restore a job from `LockedForProcessing` to its original pre-processing status when graceful shutdown interrupts active processing
- return an error after shutdown restore so the queue delivery is NACKed and can be retried instead of ACKing a stranded job
- add focused tests for shutdown restore and for successful processing not being restored later

## Incident context
During the PC mainnet orchestrator scale-down from 20 replicas to 0, pods had `terminationGracePeriodSeconds: 30` while the app logged a 120 second shutdown timeout. Several `SnosRun` jobs moved to `LockedForProcessing` and started processing immediately before SIGTERM, but the pods exited before the normal success/error paths ran. Those jobs never reached `PendingVerification`, never logged the existing `restoring job state` error path, and remained locked until stale healing.

This PR is a code-level safety net for that shutdown window. Kubernetes should still set `terminationGracePeriodSeconds >= MADARA_ORCHESTRATOR_GRACEFUL_SHUTDOWN_TIMEOUT`, but the orchestrator now actively restores in-flight processing jobs when it observes shutdown.

## Safety notes
- The restore uses the existing `reset_job_for_sqs_retry` path, so retry metadata and `process_started_at` cleanup stay consistent with processing errors/panics.
- The Mongo update path is version-checked, so a restore will not overwrite a newer job version if another path already advanced the job.
- On shutdown interruption, `process_job_with_shutdown` returns `Err`; `EventWorker` post-processing NACKs the delivery, preserving SQS retry behavior.
- This can only interrupt async work that cooperatively yields to the Tokio runtime. If a handler is executing a long synchronous/blocking section and never yields before the process is killed, Kubernetes/app timeout alignment is still required.

## Tests
- `cargo fmt`
- `git diff --check`
- attempted `cargo test -p orchestrator process_job_shutdown -- --nocapture` but local build is blocked before orchestrator tests by missing Cairo0 tooling: `cairo-compile` is not available for `apollo_starknet_os_program` build script
- attempted `cargo check -p orchestrator --no-default-features --lib` and hit the same missing `cairo-compile` prerequisite
