### PR TITLE
Gate mempool flush admin RPC behind unsafe flag

### DIFF
--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -92,6 +92,7 @@ pub trait MadaraWriteRpcApi {
     async fn set_block_header(&self, custom_block_headers: CustomHeader) -> RpcResult<()>;
 
     /// Flush transactions from the mempool using an admin-only filter.
+    /// Only available when unsafe RPC methods are enabled.
     /// Nonce filters only narrow an explicit base selector and cannot be used on their own.
     /// Nonce-range flushing is surgical: it removes only matching transactions. If that creates an
     /// account nonce gap, higher nonces remain pending so the missing nonce can be resubmitted.

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/api.rs
@@ -77,6 +77,7 @@ pub trait MadaraWriteRpcApi {
     /// before mutating the DB state, and then exits the process so Kubernetes
     /// (or another supervisor) can restart cleanly.
     ///
+    /// Only available when unsafe RPC methods are enabled.
     #[method(name = "revertToAndShutdown")]
     async fn revert_to_and_shutdown(&self, block_hash: Felt) -> RpcResult<()>;
 
@@ -87,7 +88,8 @@ pub trait MadaraWriteRpcApi {
         l1_handler_message: L1HandlerTransactionWithFee,
     ) -> RpcResult<L1HandlerTransactionResult>;
 
-    /// Sets custom headers to be used for the upcoming block
+    /// Sets custom headers to be used for the upcoming block.
+    /// Only available when unsafe RPC methods are enabled.
     #[method(name = "setCustomBlockHeader")]
     async fn set_block_header(&self, custom_block_headers: CustomHeader) -> RpcResult<()>;
 

--- a/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
+++ b/madara/crates/client/rpc/src/versions/admin/v0_1_0/methods/write.rs
@@ -346,6 +346,13 @@ impl MadaraWriteRpcApiV0_1_0Server for Starknet {
     }
 
     async fn flush_mempool_txns(&self, params: FlushMempoolTxnsParams) -> RpcResult<FlushMempoolTxnsResult> {
+        if !self.rpc_unsafe_enabled {
+            return Err(StarknetRpcApiError::ErrUnexpectedError {
+                error: "This method requires the --rpc-unsafe flag to be enabled".to_string().into(),
+            }
+            .into());
+        }
+
         let mempool = self.mempool.as_ref().ok_or(StarknetRpcApiError::UnimplementedMethod)?;
         let flush_mode = FlushMode::from_params(params)?;
         let removed_transactions = match flush_mode {
@@ -399,12 +406,17 @@ mod tests {
         rpc
     }
 
-    fn make_starknet_with_mempool() -> (Arc<Mempool>, Starknet) {
+    fn make_starknet_with_mempool_and_unsafe(rpc_unsafe_enabled: bool) -> (Arc<Mempool>, Starknet) {
         let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
         let mempool = Arc::new(Mempool::new(backend.clone(), MempoolConfig::default()));
         let mut rpc = make_starknet(backend, ServiceContext::new_for_testing());
+        rpc.set_rpc_unsafe_enabled(rpc_unsafe_enabled);
         rpc.set_mempool(mempool.clone());
         (mempool, rpc)
+    }
+
+    fn make_starknet_with_mempool() -> (Arc<Mempool>, Starknet) {
+        make_starknet_with_mempool_and_unsafe(true)
     }
 
     fn invoke_v1_tx(sender: Felt, nonce: Felt, hash: Felt, arrived_at: u64) -> ValidatedTransaction {
@@ -547,6 +559,26 @@ mod tests {
 
         assert_eq!(result.removed_transaction_hashes, vec![tx1.hash, tx2.hash]);
         assert!(mempool.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn flush_mempool_txns_requires_unsafe_rpc() {
+        let (mempool, rpc) = make_starknet_with_mempool_and_unsafe(false);
+        let tx = invoke_v1_tx(Felt::from(11_u64), Felt::ZERO, Felt::from(101_u64), TxTimestamp::now().0);
+        mempool.accept_tx(tx.clone()).await.unwrap();
+
+        let err = rpc.flush_mempool_txns(FlushMempoolTxnsParams { all: true, ..Default::default() }).await.unwrap_err();
+
+        assert_eq!(err.message(), "This method requires the --rpc-unsafe flag to be enabled");
+        assert_eq!(
+            mempool
+                .snapshot_transaction_hashes_matching(0, usize::MAX, false, |_| true)
+                .await
+                .into_iter()
+                .map(|tx| tx.transaction_hash)
+                .collect::<Vec<_>>(),
+            vec![tx.hash]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- require `MADARA_RPC_UNSAFE` / `--rpc-unsafe` before executing `madara_flushMempoolTxns`
- document the unsafe requirement on the admin RPC trait
- add a regression test that verifies the method is rejected and leaves the mempool untouched when unsafe RPC is disabled

## Testing
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p mc-rpc flush_mempool_txns_requires_unsafe_rpc` *(failed during dependency compilation: local filesystem ran out of space before the test executed)*