### PR TITLE
fix(rpc): serialize receipt resources as integers

### DIFF
--- a/madara/crates/primitives/rpc/src/v0_8_1/starknet_api_openrpc.rs
+++ b/madara/crates/primitives/rpc/src/v0_8_1/starknet_api_openrpc.rs
@@ -391,12 +391,21 @@ pub struct CommonReceiptProperties {
 /// the resources consumed by the transaction, includes both computation and data
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ExecutionResources {
-    #[serde(with = "NumAsHex")]
     pub l1_gas: u128,
-    #[serde(with = "NumAsHex")]
     pub l2_gas: u128,
-    #[serde(with = "NumAsHex")]
     pub l1_data_gas: u128,
+}
+
+/// RPC v0.9 re-exports this type, so this guards both versions.
+#[cfg(test)]
+#[test]
+fn execution_resources_serialize_as_numbers() {
+    let resources = ExecutionResources { l1_gas: 1, l2_gas: 2, l1_data_gas: 3 };
+
+    assert_eq!(
+        serde_json::to_value(resources).unwrap(),
+        serde_json::json!({ "l1_gas": 1, "l2_gas": 2, "l1_data_gas": 3 })
+    );
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Restore spec-compliant JSON integer serialization for receipt execution resources in RPC v0.8 and v0.9.

This prevents downstream decoders from rejecting l1_data_gas when handling block and transaction receipts.

## Root cause

The websocket subscription merge applied hex serialization to the shared v0.8 receipt resource type. RPC v0.9 reuses that type, while v0.10 has its own integer representation.