### PR TITLE
chore(orchestrator): instrument aggregator batching

### DIFF
--- a/orchestrator/src/utils/metrics.rs
+++ b/orchestrator/src/utils/metrics.rs
@@ -75,6 +75,8 @@ pub struct OrchestratorMetrics {
     pub aggregator_program_output_bytes: Gauge<f64>,
     pub aggregator_da_segment_bytes: Gauge<f64>,
     pub aggregator_pie_zip_bytes: Gauge<f64>,
+    pub aggregator_batching_batch_number: Gauge<f64>,
+    pub aggregator_batching_duration_seconds: Histogram<f64>,
     // Storage cleanup metrics
     pub cleanup_runs_total: Counter<f64>,
     pub cleanup_jobs_attempted: Counter<f64>,
@@ -433,6 +435,20 @@ impl Metrics for OrchestratorMetrics {
             "bytes".to_string(),
         );
 
+        let aggregator_batching_batch_number = register_gauge_metric_instrument(
+            &orchestrator_meter,
+            "aggregator_batching_batch_number".to_string(),
+            "Latest aggregator batch number handled by the batching worker".to_string(),
+            "batch".to_string(),
+        );
+
+        let aggregator_batching_duration_seconds = register_histogram_metric_instrument(
+            &orchestrator_meter,
+            "aggregator_batching_duration_seconds".to_string(),
+            "Duration of aggregator batching worker runs".to_string(),
+            "s".to_string(),
+        );
+
         // Storage cleanup metrics
         let cleanup_runs_total = register_counter_metric_instrument(
             &orchestrator_meter,
@@ -530,6 +546,8 @@ impl Metrics for OrchestratorMetrics {
             aggregator_program_output_bytes,
             aggregator_da_segment_bytes,
             aggregator_pie_zip_bytes,
+            aggregator_batching_batch_number,
+            aggregator_batching_duration_seconds,
             job_status_tracker,
             atlantic_api_call_duration,
             atlantic_api_calls_total,

--- a/orchestrator/src/utils/metrics_recorder.rs
+++ b/orchestrator/src/utils/metrics_recorder.rs
@@ -650,6 +650,14 @@ impl MetricsRecorder {
         ORCHESTRATOR_METRICS.aggregator_da_segment_bytes.record(da_segment_bytes as f64, &attrs);
         ORCHESTRATOR_METRICS.aggregator_pie_zip_bytes.record(pie_zip_bytes as f64, &attrs);
     }
+
+    pub fn record_aggregator_batching_duration(duration_seconds: f64) {
+        ORCHESTRATOR_METRICS.aggregator_batching_duration_seconds.record(duration_seconds, &[]);
+    }
+
+    pub fn record_aggregator_batching_batch_number(batch_number: u64) {
+        ORCHESTRATOR_METRICS.aggregator_batching_batch_number.record(batch_number as f64, &[]);
+    }
 }
 
 #[cfg(test)]

--- a/orchestrator/src/worker/event_handler/triggers/aggregator_batching.rs
+++ b/orchestrator/src/worker/event_handler/triggers/aggregator_batching.rs
@@ -1,6 +1,7 @@
 use crate::core::client::lock::LockValue;
 use crate::core::config::Config;
 use crate::error::job::JobError;
+use crate::utils::metrics_recorder::MetricsRecorder;
 use crate::worker::event_handler::triggers::batching::aggregator::{
     AggregatorBatchConfig, AggregatorHandler, AggregatorState, AggregatorStateHandler,
 };
@@ -10,6 +11,7 @@ use crate::worker::event_handler::triggers::JobTrigger;
 use starknet::providers::Provider;
 use std::cmp::{max, min};
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::{debug, error, info};
 
 pub const AGGREGATOR_BATCHING_WORKER_KEY: &str = "AggregatorBatchingWorker";
@@ -20,6 +22,7 @@ pub struct AggregatorBatchingTrigger;
 impl JobTrigger for AggregatorBatchingTrigger {
     async fn run_worker(&self, config: Arc<Config>) -> color_eyre::Result<()> {
         // Trying to acquire lock on Aggregator Batching Worker
+        let worker_started_at = Instant::now();
         match config
             .lock()
             .acquire_lock(
@@ -32,12 +35,20 @@ impl JobTrigger for AggregatorBatchingTrigger {
         {
             Ok(_) => {
                 // Lock acquired successfully
-                debug!("{} acquired lock", AGGREGATOR_BATCHING_WORKER_KEY);
+                info!(
+                    lock_key = AGGREGATOR_BATCHING_WORKER_KEY,
+                    lock_duration_seconds = config.params.batching_config.batching_worker_lock_duration,
+                    "Aggregator batching worker acquired lock"
+                );
             }
             Err(err) => {
                 // Failed to acquire lock
                 // Returning safely
-                debug!("{} failed to acquire lock, returning safely: {}", AGGREGATOR_BATCHING_WORKER_KEY, err);
+                info!(
+                    lock_key = AGGREGATOR_BATCHING_WORKER_KEY,
+                    error = %err,
+                    "Aggregator batching worker failed to acquire lock, returning safely"
+                );
                 return Ok(());
             }
         }
@@ -48,12 +59,13 @@ impl JobTrigger for AggregatorBatchingTrigger {
         let state_handler = AggregatorStateHandler::from_config(&config);
 
         // Execute the main work and capture the result
+        let mut batch_number = None;
         let result = async {
             let (start_block, end_block) = self.calculate_range(&config).await?;
 
             // If there are no blocks to process, return early
             if start_block > end_block {
-                debug!("No Aggregator blocks to process: start_block ({}) > end_block ({})", start_block, end_block);
+                info!(start_block, end_block, "No Aggregator blocks to process");
                 return Ok(());
             }
 
@@ -63,6 +75,7 @@ impl JobTrigger for AggregatorBatchingTrigger {
             let mut replay_bounds_error: Option<replay_bounds::ReplayBoundsError> = None;
 
             for block_num in start_block..=end_block {
+                let block_started_at = Instant::now();
                 if let Some(ref_client) = config.replay_bounds_client() {
                     if let Err(e) =
                         replay_bounds::validate_block_hash(config.madara_rpc_client(), ref_client, block_num).await
@@ -73,19 +86,30 @@ impl JobTrigger for AggregatorBatchingTrigger {
                     }
                 }
 
-                match batching_handler.include_block(block_num, state).await? {
+                let block_result = match batching_handler.include_block(block_num, state).await? {
                     BlockProcessingResult::Accumulated(updated_state) => {
                         state = AggregatorState::NonEmpty(updated_state);
+                        "accumulated"
                     }
                     BlockProcessingResult::BatchCompleted { completed_state, new_state } => {
+                        batch_number = Some(completed_state.batch_index());
                         state_handler.save_batch_state(&completed_state).await?;
                         state = new_state;
+                        "batch_completed"
                     }
                     BlockProcessingResult::NotBatched(current_state) => {
                         state = current_state;
-                        // Since this block wasn't able to get batches, we shouldn't move forward
-                        break;
+                        "not_batched"
                     }
+                };
+                info!(
+                    block_num,
+                    duration_ms = %block_started_at.elapsed().as_millis(),
+                    result = block_result,
+                    "Aggregator batching worker finished block"
+                );
+                if block_result == "not_batched" {
+                    break;
                 }
             }
 
@@ -93,6 +117,7 @@ impl JobTrigger for AggregatorBatchingTrigger {
             match state {
                 AggregatorState::Empty(_) => {}
                 AggregatorState::NonEmpty(state) => {
+                    batch_number = Some(state.batch_index());
                     state_handler.save_batch_state(&state).await?;
                 }
             }
@@ -106,15 +131,38 @@ impl JobTrigger for AggregatorBatchingTrigger {
         .await;
 
         // Always release the lock, regardless of whether work succeeded or failed
-        if let Err(e) = config.lock().release_lock(AGGREGATOR_BATCHING_WORKER_KEY, None).await {
-            error!("Failed to release {} lock: {}", AGGREGATOR_BATCHING_WORKER_KEY, e);
-            // If work succeeded but lock release failed, return the lock release error
-            if result.is_ok() {
-                return Err(e.into());
-            }
-            // If work failed, we still want to return the original work error
+        let release_started_at = Instant::now();
+        info!(lock_key = AGGREGATOR_BATCHING_WORKER_KEY, "Aggregator batching worker releasing lock");
+        let release_result = config.lock().release_lock(AGGREGATOR_BATCHING_WORKER_KEY, None).await;
+        if let Err(e) = &release_result {
+            error!(
+                lock_key = AGGREGATOR_BATCHING_WORKER_KEY,
+                duration_ms = %release_started_at.elapsed().as_millis(),
+                "Failed to release {} lock: {}",
+                AGGREGATOR_BATCHING_WORKER_KEY,
+                e
+            );
+        } else {
+            info!(
+                lock_key = AGGREGATOR_BATCHING_WORKER_KEY,
+                duration_ms = %release_started_at.elapsed().as_millis(),
+                worker_duration_ms = %worker_started_at.elapsed().as_millis(),
+                "Aggregator batching worker released lock"
+            );
         }
 
+        MetricsRecorder::record_aggregator_batching_duration(worker_started_at.elapsed().as_secs_f64());
+        if let Some(batch_number) = batch_number {
+            MetricsRecorder::record_aggregator_batching_batch_number(batch_number);
+        }
+
+        // If work succeeded but lock release failed, return the lock release error.
+        if result.is_ok() {
+            if let Err(e) = release_result {
+                return Err(e.into());
+            }
+        }
+        // If work failed, return the original work error even if lock release also failed.
         result
     }
 }

--- a/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
@@ -20,10 +20,11 @@ use opentelemetry::KeyValue;
 use orchestrator_prover_client_interface::Task;
 use starknet::providers::Provider;
 use starknet_core::types::MaybePreConfirmedStateUpdate::{PreConfirmedUpdate, Update};
-use starknet_core::types::{BlockId, StateUpdate};
+use starknet_core::types::{BlockId, MaybePreConfirmedStateUpdate, StateUpdate};
 use starknet_types_core::felt::Felt;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
 const AGGREGATOR_N_TASKS_WORDS: usize = 1;
@@ -80,10 +81,12 @@ impl AggregatorStateHandler {
     /// 1. Assuming all the details are already updated in state
     /// 2. Not making database and storage updates atomically. It might happen that one fails and the other passes
     pub async fn save_batch_state(&self, state: &NonEmptyAggregatorState) -> Result<(), JobError> {
+        let save_started_at = Instant::now();
         info!(batch=?state.batch, "Saving aggregator batch state");
         // Compressing the state update into vector of felts
         // Doing this first since this is dependent on external RPC => Higher chances of failure
         // i.e. if this fails, we won't update anything in our state and prevent data inconsistency
+        let compress_started_at = Instant::now();
         let compressed_state_update = compress_state_update(
             &state.blob,
             state.batch.end_block,
@@ -91,6 +94,13 @@ impl AggregatorStateHandler {
             self.config.batch_rpc_client(),
         )
         .await?;
+        info!(
+            batch_index = %state.batch.index,
+            end_block = %state.batch.end_block,
+            blob_len = compressed_state_update.len(),
+            duration_ms = %compress_started_at.elapsed().as_millis(),
+            "Compressed aggregator batch state for save"
+        );
 
         // Update batch status in the database
         self.config
@@ -109,14 +119,15 @@ impl AggregatorStateHandler {
             .await?;
         let blobs = convert_felt_vec_to_blob_data(&compressed_state_update)?;
         for (i, blob) in blobs.iter().enumerate() {
-            self.config
-                .storage()
-                .put_data(
-                    biguint_vec_to_u8_vec(blob.as_slice()).into(),
-                    &AggregatorBatch::get_blob_file_path(state.batch.index, i as u64 + 1),
-                )
-                .await?;
+            let path = AggregatorBatch::get_blob_file_path(state.batch.index, i as u64 + 1);
+            self.config.storage().put_data(biguint_vec_to_u8_vec(blob.as_slice()).into(), &path).await?;
         }
+        info!(
+            batch_index = %state.batch.index,
+            blob_count = blobs.len(),
+            duration_ms = %save_started_at.elapsed().as_millis(),
+            "Saved aggregator batch state"
+        );
 
         Ok(())
     }
@@ -175,9 +186,13 @@ impl AggregatorHandler {
         block_num: u64,
         state: AggregatorState,
     ) -> Result<BlockProcessingResult<AggregatorState, NonEmptyAggregatorState>, JobError> {
-        info!("Including block {} in aggregator batch", block_num);
+        let state_kind = match &state {
+            Empty(_) => "empty",
+            NonEmpty(_) => "non_empty",
+        };
+        info!(block_num, state = state_kind, "Including block in aggregator batch");
         // Fetch Starknet version for the current block
-        let current_block_starknet_version = get_block_version(block_num, self.config.madara_rpc_client()).await?;
+        let current_block_starknet_version = self.fetch_block_version(block_num, "include_block").await?;
 
         // Check if block's Starknet version is supported (applies to all states)
         if !current_block_starknet_version.is_supported() {
@@ -200,23 +215,11 @@ impl AggregatorHandler {
         match state {
             Empty(empty_state) => {
                 // Get state update for the current block
-                let current_state_update = self
-                    .config
-                    .madara_rpc_client()
-                    .get_state_update(BlockId::Number(block_num))
-                    .await
-                    .map_err(|e| JobError::ProviderError(e.to_string()))?;
+                let current_state_update = self.fetch_state_update(block_num, "empty_state").await?;
 
                 match current_state_update {
                     Update(state_update) => {
-                        let block_weights = AggregatorBatchWeights::from(
-                            &get_block_builtin_weights(
-                                block_num,
-                                self.config.madara_feeder_gateway_client(),
-                                self.batch_config.empty_block_proving_gas,
-                            )
-                            .await?,
-                        );
+                        let block_weights = self.fetch_block_weights(block_num, "empty_state").await?;
                         let aggregator_input_size_upper_bound = initial_aggregator_input_size_upper_bound(
                             &state_update,
                             block_weights.message_segment_length,
@@ -260,6 +263,78 @@ impl AggregatorHandler {
         }
     }
 
+    async fn fetch_block_version(&self, block_num: u64, operation: &str) -> Result<StarknetVersion, JobError> {
+        let started_at = Instant::now();
+        let version = get_block_version(block_num, self.config.madara_rpc_client()).await?;
+        info!(
+            block_num,
+            operation,
+            version = %version,
+            duration_ms = %started_at.elapsed().as_millis(),
+            "Fetched aggregator block Starknet version"
+        );
+        Ok(version)
+    }
+
+    async fn fetch_block_weights(&self, block_num: u64, operation: &str) -> Result<AggregatorBatchWeights, JobError> {
+        let started_at = Instant::now();
+        let weights = AggregatorBatchWeights::from(
+            &get_block_builtin_weights(
+                block_num,
+                self.config.madara_feeder_gateway_client(),
+                self.batch_config.empty_block_proving_gas,
+            )
+            .await?,
+        );
+        info!(
+            block_num,
+            operation,
+            l1_gas = %weights.l1_gas,
+            message_segment_length = %weights.message_segment_length,
+            duration_ms = %started_at.elapsed().as_millis(),
+            "Fetched aggregator block bouncer weights"
+        );
+        Ok(weights)
+    }
+
+    async fn fetch_state_update(
+        &self,
+        block_num: u64,
+        operation: &str,
+    ) -> Result<MaybePreConfirmedStateUpdate, JobError> {
+        let started_at = Instant::now();
+        let update = self
+            .config
+            .madara_rpc_client()
+            .get_state_update(BlockId::Number(block_num))
+            .await
+            .map_err(|e| JobError::ProviderError(e.to_string()))?;
+        match &update {
+            Update(state_update) => {
+                let (modified_contracts, storage_updates, declared_classes) =
+                    state_update_full_output_counts(state_update);
+                info!(
+                    block_num,
+                    operation,
+                    modified_contracts,
+                    storage_updates,
+                    declared_classes,
+                    duration_ms = %started_at.elapsed().as_millis(),
+                    "Fetched aggregator state update"
+                );
+            }
+            PreConfirmedUpdate(_) => {
+                info!(
+                    block_num,
+                    operation,
+                    duration_ms = %started_at.elapsed().as_millis(),
+                    "Fetched pre-confirmed aggregator state update"
+                );
+            }
+        }
+        Ok(update)
+    }
+
     async fn process_block(
         &self,
         block_num: u64,
@@ -278,25 +353,13 @@ impl AggregatorHandler {
         }
 
         // Fetch block weights for the current block
-        let block_weights = AggregatorBatchWeights::from(
-            &get_block_builtin_weights(
-                block_num,
-                self.config.madara_feeder_gateway_client(),
-                self.batch_config.empty_block_proving_gas,
-            )
-            .await?,
-        );
+        let block_weights = self.fetch_block_weights(block_num, "non_empty_state").await?;
 
         // Fetch Starknet version of the current block
-        let block_version = get_block_version(block_num, self.config.madara_rpc_client()).await?;
+        let block_version = self.fetch_block_version(block_num, "non_empty_state").await?;
 
         // Get the state update for the block
-        let block_state_update = self
-            .config
-            .madara_rpc_client()
-            .get_state_update(BlockId::Number(block_num))
-            .await
-            .map_err(|e| JobError::ProviderError(e.to_string()))?;
+        let block_state_update = self.fetch_state_update(block_num, "non_empty_state").await?;
 
         match block_state_update {
             Update(state_update) => {
@@ -369,23 +432,10 @@ impl AggregatorHandler {
     ) -> Result<AggregatorBatch, JobError> {
         // Fetch Starknet version for the start block
         // In tests, use a default version if fetch fails due to HTTP mocking limitations
-        let starknet_version = get_block_version(start_block, self.config.madara_rpc_client()).await?;
-        debug!(
-            index = %index,
-            start_block = %start_block,
-            starknet_version = %starknet_version,
-            "Fetched Starknet version for new batch"
-        );
+        let starknet_version = self.fetch_block_version(start_block, "start_aggregator_batch").await?;
 
         // Getting the builtin weights for the start_block and adding it in the DB
-        let weights = AggregatorBatchWeights::from(
-            &get_block_builtin_weights(
-                start_block,
-                self.config.madara_feeder_gateway_client(),
-                self.batch_config.empty_block_proving_gas,
-            )
-            .await?,
-        );
+        let weights = self.fetch_block_weights(start_block, "start_aggregator_batch").await?;
 
         let aggregator_input_size_upper_bound =
             initial_aggregator_input_size_upper_bound(state_update, weights.message_segment_length)?;
@@ -469,6 +519,10 @@ pub enum BatchCheckResult {
 impl NonEmptyAggregatorState {
     pub fn new(batch: AggregatorBatch, blob: StateUpdate) -> Self {
         Self { batch, blob }
+    }
+
+    pub fn batch_index(&self) -> u64 {
+        self.batch.index
     }
 
     /// Check if a block can be added to this batch based on synchronous conditions.
@@ -576,13 +630,23 @@ impl NonEmptyAggregatorState {
 
         // Check compressed state update is within limits (async)
         // Squash state updates
-        let squashed_state_update = squash(
-            vec![&self.blob, block_state_update],
-            if self.batch.start_block == 0 { None } else { Some(self.batch.start_block - 1) },
-            batch_client,
-        )
-        .await?;
+        let pre_range_block = if self.batch.start_block == 0 { None } else { Some(self.batch.start_block - 1) };
+        let squash_started_at = Instant::now();
+        let squashed_state_update = squash(vec![&self.blob, block_state_update], pre_range_block, batch_client).await?;
+        let (squashed_modified_contracts, squashed_storage_updates, squashed_declared_classes) =
+            state_update_full_output_counts(&squashed_state_update);
+        info!(
+            batch_index = %self.batch.index,
+            block_num,
+            ?pre_range_block,
+            modified_contracts = squashed_modified_contracts,
+            storage_updates = squashed_storage_updates,
+            declared_classes = squashed_declared_classes,
+            duration_ms = %squash_started_at.elapsed().as_millis(),
+            "Squashed aggregator state updates"
+        );
         // Compress the squashed state update
+        let compress_started_at = Instant::now();
         let compressed_state_update = compress_state_update(
             &squashed_state_update,
             block_num.saturating_sub(1),
@@ -590,6 +654,13 @@ impl NonEmptyAggregatorState {
             batch_client,
         )
         .await?;
+        info!(
+            batch_index = %self.batch.index,
+            block_num,
+            blob_len = compressed_state_update.len(),
+            duration_ms = %compress_started_at.elapsed().as_millis(),
+            "Compressed squashed aggregator state update"
+        );
         let blob_len = compressed_state_update.len();
         if blob_len > batch_limits.max_blob_size {
             debug!(
@@ -712,11 +783,19 @@ async fn compress_state_update(
     madara_version: StarknetVersion,
     batch_client: &BatchRpcClient,
 ) -> Result<Vec<Felt>, JobError> {
+    let started_at = Instant::now();
     // Perform stateful compression if needed
     let state_update = if madara_version >= StarknetVersion::V0_13_4 {
-        crate::compression::stateful::compress(blob, end_block, batch_client)
+        let stateful_started_at = Instant::now();
+        let state_update = crate::compression::stateful::compress(blob, end_block, batch_client)
             .await
-            .map_err(|err| JobError::Other(OtherError(err)))?
+            .map_err(|err| JobError::Other(OtherError(err)))?;
+        info!(
+            end_block,
+            duration_ms = %stateful_started_at.elapsed().as_millis(),
+            "Applied stateful compression to aggregator state update"
+        );
+        state_update
     } else {
         blob.clone()
     };
@@ -725,11 +804,18 @@ async fn compress_state_update(
     let vec_felts = state_update_to_blob_data(state_update, madara_version).await?;
 
     // Perform stateless compression if needed
-    if madara_version >= StarknetVersion::V0_13_3 {
-        crate::compression::stateless::compress(&vec_felts).map_err(|err| JobError::Other(OtherError(err)))
+    let compressed = if madara_version >= StarknetVersion::V0_13_3 {
+        crate::compression::stateless::compress(&vec_felts).map_err(|err| JobError::Other(OtherError(err)))?
     } else {
-        Ok(vec_felts)
-    }
+        vec_felts
+    };
+    info!(
+        end_block,
+        felt_count = compressed.len(),
+        duration_ms = %started_at.elapsed().as_millis(),
+        "Compressed aggregator state update"
+    );
+    Ok(compressed)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add INFO timing logs around AggregatorBatching lock lifecycle, per-block handling, state saves, bouncer weight fetches, state update fetches, squash, and compression
- add `aggregator_batching_duration_seconds` to record worker run duration in seconds with no attributes
- add `aggregator_batching_batch_number` to record the handled aggregator batch number with no attributes
- keep block range details in logs only; no block numbers or outcomes are attached to metrics

## Verification
- `cargo fmt --manifest-path orchestrator/Cargo.toml --check`
- `git diff --check`
- `cargo check -p orchestrator --all-targets`

Note: local cargo check completed successfully, but artifact Docker pulls emitted warnings because Docker was not available locally; the build fallback still completed.