### PR TITLE
fix(orchestrator): retry transient Madara provider reads

### DIFF
--- a/orchestrator/src/utils/mod.rs
+++ b/orchestrator/src/utils/mod.rs
@@ -6,5 +6,6 @@ pub mod logging;
 pub mod metrics;
 pub mod metrics_recorder;
 pub mod preflight;
+pub mod provider_retry;
 pub mod rest_client;
 pub mod signal_handler;

--- a/orchestrator/src/utils/provider_retry.rs
+++ b/orchestrator/src/utils/provider_retry.rs
@@ -1,0 +1,172 @@
+use std::future::Future;
+use std::time::Duration;
+
+use rand::Rng;
+use starknet::providers::ProviderError;
+use thiserror::Error;
+use tokio::time::timeout;
+use tracing::warn;
+
+const PROVIDER_READ_RETRY_CONFIG: ProviderReadRetryConfig = ProviderReadRetryConfig {
+    max_attempts: 3,
+    timeout: Duration::from_secs(30),
+    initial_backoff: Duration::from_millis(200),
+};
+
+#[derive(Clone, Copy)]
+struct ProviderReadRetryConfig {
+    max_attempts: usize,
+    timeout: Duration,
+    initial_backoff: Duration,
+}
+
+#[derive(Debug, Error)]
+pub enum ProviderReadError {
+    #[error("Provider request timed out after {timeout:?}")]
+    Timeout { timeout: Duration },
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+}
+
+pub async fn retry_provider_read<F, Fut, T>(operation: &'static str, request: F) -> Result<T, ProviderReadError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, ProviderError>>,
+{
+    retry_provider_read_with_config(operation, PROVIDER_READ_RETRY_CONFIG, request).await
+}
+
+async fn retry_provider_read_with_config<F, Fut, T>(
+    operation: &'static str,
+    config: ProviderReadRetryConfig,
+    mut request: F,
+) -> Result<T, ProviderReadError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, ProviderError>>,
+{
+    let mut backoff = config.initial_backoff;
+
+    for attempt in 1..=config.max_attempts {
+        match timeout(config.timeout, request()).await {
+            Ok(Ok(value)) => return Ok(value),
+            Ok(Err(error)) => {
+                if attempt == config.max_attempts || !is_retryable_provider_error(&error) {
+                    return Err(error.into());
+                }
+                warn!(operation, attempt, max_attempts = config.max_attempts, error = %error, "Retrying Madara provider read");
+            }
+            Err(_) => {
+                if attempt == config.max_attempts {
+                    return Err(ProviderReadError::Timeout { timeout: config.timeout });
+                }
+                warn!(operation, attempt, max_attempts = config.max_attempts, timeout = ?config.timeout, "Retrying timed out Madara provider read");
+            }
+        }
+
+        tokio::time::sleep(backoff + jitter(backoff)).await;
+        backoff = backoff.saturating_mul(2);
+    }
+
+    unreachable!("retry loop returns on final attempt")
+}
+
+fn jitter(backoff: Duration) -> Duration {
+    let max_jitter_ms = backoff.as_millis().min(100) as u64;
+    Duration::from_millis(rand::thread_rng().gen_range(0..=max_jitter_ms))
+}
+
+fn is_retryable_provider_error(error: &ProviderError) -> bool {
+    match error {
+        ProviderError::RateLimited => true,
+        ProviderError::Other(error) => {
+            let message = error.to_string().to_lowercase();
+            [
+                "error sending request",
+                "transport error",
+                "timeout",
+                "timed out",
+                "connection",
+                "connection reset",
+                "connection refused",
+                "dns",
+                "temporarily unavailable",
+                "502",
+                "503",
+                "504",
+            ]
+            .iter()
+            .any(|marker| message.contains(marker))
+        }
+        ProviderError::StarknetError(_) | ProviderError::ArrayLengthMismatch => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
+
+    use starknet::providers::ProviderError;
+
+    use super::{retry_provider_read_with_config, ProviderReadError, ProviderReadRetryConfig};
+
+    #[tokio::test]
+    async fn retries_retryable_errors_then_succeeds() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let result = retry_provider_read_with_config("test", test_config(), || {
+            let attempts = attempts.clone();
+            async move {
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(ProviderError::RateLimited)
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_non_retryable_errors() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let result = retry_provider_read_with_config("test", test_config(), || {
+            let attempts = attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(ProviderError::ArrayLengthMismatch)
+            }
+        })
+        .await;
+
+        assert!(matches!(result, Err(ProviderReadError::Provider(ProviderError::ArrayLengthMismatch))));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_timeouts_until_exhausted() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let result = retry_provider_read_with_config("test", test_config(), || {
+            let attempts = attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Ok::<(), ProviderError>(())
+            }
+        })
+        .await;
+
+        assert!(matches!(result, Err(ProviderReadError::Timeout { .. })));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    fn test_config() -> ProviderReadRetryConfig {
+        ProviderReadRetryConfig { max_attempts: 3, timeout: Duration::from_millis(1), initial_backoff: Duration::ZERO }
+    }
+}

--- a/orchestrator/src/worker/event_handler/jobs/da.rs
+++ b/orchestrator/src/worker/event_handler/jobs/da.rs
@@ -9,6 +9,7 @@ use crate::types::jobs::metadata::{DaMetadata, JobMetadata, JobSpecificMetadata}
 use crate::types::jobs::status::JobVerificationStatus;
 use crate::types::jobs::types::{JobStatus, JobType};
 use crate::utils::metrics_recorder::MetricsRecorder;
+use crate::utils::provider_retry::retry_provider_read;
 use crate::worker::event_handler::jobs::JobHandlerTrait;
 use crate::worker::utils::biguint_vec_to_u8_vec;
 use async_trait::async_trait;
@@ -135,12 +136,15 @@ impl DAJobHandler {
             // nonce for the block
 
             if nonce.is_none() && !storage_entries.is_empty() && address != Felt::ONE && address != Felt::TWO {
+                let provider = config.madara_rpc_client();
                 let get_current_nonce_result =
-                    config.madara_rpc_client().get_nonce(BlockId::Number(block_no), address).await.map_err(|e| {
-                        JobError::ProviderError(format!(
-                            "Failed to get nonce for address {address} at block {block_no}: {e}"
-                        ))
-                    })?;
+                    retry_provider_read("madara_get_nonce", || provider.get_nonce(BlockId::Number(block_no), address))
+                        .await
+                        .map_err(|e| {
+                            JobError::ProviderError(format!(
+                                "Failed to get nonce for address {address} at block {block_no}: {e}"
+                            ))
+                        })?;
 
                 nonce = Some(get_current_nonce_result);
             }
@@ -235,11 +239,11 @@ impl JobHandlerTrait for DAJobHandler {
         let mut da_metadata: DaMetadata = job.metadata.specific.clone().try_into()?;
         let block_no = internal_id;
 
-        let state_update = config
-            .madara_rpc_client()
-            .get_state_update(BlockId::Number(block_no))
-            .await
-            .map_err(|e| JobError::ProviderError(e.to_string()))?;
+        let provider = config.madara_rpc_client();
+        let state_update =
+            retry_provider_read("madara_get_state_update", || provider.get_state_update(BlockId::Number(block_no)))
+                .await
+                .map_err(|e| JobError::ProviderError(e.to_string()))?;
 
         let state_update = match state_update {
             MaybePreConfirmedStateUpdate::PreConfirmedUpdate(_) => {

--- a/orchestrator/src/worker/event_handler/triggers/aggregator_batching.rs
+++ b/orchestrator/src/worker/event_handler/triggers/aggregator_batching.rs
@@ -2,6 +2,7 @@ use crate::core::client::lock::LockValue;
 use crate::core::config::Config;
 use crate::error::job::JobError;
 use crate::utils::metrics_recorder::MetricsRecorder;
+use crate::utils::provider_retry::retry_provider_read;
 use crate::worker::event_handler::triggers::batching::aggregator::{
     AggregatorBatchConfig, AggregatorHandler, AggregatorState, AggregatorStateHandler,
 };
@@ -177,8 +178,9 @@ impl AggregatorBatchingTrigger {
 
         // Getting the latest block number from the sequencer
         let provider = config.madara_rpc_client();
-        let last_block_in_provider =
-            provider.block_number().await.map_err(|e| JobError::ProviderError(e.to_string()))?;
+        let last_block_in_provider = retry_provider_read("madara_block_number", || provider.block_number())
+            .await
+            .map_err(|e| JobError::ProviderError(e.to_string()))?;
 
         // Calculating the last block number that needs to be assigned to a batch
         let last_block = config

--- a/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching/aggregator.rs
@@ -9,6 +9,7 @@ use crate::types::constant::ORCHESTRATOR_VERSION;
 use crate::types::jobs::types::JobType;
 use crate::utils::metrics::ORCHESTRATOR_METRICS;
 use crate::utils::metrics_recorder::MetricsRecorder;
+use crate::utils::provider_retry::retry_provider_read;
 use crate::worker::event_handler::triggers::batching::aggregator::AggregatorState::{Empty, NonEmpty};
 use crate::worker::event_handler::triggers::batching::utils::{get_block_builtin_weights, get_block_version};
 use crate::worker::event_handler::triggers::batching::BlockProcessingResult;
@@ -303,12 +304,11 @@ impl AggregatorHandler {
         operation: &str,
     ) -> Result<MaybePreConfirmedStateUpdate, JobError> {
         let started_at = Instant::now();
-        let update = self
-            .config
-            .madara_rpc_client()
-            .get_state_update(BlockId::Number(block_num))
-            .await
-            .map_err(|e| JobError::ProviderError(e.to_string()))?;
+        let provider = self.config.madara_rpc_client();
+        let update =
+            retry_provider_read("madara_get_state_update", || provider.get_state_update(BlockId::Number(block_num)))
+                .await
+                .map_err(|e| JobError::ProviderError(e.to_string()))?;
         match &update {
             Update(state_update) => {
                 let (modified_contracts, storage_updates, declared_classes) =

--- a/orchestrator/src/worker/event_handler/triggers/batching/replay_bounds.rs
+++ b/orchestrator/src/worker/event_handler/triggers/batching/replay_bounds.rs
@@ -3,6 +3,8 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
 use std::sync::Arc;
 
+use crate::utils::provider_retry::retry_provider_read;
+
 #[derive(Debug)]
 pub enum ReplayBoundsError {
     HashMismatch { block_number: u64, madara_hash: String, reference_hash: String },
@@ -47,11 +49,13 @@ pub async fn validate_block_hash(
     reference_client: &Arc<JsonRpcClient<HttpTransport>>,
     block_number: u64,
 ) -> Result<(), ReplayBoundsError> {
-    let block_id = BlockId::Number(block_number);
-
     let (madara_result, reference_result) = tokio::join!(
-        madara_client.get_block_with_tx_hashes(block_id),
-        reference_client.get_block_with_tx_hashes(block_id),
+        retry_provider_read("madara_replay_bounds_get_block_with_tx_hashes", || {
+            madara_client.get_block_with_tx_hashes(BlockId::Number(block_number))
+        }),
+        retry_provider_read("reference_replay_bounds_get_block_with_tx_hashes", || {
+            reference_client.get_block_with_tx_hashes(BlockId::Number(block_number))
+        }),
     );
 
     let madara_hash = extract_block_hash(madara_result, block_number, "madara")?;

--- a/orchestrator/src/worker/event_handler/triggers/snos.rs
+++ b/orchestrator/src/worker/event_handler/triggers/snos.rs
@@ -6,6 +6,7 @@ use crate::types::constant::{
 use crate::types::jobs::metadata::{CommonMetadata, JobMetadata, JobSpecificMetadata, SnosMetadata};
 use crate::types::jobs::types::JobType;
 use crate::utils::metrics_recorder::MetricsRecorder;
+use crate::utils::provider_retry::retry_provider_read;
 use crate::worker::event_handler::service::JobHandlerService;
 use crate::worker::event_handler::triggers::{
     calculate_jobs_to_create, first_unsettled_snos_batch_index_or_zero, JobTrigger,
@@ -138,10 +139,11 @@ pub async fn fetch_block_starknet_version(
     debug!("Fetching block header for block {} to extract Starknet version", block_number);
 
     // Fetch block with transaction hashes (lighter than full txs)
-    let block = provider
-        .get_block_with_tx_hashes(BlockId::Number(block_number))
-        .await
-        .map_err(|e| eyre!("Failed to fetch block {} from sequencer: {}", block_number, e))?;
+    let block = retry_provider_read("madara_get_block_with_tx_hashes", || {
+        provider.get_block_with_tx_hashes(BlockId::Number(block_number))
+    })
+    .await
+    .map_err(|e| eyre!("Failed to fetch block {} from sequencer: {}", block_number, e))?;
 
     let starknet_version = match block {
         starknet::core::types::MaybePreConfirmedBlockWithTxHashes::Block(block) => block.starknet_version,

--- a/orchestrator/src/worker/event_handler/triggers/snos_batching.rs
+++ b/orchestrator/src/worker/event_handler/triggers/snos_batching.rs
@@ -2,6 +2,7 @@ use crate::core::client::lock::LockValue;
 use crate::core::config::Config;
 use crate::error::job::JobError;
 use crate::types::constant::ORCHESTRATOR_VERSION;
+use crate::utils::provider_retry::retry_provider_read;
 use crate::worker::event_handler::triggers::batching::replay_bounds;
 use crate::worker::event_handler::triggers::batching::snos::{
     SnosBatchLimits, SnosHandler, SnosState, SnosStateHandler,
@@ -228,8 +229,9 @@ impl SnosBatchingTrigger {
 
         // Get the latest block number from the sequencer
         let provider = config.madara_rpc_client();
-        let block_number_provider =
-            provider.block_number().await.map_err(|e| JobError::ProviderError(e.to_string()))?;
+        let block_number_provider = retry_provider_read("madara_block_number", || provider.block_number())
+            .await
+            .map_err(|e| JobError::ProviderError(e.to_string()))?;
 
         // Calculate the first block to assign to SNOS batch
         let first_block = max(config.service_config().min_block_to_process, (last_processed_block + 1) as u64);


### PR DESCRIPTION
## Summary
- add a small retry helper for transient Madara provider reads with 3 attempts and a 30s per-attempt timeout
- wrap batching block-number reads, block version/hash reads, state-update reads, and DA nonce reads
- keep Starknet semantic provider errors non-retryable so correctness checks fail closed

## Testing
- cargo fmt --manifest-path orchestrator/Cargo.toml
- git diff --check
- local cargo test/build skipped by request; CI should cover compile/tests
