### PR TITLE
ci: harden LLVM apt setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,9 +549,12 @@ install-llvm19:
 		CODENAME=$(CODENAME); \
 	fi; \
 	echo "Using LLVM repository codename: $$CODENAME"; \
+	if [ -f /etc/apt/blacksmith-ubuntu-mirrors.txt ]; then \
+		printf '%s\n' "http://archive.ubuntu.com/ubuntu" | $(if $(SUDO),sudo,) tee /etc/apt/blacksmith-ubuntu-mirrors.txt > /dev/null; \
+	fi; \
 	$(if $(SUDO),sudo,) wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | $(if $(SUDO),sudo,) tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null; \
-	$(if $(SUDO),sudo,) add-apt-repository -y "deb http://apt.llvm.org/$$CODENAME/ llvm-toolchain-$$CODENAME-19 main"; \
-	$(if $(SUDO),sudo,) apt-get update -y; \
+	$(if $(SUDO),sudo,) add-apt-repository -y -n "deb http://apt.llvm.org/$$CODENAME/ llvm-toolchain-$$CODENAME-19 main"; \
+	$(if $(SUDO),sudo,) apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 update -y; \
 	$(if $(SUDO),sudo,) apt-get install -y \
 		clang-19 llvm-19 llvm-19-dev llvm-19-runtime \
 		libmlir-19-dev mlir-19-tools \


### PR DESCRIPTION
## Summary
- Pin Blacksmith Ubuntu mirror selection to `archive.ubuntu.com` before installing LLVM 19
- Disable `add-apt-repository`'s implicit unbounded update with `-n`
- Add APT retry and 20s HTTP/HTTPS timeouts to the explicit update

## Context
Karnot PR15 manual image runs `31577535715`, `31579528101`, and `31579595595` stalled during Cairo Native setup while `apt-get update` selected `mirror.arizona.edu` through `/etc/apt/blacksmith-ubuntu-mirrors.txt`. The same fix was validated in Karnot PR15 commit `88159bfc9`; replacement run `31580657167` completed Cairo Native setup in 26 seconds and advanced to artifact generation.

## Validation
- `git diff --check`
- `make -n install-llvm19 SUDO=sudo CODENAME=jammy`