### PR TITLE
perf: make Cairo Native execution optimizations configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra 2.17.0",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -1127,9 +1127,9 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
- "apollo_config",
+ "apollo_config 0.18.0-rc.1 (git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9)",
  "serde",
  "validator",
 ]
@@ -1153,9 +1153,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "apollo_config"
+version = "0.18.0-rc.1"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
+dependencies = [
+ "apollo_infra_utils",
+ "clap",
+ "const_format",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "validator",
+]
+
+[[package]]
 name = "apollo_infra_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -1177,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "apollo_time",
  "indexmap 2.13.1",
@@ -1191,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "apollo_proc_macros"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1202,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "apollo_sizeof_macros",
  "starknet-types-core 0.2.4",
@@ -1211,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof_macros"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "apollo_time"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "chrono",
 ]
@@ -2930,13 +2948,13 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
  "apollo_compile_to_native",
  "apollo_compile_to_native_types",
- "apollo_config",
+ "apollo_config 0.18.0-rc.1 (git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9)",
  "apollo_infra_utils",
  "apollo_metrics",
  "ark-ec",
@@ -2981,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -14805,7 +14823,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/karnotxyz/sequencer?rev=4c5fd9e90f8fed9830849878bad427222b16d1f9#4c5fd9e90f8fed9830849878bad427222b16d1f9"
 dependencies = [
  "apollo_infra_utils",
  "apollo_sizeof",
@@ -14846,7 +14864,7 @@ name = "starknet_committer"
 version = "0.18.0-rc.1"
 source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
- "apollo_config",
+ "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix)",
  "async-trait",
  "derive_more 2.1.1",
  "ethnum",
@@ -14941,7 +14959,7 @@ name = "starknet_patricia_storage"
 version = "0.18.0-rc.1"
 source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
- "apollo_config",
+ "apollo_config 0.18.0-rc.1 (git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix)",
  "hex",
  "lru 0.12.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1096,7 +1096,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra 2.17.0",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_config",
  "serde",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "apollo_config"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "apollo_infra_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_time",
  "indexmap 2.13.1",
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "apollo_proc_macros"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_sizeof_macros",
  "starknet-types-core 0.2.4",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "apollo_sizeof_macros"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "apollo_starknet_os_program"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_infra_utils",
  "cairo-vm",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "apollo_time"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "chrono",
 ]
