### PR TITLE
fix(orchestrator): bound anti-join queries

### DIFF
--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -129,13 +129,14 @@ pub trait DatabaseClient: Send + Sync {
     /// * `job_a_status` - Status of the first job
     /// * `job_b_type` - Type of the successor job to check for
     /// * `orchestrator_version` - Optional orchestrator version filter
+    /// * `min_internal_id` - Inclusive lower bound, or 0 for an unbounded scan
     async fn get_jobs_without_successor(
         &self,
         job_a_type: JobType,
         job_a_status: JobStatus,
         job_b_type: JobType,
         orchestrator_version: Option<String>,
-        min_internal_id: Option<u64>,
+        min_internal_id: u64,
     ) -> Result<Vec<JobItem>, DatabaseError>;
 
     /// Get jobs after a specific internal id by job type
@@ -246,6 +247,7 @@ pub trait DatabaseClient: Send + Sync {
     /// * `snos_batch_status` - Status of SNOS batches to check (typically Closed)
     /// * `limit` - Maximum number of batches to return
     /// * `orchestrator_version` - Optional orchestrator version filter
+    /// * `min_index` - Inclusive lower bound, or 0 for an unbounded scan
     ///
     /// # Returns
     /// Vector of SNOS batches that don't have corresponding SNOS jobs (in any status)
@@ -254,7 +256,7 @@ pub trait DatabaseClient: Send + Sync {
         snos_batch_status: SnosBatchStatus,
         limit: u64,
         orchestrator_version: Option<String>,
-        min_index: Option<u64>,
+        min_index: u64,
     ) -> Result<Vec<SnosBatch>, DatabaseError>;
 
     /// Update or create a SNOS batch

--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -122,6 +122,19 @@ pub trait DatabaseClient: Send + Sync {
         orchestrator_version: Option<String>,
     ) -> Result<Option<JobItem>, DatabaseError>;
 
+    /// Get the latest job of a specific type and status
+    ///
+    /// # Arguments
+    /// * `job_type` - The type of job to search for
+    /// * `job_status` - The status of job to search for
+    /// * `orchestrator_version` - Optional orchestrator version filter
+    async fn get_latest_job_by_type_and_status(
+        &self,
+        job_type: JobType,
+        job_status: JobStatus,
+        orchestrator_version: Option<String>,
+    ) -> Result<Option<JobItem>, DatabaseError>;
+
     /// Get jobs without a successor
     ///
     /// # Arguments

--- a/orchestrator/src/core/client/database/mod.rs
+++ b/orchestrator/src/core/client/database/mod.rs
@@ -135,6 +135,7 @@ pub trait DatabaseClient: Send + Sync {
         job_a_status: JobStatus,
         job_b_type: JobType,
         orchestrator_version: Option<String>,
+        min_internal_id: Option<u64>,
     ) -> Result<Vec<JobItem>, DatabaseError>;
 
     /// Get jobs after a specific internal id by job type
@@ -253,6 +254,7 @@ pub trait DatabaseClient: Send + Sync {
         snos_batch_status: SnosBatchStatus,
         limit: u64,
         orchestrator_version: Option<String>,
+        min_index: Option<u64>,
     ) -> Result<Vec<SnosBatch>, DatabaseError>;
 
     /// Update or create a SNOS batch

--- a/orchestrator/src/core/client/database/mongodb.rs
+++ b/orchestrator/src/core/client/database/mongodb.rs
@@ -826,6 +826,50 @@ impl DatabaseClient for MongoDbClient {
         Ok(result)
     }
 
+    async fn get_latest_job_by_type_and_status(
+        &self,
+        job_type: JobType,
+        job_status: JobStatus,
+        orchestrator_version: Option<String>,
+    ) -> Result<Option<JobItem>, DatabaseError> {
+        let start = Instant::now();
+
+        let mut match_filter = doc! {
+            "job_type": bson::to_bson(&job_type)?,
+            "status": bson::to_bson(&job_status)?,
+        };
+
+        if let Some(version) = &orchestrator_version {
+            match_filter.insert("metadata.common.orchestrator_version", version.as_str());
+        }
+
+        let pipeline = vec![
+            doc! {
+                "$match": match_filter,
+            },
+            doc! {
+                "$sort": {
+                    "internal_id": -1
+                }
+            },
+            doc! {
+                "$limit": 1
+            },
+        ];
+
+        debug!("Fetching latest job by type and status");
+
+        let results = self.execute_pipeline::<JobItem, JobItem>(self.get_job_collection(), pipeline, None).await?;
+
+        let attributes = [KeyValue::new("db_operation_name", "get_latest_job_by_type_and_status")];
+        let duration = start.elapsed();
+
+        let result = vec_to_single_result(results, "get_latest_job_by_type_and_status")?;
+
+        MetricsRecorder::record_db_call(duration.as_secs_f64(), &attributes);
+        Ok(result)
+    }
+
     /// Function to get jobs that don't have a successor job.
     ///
     /// `job_a_type`: Type of job that we need to get that doesn't have any successor.

--- a/orchestrator/src/core/client/database/mongodb.rs
+++ b/orchestrator/src/core/client/database/mongodb.rs
@@ -866,7 +866,9 @@ impl DatabaseClient for MongoDbClient {
             match_filter.insert("metadata.common.orchestrator_version", version.as_str());
         }
         if let Some(min_internal_id) = min_internal_id {
-            let min_internal_id = i64::try_from(min_internal_id).unwrap_or(i64::MAX);
+            // If the caller somehow passes a value Mongo cannot represent as i64,
+            // fall back to the broad scan instead of filtering out real work.
+            let min_internal_id = i64::try_from(min_internal_id).unwrap_or(0);
             match_filter.insert("internal_id", doc! { "$gte": min_internal_id });
         }
 
@@ -1497,7 +1499,9 @@ impl DatabaseClient for MongoDbClient {
             match_filter.insert("orchestrator_version", version.as_str());
         }
         if let Some(min_index) = min_index {
-            let min_index = i64::try_from(min_index).unwrap_or(i64::MAX);
+            // If the caller somehow passes a value Mongo cannot represent as i64,
+            // fall back to the broad scan instead of filtering out real work.
+            let min_index = i64::try_from(min_index).unwrap_or(0);
             match_filter.insert("index", doc! { "$gte": min_index });
         }
 

--- a/orchestrator/src/core/client/database/mongodb.rs
+++ b/orchestrator/src/core/client/database/mongodb.rs
@@ -849,6 +849,7 @@ impl DatabaseClient for MongoDbClient {
         job_a_status: JobStatus,
         job_b_type: JobType,
         orchestrator_version: Option<String>,
+        min_internal_id: Option<u64>,
     ) -> Result<Vec<JobItem>, DatabaseError> {
         let start = Instant::now();
         // Convert enums to Bson strings
@@ -863,6 +864,10 @@ impl DatabaseClient for MongoDbClient {
         };
         if let Some(version) = &orchestrator_version {
             match_filter.insert("metadata.common.orchestrator_version", version.as_str());
+        }
+        if let Some(min_internal_id) = min_internal_id {
+            let min_internal_id = i64::try_from(min_internal_id).unwrap_or(i64::MAX);
+            match_filter.insert("internal_id", doc! { "$gte": min_internal_id });
         }
 
         // Construct the aggregation pipeline
@@ -1476,6 +1481,7 @@ impl DatabaseClient for MongoDbClient {
         snos_batch_status: SnosBatchStatus,
         limit: u64,
         orchestrator_version: Option<String>,
+        min_index: Option<u64>,
     ) -> Result<Vec<SnosBatch>, DatabaseError> {
         let start = Instant::now();
 
@@ -1489,6 +1495,10 @@ impl DatabaseClient for MongoDbClient {
         };
         if let Some(version) = &orchestrator_version {
             match_filter.insert("orchestrator_version", version.as_str());
+        }
+        if let Some(min_index) = min_index {
+            let min_index = i64::try_from(min_index).unwrap_or(i64::MAX);
+            match_filter.insert("index", doc! { "$gte": min_index });
         }
 
         // Construct the aggregation pipeline

--- a/orchestrator/src/core/client/database/mongodb.rs
+++ b/orchestrator/src/core/client/database/mongodb.rs
@@ -849,7 +849,7 @@ impl DatabaseClient for MongoDbClient {
         job_a_status: JobStatus,
         job_b_type: JobType,
         orchestrator_version: Option<String>,
-        min_internal_id: Option<u64>,
+        min_internal_id: u64,
     ) -> Result<Vec<JobItem>, DatabaseError> {
         let start = Instant::now();
         // Convert enums to Bson strings
@@ -865,12 +865,10 @@ impl DatabaseClient for MongoDbClient {
         if let Some(version) = &orchestrator_version {
             match_filter.insert("metadata.common.orchestrator_version", version.as_str());
         }
-        if let Some(min_internal_id) = min_internal_id {
-            // If the caller somehow passes a value Mongo cannot represent as i64,
-            // fall back to the broad scan instead of filtering out real work.
-            let min_internal_id = i64::try_from(min_internal_id).unwrap_or(0);
-            match_filter.insert("internal_id", doc! { "$gte": min_internal_id });
-        }
+        // If the caller somehow passes a value Mongo cannot represent as i64,
+        // fall back to the broad scan instead of filtering out real work.
+        let min_internal_id = i64::try_from(min_internal_id).unwrap_or(0);
+        match_filter.insert("internal_id", doc! { "$gte": min_internal_id });
 
         // Construct the aggregation pipeline
         let pipeline = vec![
@@ -1483,7 +1481,7 @@ impl DatabaseClient for MongoDbClient {
         snos_batch_status: SnosBatchStatus,
         limit: u64,
         orchestrator_version: Option<String>,
-        min_index: Option<u64>,
+        min_index: u64,
     ) -> Result<Vec<SnosBatch>, DatabaseError> {
         let start = Instant::now();
 
@@ -1498,12 +1496,10 @@ impl DatabaseClient for MongoDbClient {
         if let Some(version) = &orchestrator_version {
             match_filter.insert("orchestrator_version", version.as_str());
         }
-        if let Some(min_index) = min_index {
-            // If the caller somehow passes a value Mongo cannot represent as i64,
-            // fall back to the broad scan instead of filtering out real work.
-            let min_index = i64::try_from(min_index).unwrap_or(0);
-            match_filter.insert("index", doc! { "$gte": min_index });
-        }
+        // If the caller somehow passes a value Mongo cannot represent as i64,
+        // fall back to the broad scan instead of filtering out real work.
+        let min_index = i64::try_from(min_index).unwrap_or(0);
+        match_filter.insert("index", doc! { "$gte": min_index });
 
         // Construct the aggregation pipeline
         let pipeline = vec![

--- a/orchestrator/src/tests/database/mod.rs
+++ b/orchestrator/src/tests/database/mod.rs
@@ -113,7 +113,7 @@ async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
 
     // Test without version filter
     let jobs_without_successor = database_client
-        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None)
+        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, None)
         .await
         .unwrap();
 
@@ -134,6 +134,7 @@ async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
             JobStatus::Completed,
             JobType::ProofCreation,
             Some(current_version),
+            None,
         )
         .await
         .unwrap();
@@ -152,6 +153,7 @@ async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
             JobStatus::Completed,
             JobType::ProofCreation,
             Some("old-version".to_string()),
+            None,
         )
         .await
         .unwrap();
@@ -185,13 +187,33 @@ async fn database_get_jobs_without_successor_returns_missing_jobs_oldest_first()
     }
 
     let jobs_without_successor = database_client
-        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None)
+        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, None)
         .await
         .unwrap();
 
     let returned_ids: Vec<u64> = jobs_without_successor.iter().map(|job| job.internal_id).collect();
 
     assert_eq!(returned_ids, vec![1, backlog_size], "Expected the oldest missing jobs in oldest-first order");
+}
+
+#[rstest]
+#[tokio::test]
+async fn database_get_jobs_without_successor_respects_min_internal_id() {
+    let services = TestConfigBuilder::new().configure_database(ConfigType::Actual).build().await;
+    let config = services.config;
+    let database_client = config.database();
+
+    database_client.create_job(build_job_item(JobType::SnosRun, JobStatus::Completed, 1)).await.unwrap();
+    database_client.create_job(build_job_item(JobType::SnosRun, JobStatus::Completed, 2)).await.unwrap();
+    database_client.create_job(build_job_item(JobType::SnosRun, JobStatus::Completed, 3)).await.unwrap();
+
+    let jobs_without_successor = database_client
+        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, Some(2))
+        .await
+        .unwrap();
+
+    let returned_ids: Vec<u64> = jobs_without_successor.iter().map(|job| job.internal_id).collect();
+    assert_eq!(returned_ids, vec![2, 3]);
 }
 
 /// Test for `get_latest_job_by_type` operation in database trait.
@@ -786,29 +808,49 @@ async fn test_get_snos_batches_without_jobs() {
 
     // Test without version filter - should return batches 2 and 3 (no jobs)
     let batches_without_jobs =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None).await.unwrap();
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, None).await.unwrap();
     assert_eq!(batches_without_jobs.len(), 2);
     assert!(batches_without_jobs.iter().any(|b| b.index == 2));
     assert!(batches_without_jobs.iter().any(|b| b.index == 3));
 
     // Test with current version filter - should only return batch 2
     let current_version = crate::types::constant::ORCHESTRATOR_VERSION.to_string();
