### PR TITLE
fix(mempool): prevent L1 catch-up starvation

### DIFF
--- a/madara/crates/client/db/src/subscription.rs
+++ b/madara/crates/client/db/src/subscription.rs
@@ -65,6 +65,10 @@ impl<D: MadaraStorageRead> SubscribeNewL1Heads<D> {
             let highest_block_plus_one = self.subscription.current().map(|v| v + 1).unwrap_or(0);
 
             if next_block_to_return < highest_block_plus_one {
+                // A historical range is immediately ready; consume cooperative budget so a large catch-up
+                // cannot starve peer tasks.
+                tokio::task::coop::consume_budget().await;
+                // Only advance after the yield point so cancelling this future cannot skip an unreturned head.
                 self.current_value = Some(next_block_to_return);
                 return &self.current_value;
             }
@@ -211,5 +215,73 @@ impl<D: MadaraStorageRead> MadaraBackend<D> {
     /// Subscribe to new blocks. See [`SubscribeNewHeads`] for more details
     pub fn subscribe_new_heads(self: &Arc<Self>, tag: SubscribeNewBlocksTag) -> SubscribeNewHeads<D> {
         SubscribeNewHeads::new(self, tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mp_chain_config::ChainConfig;
+    use std::{
+        future::{poll_fn, Future},
+        pin::pin,
+        sync::atomic::{AtomicBool, Ordering},
+        task::Poll,
+    };
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn historical_l1_backlog_yields_to_peer_tasks() {
+        let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
+        let mut subscription = backend.subscribe_new_l1_confirmed_heads();
+        backend.set_latest_l1_confirmed(Some(1_000)).expect("L1 tip should be set");
+
+        let peer_ran = AtomicBool::new(false);
+        let drain_backlog = async {
+            for expected in 0..=1_000 {
+                assert_eq!(*subscription.next_head().await, Some(expected));
+            }
+            assert!(peer_ran.load(Ordering::SeqCst), "historical catch-up monopolized the runtime");
+        };
+        let peer_task = async {
+            peer_ran.store(true, Ordering::SeqCst);
+        };
+
+        tokio::join!(biased; drain_backlog, peer_task);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_historical_l1_head_is_returned_on_retry() {
+        tokio::spawn(async {
+            let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
+            let mut subscription = backend.subscribe_new_l1_confirmed_heads();
+            backend.set_latest_l1_confirmed(Some(1)).expect("L1 tip should be set");
+
+            // Exhaust this task's cooperative budget without awaiting the Pending call, which would let Tokio
+            // reschedule the task with a fresh budget.
+            loop {
+                let consumed = poll_fn(|cx| {
+                    let future = tokio::task::coop::consume_budget();
+                    let mut future = pin!(future);
+                    Poll::Ready(future.as_mut().poll(cx).is_ready())
+                })
+                .await;
+                if !consumed {
+                    break;
+                }
+            }
+
+            // Poll the subscription to its cooperative yield point, then cancel it before it returns a head.
+            {
+                let mut next_head = Box::pin(subscription.next_head());
+                let yielded = poll_fn(|cx| Poll::Ready(next_head.as_mut().poll(cx).is_pending())).await;
+                assert!(yielded, "subscription should yield when its cooperative budget is exhausted");
+            }
+
+            assert_eq!(*subscription.current(), None, "a cancelled call must not advance the subscription cursor");
+            assert_eq!(*subscription.next_head().await, Some(0), "the cancelled head should be returned on retry");
+            assert_eq!(*subscription.next_head().await, Some(1), "later heads should retain their order");
+        })
+        .await
+        .expect("cancellation regression task should complete");
     }
 }

--- a/madara/crates/client/settlement_client/src/state_update.rs
+++ b/madara/crates/client/settlement_client/src/state_update.rs
@@ -62,19 +62,6 @@ pub async fn state_update_worker(
     l1_head_sender: L1HeadSender,
     block_metrics: Arc<L1BlockMetrics>,
 ) -> Result<(), SettlementClientError> {
-    let state = StateUpdateWorker {
-        block_metrics: block_metrics.clone(),
-        backend: backend.clone(),
-        l1_head_sender: l1_head_sender.clone(),
-    };
-
-    // Clear L1 confirmed block at startup
-    // TODO: remove this
-    state.backend.set_latest_l1_confirmed(None).map_err(|e| {
-        SettlementClientError::DatabaseError(format!("Failed to clear last confirmed block at startup: {}", e))
-    })?;
-    tracing::debug!("update_l1: cleared confirmed block number");
-
     let mut reconnect_delay = RECONNECT_BASE_DELAY;
 
     loop {
@@ -136,8 +123,64 @@ mod state_update_worker_tests {
     use super::*;
     use crate::client::MockSettlementLayerProvider;
     use mp_chain_config::ChainConfig;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Mutex,
+    };
     use std::time::Duration;
+
+    #[test]
+    fn worker_preserves_persisted_l1_cursor_while_fetching_current_state() {
+        const PERSISTED_CURSOR: u64 = 123;
+
+        let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
+        backend.set_latest_l1_confirmed(Some(PERSISTED_CURSOR)).expect("cursor should be persisted");
+
+        let (fetch_started_tx, fetch_started_rx) = mpsc::channel();
+        let (release_fetch_tx, release_fetch_rx) = mpsc::channel();
+        let release_fetch_rx = Arc::new(Mutex::new(release_fetch_rx));
+
+        let mut mock = MockSettlementLayerProvider::new();
+        mock.expect_get_current_core_contract_state().times(1).returning({
+            let release_fetch_rx = Arc::clone(&release_fetch_rx);
+            move || {
+                fetch_started_tx.send(()).expect("test should still be waiting for the fetch");
+                release_fetch_rx
+                    .lock()
+                    .expect("release channel lock should not be poisoned")
+                    .recv()
+                    .expect("test should release the mocked fetch after observing the cursor");
+                Ok(StateUpdate {
+                    block_number: Some(PERSISTED_CURSOR),
+                    global_root: Felt::ZERO,
+                    block_hash: Felt::ZERO,
+                })
+            }
+        });
+        mock.expect_listen_for_update_state_events().times(1).returning(|_ctx, _worker| Ok(()));
+
+        let worker_backend = Arc::clone(&backend);
+        let worker = std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime should build").block_on(
+                state_update_worker(
+                    worker_backend,
+                    Arc::new(mock),
+                    ServiceContext::new_for_testing(),
+                    tokio::sync::watch::channel(None).0,
+                    Arc::new(L1BlockMetrics::register().expect("metrics should register")),
+                ),
+            )
+        });
+
+        fetch_started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("worker should start fetching the current L1 state");
+        let cursor_during_fetch = backend.latest_l1_confirmed_block_n();
+        release_fetch_tx.send(()).expect("worker should still be waiting for the mocked fetch");
+        worker.join().expect("worker thread should not panic").expect("worker should exit cleanly");
+
+        assert_eq!(cursor_during_fetch, Some(PERSISTED_CURSOR));
+    }
 
     /// End-to-end recovery test: when a state update subscription dies with the
     /// recoverable error produced by the liveness watchdog terminating a stuck


### PR DESCRIPTION
## Summary

- Preserve the persisted L1-confirmed cursor while the settlement client fetches the authoritative core-contract state, preventing an erroneous genesis-to-tip replay during restart.
- Cooperatively yield during legitimate historical L1 catch-up so block production and other ready tasks continue receiving runtime.
- Advance the subscription cursor only after the yield point so cancellation cannot skip an L1 head.

## Flow

```mermaid
flowchart LR
    A["Restart loads persisted cursor P"] --> B["Fetch authoritative L1 tip T"]
    B --> C["Process only the real gap P+1 through T"]
    C --> D["Cooperative yield during a large backlog"]
    D --> E["Batcher and peer tasks continue running"]
```

## Validation

Local regression coverage passes for cursor preservation, historical catch-up fairness, and cancellation safety. Formatting and diff checks also pass.
