### PR TITLE
chore: disable Dependabot version PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly" # can be `daily` or `monthly` also
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- set Cargo Dependabot `open-pull-requests-limit` to `0`
- stops normal Dependabot version-update PRs for the Cargo ecosystem

## Checks
- `git diff --check`
- attempted repo pre-push hook; first run hit macOS SDK header lookup for `mlir-sys`, retry with `SDKROOT`/`BINDGEN_EXTRA_CLANG_ARGS` progressed but was stopped after long native dependency builds because this is a config-only change

Note: Dependabot security-update PRs are controlled separately by GitHub settings.