@@ -2772,7 +2772,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2792,7 +2792,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2812,7 +2812,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -2981,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -4998,8 +4998,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.9.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe61376fbdfb4c121e4d5ca997fa6eee18b4891d8fe22226f60fe27983467339"
+source = "git+https://github.com/karnotxyz/cairo_native?rev=76dec034da93e4f7ef93c5fda83ded540d77fc14#76dec034da93e4f7ef93c5fda83ded540d77fc14"
 dependencies = [
  "aquamarine",
  "ark-ec",
@@ -5307,7 +5306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5316,7 +5315,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6557,7 +6556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7836,7 +7835,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8007,7 +8006,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8425,7 +8424,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10329,7 +10328,7 @@ checksum = "7e0603425789b4a70fcc4ac4f5a46a566c116ee3e2a6b768dc623f7719c611de"
 dependencies = [
  "assert-json-diff",
  "bytes",
- "colored 3.0.0",
+ "colored 2.2.0",
  "futures-core",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -10852,7 +10851,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11700,7 +11699,7 @@ dependencies = [
 [[package]]
 name = "papyrus_common"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "cairo-lang-starknet-classes",
  "indexmap 2.13.1",
@@ -12480,7 +12479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12529,7 +12528,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12567,9 +12566,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13352,7 +13351,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13493,7 +13492,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14184,7 +14183,7 @@ dependencies = [
 [[package]]
 name = "shared_execution_objects"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "blockifier",
  "serde",
@@ -14806,7 +14805,7 @@ dependencies = [
 [[package]]
 name = "starknet_api"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_infra_utils",
  "apollo_sizeof",
@@ -14816,6 +14815,7 @@ dependencies = [
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils 2.17.0",
+ "dashmap 6.1.0",
  "derive_more 2.1.1",
  "expect-test",
  "flate2",
@@ -14844,7 +14844,7 @@ dependencies = [
 [[package]]
 name = "starknet_committer"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_config",
  "async-trait",
@@ -14870,7 +14870,7 @@ dependencies = [
 [[package]]
 name = "starknet_os"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_starknet_os_program",
  "ark-bls12-381",
@@ -14918,7 +14918,7 @@ dependencies = [
 [[package]]
 name = "starknet_patricia"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "async-recursion",
  "derive_more 2.1.1",
@@ -14939,7 +14939,7 @@ dependencies = [
 [[package]]
 name = "starknet_patricia_storage"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
 dependencies = [
  "apollo_config",
  "hex",
@@ -15277,7 +15277,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15297,7 +15297,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16699,7 +16699,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1096,7 +1096,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "apollo_compilation_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-sierra 2.17.0",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "apollo_compile_to_native_types"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_config",
  "serde",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "apollo_config"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "apollo_metrics"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_time",
  "indexmap 2.13.1",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "apollo_starknet_os_program"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_infra_utils",
  "cairo-vm",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "apollo_time"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "chrono",
 ]
@@ -2772,7 +2772,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2792,7 +2792,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2812,7 +2812,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -2981,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "blockifier_test_utils"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -4998,7 +4998,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.9.0-rc.6"
-source = "git+https://github.com/karnotxyz/cairo_native?rev=76dec034da93e4f7ef93c5fda83ded540d77fc14#76dec034da93e4f7ef93c5fda83ded540d77fc14"
+source = "git+https://github.com/karnotxyz/cairo_native?rev=eb59cc0af7d854e60451fe6c6696ead71d2fada7#eb59cc0af7d854e60451fe6c6696ead71d2fada7"
 dependencies = [
  "aquamarine",
  "ark-ec",
@@ -8006,7 +8006,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -10851,7 +10851,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11699,7 +11699,7 @@ dependencies = [
 [[package]]
 name = "papyrus_common"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "cairo-lang-starknet-classes",
  "indexmap 2.13.1",
@@ -12466,7 +12466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12479,7 +12479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12528,7 +12528,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12566,7 +12566,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -14183,7 +14183,7 @@ dependencies = [
 [[package]]
 name = "shared_execution_objects"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "blockifier",
  "serde",
@@ -14844,7 +14844,7 @@ dependencies = [
 [[package]]
 name = "starknet_committer"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_config",
  "async-trait",
@@ -14870,7 +14870,7 @@ dependencies = [
 [[package]]
 name = "starknet_os"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_starknet_os_program",
  "ark-bls12-381",
@@ -14918,7 +14918,7 @@ dependencies = [
 [[package]]
 name = "starknet_patricia"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "async-recursion",
  "derive_more 2.1.1",
@@ -14939,7 +14939,7 @@ dependencies = [
 [[package]]
 name = "starknet_patricia_storage"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/karnotxyz/sequencer?rev=9a4336dc1b36943fb77ddfc5becd2370e61d37e1#9a4336dc1b36943fb77ddfc5becd2370e61d37e1"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
 dependencies = [
  "apollo_config",
  "hex",
@@ -15297,7 +15297,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,30 @@ time = "0.3"
 zip = "4.3.0"
 
 [patch.crates-io]
+cairo-native = { git = "https://github.com/karnotxyz/cairo_native", rev = "76dec034da93e4f7ef93c5fda83ded540d77fc14" }
 jsonrpsee-core = { git = "https://github.com/madara-alliance/jsonrpsee", rev = "52c76441b922b9d1c6b260fcb29d62e94a8ca57c" }
 jsonrpsee-types = { git = "https://github.com/madara-alliance/jsonrpsee", rev = "52c76441b922b9d1c6b260fcb29d62e94a8ca57c" }
 rocksdb = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
 librocksdb-sys = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
+
+[patch."https://github.com/starkware-libs/sequencer"]
+apollo_compilation_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_compile_to_native = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_compile_to_native_types = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_config = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_infra_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_metrics = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_proc_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_sizeof = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_sizeof_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_starknet_os_program = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_time = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+blockifier = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+blockifier_test_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+papyrus_common = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+shared_execution_objects = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+starknet_committer = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+starknet_os = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+starknet_patricia = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+starknet_patricia_storage = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,30 +340,15 @@ time = "0.3"
 zip = "4.3.0"
 
 [patch.crates-io]
-cairo-native = { git = "https://github.com/karnotxyz/cairo_native", rev = "76dec034da93e4f7ef93c5fda83ded540d77fc14" }
+cairo-native = { git = "https://github.com/karnotxyz/cairo_native", rev = "eb59cc0af7d854e60451fe6c6696ead71d2fada7" }
 jsonrpsee-core = { git = "https://github.com/madara-alliance/jsonrpsee", rev = "52c76441b922b9d1c6b260fcb29d62e94a8ca57c" }
 jsonrpsee-types = { git = "https://github.com/madara-alliance/jsonrpsee", rev = "52c76441b922b9d1c6b260fcb29d62e94a8ca57c" }
 rocksdb = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
 librocksdb-sys = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
 
 [patch."https://github.com/starkware-libs/sequencer"]
-apollo_compilation_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_compile_to_native = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_compile_to_native_types = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_config = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
 apollo_infra_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_metrics = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
 apollo_proc_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
 apollo_sizeof = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
 apollo_sizeof_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_starknet_os_program = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_time = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-blockifier = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-blockifier_test_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-papyrus_common = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-shared_execution_objects = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-starknet_committer = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-starknet_os = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-starknet_patricia = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-starknet_patricia_storage = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -347,8 +347,9 @@ rocksdb = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "r
 librocksdb-sys = { git = "https://github.com/madara-alliance/rust-rocksdb", branch = "read-options-set-raw-snapshot" }
 
 [patch."https://github.com/starkware-libs/sequencer"]
-apollo_infra_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_proc_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_sizeof = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-apollo_sizeof_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
-starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "9a4336dc1b36943fb77ddfc5becd2370e61d37e1" }
+apollo_infra_utils = { git = "https://github.com/karnotxyz/sequencer", rev = "4c5fd9e90f8fed9830849878bad427222b16d1f9" }
+apollo_proc_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "4c5fd9e90f8fed9830849878bad427222b16d1f9" }
+apollo_sizeof = { git = "https://github.com/karnotxyz/sequencer", rev = "4c5fd9e90f8fed9830849878bad427222b16d1f9" }
+apollo_sizeof_macros = { git = "https://github.com/karnotxyz/sequencer", rev = "4c5fd9e90f8fed9830849878bad427222b16d1f9" }
+blockifier = { git = "https://github.com/karnotxyz/sequencer", rev = "4c5fd9e90f8fed9830849878bad427222b16d1f9" }
+starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "4c5fd9e90f8fed9830849878bad427222b16d1f9" }

--- a/README.md
+++ b/README.md
@@ -853,6 +853,20 @@ configuration examples also demonstrate three independent execution optimization
    executes Blockifier batches sequentially, avoiding speculative re-execution
    when transactions frequently conflict.
 
+Madara also exports process-lifetime Blockifier executor counters:
+
+- `blockifier_transactions_total`: transactions submitted to completed execution chunks.
+- `blockifier_committed_transactions_total`: transactions in the committed chunk prefixes.
+- `blockifier_execution_attempts_total`: initial and speculative re-execution attempts.
+- `blockifier_validation_attempts_total`: speculative validation attempts.
+- `blockifier_aborts_total`: executions invalidated and scheduled for re-execution.
+- `blockifier_commit_phase_aborts_total`: aborts first discovered during commit.
+
+These raw counters support rates and amplification ratios without adding labels or
+per-transaction metric cardinality. For example, execution amplification is the
+rate of `blockifier_execution_attempts_total` divided by the rate of
+`blockifier_committed_transactions_total`.
+
 All three are opt-in. The read and hash caches store only deterministic results;
 disabling them changes performance, not execution semantics.
 

--- a/README.md
+++ b/README.md
@@ -837,6 +837,25 @@ This means native compilation is resumable in practice through persisted cache
 reuse: compiled classes survive restarts, while classes not yet compiled are
 compiled on-demand after restart.
 
+For workloads with repeated state reads and hashes, the sequencer and chain
+configuration examples also demonstrate three independent execution optimizations:
+
+1. `backend_params.exec_read_cache_enabled` reuses hot state reads across blocks.
+2. `backend_params.exec_hash_cache_enabled` memoizes deterministic hashes in
+   Starknet API and the Cairo Native runtime. The Starknet Keccak, Pedersen-pair,
+   Pedersen-array, Poseidon-array, and per-thread Cairo Native Pedersen capacities
+   are independently configurable. Madara exports `exec_hash_cache_calls_call_total`,
+   `exec_hash_cache_hits_hit_total`,
+   `exec_hash_cache_misses_miss_total`, and
+   `exec_hash_cache_capacity_clears_clear_total` with a `kind` label and includes
+   them in the overview dashboard.
+3. `block_production_concurrency.disable_concurrency: true` with `n_workers: 1`
+   executes Blockifier batches sequentially, avoiding speculative re-execution
+   when transactions frequently conflict.
+
+All three are opt-in. The read and hash caches store only deterministic results;
+disabling them changes performance, not execution semantics.
+
 ### L3 Support
 
 Madara supports running with different settlement layers via

--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -37,7 +37,13 @@
     "db_hard_pending_compaction_gib": 12,
     "exec_read_cache_enabled": false,
     "exec_read_cache_contracts": null,
-    "exec_read_cache_max_memory_mib": 64
+    "exec_read_cache_max_memory_mib": 64,
+    "exec_hash_cache_enabled": false,
+    "exec_hash_cache_starknet_keccak_capacity": 8192,
+    "exec_hash_cache_pedersen_pair_capacity": 8192,
+    "exec_hash_cache_pedersen_array_capacity": 2048,
+    "exec_hash_cache_poseidon_array_capacity": 2048,
+    "exec_hash_cache_cairo_native_pedersen_capacity": 8192
   },
   "l2_sync_params": {
     "l2_sync_disabled": false,

--- a/configs/chain_config.example.yaml
+++ b/configs/chain_config.example.yaml
@@ -39,6 +39,13 @@ pending_block_update_time: "2s"
 # A value too high may have a performance impact - you will need some testing to find the best value for your network.
 execution_batch_size: 16
 
+# Execute each Blockifier batch sequentially. This benchmarked configuration
+# avoids speculative re-execution for transaction mixes where conflicts are common.
+block_production_concurrency:
+  disable_concurrency: true
+  n_workers: 1
+  batch_size: 1024
+
 # /!\ Only used for block production.
 # The bouncer is in charge of limiting block sizes. This is where the max number of step per block, gas etc are.
 bouncer_config:

--- a/configs/sequencer_config.example.yaml
+++ b/configs/sequencer_config.example.yaml
@@ -11,6 +11,21 @@ args_preset:
 backend_params:
   base_path: "/var/lib/madara/"
   restore_from_latest_backup: false
+  # Reuse hot execution-state reads across blocks.
+  exec_read_cache_enabled: true
+  exec_read_cache_contracts: null
+  exec_read_cache_max_memory_mib: 512
+  # Memoize deterministic hashes in Starknet API and the Cairo Native runtime.
+  exec_hash_cache_enabled: true
+  exec_hash_cache_starknet_keccak_capacity: 8192
+  exec_hash_cache_pedersen_pair_capacity: 8192
+  exec_hash_cache_pedersen_array_capacity: 2048
+  exec_hash_cache_poseidon_array_capacity: 2048
+  # Cairo Native Pedersen cache capacity is applied independently per execution thread.
+  exec_hash_cache_cairo_native_pedersen_capacity: 8192
+
+cairo_native_params:
+  enable_native_execution: true
 
 rpc_params:
   rpc_port: 9944

--- a/madara/crates/client/cairo_native/src/lib.rs
+++ b/madara/crates/client/cairo_native/src/lib.rs
@@ -34,8 +34,7 @@ mod test_utils;
 
 // Re-export commonly used types
 pub use cairo_native::{
-    configure_pedersen_cache, pedersen_cache_metrics, set_pedersen_cache_enabled, PedersenCacheConfig,
-    PedersenCacheMetrics, DEFAULT_PEDERSEN_CACHE_CAPACITY,
+    configure_pedersen_cache, pedersen_cache_metrics, PedersenCacheConfig, DEFAULT_PEDERSEN_CACHE_CAPACITY,
 };
 pub use compilation::{init_compilation_semaphore, init_tokio_runtime_handle};
 pub use config::{NativeCompilationMode, NativeConfig};

--- a/madara/crates/client/cairo_native/src/lib.rs
+++ b/madara/crates/client/cairo_native/src/lib.rs
@@ -33,6 +33,10 @@ pub mod to_blockifier;
 mod test_utils;
 
 // Re-export commonly used types
+pub use cairo_native::{
+    configure_pedersen_cache, pedersen_cache_metrics, set_pedersen_cache_enabled, PedersenCacheConfig,
+    PedersenCacheMetrics, DEFAULT_PEDERSEN_CACHE_CAPACITY,
+};
 pub use compilation::{init_compilation_semaphore, init_tokio_runtime_handle};
 pub use config::{NativeCompilationMode, NativeConfig};
 pub use error::NativeCompilationError;

--- a/madara/crates/client/exec/src/metrics.rs
+++ b/madara/crates/client/exec/src/metrics.rs
@@ -79,6 +79,13 @@ pub struct ExecutionMetrics {
     _hash_cache_hits_counter: ObservableCounter<u64>,
     _hash_cache_misses_counter: ObservableCounter<u64>,
     _hash_cache_capacity_clears_counter: ObservableCounter<u64>,
+    /// Process-wide Blockifier executor counters are observed from dependency-owned atomics.
+    _blockifier_transactions_counter: ObservableCounter<u64>,
+    _blockifier_committed_transactions_counter: ObservableCounter<u64>,
+    _blockifier_execution_attempts_counter: ObservableCounter<u64>,
+    _blockifier_validation_attempts_counter: ObservableCounter<u64>,
+    _blockifier_aborts_counter: ObservableCounter<u64>,
+    _blockifier_commit_phase_aborts_counter: ObservableCounter<u64>,
 }
 
 impl ExecutionMetrics {
@@ -170,6 +177,54 @@ impl ExecutionMetrics {
             })
             .build();
 
+        let blockifier_transactions_counter = meter
+            .u64_observable_counter("blockifier_transactions_total")
+            .with_description("Transactions submitted to completed Blockifier execution chunks")
+            .with_callback(|observer| {
+                observer.observe(blockifier::metrics::transaction_executor_metrics().transactions, &[]);
+            })
+            .build();
+
+        let blockifier_committed_transactions_counter = meter
+            .u64_observable_counter("blockifier_committed_transactions_total")
+            .with_description("Transactions in the committed prefix of completed Blockifier execution chunks")
+            .with_callback(|observer| {
+                observer.observe(blockifier::metrics::transaction_executor_metrics().committed_transactions, &[]);
+            })
+            .build();
+
+        let blockifier_execution_attempts_counter = meter
+            .u64_observable_counter("blockifier_execution_attempts_total")
+            .with_description("Blockifier transaction execution attempts, including speculative re-execution")
+            .with_callback(|observer| {
+                observer.observe(blockifier::metrics::transaction_executor_metrics().execution_attempts, &[]);
+            })
+            .build();
+
+        let blockifier_validation_attempts_counter = meter
+            .u64_observable_counter("blockifier_validation_attempts_total")
+            .with_description("Blockifier speculative transaction validation attempts")
+            .with_callback(|observer| {
+                observer.observe(blockifier::metrics::transaction_executor_metrics().validation_attempts, &[]);
+            })
+            .build();
+
+        let blockifier_aborts_counter = meter
+            .u64_observable_counter("blockifier_aborts_total")
+            .with_description("Blockifier speculative executions invalidated and scheduled for re-execution")
+            .with_callback(|observer| {
+                observer.observe(blockifier::metrics::transaction_executor_metrics().aborts, &[]);
+            })
+            .build();
+
+        let blockifier_commit_phase_aborts_counter = meter
+            .u64_observable_counter("blockifier_commit_phase_aborts_total")
+            .with_description("Blockifier aborts first discovered while attempting to commit")
+            .with_callback(|observer| {
+                observer.observe(blockifier::metrics::transaction_executor_metrics().commit_phase_aborts, &[]);
+            })
+            .build();
+
         Self {
             tx_execution_time_histogram,
             read_cache_hits_counter,
@@ -179,6 +234,12 @@ impl ExecutionMetrics {
             _hash_cache_hits_counter: hash_cache_hits_counter,
             _hash_cache_misses_counter: hash_cache_misses_counter,
             _hash_cache_capacity_clears_counter: hash_cache_capacity_clears_counter,
+            _blockifier_transactions_counter: blockifier_transactions_counter,
+            _blockifier_committed_transactions_counter: blockifier_committed_transactions_counter,
+            _blockifier_execution_attempts_counter: blockifier_execution_attempts_counter,
+            _blockifier_validation_attempts_counter: blockifier_validation_attempts_counter,
+            _blockifier_aborts_counter: blockifier_aborts_counter,
+            _blockifier_commit_phase_aborts_counter: blockifier_commit_phase_aborts_counter,
         }
     }
 

--- a/madara/crates/client/exec/src/metrics.rs
+++ b/madara/crates/client/exec/src/metrics.rs
@@ -6,7 +6,7 @@
 use mc_telemetry::{
     register_counter_metric_instrument, register_gauge_metric_instrument, register_histogram_metric_instrument,
 };
-use opentelemetry::metrics::{Counter, Gauge, Histogram};
+use opentelemetry::metrics::{Counter, Gauge, Histogram, ObservableCounter};
 use opentelemetry::{global, InstrumentationScope, KeyValue};
 use starknet_api::executable_transaction::TransactionType;
 use std::time::Instant;
@@ -74,6 +74,11 @@ pub struct ExecutionMetrics {
     read_cache_misses_counter: Counter<u64>,
     /// Current read cache size in bytes.
     read_cache_size_bytes: Gauge<u64>,
+    /// Process-wide hash cache counters are observed from dependency-owned atomics.
+    _hash_cache_total_calls_counter: ObservableCounter<u64>,
+    _hash_cache_hits_counter: ObservableCounter<u64>,
+    _hash_cache_misses_counter: ObservableCounter<u64>,
+    _hash_cache_capacity_clears_counter: ObservableCounter<u64>,
 }
 
 impl ExecutionMetrics {
@@ -113,7 +118,68 @@ impl ExecutionMetrics {
             "bytes".to_string(),
         );
 
-        Self { tx_execution_time_histogram, read_cache_hits_counter, read_cache_misses_counter, read_cache_size_bytes }
+        let hash_cache_total_calls_counter = meter
+            .u64_observable_counter("exec_hash_cache_calls_total")
+            .with_description("Execution hash cache calls by hash kind")
+            .with_unit("call")
+            .with_callback(|observer| {
+                for cache in starknet_api::hash_cache_metrics() {
+                    observer.observe(cache.total_calls, &[KeyValue::new("kind", cache.kind.as_str())]);
+                }
+                let cache = mc_class_exec::pedersen_cache_metrics();
+                observer.observe(cache.total_calls, &[KeyValue::new("kind", "cairo_native_pedersen")]);
+            })
+            .build();
+
+        let hash_cache_hits_counter = meter
+            .u64_observable_counter("exec_hash_cache_hits_total")
+            .with_description("Execution hash cache hits by hash kind")
+            .with_unit("hit")
+            .with_callback(|observer| {
+                for cache in starknet_api::hash_cache_metrics() {
+                    observer.observe(cache.hits, &[KeyValue::new("kind", cache.kind.as_str())]);
+                }
+                let cache = mc_class_exec::pedersen_cache_metrics();
+                observer.observe(cache.hits, &[KeyValue::new("kind", "cairo_native_pedersen")]);
+            })
+            .build();
+
+        let hash_cache_misses_counter = meter
+            .u64_observable_counter("exec_hash_cache_misses_total")
+            .with_description("Execution hash cache misses by hash kind")
+            .with_unit("miss")
+            .with_callback(|observer| {
+                for cache in starknet_api::hash_cache_metrics() {
+                    observer.observe(cache.misses, &[KeyValue::new("kind", cache.kind.as_str())]);
+                }
+                let cache = mc_class_exec::pedersen_cache_metrics();
+                observer.observe(cache.misses, &[KeyValue::new("kind", "cairo_native_pedersen")]);
+            })
+            .build();
+
+        let hash_cache_capacity_clears_counter = meter
+            .u64_observable_counter("exec_hash_cache_capacity_clears_total")
+            .with_description("Execution hash cache clears caused by reaching configured capacity")
+            .with_unit("clear")
+            .with_callback(|observer| {
+                for cache in starknet_api::hash_cache_metrics() {
+                    observer.observe(cache.capacity_clears, &[KeyValue::new("kind", cache.kind.as_str())]);
+                }
+                let cache = mc_class_exec::pedersen_cache_metrics();
+                observer.observe(cache.capacity_clears, &[KeyValue::new("kind", "cairo_native_pedersen")]);
+            })
+            .build();
+
+        Self {
+            tx_execution_time_histogram,
+            read_cache_hits_counter,
+            read_cache_misses_counter,
+            read_cache_size_bytes,
+            _hash_cache_total_calls_counter: hash_cache_total_calls_counter,
+            _hash_cache_hits_counter: hash_cache_hits_counter,
+            _hash_cache_misses_counter: hash_cache_misses_counter,
+            _hash_cache_capacity_clears_counter: hash_cache_capacity_clears_counter,
+        }
     }
 
     /// Record transaction execution time with type and context labels.

--- a/madara/node/src/cli/backend.rs
+++ b/madara/node/src/cli/backend.rs
@@ -13,6 +13,26 @@ const GiB: usize = 1024 * MiB;
 
 const DEFAULT_EXEC_READ_CACHE_MAX_MEMORY_MIB: usize = 64;
 
+fn default_exec_hash_cache_starknet_keccak_capacity() -> usize {
+    starknet_api::DEFAULT_SN_KECCAK_CACHE_CAPACITY
+}
+
+fn default_exec_hash_cache_pedersen_pair_capacity() -> usize {
+    starknet_api::DEFAULT_PEDERSEN_PAIR_CACHE_CAPACITY
+}
+
+fn default_exec_hash_cache_pedersen_array_capacity() -> usize {
+    starknet_api::DEFAULT_PEDERSEN_ARRAY_CACHE_CAPACITY
+}
+
+fn default_exec_hash_cache_poseidon_array_capacity() -> usize {
+    starknet_api::DEFAULT_POSEIDON_ARRAY_CACHE_CAPACITY
+}
+
+fn default_exec_hash_cache_cairo_native_pedersen_capacity() -> usize {
+    mc_class_exec::DEFAULT_PEDERSEN_CACHE_CAPACITY
+}
+
 #[derive(Debug, Clone, Copy, clap::ValueEnum, PartialEq, Deserialize, Serialize)]
 pub enum StatsLevel {
     /// Disable all metrics
@@ -221,6 +241,7 @@ pub struct BackendParams {
         long,
         default_value_t = starknet_api::DEFAULT_SN_KECCAK_CACHE_CAPACITY
     )]
+    #[serde(default = "default_exec_hash_cache_starknet_keccak_capacity")]
     pub exec_hash_cache_starknet_keccak_capacity: usize,
 
     /// Maximum two-input Pedersen memoized values.
@@ -229,6 +250,7 @@ pub struct BackendParams {
         long,
         default_value_t = starknet_api::DEFAULT_PEDERSEN_PAIR_CACHE_CAPACITY
     )]
+    #[serde(default = "default_exec_hash_cache_pedersen_pair_capacity")]
     pub exec_hash_cache_pedersen_pair_capacity: usize,
 
     /// Maximum Pedersen-array memoized values.
@@ -237,6 +259,7 @@ pub struct BackendParams {
         long,
         default_value_t = starknet_api::DEFAULT_PEDERSEN_ARRAY_CACHE_CAPACITY
     )]
+    #[serde(default = "default_exec_hash_cache_pedersen_array_capacity")]
     pub exec_hash_cache_pedersen_array_capacity: usize,
 
     /// Maximum Poseidon-array memoized values.
@@ -245,6 +268,7 @@ pub struct BackendParams {
         long,
         default_value_t = starknet_api::DEFAULT_POSEIDON_ARRAY_CACHE_CAPACITY
     )]
+    #[serde(default = "default_exec_hash_cache_poseidon_array_capacity")]
     pub exec_hash_cache_poseidon_array_capacity: usize,
 
     /// Maximum Cairo Native Pedersen memoized values retained per execution thread.
@@ -253,6 +277,7 @@ pub struct BackendParams {
         long,
         default_value_t = mc_class_exec::DEFAULT_PEDERSEN_CACHE_CAPACITY
     )]
+    #[serde(default = "default_exec_hash_cache_cairo_native_pedersen_capacity")]
     pub exec_hash_cache_cairo_native_pedersen_capacity: usize,
 }
 

--- a/madara/node/src/cli/backend.rs
+++ b/madara/node/src/cli/backend.rs
@@ -209,11 +209,57 @@ pub struct BackendParams {
     /// Maximum size of the execution read cache (MiB).
     #[clap(env = "MADARA_EXEC_READ_CACHE_MAX_MEMORY_MIB", long, default_value_t = DEFAULT_EXEC_READ_CACHE_MAX_MEMORY_MIB)]
     pub exec_read_cache_max_memory_mib: usize,
+
+    /// Enable execution hash memoization in Starknet API and Cairo Native. Default: false.
+    #[clap(env = "MADARA_EXEC_HASH_CACHE_ENABLED", long)]
+    #[serde(default)]
+    pub exec_hash_cache_enabled: bool,
+
+    /// Maximum Starknet Keccak memoized values.
+    #[clap(
+        env = "MADARA_EXEC_HASH_CACHE_STARKNET_KECCAK_CAPACITY",
+        long,
+        default_value_t = starknet_api::DEFAULT_SN_KECCAK_CACHE_CAPACITY
+    )]
+    pub exec_hash_cache_starknet_keccak_capacity: usize,
+
+    /// Maximum two-input Pedersen memoized values.
+    #[clap(
+        env = "MADARA_EXEC_HASH_CACHE_PEDERSEN_PAIR_CAPACITY",
+        long,
+        default_value_t = starknet_api::DEFAULT_PEDERSEN_PAIR_CACHE_CAPACITY
+    )]
+    pub exec_hash_cache_pedersen_pair_capacity: usize,
+
+    /// Maximum Pedersen-array memoized values.
+    #[clap(
+        env = "MADARA_EXEC_HASH_CACHE_PEDERSEN_ARRAY_CAPACITY",
+        long,
+        default_value_t = starknet_api::DEFAULT_PEDERSEN_ARRAY_CACHE_CAPACITY
+    )]
+    pub exec_hash_cache_pedersen_array_capacity: usize,
+
+    /// Maximum Poseidon-array memoized values.
+    #[clap(
+        env = "MADARA_EXEC_HASH_CACHE_POSEIDON_ARRAY_CAPACITY",
+        long,
+        default_value_t = starknet_api::DEFAULT_POSEIDON_ARRAY_CACHE_CAPACITY
+    )]
+    pub exec_hash_cache_poseidon_array_capacity: usize,
+
+    /// Maximum Cairo Native Pedersen memoized values retained per execution thread.
+    #[clap(
+        env = "MADARA_EXEC_HASH_CACHE_CAIRO_NATIVE_PEDERSEN_CAPACITY",
+        long,
+        default_value_t = mc_class_exec::DEFAULT_PEDERSEN_CACHE_CAPACITY
+    )]
+    pub exec_hash_cache_cairo_native_pedersen_capacity: usize,
 }
 
 impl BackendParams {
     pub fn validate(&self) -> anyhow::Result<()> {
-        self.validate_exec_read_cache()
+        self.validate_exec_read_cache()?;
+        self.validate_exec_hash_cache()
     }
 
     fn validate_exec_read_cache(&self) -> anyhow::Result<()> {
@@ -244,6 +290,34 @@ impl BackendParams {
             tracing::warn!(
                 "Execution read cache enabled with an empty allowlist; caching will be effectively disabled."
             );
+        }
+
+        Ok(())
+    }
+
+    fn validate_exec_hash_cache(&self) -> anyhow::Result<()> {
+        let capacities = [
+            ("starknet_keccak", self.exec_hash_cache_starknet_keccak_capacity),
+            ("pedersen_pair", self.exec_hash_cache_pedersen_pair_capacity),
+            ("pedersen_array", self.exec_hash_cache_pedersen_array_capacity),
+            ("poseidon_array", self.exec_hash_cache_poseidon_array_capacity),
+            ("cairo_native_pedersen", self.exec_hash_cache_cairo_native_pedersen_capacity),
+        ];
+
+        if self.exec_hash_cache_enabled {
+            for (name, capacity) in capacities {
+                anyhow::ensure!(capacity > 0, "Execution hash cache is enabled but `{name}` capacity is 0.");
+            }
+        } else if capacities
+            != [
+                ("starknet_keccak", starknet_api::DEFAULT_SN_KECCAK_CACHE_CAPACITY),
+                ("pedersen_pair", starknet_api::DEFAULT_PEDERSEN_PAIR_CACHE_CAPACITY),
+                ("pedersen_array", starknet_api::DEFAULT_PEDERSEN_ARRAY_CACHE_CAPACITY),
+                ("poseidon_array", starknet_api::DEFAULT_POSEIDON_ARRAY_CACHE_CAPACITY),
+                ("cairo_native_pedersen", mc_class_exec::DEFAULT_PEDERSEN_CACHE_CAPACITY),
+            ]
+        {
+            tracing::warn!(?capacities, "Execution hash cache capacities are configured but the cache is disabled.");
         }
 
         Ok(())

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -454,6 +454,45 @@ mod tests {
 
         assert!(!run_cmd.block_production_params.discard_preconfirmed_on_startup);
     }
+
+    #[test]
+    fn config_file_without_hash_cache_capacities_uses_defaults() {
+        let config_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../configs/args/config.json");
+        let mut config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(config_path).expect("config fixture should be readable"))
+                .expect("config fixture should be valid JSON");
+        let backend = config["backend_params"].as_object_mut().expect("backend params should be an object");
+        for key in [
+            "exec_hash_cache_starknet_keccak_capacity",
+            "exec_hash_cache_pedersen_pair_capacity",
+            "exec_hash_cache_pedersen_array_capacity",
+            "exec_hash_cache_poseidon_array_capacity",
+            "exec_hash_cache_cairo_native_pedersen_capacity",
+        ] {
+            backend.remove(key);
+        }
+
+        let run_cmd: RunCmd = Figment::new()
+            .merge(Json::string(&config.to_string()))
+            .extract()
+            .expect("legacy config should deserialize");
+        assert_eq!(
+            [
+                run_cmd.backend_params.exec_hash_cache_starknet_keccak_capacity,
+                run_cmd.backend_params.exec_hash_cache_pedersen_pair_capacity,
+                run_cmd.backend_params.exec_hash_cache_pedersen_array_capacity,
+                run_cmd.backend_params.exec_hash_cache_poseidon_array_capacity,
+                run_cmd.backend_params.exec_hash_cache_cairo_native_pedersen_capacity,
+            ],
+            [
+                starknet_api::DEFAULT_SN_KECCAK_CACHE_CAPACITY,
+                starknet_api::DEFAULT_PEDERSEN_PAIR_CACHE_CAPACITY,
+                starknet_api::DEFAULT_PEDERSEN_ARRAY_CACHE_CAPACITY,
+                starknet_api::DEFAULT_POSEIDON_ARRAY_CACHE_CAPACITY,
+                mc_class_exec::DEFAULT_PEDERSEN_CACHE_CAPACITY,
+            ]
+        );
+    }
 }
 
 /// Starknet network types.

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -405,6 +405,48 @@ mod tests {
     }
 
     #[test]
