### PR TITLE
fix(orchestrator): reuse SQS consumers and preserve AWS error context

### DIFF
--- a/orchestrator/src/core/client/queue/sqs.rs
+++ b/orchestrator/src/core/client/queue/sqs.rs
@@ -19,6 +19,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{OnceCell, RwLock};
 
+type QueueUrlCache = Arc<RwLock<HashMap<QueueType, Arc<OnceCell<String>>>>>;
+type SqsConsumerCache = Arc<RwLock<HashMap<QueueType, Arc<OnceCell<Arc<SqsConsumer>>>>>>;
+
 #[derive(Clone)]
 pub struct InnerSQS(Client);
 
@@ -155,10 +158,10 @@ pub struct SQS {
     queue_template_identifier: AWSResourceIdentifier,
     /// Cache for queue URLs, keyed by QueueType.
     /// Each entry is lazily initialized on first use.
-    queue_url_cache: Arc<RwLock<HashMap<QueueType, Arc<OnceCell<String>>>>>,
+    queue_url_cache: QueueUrlCache,
     /// Cache for OmniQueue consumers, keyed by QueueType.
     /// Reusing consumers avoids rebuilding AWS SDK config/client state for every received message.
-    consumer_cache: Arc<RwLock<HashMap<QueueType, Arc<OnceCell<Arc<SqsConsumer>>>>>>,
+    consumer_cache: SqsConsumerCache,
 }
 
 impl SQS {

--- a/orchestrator/src/core/client/queue/sqs.rs
+++ b/orchestrator/src/core/client/queue/sqs.rs
@@ -156,6 +156,9 @@ pub struct SQS {
     /// Cache for queue URLs, keyed by QueueType.
     /// Each entry is lazily initialized on first use.
     queue_url_cache: Arc<RwLock<HashMap<QueueType, Arc<OnceCell<String>>>>>,
+    /// Cache for OmniQueue consumers, keyed by QueueType.
+    /// Reusing consumers avoids rebuilding AWS SDK config/client state for every received message.
+    consumer_cache: Arc<RwLock<HashMap<QueueType, Arc<OnceCell<Arc<SqsConsumer>>>>>>,
 }
 
 impl SQS {
@@ -187,6 +190,7 @@ impl SQS {
             inner: InnerSQS::new(&latest_aws_config),
             queue_template_identifier: args.queue_template_identifier.clone(),
             queue_url_cache: Arc::new(RwLock::new(HashMap::new())),
+            consumer_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -233,6 +237,26 @@ impl SQS {
 
     pub fn client(&self) -> &Client {
         self.inner.client()
+    }
+
+    async fn get_or_create_consumer(&self, queue: &QueueType) -> Result<Arc<SqsConsumer>, QueueError> {
+        {
+            let cache = self.consumer_cache.read().await;
+            if let Some(cell) = cache.get(queue) {
+                if let Some(consumer) = cell.get() {
+                    return Ok(consumer.clone());
+                }
+            }
+        }
+
+        let cell = {
+            let mut cache = self.consumer_cache.write().await;
+            cache.entry(queue.clone()).or_insert_with(|| Arc::new(OnceCell::new())).clone()
+        };
+
+        let consumer = cell.get_or_try_init(|| async { self.get_consumer(queue.clone()).await.map(Arc::new) }).await?;
+
+        Ok(consumer.clone())
     }
 
     /// Returns the number of queue URLs currently cached.
@@ -501,7 +525,7 @@ impl QueueClient for SQS {
 
             return Err(omniqueue::QueueError::NoData.into());
         }
-        let consumer = self.get_consumer(queue.clone()).await?;
+        let consumer = self.get_or_create_consumer(&queue).await?;
         let delivery = consumer.wrap_message(messages_vec.first().unwrap());
 
         Ok(delivery)

--- a/orchestrator/src/error/consumer.rs
+++ b/orchestrator/src/error/consumer.rs
@@ -1,5 +1,6 @@
 use crate::error::other::OtherError;
 use crate::types::jobs::WorkerTriggerType;
+use aws_sdk_sqs::error::DisplayErrorContext;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -28,4 +29,8 @@ pub enum ConsumptionError {
 
     #[error("Queue Type not found: {0}")]
     QueueNotFound(String),
+}
+
+pub fn format_queue_ack_error(error: &omniqueue::QueueError) -> String {
+    DisplayErrorContext(error).to_string()
 }

--- a/orchestrator/src/error/consumer.rs
+++ b/orchestrator/src/error/consumer.rs
@@ -1,6 +1,7 @@
 use crate::error::other::OtherError;
 use crate::types::jobs::WorkerTriggerType;
 use aws_sdk_sqs::error::DisplayErrorContext;
+use std::error::Error as StdError;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -31,6 +32,6 @@ pub enum ConsumptionError {
     QueueNotFound(String),
 }
 
-pub fn format_queue_ack_error(error: &omniqueue::QueueError) -> String {
+pub fn format_error_context(error: &impl StdError) -> String {
     DisplayErrorContext(error).to_string()
 }

--- a/orchestrator/src/error/event.rs
+++ b/orchestrator/src/error/event.rs
@@ -3,6 +3,7 @@ use crate::core::client::database::DatabaseError;
 use crate::core::client::queue::QueueError;
 use crate::core::client::storage::StorageError;
 use crate::core::error::OrchestratorCoreError;
+use crate::error::job::JobError;
 use crate::error::other::OtherError;
 use crate::error::ConsumptionError;
 use crate::types::jobs::WorkerTriggerType;
@@ -30,6 +31,9 @@ pub enum EventSystemError {
 
     #[error("Database error: {0}")]
     DatabaseCoreError(#[from] DatabaseError),
+
+    #[error("Job error: {0}")]
+    JobError(#[from] JobError),
 
     #[error("Orchestrator Core Error: {0}")]
     OrchestratorCoreError(#[from] OrchestratorCoreError),

--- a/orchestrator/src/error/job/snos.rs
+++ b/orchestrator/src/error/job/snos.rs
@@ -1,3 +1,4 @@
+use crate::core::client::storage::StorageError;
 use crate::error::job::fact::FactError;
 use crate::error::other::OtherError;
 use blockifier::blockifier::transaction_executor::TransactionExecutorError;
@@ -17,17 +18,29 @@ pub enum SnosError {
 
     #[error("Could not serialize the Cairo Pie (snos job #{internal_id:?}): {message}")]
     CairoPieUnserializable { internal_id: u64, message: String },
-    #[error("Could not store the Cairo Pie (snos job #{internal_id:?}): {message}")]
-    CairoPieUnstorable { internal_id: u64, message: String },
+    #[error("Could not store the Cairo Pie (snos job #{internal_id:?}): {source}")]
+    CairoPieUnstorable {
+        internal_id: u64,
+        #[source]
+        source: StorageError,
+    },
 
     #[error("Could not serialize the Snos Output (snos job #{internal_id:?}): {message}")]
     SnosOutputUnserializable { internal_id: u64, message: String },
     #[error("Could not serialize the Program Output (snos job #{internal_id:?}): {message}")]
     ProgramOutputUnserializable { internal_id: u64, message: String },
-    #[error("Could not store the Snos output (snos job #{internal_id:?}): {message}")]
-    SnosOutputUnstorable { internal_id: u64, message: String },
-    #[error("Could not store the Program output (snos job #{internal_id:?}): {message}")]
-    ProgramOutputUnstorable { internal_id: u64, message: String },
+    #[error("Could not store the Snos output (snos job #{internal_id:?}): {source}")]
+    SnosOutputUnstorable {
+        internal_id: u64,
+        #[source]
+        source: StorageError,
+    },
+    #[error("Could not store the Program output (snos job #{internal_id:?}): {source}")]
+    ProgramOutputUnstorable {
+        internal_id: u64,
+        #[source]
+        source: StorageError,
+    },
 
     #[error("Error while running SNOS (snos job #{internal_id:?}): {source}")]
     SnosExecutionError {

--- a/orchestrator/src/worker/controller/delivery_retry.rs
+++ b/orchestrator/src/worker/controller/delivery_retry.rs
@@ -1,0 +1,50 @@
+use crate::error::consumer::format_error_context;
+use crate::error::ConsumptionError;
+use omniqueue::Delivery;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::{error, warn};
+
+const QUEUE_DELIVERY_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+pub async fn ack_delivery_with_retry(delivery: Delivery) -> Result<(), ConsumptionError> {
+    if let Err((first_error, delivery)) = delivery.ack().await {
+        let first_error = format_error_context(&first_error);
+        warn!(error = %first_error, "Failed to ACK message, retrying once");
+
+        sleep(QUEUE_DELIVERY_RETRY_DELAY).await;
+
+        if let Err((second_error, _delivery)) = delivery.ack().await {
+            let second_error = format_error_context(&second_error);
+            error!(
+                first_error = %first_error,
+                error = %second_error,
+                "Failed to ACK message after retry"
+            );
+            return Err(ConsumptionError::FailedToAcknowledgeMessage(second_error));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn nack_delivery_with_retry(delivery: Delivery) -> Result<(), ConsumptionError> {
+    if let Err((first_error, delivery)) = delivery.nack().await {
+        let first_error = format_error_context(&first_error);
+        warn!(error = %first_error, "Failed to NACK message, retrying once");
+
+        sleep(QUEUE_DELIVERY_RETRY_DELAY).await;
+
+        if let Err((second_error, _delivery)) = delivery.nack().await {
+            let second_error = format_error_context(&second_error);
+            error!(
+                first_error = %first_error,
+                error = %second_error,
+                "Failed to NACK message after retry"
+            );
+            return Err(ConsumptionError::FailedToNackMessage(second_error));
+        }
+    }
+
+    Ok(())
+}

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -46,15 +46,15 @@ fn format_error_context(error: &impl Error) -> String {
     DisplayErrorContext(error).to_string()
 }
 
-async fn ack_message_with_retry(message: &Delivery) -> Result<(), ConsumptionError> {
-    if let Err(first_error) = message.ack().await {
-        let first_error = format_queue_ack_error(&first_error.0);
+async fn ack_message_with_retry(message: Delivery) -> Result<(), ConsumptionError> {
+    if let Err((first_error, message)) = message.ack().await {
+        let first_error = format_queue_ack_error(&first_error);
         warn!(error = %first_error, "Failed to ACK message, retrying once");
 
         sleep(QUEUE_ACK_RETRY_DELAY).await;
 
-        if let Err(second_error) = message.ack().await {
-            let second_error = format_queue_ack_error(&second_error.0);
+        if let Err((second_error, _message)) = message.ack().await {
+            let second_error = format_queue_ack_error(&second_error);
             error!(
                 first_error = %first_error,
                 error = %second_error,
@@ -207,9 +207,7 @@ impl EventWorker {
         let worker_handler =
             JobHandlerService::get_worker_handler_from_worker_trigger_type(worker_message.worker.clone());
         let workload = MetricsRecorder::start_worker_trigger_workload(&worker_message.worker);
-        worker_handler
-            .run_worker_if_enabled(self.config.clone())
-            .await?;
+        worker_handler.run_worker_if_enabled(self.config.clone()).await.map_err(OtherError::from)?;
         workload.finish_success();
         Ok(())
     }
@@ -313,10 +311,7 @@ impl EventWorker {
                     tracing::error!(worker = ?worker, error = %error_msg, "Failed to handle worker trigger");
                     (
                         format!("Worker {worker:?} handling failed: {error_msg}"),
-                        ConsumptionError::FailedToSpawnWorker {
-                            worker_trigger_type: worker.clone(),
-                            error_msg,
-                        },
+                        ConsumptionError::FailedToSpawnWorker { worker_trigger_type: worker.clone(), error_msg },
                     )
                 }
                 ParsedMessage::JobQueue(msg) => {
@@ -348,7 +343,7 @@ impl EventWorker {
             return Err(consumption_error.into());
         }
 
-        ack_message_with_retry(&message).await?;
+        ack_message_with_retry(message).await?;
         Ok(())
     }
 
@@ -431,7 +426,7 @@ impl EventWorker {
                         // ACK/NACK the priority delivery after processing
                         match &result {
                             Ok(_) => {
-                                if let Err(e) = ack_message_with_retry(&delivery).await {
+                                if let Err(e) = ack_message_with_retry(delivery).await {
                                     error!("Failed to ACK priority message: {:?}", e);
                                 }
                             }

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -187,8 +187,7 @@ impl EventWorker {
         let workload = MetricsRecorder::start_worker_trigger_workload(&worker_message.worker);
         worker_handler
             .run_worker_if_enabled(self.config.clone())
-            .await
-            .map_err(|e| ConsumptionError::Other(OtherError::from(e.to_string())))?;
+            .await?;
         workload.finish_success();
         Ok(())
     }
@@ -203,9 +202,7 @@ impl EventWorker {
     /// # Errors
     /// * Returns an EventSystemError if the message cannot be handled
     async fn handle_job_failure(&self, queue_message: &JobQueueMessage) -> EventSystemResult<()> {
-        JobHandlerService::handle_job_failure(queue_message.id, self.config.clone())
-            .await
-            .map_err(|e| ConsumptionError::Other(OtherError::from(e.to_string())))?;
+        JobHandlerService::handle_job_failure(queue_message.id, self.config.clone()).await?;
         Ok(())
     }
 
@@ -222,14 +219,10 @@ impl EventWorker {
     async fn handle_job_queue(&self, queue_message: &JobQueueMessage, job_state: JobState) -> EventSystemResult<()> {
         match job_state {
             JobState::Processing => {
-                JobHandlerService::process_job(queue_message.id, self.config.clone())
-                    .await
-                    .map_err(|e| ConsumptionError::Other(OtherError::from(e.to_string())))?;
+                JobHandlerService::process_job(queue_message.id, self.config.clone()).await?;
             }
             JobState::Verification => {
-                JobHandlerService::verify_job(queue_message.id, self.config.clone())
-                    .await
-                    .map_err(|e| ConsumptionError::Other(OtherError::from(e.to_string())))?;
+                JobHandlerService::verify_job(queue_message.id, self.config.clone()).await?;
             }
         }
         Ok(())
@@ -294,21 +287,23 @@ impl EventWorker {
             let (error_context, consumption_error) = match parsed_message {
                 ParsedMessage::WorkerTrigger(msg) => {
                     let worker = &msg.worker;
-                    tracing::error!("Failed to handle worker trigger {worker:?}. Error: {error:?}");
+                    let error_msg = format_error_context(error);
+                    tracing::error!(worker = ?worker, error = %error_msg, "Failed to handle worker trigger");
                     (
-                        format!("Worker {worker:?} handling failed: {error}"),
+                        format!("Worker {worker:?} handling failed: {error_msg}"),
                         ConsumptionError::FailedToSpawnWorker {
                             worker_trigger_type: worker.clone(),
-                            error_msg: error.to_string(),
+                            error_msg,
                         },
                     )
                 }
                 ParsedMessage::JobQueue(msg) => {
                     let job_id = &msg.id;
-                    tracing::error!("Failed to handle job {job_id:?}. Error: {error:?}");
+                    let error_msg = format_error_context(error);
+                    tracing::error!(job_id = ?job_id, error = %error_msg, "Failed to handle job");
                     (
-                        format!("Job {job_id:?} handling failed: {error}"),
-                        ConsumptionError::FailedToHandleJob { job_id: *job_id, error_msg: error.to_string() },
+                        format!("Job {job_id:?} handling failed: {error_msg}"),
+                        ConsumptionError::FailedToHandleJob { job_id: *job_id, error_msg },
                     )
                 }
             };

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -1,5 +1,5 @@
 use crate::core::config::Config;
-use crate::error::consumer::format_queue_ack_error;
+use crate::error::consumer::format_error_context;
 use crate::error::other::OtherError;
 use crate::error::{event::EventSystemResult, ConsumptionError};
 use crate::types::jobs::WorkerTriggerType;
@@ -13,10 +13,8 @@ use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
 use crate::worker::parser::{job_queue_message::JobQueueMessage, worker_trigger_message::WorkerTriggerMessage};
 use crate::worker::traits::message::{MessageParser, ParsedMessage};
-use aws_sdk_sqs::error::DisplayErrorContext;
 use color_eyre::eyre::eyre;
 use omniqueue::Delivery;
-use std::error::Error;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
@@ -42,19 +40,15 @@ const QUEUE_GET_MESSAGE_WAIT_TIMEOUT_SECS: Duration = Duration::from_secs(30);
 const QUEUE_NO_MESSAGE_SLEEP_DURATION: Duration = Duration::from_millis(1000);
 const QUEUE_ACK_RETRY_DELAY: Duration = Duration::from_millis(500);
 
-fn format_error_context(error: &impl Error) -> String {
-    DisplayErrorContext(error).to_string()
-}
-
 async fn ack_message_with_retry(message: Delivery) -> Result<(), ConsumptionError> {
     if let Err((first_error, message)) = message.ack().await {
-        let first_error = format_queue_ack_error(&first_error);
+        let first_error = format_error_context(&first_error);
         warn!(error = %first_error, "Failed to ACK message, retrying once");
 
         sleep(QUEUE_ACK_RETRY_DELAY).await;
 
         if let Err((second_error, _message)) = message.ack().await {
-            let second_error = format_queue_ack_error(&second_error);
+            let second_error = format_error_context(&second_error);
             error!(
                 first_error = %first_error,
                 error = %second_error,
@@ -335,7 +329,7 @@ impl EventWorker {
                 }
             }
 
-            message.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_queue_ack_error(&e.0)))?;
+            message.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_error_context(&e.0)))?;
 
             // TODO: Since we are using SNS, we need to send the error message to the DLQ in future
             // self.config.alerts().send_message(error_context).await?;

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -1,4 +1,5 @@
 use crate::core::config::Config;
+use crate::error::consumer::format_queue_ack_error;
 use crate::error::other::OtherError;
 use crate::error::{event::EventSystemResult, ConsumptionError};
 use crate::types::jobs::WorkerTriggerType;
@@ -12,8 +13,10 @@ use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::service::JobHandlerService;
 use crate::worker::parser::{job_queue_message::JobQueueMessage, worker_trigger_message::WorkerTriggerMessage};
 use crate::worker::traits::message::{MessageParser, ParsedMessage};
+use aws_sdk_sqs::error::DisplayErrorContext;
 use color_eyre::eyre::eyre;
 use omniqueue::Delivery;
+use std::error::Error;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
@@ -37,6 +40,10 @@ pub struct EventWorker {
 
 const QUEUE_GET_MESSAGE_WAIT_TIMEOUT_SECS: Duration = Duration::from_secs(30);
 const QUEUE_NO_MESSAGE_SLEEP_DURATION: Duration = Duration::from_millis(1000);
+
+fn format_error_context(error: &impl Error) -> String {
+    DisplayErrorContext(error).to_string()
+}
 
 impl EventWorker {
     /// new - Create a new EventWorker
@@ -137,12 +144,13 @@ impl EventWorker {
                     continue;
                 }
                 Err(e) => {
+                    let error_msg = format_error_context(&e);
                     error!(
                         queue = ?self.queue_type,
-                        error = %e,
+                        error = %error_msg,
                         "Failed to consume message from queue"
                     );
-                    return Err(ConsumptionError::FailedToConsumeFromQueue { error_msg: e.to_string() })?;
+                    return Err(ConsumptionError::FailedToConsumeFromQueue { error_msg })?;
                 }
             }
         }
@@ -315,7 +323,7 @@ impl EventWorker {
                 }
             }
 
-            message.nack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
+            message.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_queue_ack_error(&e.0)))?;
 
             // TODO: Since we are using SNS, we need to send the error message to the DLQ in future
             // self.config.alerts().send_message(error_context).await?;
@@ -323,7 +331,7 @@ impl EventWorker {
             return Err(consumption_error.into());
         }
 
-        message.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
+        message.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_queue_ack_error(&e.0)))?;
         Ok(())
     }
 

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -10,6 +10,7 @@ use crate::types::queue::JobAction;
 use crate::types::queue::{JobState, QueueType};
 use crate::types::queue_control::{QueueControlConfig, QUEUES};
 use crate::utils::metrics_recorder::MetricsRecorder;
+use crate::worker::controller::delivery_retry::{ack_delivery_with_retry, nack_delivery_with_retry};
 use crate::worker::event_handler::service::JobHandlerService;
 use crate::worker::parser::{job_queue_message::JobQueueMessage, worker_trigger_message::WorkerTriggerMessage};
 use crate::worker::traits::message::{MessageParser, ParsedMessage};
@@ -38,28 +39,6 @@ pub struct EventWorker {
 
 const QUEUE_GET_MESSAGE_WAIT_TIMEOUT_SECS: Duration = Duration::from_secs(30);
 const QUEUE_NO_MESSAGE_SLEEP_DURATION: Duration = Duration::from_millis(1000);
-const QUEUE_ACK_RETRY_DELAY: Duration = Duration::from_millis(500);
-
-async fn ack_message_with_retry(message: Delivery) -> Result<(), ConsumptionError> {
-    if let Err((first_error, message)) = message.ack().await {
-        let first_error = format_error_context(&first_error);
-        warn!(error = %first_error, "Failed to ACK message, retrying once");
-
-        sleep(QUEUE_ACK_RETRY_DELAY).await;
-
-        if let Err((second_error, _message)) = message.ack().await {
-            let second_error = format_error_context(&second_error);
-            error!(
-                first_error = %first_error,
-                error = %second_error,
-                "Failed to ACK message after retry"
-            );
-            return Err(ConsumptionError::FailedToAcknowledgeMessage(second_error));
-        }
-    }
-
-    Ok(())
-}
 
 impl EventWorker {
     /// new - Create a new EventWorker
@@ -329,7 +308,7 @@ impl EventWorker {
                 }
             }
 
-            message.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_error_context(&e.0)))?;
+            nack_delivery_with_retry(message).await?;
 
             // TODO: Since we are using SNS, we need to send the error message to the DLQ in future
             // self.config.alerts().send_message(error_context).await?;
@@ -337,7 +316,7 @@ impl EventWorker {
             return Err(consumption_error.into());
         }
 
-        ack_message_with_retry(message).await?;
+        ack_delivery_with_retry(message).await?;
         Ok(())
     }
 
@@ -420,12 +399,12 @@ impl EventWorker {
                         // ACK/NACK the priority delivery after processing
                         match &result {
                             Ok(_) => {
-                                if let Err(e) = ack_message_with_retry(delivery).await {
+                                if let Err(e) = ack_delivery_with_retry(delivery).await {
                                     error!("Failed to ACK priority message: {:?}", e);
                                 }
                             }
                             Err(_) => {
-                                if let Err(e) = delivery.nack().await {
+                                if let Err(e) = nack_delivery_with_retry(delivery).await {
                                     error!("Failed to NACK priority message: {:?}", e);
                                 }
                             }

--- a/orchestrator/src/worker/controller/event_worker.rs
+++ b/orchestrator/src/worker/controller/event_worker.rs
@@ -40,9 +40,31 @@ pub struct EventWorker {
 
 const QUEUE_GET_MESSAGE_WAIT_TIMEOUT_SECS: Duration = Duration::from_secs(30);
 const QUEUE_NO_MESSAGE_SLEEP_DURATION: Duration = Duration::from_millis(1000);
+const QUEUE_ACK_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 fn format_error_context(error: &impl Error) -> String {
     DisplayErrorContext(error).to_string()
+}
+
+async fn ack_message_with_retry(message: &Delivery) -> Result<(), ConsumptionError> {
+    if let Err(first_error) = message.ack().await {
+        let first_error = format_queue_ack_error(&first_error.0);
+        warn!(error = %first_error, "Failed to ACK message, retrying once");
+
+        sleep(QUEUE_ACK_RETRY_DELAY).await;
+
+        if let Err(second_error) = message.ack().await {
+            let second_error = format_queue_ack_error(&second_error.0);
+            error!(
+                first_error = %first_error,
+                error = %second_error,
+                "Failed to ACK message after retry"
+            );
+            return Err(ConsumptionError::FailedToAcknowledgeMessage(second_error));
+        }
+    }
+
+    Ok(())
 }
 
 impl EventWorker {
@@ -326,7 +348,7 @@ impl EventWorker {
             return Err(consumption_error.into());
         }
 
-        message.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_queue_ack_error(&e.0)))?;
+        ack_message_with_retry(&message).await?;
         Ok(())
     }
 
@@ -409,7 +431,7 @@ impl EventWorker {
                         // ACK/NACK the priority delivery after processing
                         match &result {
                             Ok(_) => {
-                                if let Err(e) = delivery.ack().await {
+                                if let Err(e) = ack_message_with_retry(&delivery).await {
                                     error!("Failed to ACK priority message: {:?}", e);
                                 }
                             }

--- a/orchestrator/src/worker/controller/mod.rs
+++ b/orchestrator/src/worker/controller/mod.rs
@@ -1,3 +1,4 @@
+pub mod delivery_retry;
 pub mod event_worker;
 pub mod priority_queue_worker;
 pub mod worker_controller;

--- a/orchestrator/src/worker/controller/priority_queue_worker.rs
+++ b/orchestrator/src/worker/controller/priority_queue_worker.rs
@@ -251,13 +251,19 @@ impl PriorityQueueWorker {
             Ok(Some(job)) => job,
             Ok(None) => {
                 warn!("PQ Worker ({}): Job {} not found, ACKing message", self.action, parsed_msg.id);
-                delivery.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_queue_ack_error(&e.0)))?;
+                delivery
+                    .ack()
+                    .await
+                    .map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_queue_ack_error(&e.0)))?;
                 return Ok(());
             }
             Err(e) => {
                 error!("PQ Worker ({}): Database error fetching job {}: {:?}", self.action, parsed_msg.id, e);
                 // NACK to retry later
-                delivery.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_queue_ack_error(&e.0)))?;
+                delivery
+                    .nack()
+                    .await
+                    .map_err(|e| ConsumptionError::FailedToNackMessage(format_queue_ack_error(&e.0)))?;
                 return Ok(());
             }
         };

--- a/orchestrator/src/worker/controller/priority_queue_worker.rs
+++ b/orchestrator/src/worker/controller/priority_queue_worker.rs
@@ -16,6 +16,7 @@
 
 use crate::core::client::queue::QueueError;
 use crate::core::config::Config;
+use crate::error::consumer::format_queue_ack_error;
 use crate::error::event::EventSystemResult;
 use crate::error::ConsumptionError;
 use crate::types::priority_slot::{
@@ -250,13 +251,13 @@ impl PriorityQueueWorker {
             Ok(Some(job)) => job,
             Ok(None) => {
                 warn!("PQ Worker ({}): Job {} not found, ACKing message", self.action, parsed_msg.id);
-                delivery.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(e.0.to_string()))?;
+                delivery.ack().await.map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_queue_ack_error(&e.0)))?;
                 return Ok(());
             }
             Err(e) => {
                 error!("PQ Worker ({}): Database error fetching job {}: {:?}", self.action, parsed_msg.id, e);
                 // NACK to retry later
-                delivery.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(e.0.to_string()))?;
+                delivery.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_queue_ack_error(&e.0)))?;
                 return Ok(());
             }
         };

--- a/orchestrator/src/worker/controller/priority_queue_worker.rs
+++ b/orchestrator/src/worker/controller/priority_queue_worker.rs
@@ -16,7 +16,7 @@
 
 use crate::core::client::queue::QueueError;
 use crate::core::config::Config;
-use crate::error::consumer::format_queue_ack_error;
+use crate::error::consumer::format_error_context;
 use crate::error::event::EventSystemResult;
 use crate::error::ConsumptionError;
 use crate::types::priority_slot::{
@@ -254,16 +254,13 @@ impl PriorityQueueWorker {
                 delivery
                     .ack()
                     .await
-                    .map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_queue_ack_error(&e.0)))?;
+                    .map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_error_context(&e.0)))?;
                 return Ok(());
             }
             Err(e) => {
                 error!("PQ Worker ({}): Database error fetching job {}: {:?}", self.action, parsed_msg.id, e);
                 // NACK to retry later
-                delivery
-                    .nack()
-                    .await
-                    .map_err(|e| ConsumptionError::FailedToNackMessage(format_queue_ack_error(&e.0)))?;
+                delivery.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_error_context(&e.0)))?;
                 return Ok(());
             }
         };

--- a/orchestrator/src/worker/controller/priority_queue_worker.rs
+++ b/orchestrator/src/worker/controller/priority_queue_worker.rs
@@ -16,9 +16,7 @@
 
 use crate::core::client::queue::QueueError;
 use crate::core::config::Config;
-use crate::error::consumer::format_error_context;
 use crate::error::event::EventSystemResult;
-use crate::error::ConsumptionError;
 use crate::types::priority_slot::{
     clear_stale_from_processing_slot, clear_stale_from_verification_slot, is_processing_slot_empty,
     is_verification_slot_empty, place_in_processing_slot, place_in_verification_slot, PriorityJobSlot,
@@ -27,6 +25,7 @@ use crate::types::queue::QueueType;
 use crate::types::queue_control::{
     PRIORITY_SLOT_CHECK_INTERVAL, PRIORITY_SLOT_STALENESS_TIMEOUT_SECS, PRIORITY_SLOT_WAIT_TIMEOUT,
 };
+use crate::worker::controller::delivery_retry::{ack_delivery_with_retry, nack_delivery_with_retry};
 use crate::worker::parser::job_queue_message::JobQueueMessage;
 use crate::worker::traits::message::MessageParser;
 use omniqueue::Delivery;
@@ -173,7 +172,7 @@ impl PriorityQueueWorker {
             // Check and clear stale messages
             if let Some(stale_delivery) = self.clear_stale_if_needed(PRIORITY_SLOT_STALENESS_TIMEOUT_SECS).await {
                 warn!("PQ Worker ({}): Cleared stale message from slot, NACKing", self.action);
-                if let Err(e) = stale_delivery.nack().await {
+                if let Err(e) = nack_delivery_with_retry(stale_delivery).await {
                     error!("PQ Worker ({}): Failed to NACK stale delivery: {:?}", self.action, e);
                 }
             }
@@ -237,7 +236,7 @@ impl PriorityQueueWorker {
             Err(e) => {
                 error!("PQ Worker ({}): Failed to parse message: {:?}", self.action, e);
                 // ACK malformed messages to prevent infinite retries
-                if let Err(ack_err) = delivery.ack().await {
+                if let Err(ack_err) = ack_delivery_with_retry(delivery).await {
                     error!("PQ Worker ({}): Failed to ACK malformed message: {:?}", self.action, ack_err);
                 }
                 return Ok(());
@@ -251,16 +250,13 @@ impl PriorityQueueWorker {
             Ok(Some(job)) => job,
             Ok(None) => {
                 warn!("PQ Worker ({}): Job {} not found, ACKing message", self.action, parsed_msg.id);
-                delivery
-                    .ack()
-                    .await
-                    .map_err(|e| ConsumptionError::FailedToAcknowledgeMessage(format_error_context(&e.0)))?;
+                ack_delivery_with_retry(delivery).await?;
                 return Ok(());
             }
             Err(e) => {
                 error!("PQ Worker ({}): Database error fetching job {}: {:?}", self.action, parsed_msg.id, e);
                 // NACK to retry later
-                delivery.nack().await.map_err(|e| ConsumptionError::FailedToNackMessage(format_error_context(&e.0)))?;
+                nack_delivery_with_retry(delivery).await?;
                 return Ok(());
             }
         };

--- a/orchestrator/src/worker/event_handler/jobs/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/jobs/aggregator.rs
@@ -368,7 +368,7 @@ impl AggregatorJobHandler {
             .storage()
             .put_data(encoded_data.into(), storage_path)
             .await
-            .map_err(|e| SnosError::ProgramOutputUnstorable { internal_id: batch_index, message: e.to_string() })?;
+            .map_err(|source| SnosError::ProgramOutputUnstorable { internal_id: batch_index, source })?;
         Ok(())
     }
 

--- a/orchestrator/src/worker/event_handler/jobs/snos.rs
+++ b/orchestrator/src/worker/event_handler/jobs/snos.rs
@@ -266,7 +266,7 @@ impl SnosJobHandler {
             data_storage
                 .put_data(cairo_pie_zip_bytes, cairo_pie_key)
                 .await
-                .map_err(|e| SnosError::CairoPieUnstorable { internal_id, message: e.to_string() })?;
+                .map_err(|source| SnosError::CairoPieUnstorable { internal_id, source })?;
         }
 
         // Store SNOS Output
@@ -276,7 +276,7 @@ impl SnosJobHandler {
             data_storage
                 .put_data(snos_output_json.into(), snos_output_key)
                 .await
-                .map_err(|e| SnosError::SnosOutputUnstorable { internal_id, message: e.to_string() })?;
+                .map_err(|source| SnosError::SnosOutputUnstorable { internal_id, source })?;
         }
 
         // Store Program Output
@@ -287,7 +287,7 @@ impl SnosJobHandler {
             data_storage
                 .put_data(encoded_data.into(), program_output_key)
                 .await
-                .map_err(|e| SnosError::ProgramOutputUnstorable { internal_id, message: e.to_string() })?;
+                .map_err(|source| SnosError::ProgramOutputUnstorable { internal_id, source })?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Fixes the orchestrator SQS path involved in the pc-mainnet incident by reducing AWS SDK client/credential churn and preserving the underlying AWS SDK error context in logs/alerts.

Changes included:

- cache and reuse OmniQueue SQS consumers per queue type instead of rebuilding a consumer while wrapping every received message for ACK/NACK
- preserve full AWS SDK error context for SQS receive/ACK/NACK failures
- preserve storage/job error source context so S3 dispatch/service failures are no longer collapsed into a plain string
- retry successful-message ACK once after a short delay before surfacing the ACK failure

## Why

The incident evidence showed a large spike in `AssumeRoleWithWebIdentity` calls from the orchestrator role, close to the SQS receive volume. The old flow received messages with the persistent SQS client, then rebuilt an OmniQueue consumer while wrapping each message for ACK/NACK. That recreated AWS config/client/credential state in the ACK path.

The alerts also hid useful root-cause detail behind plain `dispatch failure` strings because SDK errors were converted with `to_string()` and source chains were dropped.

## Follow-up Required

This PR intentionally does not change verification retry semantics.

A follow-up PR should address idempotent verification retry messages as described in:

- https://github.com/madara-alliance/madara/issues/1232

That follow-up should add `verification_attempt` to verification queue messages so stale duplicate deliveries can be ACKed and ignored instead of producing additional successor verification messages.

## Testing

Not run locally. We intentionally deferred format/lint/checks for one combined validation pass later.
