### PR TITLE
fix(settlement): retry L1 state update sync on all errors

### DIFF
--- a/madara/crates/client/settlement_client/src/eth/error.rs
+++ b/madara/crates/client/settlement_client/src/eth/error.rs
@@ -46,7 +46,9 @@ impl From<sol_types::Error> for EthereumClientError {
 impl EthereumClientError {
     /// Returns true if the error is recoverable (network/connection issues).
     /// These are transient errors that should be retried with backoff.
+    /// `Contract` is included because contract `.call()` failures wrap the
+    /// underlying transport error, so at runtime they are usually RPC outages.
     pub fn is_recoverable(&self) -> bool {
-        matches!(self, Self::Rpc(_) | Self::EventStream { .. } | Self::NetworkConnection { .. })
+        matches!(self, Self::Rpc(_) | Self::Contract(_) | Self::EventStream { .. } | Self::NetworkConnection { .. })
     }
 }

--- a/madara/crates/client/settlement_client/src/starknet/error.rs
+++ b/madara/crates/client/settlement_client/src/starknet/error.rs
@@ -49,7 +49,15 @@ impl From<StarknetError> for StarknetClientError {
 impl StarknetClientError {
     /// Returns true if the error is recoverable (network/connection issues).
     /// These are transient errors that should be retried with backoff.
+    /// `StateInitialization` is included because the `get_state` call maps its
+    /// transport failures to it, so at runtime it is usually an RPC outage.
     pub fn is_recoverable(&self) -> bool {
-        matches!(self, Self::Provider(_) | Self::EventSubscription { .. } | Self::NetworkConnection { .. })
+        matches!(
+            self,
+            Self::Provider(_)
+                | Self::EventSubscription { .. }
+                | Self::NetworkConnection { .. }
+                | Self::StateInitialization { .. }
+        )
     }
 }

--- a/madara/crates/client/settlement_client/src/state_update.rs
+++ b/madara/crates/client/settlement_client/src/state_update.rs
@@ -78,6 +78,7 @@ pub async fn state_update_worker(
     let mut reconnect_delay = RECONNECT_BASE_DELAY;
 
     loop {
+        let session_start = std::time::Instant::now();
         match ctx
             .run_until_cancelled(try_sync_once(
                 &settlement_client,
@@ -90,12 +91,23 @@ pub async fn state_update_worker(
         {
             None => return Ok(()),         // Service shutdown
             Some(Ok(())) => return Ok(()), // Clean exit
-            Some(Err(e)) if e.is_recoverable() => {
-                tracing::warn!("L1 state sync failed: {e:#}, reconnecting in {reconnect_delay:?}");
+            // This worker only observes L1 confirmations: an outage degrades finality
+            // reporting but is never unsafe, so every error is retried rather than
+            // aborting the node (which a returned Err would do via the ServiceMonitor).
+            Some(Err(e)) => {
+                if session_start.elapsed() >= RECONNECT_MAX_DELAY {
+                    reconnect_delay = RECONNECT_BASE_DELAY;
+                }
+                if e.is_recoverable() {
+                    tracing::warn!("L1 state sync failed: {e:#}, reconnecting in {reconnect_delay:?}");
+                } else {
+                    tracing::error!(
+                        "L1 state sync failed with an unexpected error: {e:#}, reconnecting in {reconnect_delay:?}"
+                    );
+                }
                 tokio::time::sleep(reconnect_delay).await;
                 reconnect_delay = std::cmp::min(reconnect_delay * 2, RECONNECT_MAX_DELAY);
             }
-            Some(Err(e)) => return Err(e), // Non-recoverable
         }
     }
 }
@@ -186,5 +198,53 @@ mod state_update_worker_tests {
         // #100 (initial, session 1) → #200 (event) → reconnect → #101 (initial,
         // session 2): the last head proves the fresh subscription was used.
         assert_eq!(l1_head_rx.borrow().as_ref().and_then(|s| s.block_number), Some(101));
+    }
+
+    /// The worker must retry even on errors that are not classified recoverable:
+    /// a transient RPC failure surfacing through an unclassified path previously
+    /// propagated out of the worker and took down the whole node via the
+    /// ServiceMonitor.
+    #[tokio::test(start_paused = true)]
+    async fn worker_retries_after_unclassified_error() {
+        let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
+        let block_metrics = Arc::new(L1BlockMetrics::register().expect("metrics should register"));
+        let ctx = ServiceContext::new_for_testing();
+        let (l1_head_tx, l1_head_rx) = tokio::sync::watch::channel(None);
+
+        let sessions = Arc::new(AtomicUsize::new(0));
+        let mut mock = MockSettlementLayerProvider::new();
+        mock.expect_get_current_core_contract_state().times(2).returning({
+            let sessions = Arc::clone(&sessions);
+            move || match sessions.fetch_add(1, Ordering::SeqCst) {
+                0 => Err(SettlementClientError::Other("transient failure on an unclassified path".to_string())),
+                _ => Ok(StateUpdate { block_number: Some(100), global_root: Felt::ZERO, block_hash: Felt::ZERO }),
+            }
+        });
+        mock.expect_listen_for_update_state_events().times(1).returning(|_ctx, _worker| Ok(()));
+
+        tokio::time::timeout(
+            Duration::from_secs(30),
+            state_update_worker(backend, Arc::new(mock), ctx, l1_head_tx, block_metrics),
+        )
+        .await
+        .expect("worker should not hang after an unclassified error")
+        .expect("worker should exit cleanly after the second session");
+
+        assert_eq!(l1_head_rx.borrow().as_ref().and_then(|s| s.block_number), Some(100));
+    }
+
+    #[test]
+    fn transport_failures_in_contract_calls_are_recoverable() {
+        use crate::eth::error::EthereumClientError;
+        use crate::starknet::error::StarknetClientError;
+
+        assert!(SettlementClientError::from(EthereumClientError::Contract(
+            "Failed to get state root: transport error".to_string()
+        ))
+        .is_recoverable());
+        assert!(SettlementClientError::from(StarknetClientError::StateInitialization {
+            message: "Failed to get state: transport error".to_string()
+        })
+        .is_recoverable());
     }
 }

--- a/madara/crates/client/settlement_client/src/state_update.rs
+++ b/madara/crates/client/settlement_client/src/state_update.rs
@@ -105,7 +105,9 @@ pub async fn state_update_worker(
                         "L1 state sync failed with an unexpected error: {e:#}, reconnecting in {reconnect_delay:?}"
                     );
                 }
-                tokio::time::sleep(reconnect_delay).await;
+                if ctx.run_until_cancelled(tokio::time::sleep(reconnect_delay)).await.is_none() {
+                    return Ok(());
+                }
                 reconnect_delay = std::cmp::min(reconnect_delay * 2, RECONNECT_MAX_DELAY);
             }
         }


### PR DESCRIPTION
## Pull Request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

## What is the current behavior?

A transient L1 RPC failure (timeout, connection reset, 429) that surfaces inside one of the core-contract calls in `get_current_core_contract_state` is wrapped in `EthereumClientError::Contract` (or `StarknetClientError::StateInitialization` on Starknet settlement). `is_recoverable()` classifies these as non-recoverable, so the state update worker returns `Err`, which propagates through `run_sync_worker` and the `ServiceMonitor` and **kills the entire node**. Whether the same network blip crashes the node or is retried depends purely on which RPC call it happens to land on: `get_latest_block_number` failures retry, contract-call failures crash.

## What is the new behavior?

- The state update worker retries **every** sync-session error with the existing capped exponential backoff (1s → 60s). This worker only observes L1 confirmations — an L1 outage degrades finality reporting but is never unsafe — so no error from it should take down the node. `is_recoverable()` now only selects the log level: `warn` for known-transient errors, `error` for unexpected ones, so genuine misconfiguration stays loudly visible without being fatal.
- The backoff resets to base once a session has been healthy for longer than the max delay (previously it escalated across the process lifetime and never reset).
- `EthereumClientError::Contract` and `StarknetClientError::StateInitialization` are reclassified as recoverable, since at runtime they wrap the underlying transport error of contract calls.
- Regression tests: the worker survives an error that is *not* classified recoverable (the exact shape that previously aborted the node), and the classification of the two reclassified variants is pinned.

## Scope notes

- **Gas prices are deliberately not included.** For gas prices we want the node to panic rather than keep producing blocks with stale prices, so the gas price worker's failure behavior is left untouched. (Nodes running with all prices fixed via `--l1-gas-price`/`--blob-gas-price`/`--strk-per-eth` don't run the gas poller at all.)
- Startup behavior is unchanged: client construction still verifies the core contract and fails boot if L1 is unreachable at start. Startup resilience can be addressed separately.
- L1→L2 messaging already has its own infinite reconnect loop and is unaffected.