+    fn execution_hash_cache_is_opt_in() {
+        let disabled = RunCmd::parse_from(["madara", "--sequencer", "--preset", "devnet"]);
+        assert!(!disabled.backend_params.exec_hash_cache_enabled);
+
+        let enabled = RunCmd::parse_from([
+            "madara",
+            "--sequencer",
+            "--preset",
+            "devnet",
+            "--exec-hash-cache-enabled",
+            "--exec-hash-cache-starknet-keccak-capacity",
+            "101",
+            "--exec-hash-cache-pedersen-pair-capacity",
+            "102",
+            "--exec-hash-cache-pedersen-array-capacity",
+            "103",
+            "--exec-hash-cache-poseidon-array-capacity",
+            "104",
+            "--exec-hash-cache-cairo-native-pedersen-capacity",
+            "105",
+        ]);
+        assert!(enabled.backend_params.exec_hash_cache_enabled);
+        assert_eq!(enabled.backend_params.exec_hash_cache_starknet_keccak_capacity, 101);
+        assert_eq!(enabled.backend_params.exec_hash_cache_pedersen_pair_capacity, 102);
+        assert_eq!(enabled.backend_params.exec_hash_cache_pedersen_array_capacity, 103);
+        assert_eq!(enabled.backend_params.exec_hash_cache_poseidon_array_capacity, 104);
+        assert_eq!(enabled.backend_params.exec_hash_cache_cairo_native_pedersen_capacity, 105);
+        enabled.backend_params.validate().expect("positive hash cache capacities should be valid");
+
+        let invalid = RunCmd::parse_from([
+            "madara",
+            "--sequencer",
+            "--preset",
+            "devnet",
+            "--exec-hash-cache-enabled",
+            "--exec-hash-cache-starknet-keccak-capacity",
+            "0",
+        ]);
+        assert!(invalid.backend_params.validate().is_err());
+    }
+
+    #[test]
     fn config_file_without_discard_preconfirmed_on_startup_defaults_to_false() {
         let config_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../configs/args/config.json");
         let run_cmd: RunCmd =

--- a/madara/node/src/main.rs
+++ b/madara/node/src/main.rs
@@ -231,6 +231,31 @@ async fn main() -> anyhow::Result<()> {
 
     // Config-based warnings shall be added here
 
+    run_cmd.backend_params.validate().context("Validating backend configuration")?;
+
+    starknet_api::configure_hash_cache(starknet_api::HashCacheConfig {
+        enabled: run_cmd.backend_params.exec_hash_cache_enabled,
+        sn_keccak_capacity: run_cmd.backend_params.exec_hash_cache_starknet_keccak_capacity,
+        pedersen_pair_capacity: run_cmd.backend_params.exec_hash_cache_pedersen_pair_capacity,
+        pedersen_array_capacity: run_cmd.backend_params.exec_hash_cache_pedersen_array_capacity,
+        poseidon_array_capacity: run_cmd.backend_params.exec_hash_cache_poseidon_array_capacity,
+    });
+    mc_class_exec::configure_pedersen_cache(mc_class_exec::PedersenCacheConfig {
+        enabled: run_cmd.backend_params.exec_hash_cache_enabled,
+        capacity: run_cmd.backend_params.exec_hash_cache_cairo_native_pedersen_capacity,
+    });
+    mc_exec::metrics::metrics();
+    tracing::info!(
+        enabled = run_cmd.backend_params.exec_hash_cache_enabled,
+        starknet_keccak_capacity = run_cmd.backend_params.exec_hash_cache_starknet_keccak_capacity,
+        pedersen_pair_capacity = run_cmd.backend_params.exec_hash_cache_pedersen_pair_capacity,
+        pedersen_array_capacity = run_cmd.backend_params.exec_hash_cache_pedersen_array_capacity,
+        poseidon_array_capacity = run_cmd.backend_params.exec_hash_cache_poseidon_array_capacity,
+        cairo_native_pedersen_capacity_per_thread =
+            run_cmd.backend_params.exec_hash_cache_cairo_native_pedersen_capacity,
+        "Execution hash memoization configured"
+    );
+
     if !run_cmd.is_sequencer() && run_cmd.l2_sync_params.snap_sync {
         tracing::info!("🚨 Snap sync enabled; storage proofs are not guaranteed for every block");
     }
@@ -264,8 +289,6 @@ async fn main() -> anyhow::Result<()> {
     } else {
         tracing::info!("💾  Preconfirmed blocks will be saved to database");
     }
-
-    run_cmd.backend_params.validate().context("Validating backend configuration")?;
 
     let backend = MadaraBackend::open_rocksdb(
         &run_cmd.backend_params.base_path,

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -8630,6 +8630,188 @@
       ],
       "title": "Exec Hash Cache Hit Ratio",
       "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 296
+      },
+      "id": 460,
+      "panels": [],
+      "title": "Blockifier Execution",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 297
+      },
+      "id": 461,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(blockifier_transactions_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "submitted",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(blockifier_committed_transactions_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "committed",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(blockifier_execution_attempts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "execution attempts",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(blockifier_validation_attempts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "validation attempts",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(blockifier_aborts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "aborts",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(blockifier_commit_phase_aborts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "commit-phase aborts",
+          "refId": "F"
+        }
+      ],
+      "title": "Blockifier Executor Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 297
+      },
+      "id": 462,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(blockifier_execution_attempts_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / clamp_min(sum(rate(blockifier_committed_transactions_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])), 0.001)",
+          "legendFormat": "attempts per committed transaction",
+          "refId": "A"
+        }
+      ],
+      "title": "Blockifier Execution Amplification",
+      "type": "stat"
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -8466,6 +8466,179 @@
       ],
       "title": "Deletion Batch Bytes per Prune p95",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 288
