### PR TITLE
fix: redact logged account identifiers

### DIFF
--- a/bootstrapper-v2/src/setup/madara/mod.rs
+++ b/bootstrapper-v2/src/setup/madara/mod.rs
@@ -108,7 +108,7 @@ impl MadaraSetup {
         let madara_factory_address =
             self.deploy_madara_factory(udc_address, l1_eth_bridge_address, l1_erc20_bridge_address).await?;
 
-        log::info!("MadaraFactory deployed successfully at address: 0x{:x}", madara_factory_address);
+        log::info!("MadaraFactory deployment completed successfully");
 
         // Call MadaraFactory.deploy_bridges() to deploy bridge contracts
         self.deploy_bridges_via_madara_factory(madara_factory_address).await?;
@@ -133,7 +133,7 @@ impl MadaraSetup {
         let udc_address = get_contract_address_from_deploy_tx(account_provider, &res).await?;
 
         self.insert_address(DeployedContract::UniversalDeployer, udc_address);
-        log::info!("Universal deployer deployed successfully at address: 0x{:x}", udc_address);
+        log::info!("Universal deployer deployment completed successfully");
 
         Ok(udc_address)
     }
@@ -200,7 +200,7 @@ impl MadaraSetup {
             get_contract_address_from_deploy_tx(account.provider(), &madara_factory_res).await?;
         self.insert_address(DeployedContract::MadaraFactory, madara_factory_address);
 
-        log::info!("MadaraFactory deployed successfully at address: 0x{:x}", madara_factory_address);
+        log::info!("MadaraFactory deployment completed successfully");
 
         Ok(madara_factory_address)
     }

--- a/bootstrapper/src/contract_clients/utils.rs
+++ b/bootstrapper/src/contract_clients/utils.rs
@@ -206,7 +206,7 @@ pub(crate) async fn deploy_account_using_priv_key(
 
     let deploy_txn = oz_account_factory.deploy_v3(Felt::ZERO).l1_gas(0).l2_gas(0).l1_data_gas(0);
     let account_address = deploy_txn.address();
-    log::debug!("OZ Account will be deployed at the address: {:?}", account_address);
+    log::debug!("OZ Account deployment address derived successfully");
     save_to_json("account_address", &JsonValueType::StringType(account_address.to_string())).unwrap();
 
     if provider.get_class_at(BlockId::Tag(BlockTag::PreConfirmed), account_address).await.is_ok() {

--- a/madara/crates/client/mempool/src/inner/accounts.rs
+++ b/madara/crates/client/mempool/src/inner/accounts.rs
@@ -337,7 +337,7 @@ impl Accounts {
             Some(removed)
         }) else {
             // not found
-            unreachable!("Invariant violation: AccountKey is invalid: contract_address={contract_address:?}")
+            unreachable!("Invariant violation: AccountKey is invalid")
         };
 
         AccountUpdate {
@@ -352,15 +352,13 @@ impl Accounts {
     pub fn remove_tx(&mut self, TxKey(contract_address, nonce): &TxKey) -> AccountUpdate {
         let Some((data, removed)) = self.account_update_helper(contract_address, move |account_state| {
             let Some(removed) = account_state.remove_tx(nonce) else {
-                unreachable!(
-                    "Invariant violation: TxKey has invalid nonce: contract_address={contract_address:?} nonce={nonce:?}."
-                )
+                unreachable!("Invariant violation: TxKey has invalid nonce")
             };
 
             Some(removed)
         }) else {
             // not found
-            unreachable!("Invariant violation: TxKey has invalid contract_address: contract_address={contract_address:?} nonce={nonce:?}.")
+            unreachable!("Invariant violation: TxKey has invalid contract address")
         };
 
         AccountUpdate {
@@ -380,7 +378,7 @@ impl Accounts {
             Some(removed)
         }) else {
             // not found
-            unreachable!("Invariant violation: AccountKey is invalid: contract_address={contract_address:?}")
+            unreachable!("Invariant violation: AccountKey is invalid")
         };
 
         AccountUpdate {


### PR DESCRIPTION
## Summary
- remove live address values from bootstrapper deployment logs
- remove account and nonce values from mempool invariant panic messages
- dismiss test-only invariant alerts compiled only under test/testing cfg

## Validation
- cargo fmt --all --check
- cargo fmt --all --check (bootstrapper-v2)
- cargo check --manifest-path bootstrapper/Cargo.toml  # blocked by missing build-artifacts/starkgate_latest/*.json
- cargo check -p mc-mempool --lib  # started but stopped after broad dependency compilation
- cargo check (bootstrapper-v2)  # started but stopped after broad dependency compilation