-    let current_version_batches =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some(current_version)).await.unwrap();
+    let current_version_batches = database_client
+        .get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some(current_version), None)
+        .await
+        .unwrap();
     assert_eq!(current_version_batches.len(), 1);
     assert_eq!(current_version_batches[0].index, 2);
 
     // Test with old version filter - should only return batch 3
     let old_version_batches = database_client
-        .get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some("old-version".to_string()))
+        .get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some("old-version".to_string()), None)
         .await
         .unwrap();
     assert_eq!(old_version_batches.len(), 1);
     assert_eq!(old_version_batches[0].index, 3);
 }
 
-/// Regression test for `get_snos_batches_without_jobs`.
-/// Ensures the oldest missing batch is returned even when newer candidates exceed the former scan limit.
+#[rstest]
+#[tokio::test]
+async fn test_get_snos_batches_without_jobs_respects_min_index() {
+    let services = TestConfigBuilder::new().configure_database(ConfigType::Actual).build().await;
+    let config = services.config;
+    let database_client = config.database();
+
+    for index in 1..=3 {
+        let mut batch = build_snos_batch(index, Some(100), 200 + index);
+        batch.status = SnosBatchStatus::Closed;
+        database_client.create_snos_batch(batch).await.unwrap();
+    }
+
+    let batches_without_jobs =
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, Some(2)).await.unwrap();
+
+    let returned_ids: Vec<u64> = batches_without_jobs.iter().map(|batch| batch.index).collect();
+    assert_eq!(returned_ids, vec![2, 3]);
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_get_snos_batches_without_jobs_returns_oldest_missing_across_large_backlog() {
@@ -829,9 +871,9 @@ async fn test_get_snos_batches_without_jobs_returns_oldest_missing_across_large_
     }
 
     let oldest_missing_batch =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 1, None).await.unwrap();
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 1, None, None).await.unwrap();
     let first_two_missing_batches =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 2, None).await.unwrap();
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 2, None, None).await.unwrap();
 
     assert_eq!(oldest_missing_batch.len(), 1);
     assert_eq!(oldest_missing_batch[0].index, 1, "Expected the oldest missing batch overall");