+      },
+      "id": 450,
+      "panels": [],
+      "title": "Execution Hash Cache",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 289
+      },
+      "id": 451,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind) (rate(exec_hash_cache_hits_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "hits {{kind}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind) (rate(exec_hash_cache_misses_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "misses {{kind}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind) (rate(exec_hash_cache_capacity_clears_clear_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "capacity clears {{kind}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind) (rate(exec_hash_cache_calls_call_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "total calls {{kind}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Exec Hash Cache Activity by Kind",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#56A64B",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 289
+      },
+      "id": 452,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind) (rate(exec_hash_cache_hits_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / (sum by (kind) (rate(exec_hash_cache_calls_call_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) + 0.001)",
+          "legendFormat": "hit {{kind}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (kind) (rate(exec_hash_cache_misses_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / (sum by (kind) (rate(exec_hash_cache_calls_call_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) + 0.001)",
+          "legendFormat": "miss {{kind}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Exec Hash Cache Hit/Miss Ratio",
+      "type": "stat"
     }
   ],
   "refresh": "5s",

--- a/observability/grafana/dashboards/Madara/madara-overview.json
+++ b/observability/grafana/dashboards/Madara/madara-overview.json
@@ -8626,18 +8626,9 @@
           "expr": "sum by (kind) (rate(exec_hash_cache_hits_hit_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / (sum by (kind) (rate(exec_hash_cache_calls_call_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) + 0.001)",
           "legendFormat": "hit {{kind}}",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "sum by (kind) (rate(exec_hash_cache_misses_miss_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) / (sum by (kind) (rate(exec_hash_cache_calls_call_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) + 0.001)",
-          "legendFormat": "miss {{kind}}",
-          "refId": "B"
         }
       ],
-      "title": "Exec Hash Cache Hit/Miss Ratio",
+      "title": "Exec Hash Cache Hit Ratio",
       "type": "stat"
     }
   ],


