### PR TITLE
feat(orchestrator): support _FILE for mongodb connection url in migrations

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -202,7 +202,7 @@ RUN echo '#!/bin/bash\n\
   set -e\n\
   \n\
   # Run database migrations if MongoDB connection is configured\n\
-  if [ -n "$MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL" ] && [ -n "$MADARA_ORCHESTRATOR_DATABASE_NAME" ]; then\n\
+  if { [ -n "$MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL" ] || [ -n "$MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL_FILE" ]; } && [ -n "$MADARA_ORCHESTRATOR_DATABASE_NAME" ]; then\n\
   echo "Running database migrations..."\n\
   cd /app && npx migrate-mongo up\n\
   echo "Migrations complete"\n\

--- a/orchestrator/migrate-mongo-config.js
+++ b/orchestrator/migrate-mongo-config.js
@@ -1,10 +1,29 @@
 // In this file you can configure migrate-mongo
 
+const fs = require("node:fs");
+
+// Mirror the Rust orchestrator's resolve_secret_from_file()
+// (see crates/utils/src/env_utils.rs): if `${name}_FILE` is set, read the
+// secret from that mounted file (K8s CSI Secrets Store Driver pattern). The
+// file value takes precedence over the direct env var; an empty file is an
+// error. Reading from a tmpfs file keeps the connection string out of
+// /proc/<pid>/environ, crash dumps, and `kubectl describe pod`. Backward
+// compatible: falls back to the plain env var when `${name}_FILE` is unset.
+function resolveSecretFromFile(name) {
+  const filePath = process.env[`${name}_FILE`];
+  if (!filePath) return process.env[name];
+  const value = fs.readFileSync(filePath, "utf8").trim();
+  if (!value) {
+    throw new Error(`Secret file '${filePath}' (set via ${name}_FILE) is empty`);
+  }
+  return value;
+}
+
 const config = {
   mongodb: {
     // TODO Change (or review) the url to your MongoDB:
     url:
-      process.env.MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL ||
+      resolveSecretFromFile("MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL") ||
       "mongodb://localhost:27017",
 
     // TODO Change this to your database name:

--- a/orchestrator/migrate-mongo-config.test.js
+++ b/orchestrator/migrate-mongo-config.test.js
@@ -1,0 +1,39 @@
+// Runnable check for the _FILE secret resolution in migrate-mongo-config.js.
+// No test framework: uses Node's built-in runner + assert. Run with:
+//   node --test
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const VAR = "MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL";
+
+function loadConfig() {
+  // Re-require fresh so env changes are picked up.
+  delete require.cache[require.resolve("./migrate-mongo-config.js")];
+  return require("./migrate-mongo-config.js");
+}
+
+function tmpFileWith(contents) {
+  const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "mmc-")), "url");
+  fs.writeFileSync(p, contents);
+  return p;
+}
+
+test("_FILE variant takes precedence over the plain env var and is trimmed", () => {
+  process.env[VAR] = "mongodb://env-url:27017";
+  process.env[`${VAR}_FILE`] = tmpFileWith("  mongodb://file-url:27017\n");
+  assert.strictEqual(loadConfig().mongodb.url, "mongodb://file-url:27017");
+});
+
+test("falls back to the plain env var when _FILE is unset", () => {
+  delete process.env[`${VAR}_FILE`];
+  process.env[VAR] = "mongodb://env-url:27017";
+  assert.strictEqual(loadConfig().mongodb.url, "mongodb://env-url:27017");
+});
+
+test("an empty secret file is a hard error (never silently falls back)", () => {
+  process.env[`${VAR}_FILE`] = tmpFileWith("   \n");
+  assert.throws(() => loadConfig(), /is empty/);
+});


### PR DESCRIPTION
## Problem

The Rust orchestrator already resolves 8 sensitive env vars from a mounted `${VAR}_FILE` path (`resolve_secret_from_file`, `crates/utils/src/env_utils.rs`) — the K8s CSI Secrets Store Driver pattern — including `MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL`.

But the pre-start **migrate-mongo** step was the last place still reading only the plain `MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL`. So a file-only secret setup runs the orchestrator binary fine, yet the migrations that run before it fail (no URL / stale URL). In practice this means the DB connection string has to be duplicated into a plaintext env source (e.g. a ConfigMap) just to satisfy migrations — defeating the point of mounting it as a file from a secret manager.

## Change

Extend the existing `_FILE` convention to the migration path:

- **`migrate-mongo-config.js`** reads the `_FILE` variant with **precedence** over the plain env var, trims it, and errors on an empty file — mirroring the Rust `resolve_secret_from_file()`. Backward compatible: falls back to the plain env var when `_FILE` is unset.
- **`Dockerfile`** entrypoint gate now triggers migrations when **either** `MADARA_ORCHESTRATOR_MONGODB_CONNECTION_URL` **or** `..._FILE` is set (so file-only setups still run migrations).
- **`migrate-mongo-config.test.js`** — framework-free `node --test` covering precedence, fallback, and the empty-file error.

## Test

```
$ cd orchestrator && node --test
✔ _FILE variant takes precedence over the plain env var and is trimmed
✔ falls back to the plain env var when _FILE is unset
✔ an empty secret file is a hard error (never silently falls back)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)