--- a/orchestrator/src/tests/database/mod.rs
+++ b/orchestrator/src/tests/database/mod.rs
@@ -113,7 +113,7 @@ async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
 
     // Test without version filter
     let jobs_without_successor = database_client
-        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, None)
+        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, 0)
         .await
         .unwrap();
 
@@ -134,7 +134,7 @@ async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
             JobStatus::Completed,
             JobType::ProofCreation,
             Some(current_version),
-            None,
+            0,
         )
         .await
         .unwrap();
@@ -153,7 +153,7 @@ async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
             JobStatus::Completed,
             JobType::ProofCreation,
             Some("old-version".to_string()),
-            None,
+            0,
         )
         .await
         .unwrap();
@@ -187,7 +187,7 @@ async fn database_get_jobs_without_successor_returns_missing_jobs_oldest_first()
     }
 
     let jobs_without_successor = database_client
-        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, None)
+        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, 0)
         .await
         .unwrap();
 
@@ -208,7 +208,7 @@ async fn database_get_jobs_without_successor_respects_min_internal_id() {
     database_client.create_job(build_job_item(JobType::SnosRun, JobStatus::Completed, 3)).await.unwrap();
 
     let jobs_without_successor = database_client
-        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, Some(2))
+        .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation, None, 2)
         .await
         .unwrap();
 
@@ -808,7 +808,7 @@ async fn test_get_snos_batches_without_jobs() {
 
     // Test without version filter - should return batches 2 and 3 (no jobs)
     let batches_without_jobs =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, None).await.unwrap();
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, 0).await.unwrap();
     assert_eq!(batches_without_jobs.len(), 2);
     assert!(batches_without_jobs.iter().any(|b| b.index == 2));
     assert!(batches_without_jobs.iter().any(|b| b.index == 3));
@@ -816,7 +816,7 @@ async fn test_get_snos_batches_without_jobs() {
     // Test with current version filter - should only return batch 2
     let current_version = crate::types::constant::ORCHESTRATOR_VERSION.to_string();
     let current_version_batches = database_client
-        .get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some(current_version), None)
+        .get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some(current_version), 0)
         .await
         .unwrap();
     assert_eq!(current_version_batches.len(), 1);
@@ -824,7 +824,7 @@ async fn test_get_snos_batches_without_jobs() {
 
     // Test with old version filter - should only return batch 3
     let old_version_batches = database_client
-        .get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some("old-version".to_string()), None)
+        .get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, Some("old-version".to_string()), 0)
         .await
         .unwrap();
     assert_eq!(old_version_batches.len(), 1);
@@ -845,7 +845,7 @@ async fn test_get_snos_batches_without_jobs_respects_min_index() {
     }
 
     let batches_without_jobs =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, Some(2)).await.unwrap();
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, 2).await.unwrap();
 
     let returned_ids: Vec<u64> = batches_without_jobs.iter().map(|batch| batch.index).collect();
     assert_eq!(returned_ids, vec![2, 3]);
@@ -871,9 +871,9 @@ async fn test_get_snos_batches_without_jobs_returns_oldest_missing_across_large_
     }
 
     let oldest_missing_batch =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 1, None, None).await.unwrap();
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 1, None, 0).await.unwrap();
     let first_two_missing_batches =
-        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 2, None, None).await.unwrap();
+        database_client.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 2, None, 0).await.unwrap();
 
     assert_eq!(oldest_missing_batch.len(), 1);
     assert_eq!(oldest_missing_batch[0].index, 1, "Expected the oldest missing batch overall");

--- a/orchestrator/src/tests/database/mod.rs
+++ b/orchestrator/src/tests/database/mod.rs
@@ -244,6 +244,29 @@ async fn database_get_last_successful_job_by_type_works() {
     assert_eq!(last_successful_job, job_vec[2], "Expected job assertion failed");
 }
 
+/// Test for `get_latest_job_by_type_and_status` operation in database trait.
+#[rstest]
+#[tokio::test]
+async fn database_get_latest_job_by_type_and_status_skips_newer_jobs_with_other_statuses() {
+    let services = TestConfigBuilder::new().configure_database(ConfigType::Actual).build().await;
+    let config = services.config;
+    let database_client = config.database();
+
+    let completed_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 7);
+    let newer_in_progress_job = build_job_item(JobType::StateTransition, JobStatus::LockedForProcessing, 8);
+
+    database_client.create_job(completed_job.clone()).await.unwrap();
+    database_client.create_job(newer_in_progress_job).await.unwrap();
+
+    let latest_completed = database_client
+        .get_latest_job_by_type_and_status(JobType::StateTransition, JobStatus::Completed, None)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(latest_completed, completed_job);
+}
+
 /// Test for `get_oldest_job_by_type_excluding_statuses` operation in database trait.
 /// Creates jobs with different statuses and verifies the method returns the oldest job
 /// whose status is not in the excluded list.

--- a/orchestrator/src/tests/workers/batching/mod.rs
+++ b/orchestrator/src/tests/workers/batching/mod.rs
@@ -504,8 +504,8 @@ async fn test_batching_worker_l3(#[case] has_existing_batch: bool) -> Result<(),
 
     SnosBatchingTrigger.run_worker(services.config.clone()).await?;
 
-    let snos_batches_closed = database.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None).await?;
-    let snos_batches_open = database.get_snos_batches_without_jobs(SnosBatchStatus::Open, 5, None).await?;
+    let snos_batches_closed = database.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, None).await?;
+    let snos_batches_open = database.get_snos_batches_without_jobs(SnosBatchStatus::Open, 5, None, None).await?;
 
     assert_eq!(snos_batches_closed.len(), 2);
     assert_eq!(snos_batches_open.len(), 1);