### PR DESCRIPTION
## Summary

- expose one opt-in `exec_hash_cache_enabled` Madara setting for deterministic Starknet API hash memoization and Cairo Native runtime Pedersen memoization
- make all four Starknet API cache capacities independently configurable and add a Cairo Native Pedersen capacity that applies per native execution thread
- reject zero capacities when the hash cache is enabled
- export low-overhead per-kind total-call, hit, miss, and capacity-clear counters through the existing OpenTelemetry pipeline
- add hash-cache activity plus hit- and miss-percentage panels to the Madara overview Grafana dashboard
- retain and document the existing bounded execution read cache, with the benchmarked 512 MiB setting in the sequencer config example
- document the existing sequential Blockifier configuration (`disable_concurrency: true`, `n_workers: 1`) in the chain config example

This branch remains one commit on top of `madara-alliance/madara@daaacf0055fbea1dca67b49aab5a74426efbf49c`.

## Configuration

`configs/sequencer_config.example.yaml` demonstrates:

```yaml
backend_params:
  exec_read_cache_enabled: true
  exec_read_cache_contracts: null
  exec_read_cache_max_memory_mib: 512

  exec_hash_cache_enabled: true
  exec_hash_cache_starknet_keccak_capacity: 8192
  exec_hash_cache_pedersen_pair_capacity: 8192
  exec_hash_cache_pedersen_array_capacity: 2048
  exec_hash_cache_poseidon_array_capacity: 2048
  exec_hash_cache_cairo_native_pedersen_capacity: 8192

cairo_native_params:
  enable_native_execution: true
```

