### PR TITLE
[codex] fix orchestrator L2 SNOS artifact fetch

### DIFF
--- a/orchestrator/src/tests/jobs/state_update_job/mod.rs
+++ b/orchestrator/src/tests/jobs/state_update_job/mod.rs
@@ -219,7 +219,7 @@ async fn test_process_job_l2_with_da_segment(
     let metadata = JobMetadata {
         common: CommonMetadata { process_attempt_no: 0, ..CommonMetadata::default() },
         specific: JobSpecificMetadata::StateUpdate(StateUpdateMetadata {
-            snos_output_path: None, // Not used for L2 batch settlement
+            snos_output_path: Some(get_batch_artifact_file(batch_index, SNOS_OUTPUT_FILE_NAME)),
             program_output_path: Some(program_output_key),
             blob_data_path: None, // Not used for L2 with DA segments
             da_segment_path: Some(da_segment_key),

--- a/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/orchestrator/src/tests/workers/update_state/mod.rs
@@ -51,6 +51,7 @@ async fn update_state_worker_first_block() {
     let services = TestConfigBuilder::new()
         .configure_database(ConfigType::Actual)
         .configure_queue_client(ConfigType::Actual)
+        .configure_layer(Layer::L2)
         .build()
         .await;
 
@@ -71,6 +72,7 @@ async fn update_state_worker_first_block() {
     let state_metadata: StateUpdateMetadata = latest_job.metadata.specific.clone().try_into().unwrap();
     let SettlementContext::Batch(data) = state_metadata.context else { panic!("Failed to get Block context") };
     assert_eq!(data.to_settle, 1);
+    assert_eq!(state_metadata.snos_output_path, None);
 }
 
 #[rstest]

--- a/orchestrator/src/worker/event_handler/jobs/state_update.rs
+++ b/orchestrator/src/worker/event_handler/jobs/state_update.rs
@@ -110,15 +110,12 @@ impl JobHandlerTrait for StateUpdateJobHandler {
             }
             job.metadata.specific = JobSpecificMetadata::StateUpdate(state_metadata.clone());
         } else {
-            // Get the artifacts for the block/batch
-            let snos_output =
-                match fetch_snos_output(internal_id, config.clone(), &state_metadata.snos_output_path).await {
-                    Ok(snos_output) => Some(snos_output),
-                    Err(err) => {
-                        debug!("failed to fetch snos output, proceeding without it: {}", err);
-                        None
-                    }
-                };
+            let snos_output = match config.layer() {
+                Layer::L2 => None,
+                Layer::L3 => {
+                    Some(fetch_snos_output(internal_id, config.clone(), &state_metadata.snos_output_path).await?)
+                }
+            };
             let program_output = fetch_program_output(config.clone(), &state_metadata.program_output_path).await?;
             let blob_data = match config.layer() {
                 // For L2, use DA segment from prover (encrypted/compressed state diff)

--- a/orchestrator/src/worker/event_handler/triggers/update_state.rs
+++ b/orchestrator/src/worker/event_handler/triggers/update_state.rs
@@ -216,8 +216,6 @@ impl UpdateStateJobTrigger {
             e
         })?;
 
-        // Set the snos output path, program output path, blob data path, and da segment path in state transition metadata
-        state_metadata.snos_output_path = Some(aggregator_metadata.snos_output_path.clone());
         state_metadata.program_output_path = Some(aggregator_metadata.program_output_path.clone());
         state_metadata.blob_data_path = Some(aggregator_metadata.blob_data_path.clone());
         state_metadata.da_segment_path = Some(aggregator_metadata.da_segment_path.clone());


### PR DESCRIPTION
## Summary
- stop L2 state-transition processing from fetching SNOS output artifacts
- stop propagating aggregator snos_output_path into new L2 state-transition jobs
- add regression coverage for L2 jobs created without SNOS output and legacy L2 jobs that still contain the path

## Root cause
L2 aggregator jobs advertised artifacts/batch/<batch>/snos_output.json, but the local aggregation path only writes program_output.txt, da_blob.json, and cairo_pie.zip. State-transition processing then tried to fetch the advertised SNOS output path before continuing without it, producing noisy S3 404/service errors for an object that should not exist in the L2 blob-settlement flow.

## Validation
- cargo fmt --manifest-path orchestrator/Cargo.toml -- --check
- git diff --check

Could not complete cargo test locally because tblgen/mlir-sys requires LLVM 19 and this host has no llvm-config installed. The repo CI installs LLVM through .github/actions/setup-cairo-native.