--- a/orchestrator/src/tests/workers/batching/mod.rs
+++ b/orchestrator/src/tests/workers/batching/mod.rs
@@ -504,8 +504,8 @@ async fn test_batching_worker_l3(#[case] has_existing_batch: bool) -> Result<(),
 
     SnosBatchingTrigger.run_worker(services.config.clone()).await?;
 
-    let snos_batches_closed = database.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, None).await?;
-    let snos_batches_open = database.get_snos_batches_without_jobs(SnosBatchStatus::Open, 5, None, None).await?;
+    let snos_batches_closed = database.get_snos_batches_without_jobs(SnosBatchStatus::Closed, 5, None, 0).await?;
+    let snos_batches_open = database.get_snos_batches_without_jobs(SnosBatchStatus::Open, 5, None, 0).await?;
 
     assert_eq!(snos_batches_closed.len(), 2);
     assert_eq!(snos_batches_open.len(), 1);

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -81,7 +81,9 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
             .returning(move |_| Ok(Some(SnosBatch { index: i, ..Default::default() })));
     }
 
-    db.expect_get_latest_job_by_type().with(eq(JobType::StateTransition), eq(None)).returning(move |_, _| Ok(None));
+    db.expect_get_latest_job_by_type_and_status()
+        .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+        .returning(move |_, _, _| Ok(None));
 
     // Mock db call for getting successful SNOS jobs without successor
     db.expect_get_jobs_without_successor()

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -81,15 +81,18 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
             .returning(move |_| Ok(Some(SnosBatch { index: i, ..Default::default() })));
     }
 
+    db.expect_get_latest_job_by_type().with(eq(JobType::StateTransition), eq(None)).returning(move |_, _| Ok(None));
+
     // Mock db call for getting successful SNOS jobs without successor
     db.expect_get_jobs_without_successor()
         .times(1)
-        .withf(|job_type, job_status, successor_type, _orchestrator_version| {
+        .withf(|job_type, job_status, successor_type, _orchestrator_version, min_internal_id| {
             *job_type == JobType::SnosRun
                 && *job_status == JobStatus::Completed
                 && *successor_type == JobType::ProofCreation
+                && min_internal_id.is_none()
         })
-        .returning(move |_, _, _, _| Ok(snos_jobs.clone()));
+        .returning(move |_, _, _, _, _| Ok(snos_jobs.clone()));
 
     let expected_proving_jobs = if incomplete_runs { 4 } else { 5 };
     db.expect_get_snos_batches()

--- a/orchestrator/src/tests/workers/proving/mod.rs
+++ b/orchestrator/src/tests/workers/proving/mod.rs
@@ -90,7 +90,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
             *job_type == JobType::SnosRun
                 && *job_status == JobStatus::Completed
                 && *successor_type == JobType::ProofCreation
-                && min_internal_id.is_none()
+                && *min_internal_id == 0
         })
         .returning(move |_, _, _, _, _| Ok(snos_jobs.clone()));
 