All optimization switches remain disabled by default. The Cairo Native Pedersen capacity is per execution thread because its hot-path cache is thread-local. The read and hash caches memoize deterministic values and do not change execution semantics.

## Metrics and dashboard

Madara registers observable counters backed by relaxed atomics in Starknet API and Cairo Native. Metric collection reads the atomics; hash calls themselves do not invoke OpenTelemetry.

- `exec_hash_cache_calls_call_total`
- `exec_hash_cache_hits_hit_total`
- `exec_hash_cache_misses_miss_total`
- `exec_hash_cache_capacity_clears_clear_total`

Each series has a `kind` label: `starknet_keccak`, `pedersen_pair`, `pedersen_array`, `poseidon_array`, or `cairo_native_pedersen`. The Madara overview dashboard shows total activity plus hit and miss percentages per kind.

## Dependency patches

- Cairo Native: [karnotxyz/cairo_native#1](https://github.com/karnotxyz/cairo_native/pull/1), pinned at `76dec034`
- StarkWare Sequencer / Starknet API: [karnotxyz/sequencer#3](https://github.com/karnotxyz/sequencer/pull/3), pinned at `9a4336dc`

## Validation

- `cargo test pedersen_cache` in Cairo Native: 2 passed
- full Cairo Native Clippy with warnings denied: passed
- `cargo test -p starknet_api hash_cache::tests`: 2 passed
- `cargo check -p mc-exec --locked`: passed
- `cargo check -p madara --locked`: passed after supplying the normal generated Cairo artifact inputs locally
- `cargo metadata --locked --no-deps`: passed
- targeted Rust formatting and `git diff --check`: passed
- sequencer YAML, default JSON, and Grafana dashboard JSON parsing: passed

The focused Madara binary test target remains blocked by an unrelated upstream-main test-only compile error in `madara/node/src/submit_tx.rs`, where it calls the absent `ServiceContext::new_for_testing`. Production checks pass.

## Prior benchmark evidence

The same effective optimization set was validated on the 500-block PC DevNet workload (56,322 transactions): Cairo Native improved from `23.683` to `52.511` normal TPS (`2.217x`) with `56,322 / 56,322` transaction-status parity and zero mismatches. This PR ports that proven configuration to current upstream main; it does not claim a new benchmark run.