--- a/orchestrator/src/tests/workers/snos/mod.rs
+++ b/orchestrator/src/tests/workers/snos/mod.rs
@@ -50,11 +50,15 @@ async fn test_snos_worker(#[case] completed_snos_batches: Vec<u64>) -> Result<()
         .with(eq(JobType::SnosRun), eq(vec![JobStatus::Completed]), eq(Some(ORCHESTRATOR_VERSION.to_string())))
         .returning(move |_, _, _| Ok(Some(get_job_item_mock_by_id(10, Uuid::new_v4()))));
 
+    db.expect_get_latest_job_by_type().with(eq(JobType::StateTransition), eq(None)).returning(move |_, _| Ok(None));
+
     db.expect_get_snos_batches_without_jobs()
-        .withf(|job_status, limit, _orchestrator_version| matches!(job_status, SnosBatchStatus::Closed) && *limit == 39)
+        .withf(|job_status, limit, _orchestrator_version, min_index| {
+            matches!(job_status, SnosBatchStatus::Closed) && *limit == 39 && min_index.is_none()
+        })
         .returning({
             let completed_snos_batches = completed_snos_batches.clone();
-            move |_, _, _| {
+            move |_, _, _, _| {
                 Ok(completed_snos_batches
                     .iter()
                     .map(|&index| {
@@ -165,11 +169,15 @@ async fn test_create_snos_job_for_existing_batch(
         .with(eq(JobType::SnosRun), eq(vec![JobStatus::Completed]), eq(Some(ORCHESTRATOR_VERSION.to_string())))
         .returning(move |_, _, _| Ok(Some(get_job_item_mock_by_id(10, Uuid::new_v4()))));
 
+    db.expect_get_latest_job_by_type().with(eq(JobType::StateTransition), eq(None)).returning(move |_, _| Ok(None));
+
     db.expect_get_snos_batches_without_jobs()
-        .withf(|job_status, limit, _orchestrator_version| matches!(job_status, SnosBatchStatus::Closed) && *limit == 39)
+        .withf(|job_status, limit, _orchestrator_version, min_index| {
+            matches!(job_status, SnosBatchStatus::Closed) && *limit == 39 && min_index.is_none()
+        })
         .returning({
             let completed_snos_batches = completed_snos_batches.clone();
-            move |_, _, _| {
+            move |_, _, _, _| {
                 Ok(completed_snos_batches
                     .iter()
                     .map(|&index| {

--- a/orchestrator/src/tests/workers/snos/mod.rs
+++ b/orchestrator/src/tests/workers/snos/mod.rs
@@ -50,7 +50,9 @@ async fn test_snos_worker(#[case] completed_snos_batches: Vec<u64>) -> Result<()
         .with(eq(JobType::SnosRun), eq(vec![JobStatus::Completed]), eq(Some(ORCHESTRATOR_VERSION.to_string())))
         .returning(move |_, _, _| Ok(Some(get_job_item_mock_by_id(10, Uuid::new_v4()))));
 
-    db.expect_get_latest_job_by_type().with(eq(JobType::StateTransition), eq(None)).returning(move |_, _| Ok(None));
+    db.expect_get_latest_job_by_type_and_status()
+        .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+        .returning(move |_, _, _| Ok(None));
 
     db.expect_get_snos_batches_without_jobs()
         .withf(|job_status, limit, _orchestrator_version, min_index| {
@@ -169,7 +171,9 @@ async fn test_create_snos_job_for_existing_batch(
         .with(eq(JobType::SnosRun), eq(vec![JobStatus::Completed]), eq(Some(ORCHESTRATOR_VERSION.to_string())))
         .returning(move |_, _, _| Ok(Some(get_job_item_mock_by_id(10, Uuid::new_v4()))));
 
-    db.expect_get_latest_job_by_type().with(eq(JobType::StateTransition), eq(None)).returning(move |_, _| Ok(None));
+    db.expect_get_latest_job_by_type_and_status()
+        .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+        .returning(move |_, _, _| Ok(None));
 
     db.expect_get_snos_batches_without_jobs()
         .withf(|job_status, limit, _orchestrator_version, min_index| {

--- a/orchestrator/src/tests/workers/snos/mod.rs
+++ b/orchestrator/src/tests/workers/snos/mod.rs
@@ -54,7 +54,7 @@ async fn test_snos_worker(#[case] completed_snos_batches: Vec<u64>) -> Result<()
 
     db.expect_get_snos_batches_without_jobs()
         .withf(|job_status, limit, _orchestrator_version, min_index| {
-            matches!(job_status, SnosBatchStatus::Closed) && *limit == 39 && min_index.is_none()
+            matches!(job_status, SnosBatchStatus::Closed) && *limit == 39 && *min_index == 0
         })
         .returning({
             let completed_snos_batches = completed_snos_batches.clone();
@@ -173,7 +173,7 @@ async fn test_create_snos_job_for_existing_batch(
 
     db.expect_get_snos_batches_without_jobs()
         .withf(|job_status, limit, _orchestrator_version, min_index| {
-            matches!(job_status, SnosBatchStatus::Closed) && *limit == 39 && min_index.is_none()
+            matches!(job_status, SnosBatchStatus::Closed) && *limit == 39 && *min_index == 0
         })
         .returning({
             let completed_snos_batches = completed_snos_batches.clone();

--- a/orchestrator/src/worker/event_handler/triggers/data_submission_worker.rs
+++ b/orchestrator/src/worker/event_handler/triggers/data_submission_worker.rs
@@ -31,6 +31,7 @@ impl JobTrigger for DataSubmissionJobTrigger {
                 JobStatus::Completed,
                 JobType::DataSubmission,
                 Some(ORCHESTRATOR_VERSION.to_string()),
+                None,
             )
             .await?;
 

--- a/orchestrator/src/worker/event_handler/triggers/data_submission_worker.rs
+++ b/orchestrator/src/worker/event_handler/triggers/data_submission_worker.rs
@@ -31,7 +31,7 @@ impl JobTrigger for DataSubmissionJobTrigger {
                 JobStatus::Completed,
                 JobType::DataSubmission,
                 Some(ORCHESTRATOR_VERSION.to_string()),
-                None,
+                0,
             )
             .await?;
 

--- a/orchestrator/src/worker/event_handler/triggers/mod.rs
+++ b/orchestrator/src/worker/event_handler/triggers/mod.rs
@@ -72,35 +72,39 @@ pub(crate) async fn calculate_jobs_to_create(
     Ok(compute_buffer_slots(latest, oldest_incomplete, buffer_size))
 }
 
-pub(crate) async fn first_unsettled_snos_batch_index(config: &Arc<Config>) -> color_eyre::Result<Option<u64>> {
+/// Returns the first SNOS batch index that may still need downstream work.
+///
+/// Missing or untrusted watermarks fall back to `0`, which preserves the old
+/// broad scan. The high sentinel is reserved for the confirmed caught-up case,
+/// where scanning history would only rediscover already-settled work.
+pub(crate) async fn first_unsettled_snos_batch_index_or_zero(config: &Arc<Config>) -> color_eyre::Result<u64> {
     let Some(state_transition_job) = config.database().get_latest_job_by_type(JobType::StateTransition, None).await?
     else {
-        return Ok(None);
+        return Ok(0);
     };
 
     if state_transition_job.status != JobStatus::Completed {
-        return Ok(None);
+        return Ok(0);
     }
 
     let state_metadata: StateUpdateMetadata = state_transition_job.metadata.specific.try_into()?;
     match (config.layer(), state_metadata.context) {
-        (Layer::L2, SettlementContext::Batch(batch)) => Ok(Some(
-            config
-                .database()
-                .get_snos_batches_by_aggregator_index(batch.to_settle.saturating_add(1))
-                .await?
-                .first()
-                // No SNOS batch exists for the next aggregator batch yet, so the
-                // pipeline is caught up; use a high lower bound to avoid scanning history.
-                .map_or(NO_UNSETTLED_SNOS_BATCH_INDEX, |batch| batch.index),
-        )),
+        (Layer::L2, SettlementContext::Batch(batch)) => {
+            let snos_batches =
+                config.database().get_snos_batches_by_aggregator_index(batch.to_settle.saturating_add(1)).await?;
+
+            // No SNOS batch exists for the next aggregator batch yet, so the
+            // pipeline is caught up; use a high lower bound to avoid scanning history.
+            Ok(snos_batches.first().map_or(NO_UNSETTLED_SNOS_BATCH_INDEX, |batch| batch.index))
+        }
         (Layer::L2, SettlementContext::Block(block)) => Ok(config
             .database()
             .get_block_batch_lookup(block.to_settle.saturating_add(1))
             .await?
-            .and_then(|lookup| lookup.snos_batch_index)),
-        (Layer::L3, SettlementContext::Block(block)) => Ok(Some(block.to_settle.saturating_add(1))),
-        (Layer::L3, SettlementContext::Batch(batch)) => Ok(Some(batch.to_settle.saturating_add(1))),
+            .and_then(|lookup| lookup.snos_batch_index)
+            .unwrap_or(0)),
+        (Layer::L3, SettlementContext::Block(block)) => Ok(block.to_settle.saturating_add(1)),
+        (Layer::L3, SettlementContext::Batch(batch)) => Ok(batch.to_settle.saturating_add(1)),
     }
 }
 
@@ -162,7 +166,7 @@ pub trait JobTrigger: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_buffer_slots, first_unsettled_snos_batch_index};
+    use super::{compute_buffer_slots, first_unsettled_snos_batch_index_or_zero};
     use crate::core::client::database::MockDatabaseClient;
     use crate::tests::config::TestConfigBuilder;
     use crate::tests::utils::build_job_item;
@@ -202,7 +206,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn first_unsettled_snos_batch_index_returns_l2_batch_watermark() {
+    async fn first_unsettled_snos_batch_index_or_zero_returns_l2_batch_watermark() {
         let mut database = MockDatabaseClient::new();
         let mut state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 7);
         state_transition_job.metadata.specific = JobSpecificMetadata::StateUpdate(StateUpdateMetadata {
@@ -222,11 +226,11 @@ mod tests {
         let services =
             TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
 
-        assert_eq!(first_unsettled_snos_batch_index(&services.config).await.unwrap(), Some(42));
+        assert_eq!(first_unsettled_snos_batch_index_or_zero(&services.config).await.unwrap(), 42);
     }
 
     #[tokio::test]
-    async fn first_unsettled_snos_batch_index_maps_l2_block_watermark() {
+    async fn first_unsettled_snos_batch_index_or_zero_maps_l2_block_watermark() {
         let mut database = MockDatabaseClient::new();
         let state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 100);
 
@@ -248,6 +252,39 @@ mod tests {
         let services =
             TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
 
-        assert_eq!(first_unsettled_snos_batch_index(&services.config).await.unwrap(), Some(55));
+        assert_eq!(first_unsettled_snos_batch_index_or_zero(&services.config).await.unwrap(), 55);
+    }
+
+    #[tokio::test]
+    async fn first_unsettled_snos_batch_index_or_zero_returns_zero_without_state_transition() {
+        let mut database = MockDatabaseClient::new();
+
+        database
+            .expect_get_latest_job_by_type()
+            .with(eq(JobType::StateTransition), eq(None))
+            .returning(move |_, _| Ok(None));
+
+        let services =
+            TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
+
+        assert_eq!(first_unsettled_snos_batch_index_or_zero(&services.config).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn first_unsettled_snos_batch_index_or_zero_returns_zero_when_l2_block_lookup_is_missing() {
+        let mut database = MockDatabaseClient::new();
+        let state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 100);
+
+        database
+            .expect_get_latest_job_by_type()
+            .with(eq(JobType::StateTransition), eq(None))
+            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+        database.expect_get_snos_batches_by_aggregator_index().times(0);
+        database.expect_get_block_batch_lookup().with(eq(101)).returning(|_| Ok(None));
+
+        let services =
+            TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
+
+        assert_eq!(first_unsettled_snos_batch_index_or_zero(&services.config).await.unwrap(), 0);
     }
 }

--- a/orchestrator/src/worker/event_handler/triggers/mod.rs
+++ b/orchestrator/src/worker/event_handler/triggers/mod.rs
@@ -78,14 +78,13 @@ pub(crate) async fn calculate_jobs_to_create(
 /// broad scan. The high sentinel is reserved for the confirmed caught-up case,
 /// where scanning history would only rediscover already-settled work.
 pub(crate) async fn first_unsettled_snos_batch_index_or_zero(config: &Arc<Config>) -> color_eyre::Result<u64> {
-    let Some(state_transition_job) = config.database().get_latest_job_by_type(JobType::StateTransition, None).await?
+    let Some(state_transition_job) = config
+        .database()
+        .get_latest_job_by_type_and_status(JobType::StateTransition, JobStatus::Completed, None)
+        .await?
     else {
         return Ok(0);
     };
-
-    if state_transition_job.status != JobStatus::Completed {
-        return Ok(0);
-    }
 
     let state_metadata: StateUpdateMetadata = state_transition_job.metadata.specific.try_into()?;
     match (config.layer(), state_metadata.context) {
@@ -215,9 +214,9 @@ mod tests {
         });
 
         database
-            .expect_get_latest_job_by_type()
-            .with(eq(JobType::StateTransition), eq(None))
-            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+            .expect_get_latest_job_by_type_and_status()
+            .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+            .returning(move |_, _, _| Ok(Some(state_transition_job.clone())));
         database
             .expect_get_snos_batches_by_aggregator_index()
             .with(eq(8))
@@ -239,9 +238,9 @@ mod tests {
         });
 
         database
-            .expect_get_latest_job_by_type()
-            .with(eq(JobType::StateTransition), eq(None))
-            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+            .expect_get_latest_job_by_type_and_status()
+            .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+            .returning(move |_, _, _| Ok(Some(state_transition_job.clone())));
         database.expect_get_snos_batches_by_aggregator_index().with(eq(8)).returning(|_| Ok(vec![]));
 
         let services =
@@ -259,9 +258,9 @@ mod tests {
         let state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 100);
 
         database
-            .expect_get_latest_job_by_type()
-            .with(eq(JobType::StateTransition), eq(None))
-            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+            .expect_get_latest_job_by_type_and_status()
+            .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+            .returning(move |_, _, _| Ok(Some(state_transition_job.clone())));
         database.expect_get_snos_batches_by_aggregator_index().times(0);
         database.expect_get_block_batch_lookup().with(eq(101)).returning(|_| {
             Ok(Some(BlockBatchLookup {
@@ -284,9 +283,9 @@ mod tests {
         let mut database = MockDatabaseClient::new();
 
         database
-            .expect_get_latest_job_by_type()
-            .with(eq(JobType::StateTransition), eq(None))
-            .returning(move |_, _| Ok(None));
+            .expect_get_latest_job_by_type_and_status()
+            .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+            .returning(move |_, _, _| Ok(None));
 
         let services =
             TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
@@ -300,9 +299,9 @@ mod tests {
         let state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 100);
 
         database
-            .expect_get_latest_job_by_type()
-            .with(eq(JobType::StateTransition), eq(None))
-            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+            .expect_get_latest_job_by_type_and_status()
+            .with(eq(JobType::StateTransition), eq(JobStatus::Completed), eq(None))
+            .returning(move |_, _, _| Ok(Some(state_transition_job.clone())));
         database.expect_get_snos_batches_by_aggregator_index().times(0);
         database.expect_get_block_batch_lookup().with(eq(101)).returning(|_| Ok(None));
 

--- a/orchestrator/src/worker/event_handler/triggers/mod.rs
+++ b/orchestrator/src/worker/event_handler/triggers/mod.rs
@@ -11,8 +11,10 @@ pub(crate) mod update_state;
 
 use crate::core::config::Config;
 use crate::types::constant::ORCHESTRATOR_VERSION;
+use crate::types::jobs::metadata::{SettlementContext, StateUpdateMetadata};
 use crate::types::jobs::types::{JobStatus, JobType};
 use async_trait::async_trait;
+use orchestrator_utils::layer::Layer;
 use std::sync::Arc;
 
 /// Pure helper that computes the buffer slots available for new job creation
@@ -66,6 +68,35 @@ pub(crate) async fn calculate_jobs_to_create(
         .map(|j| j.internal_id);
 
     Ok(compute_buffer_slots(latest, oldest_incomplete, buffer_size))
+}
+
+pub(crate) async fn first_unsettled_snos_batch_index(config: &Arc<Config>) -> color_eyre::Result<Option<u64>> {
+    let Some(state_transition_job) = config.database().get_latest_job_by_type(JobType::StateTransition, None).await?
+    else {
+        return Ok(None);
+    };
+
+    if state_transition_job.status != JobStatus::Completed {
+        return Ok(None);
+    }
+
+    let state_metadata: StateUpdateMetadata = state_transition_job.metadata.specific.try_into()?;
+    let last_settled = match state_metadata.context {
+        SettlementContext::Block(block) => block.to_settle,
+        SettlementContext::Batch(batch) => batch.to_settle,
+    };
+
+    match config.layer() {
+        Layer::L2 => Ok(Some(
+            config
+                .database()
+                .get_snos_batches_by_aggregator_index(last_settled.saturating_add(1))
+                .await?
+                .first()
+                .map_or(i64::MAX as u64, |batch| batch.index),
+        )),
+        Layer::L3 => Ok(Some(last_settled.saturating_add(1))),
+    }
 }
 
 #[async_trait]

--- a/orchestrator/src/worker/event_handler/triggers/mod.rs
+++ b/orchestrator/src/worker/event_handler/triggers/mod.rs
@@ -17,6 +17,8 @@ use async_trait::async_trait;
 use orchestrator_utils::layer::Layer;
 use std::sync::Arc;
 
+const NO_UNSETTLED_SNOS_BATCH_INDEX: u64 = i64::MAX as u64;
+
 /// Pure helper that computes the buffer slots available for new job creation
 /// given the current `[oldest-incomplete, latest]` window.
 ///
@@ -81,21 +83,24 @@ pub(crate) async fn first_unsettled_snos_batch_index(config: &Arc<Config>) -> co
     }
 
     let state_metadata: StateUpdateMetadata = state_transition_job.metadata.specific.try_into()?;
-    let last_settled = match state_metadata.context {
-        SettlementContext::Block(block) => block.to_settle,
-        SettlementContext::Batch(batch) => batch.to_settle,
-    };
-
-    match config.layer() {
-        Layer::L2 => Ok(Some(
+    match (config.layer(), state_metadata.context) {
+        (Layer::L2, SettlementContext::Batch(batch)) => Ok(Some(
             config
                 .database()
-                .get_snos_batches_by_aggregator_index(last_settled.saturating_add(1))
+                .get_snos_batches_by_aggregator_index(batch.to_settle.saturating_add(1))
                 .await?
                 .first()
-                .map_or(i64::MAX as u64, |batch| batch.index),
+                // No SNOS batch exists for the next aggregator batch yet, so the
+                // pipeline is caught up; use a high lower bound to avoid scanning history.
+                .map_or(NO_UNSETTLED_SNOS_BATCH_INDEX, |batch| batch.index),
         )),
-        Layer::L3 => Ok(Some(last_settled.saturating_add(1))),
+        (Layer::L2, SettlementContext::Block(block)) => Ok(config
+            .database()
+            .get_block_batch_lookup(block.to_settle.saturating_add(1))
+            .await?
+            .and_then(|lookup| lookup.snos_batch_index)),
+        (Layer::L3, SettlementContext::Block(block)) => Ok(Some(block.to_settle.saturating_add(1))),
+        (Layer::L3, SettlementContext::Batch(batch)) => Ok(Some(batch.to_settle.saturating_add(1))),
     }
 }
 
@@ -157,7 +162,18 @@ pub trait JobTrigger: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::compute_buffer_slots;
+    use super::{compute_buffer_slots, first_unsettled_snos_batch_index};
+    use crate::core::client::database::MockDatabaseClient;
+    use crate::tests::config::TestConfigBuilder;
+    use crate::tests::utils::build_job_item;
+    use crate::types::batch::{BlockBatchLookup, SnosBatch};
+    use crate::types::jobs::metadata::{
+        JobSpecificMetadata, SettlementContext, SettlementContextData, StateUpdateMetadata,
+    };
+    use crate::types::jobs::types::{JobStatus, JobType};
+    use chrono::{SubsecRound, Utc};
+    use mockall::predicate::eq;
+    use orchestrator_utils::layer::Layer;
     use rstest::rstest;
 
     #[rstest]
@@ -183,5 +199,55 @@ mod tests {
         #[case] expected: u64,
     ) {
         assert_eq!(compute_buffer_slots(latest, oldest_incomplete, buffer_size), expected);
+    }
+
+    #[tokio::test]
+    async fn first_unsettled_snos_batch_index_returns_l2_batch_watermark() {
+        let mut database = MockDatabaseClient::new();
+        let mut state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 7);
+        state_transition_job.metadata.specific = JobSpecificMetadata::StateUpdate(StateUpdateMetadata {
+            context: SettlementContext::Batch(SettlementContextData { to_settle: 7, last_failed: None }),
+            ..Default::default()
+        });
+
+        database
+            .expect_get_latest_job_by_type()
+            .with(eq(JobType::StateTransition), eq(None))
+            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+        database
+            .expect_get_snos_batches_by_aggregator_index()
+            .with(eq(8))
+            .returning(|_| Ok(vec![SnosBatch { index: 42, aggregator_batch_index: Some(8), ..Default::default() }]));
+
+        let services =
+            TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
+
+        assert_eq!(first_unsettled_snos_batch_index(&services.config).await.unwrap(), Some(42));
+    }
+
+    #[tokio::test]
+    async fn first_unsettled_snos_batch_index_maps_l2_block_watermark() {
+        let mut database = MockDatabaseClient::new();
+        let state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 100);
+
+        database
+            .expect_get_latest_job_by_type()
+            .with(eq(JobType::StateTransition), eq(None))
+            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+        database.expect_get_snos_batches_by_aggregator_index().times(0);
+        database.expect_get_block_batch_lookup().with(eq(101)).returning(|_| {
+            Ok(Some(BlockBatchLookup {
+                block_number: 101,
+                snos_batch_index: Some(55),
+                aggregator_batch_index: Some(9),
+                created_at: None,
+                updated_at: Utc::now().round_subsecs(0),
+            }))
+        });
+
+        let services =
+            TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
+
+        assert_eq!(first_unsettled_snos_batch_index(&services.config).await.unwrap(), Some(55));
     }
 }

--- a/orchestrator/src/worker/event_handler/triggers/mod.rs
+++ b/orchestrator/src/worker/event_handler/triggers/mod.rs
@@ -166,7 +166,7 @@ pub trait JobTrigger: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_buffer_slots, first_unsettled_snos_batch_index_or_zero};
+    use super::{compute_buffer_slots, first_unsettled_snos_batch_index_or_zero, NO_UNSETTLED_SNOS_BATCH_INDEX};
     use crate::core::client::database::MockDatabaseClient;
     use crate::tests::config::TestConfigBuilder;
     use crate::tests::utils::build_job_item;
@@ -227,6 +227,30 @@ mod tests {
             TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
 
         assert_eq!(first_unsettled_snos_batch_index_or_zero(&services.config).await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn first_unsettled_snos_batch_index_or_zero_returns_sentinel_when_l2_batch_is_caught_up() {
+        let mut database = MockDatabaseClient::new();
+        let mut state_transition_job = build_job_item(JobType::StateTransition, JobStatus::Completed, 7);
+        state_transition_job.metadata.specific = JobSpecificMetadata::StateUpdate(StateUpdateMetadata {
+            context: SettlementContext::Batch(SettlementContextData { to_settle: 7, last_failed: None }),
+            ..Default::default()
+        });
+
+        database
+            .expect_get_latest_job_by_type()
+            .with(eq(JobType::StateTransition), eq(None))
+            .returning(move |_, _| Ok(Some(state_transition_job.clone())));
+        database.expect_get_snos_batches_by_aggregator_index().with(eq(8)).returning(|_| Ok(vec![]));
+
+        let services =
+            TestConfigBuilder::new().configure_database(database.into()).configure_layer(Layer::L2).build().await;
+
+        assert_eq!(
+            first_unsettled_snos_batch_index_or_zero(&services.config).await.unwrap(),
+            NO_UNSETTLED_SNOS_BATCH_INDEX
+        );
     }
 
     #[tokio::test]

--- a/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
+++ b/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
@@ -24,7 +24,7 @@ impl JobTrigger for ProofRegistrationJobTrigger {
                 JobStatus::Completed,
                 JobType::ProofRegistration,
                 Some(ORCHESTRATOR_VERSION.to_string()),
-                None,
+                0,
             )
             .await?;
 

--- a/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
+++ b/orchestrator/src/worker/event_handler/triggers/proof_registration.rs
@@ -24,6 +24,7 @@ impl JobTrigger for ProofRegistrationJobTrigger {
                 JobStatus::Completed,
                 JobType::ProofRegistration,
                 Some(ORCHESTRATOR_VERSION.to_string()),
+                None,
             )
             .await?;
 

--- a/orchestrator/src/worker/event_handler/triggers/proving.rs
+++ b/orchestrator/src/worker/event_handler/triggers/proving.rs
@@ -6,7 +6,7 @@ use crate::types::jobs::metadata::{
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
-use crate::worker::event_handler::triggers::JobTrigger;
+use crate::worker::event_handler::triggers::{first_unsettled_snos_batch_index, JobTrigger};
 use async_trait::async_trait;
 use opentelemetry::KeyValue;
 use orchestrator_utils::layer::Layer;
@@ -20,6 +20,7 @@ impl JobTrigger for ProvingJobTrigger {
     /// 1. Fetch all successful SNOS job runs that don't have a proving job
     /// 2. Create a proving job for each SNOS job run
     async fn run_worker(&self, config: Arc<Config>) -> color_eyre::Result<()> {
+        let min_snos_batch_index = first_unsettled_snos_batch_index(&config).await?;
         let successful_snos_jobs = config
             .database()
             .get_jobs_without_successor(
@@ -27,6 +28,7 @@ impl JobTrigger for ProvingJobTrigger {
                 JobStatus::Completed,
                 JobType::ProofCreation,
                 Some(ORCHESTRATOR_VERSION.to_string()),
+                min_snos_batch_index,
             )
             .await?;
 

--- a/orchestrator/src/worker/event_handler/triggers/proving.rs
+++ b/orchestrator/src/worker/event_handler/triggers/proving.rs
@@ -6,7 +6,7 @@ use crate::types::jobs::metadata::{
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
-use crate::worker::event_handler::triggers::{first_unsettled_snos_batch_index, JobTrigger};
+use crate::worker::event_handler::triggers::{first_unsettled_snos_batch_index_or_zero, JobTrigger};
 use async_trait::async_trait;
 use opentelemetry::KeyValue;
 use orchestrator_utils::layer::Layer;
@@ -20,7 +20,7 @@ impl JobTrigger for ProvingJobTrigger {
     /// 1. Fetch all successful SNOS job runs that don't have a proving job
     /// 2. Create a proving job for each SNOS job run
     async fn run_worker(&self, config: Arc<Config>) -> color_eyre::Result<()> {
-        let min_snos_batch_index = first_unsettled_snos_batch_index(&config).await?;
+        let min_snos_batch_index_or_zero = first_unsettled_snos_batch_index_or_zero(&config).await?;
         let successful_snos_jobs = config
             .database()
             .get_jobs_without_successor(
@@ -28,7 +28,7 @@ impl JobTrigger for ProvingJobTrigger {
                 JobStatus::Completed,
                 JobType::ProofCreation,
                 Some(ORCHESTRATOR_VERSION.to_string()),
-                min_snos_batch_index,
+                min_snos_batch_index_or_zero,
             )
             .await?;
 

--- a/orchestrator/src/worker/event_handler/triggers/snos.rs
+++ b/orchestrator/src/worker/event_handler/triggers/snos.rs
@@ -7,7 +7,9 @@ use crate::types::jobs::metadata::{CommonMetadata, JobMetadata, JobSpecificMetad
 use crate::types::jobs::types::JobType;
 use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
-use crate::worker::event_handler::triggers::{calculate_jobs_to_create, first_unsettled_snos_batch_index, JobTrigger};
+use crate::worker::event_handler::triggers::{
+    calculate_jobs_to_create, first_unsettled_snos_batch_index_or_zero, JobTrigger,
+};
 use async_trait::async_trait;
 use color_eyre::eyre::{eyre, Result};
 use opentelemetry::KeyValue;
@@ -60,7 +62,7 @@ impl JobTrigger for SnosJobTrigger {
 
         info!("Creating max {} {:?} jobs", max_jobs_to_create, JobType::SnosRun);
 
-        let min_snos_batch_index = first_unsettled_snos_batch_index(&config).await?;
+        let min_snos_batch_index_or_zero = first_unsettled_snos_batch_index_or_zero(&config).await?;
 
         // Get all snos batches that are closed but don't have a SnosRun job created yet
         for snos_batch in config
@@ -69,7 +71,7 @@ impl JobTrigger for SnosJobTrigger {
                 SnosBatchStatus::Closed,
                 max_jobs_to_create,
                 Some(ORCHESTRATOR_VERSION.to_string()),
-                min_snos_batch_index,
+                min_snos_batch_index_or_zero,
             )
             .await?
         {

--- a/orchestrator/src/worker/event_handler/triggers/snos.rs
+++ b/orchestrator/src/worker/event_handler/triggers/snos.rs
@@ -7,7 +7,7 @@ use crate::types::jobs::metadata::{CommonMetadata, JobMetadata, JobSpecificMetad
 use crate::types::jobs::types::JobType;
 use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
-use crate::worker::event_handler::triggers::{calculate_jobs_to_create, JobTrigger};
+use crate::worker::event_handler::triggers::{calculate_jobs_to_create, first_unsettled_snos_batch_index, JobTrigger};
 use async_trait::async_trait;
 use color_eyre::eyre::{eyre, Result};
 use opentelemetry::KeyValue;
@@ -60,6 +60,8 @@ impl JobTrigger for SnosJobTrigger {
 
         info!("Creating max {} {:?} jobs", max_jobs_to_create, JobType::SnosRun);
 
+        let min_snos_batch_index = first_unsettled_snos_batch_index(&config).await?;
+
         // Get all snos batches that are closed but don't have a SnosRun job created yet
         for snos_batch in config
             .database()
@@ -67,6 +69,7 @@ impl JobTrigger for SnosJobTrigger {
                 SnosBatchStatus::Closed,
                 max_jobs_to_create,
                 Some(ORCHESTRATOR_VERSION.to_string()),
+                min_snos_batch_index,
             )
             .await?
         {

--- a/orchestrator/src/worker/event_handler/triggers/update_state.rs
+++ b/orchestrator/src/worker/event_handler/triggers/update_state.rs
@@ -82,7 +82,7 @@ impl JobTrigger for UpdateStateJobTrigger {
                             JobStatus::Completed,
                             JobType::StateTransition,
                             Some(ORCHESTRATOR_VERSION.to_string()),
-                            None,
+                            0,
                         )
                         .await?,
                     None,

--- a/orchestrator/src/worker/event_handler/triggers/update_state.rs
+++ b/orchestrator/src/worker/event_handler/triggers/update_state.rs
@@ -82,6 +82,7 @@ impl JobTrigger for UpdateStateJobTrigger {
                             JobStatus::Completed,
                             JobType::StateTransition,
                             Some(ORCHESTRATOR_VERSION.to_string()),
+                            None,
                         )
                         .await?,
                     None,


### PR DESCRIPTION
## Summary

Bounds the SNOS and proving anti-join scans to the first unsettled SNOS batch derived from the latest completed state-transition job. This keeps already-settled historical batches/jobs out of the expensive lookup path while preserving the existing fallback when no watermark is available.

Live explain checks before this change showed the bounded shape reducing candidate scans by more than 99% on mock, testnet, and mainnet, with mainnet dropping from about 1.38M candidate batches to about 598 in the sampled path.

## Validation

- Formatting check passed
- Orchestrator clippy passed
- Mock-backed SNOS and proving trigger tests passed
- New DB lower-bound tests compile; local execution needs Mongo at localhost:27017
