### PR TITLE
feat(sync): add preconfirmed reorg protection

### DIFF
--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -57,7 +57,8 @@
     "stop_on_sync": false,
     "backup_every_n_blocks": null,
     "bouncer_config_sync_enable": false,
-    "disable_reorg": false
+    "disable_reorg": false,
+    "disable_reorg_preconfirmed": false
   },
   "l1_sync_params": {
     "l1_sync_disabled": true,

--- a/madara/crates/client/sync/src/gateway/blocks.rs
+++ b/madara/crates/client/sync/src/gateway/blocks.rs
@@ -464,6 +464,7 @@ pub fn gateway_preconfirmed_block_sync(
     client: Arc<GatewayProvider>,
     _importer: Arc<BlockImporter>,
     backend: Arc<MadaraBackend>,
+    disable_reorg_preconfirmed: bool,
 ) -> ThrottledRepeatedFuture<()> {
     ThrottledRepeatedFuture::new(
         move |_| {
@@ -517,19 +518,43 @@ pub fn gateway_preconfirmed_block_sync(
                         return Ok(None);
                     }
 
-                    // True if this gateway block should be considered as a new pre-confirmed block entirely.
-                    let new_preconfirmed = in_backend.header() != &header
-                        || in_backend.num_executed_transactions() > n_executed
+                    let local_executed = in_backend.num_executed_transactions();
+                    let executed_prefix_changed = local_executed > n_executed
                         ||
                         // Compare hashes
                         // TODO: should we compute these hashes? probably not?
                         Iterator::ne(
                             in_backend.borrow_content().executed_transactions().map(|tx| tx.transaction.receipt.transaction_hash()),
-                            block.transactions[..n_executed].iter().map(|tx| tx.transaction_hash()),
+                            block.transactions[..local_executed].iter().map(|tx| tx.transaction_hash()),
+                        );
+                    let local_candidates = in_backend.candidate_transactions();
+                    let local_transaction_count = local_executed + local_candidates.len();
+                    let candidate_prefix_changed = local_transaction_count > block.transactions.len()
+                        || Iterator::ne(
+                            local_candidates.iter().map(|tx| &tx.hash),
+                            block.transactions[local_executed..local_transaction_count]
+                                .iter()
+                                .map(|tx| tx.transaction_hash()),
                         );
 
+                    // True if this gateway block should be considered as a new pre-confirmed block entirely.
+                    let new_preconfirmed = in_backend.header() != &header || executed_prefix_changed;
+                    let preconfirmed_reorg = new_preconfirmed || candidate_prefix_changed;
+
+                    if disable_reorg_preconfirmed && preconfirmed_reorg {
+                        tracing::debug!(
+                            block_number,
+                            local_executed,
+                            local_candidates = local_candidates.len(),
+                            upstream_executed = n_executed,
+                            upstream_candidates = block.transactions.len().saturating_sub(n_executed),
+                            "Ignoring upstream preconfirmed block replacement because preconfirmed reorgs are disabled"
+                        );
+                        return Ok(None);
+                    }
+
                     if !new_preconfirmed {
-                        common_prefix = Some(in_backend.num_executed_transactions());
+                        common_prefix = Some(local_executed);
                     }
 
                     // Whether there was no change at all (no need to update the backend)

--- a/madara/crates/client/sync/src/gateway/mod.rs
+++ b/madara/crates/client/sync/src/gateway/mod.rs
@@ -28,6 +28,7 @@ pub struct ForwardSyncConfig {
     pub keep_pre_v0_13_2_hashes: bool,
     pub enable_bouncer_config_sync: bool,
     pub disable_reorg: bool,
+    pub disable_reorg_preconfirmed: bool,
 }
 
 impl Default for ForwardSyncConfig {
@@ -44,6 +45,7 @@ impl Default for ForwardSyncConfig {
             keep_pre_v0_13_2_hashes: false,
             enable_bouncer_config_sync: false,
             disable_reorg: false,
+            disable_reorg_preconfirmed: false,
         }
     }
 }
@@ -65,6 +67,9 @@ impl ForwardSyncConfig {
     pub fn disable_reorg(self, val: bool) -> Self {
         Self { disable_reorg: val, ..self }
     }
+    pub fn disable_reorg_preconfirmed(self, val: bool) -> Self {
+        Self { disable_reorg_preconfirmed: val, ..self }
+    }
 }
 
 pub type GatewaySync = SyncController<GatewayForwardSync>;
@@ -77,7 +82,12 @@ pub fn forward_sync(
 ) -> GatewaySync {
     let probe = Arc::new(GatewayLatestProbe::new(client.clone()));
     let probe = ThrottledRepeatedFuture::new(move |val| probe.clone().probe(val), Duration::from_secs(1));
-    let get_pending_block = gateway_preconfirmed_block_sync(client.clone(), importer.clone(), backend.clone());
+    let get_pending_block = gateway_preconfirmed_block_sync(
+        client.clone(),
+        importer.clone(),
+        backend.clone(),
+        config.disable_reorg_preconfirmed,
+    );
     SyncController::new(
         backend.clone(),
         GatewayForwardSync::new(backend, importer, client, config),

--- a/madara/crates/client/sync/src/tests/gateway_mock.rs
+++ b/madara/crates/client/sync/src/tests/gateway_mock.rs
@@ -198,6 +198,25 @@ impl GatewayMock {
 
     /// Ts is timestamp. We use that to differentiate pending blocks in the tests.
     pub fn mock_block_pending_with_ts(&self, block_number: u64, timestamp: usize) -> Mock<'_> {
+        self.mock_block_pending_with_ts_and_count(block_number, timestamp, 1)
+    }
+
+    pub fn mock_block_pending_with_ts_and_count(
+        &self,
+        block_number: u64,
+        timestamp: usize,
+        transaction_count: usize,
+    ) -> Mock<'_> {
+        self.mock_block_pending_with_ts_and_counts(block_number, timestamp, transaction_count, transaction_count)
+    }
+
+    pub fn mock_block_pending_with_ts_and_counts(
+        &self,
+        block_number: u64,
+        timestamp: usize,
+        transaction_count: usize,
+        executed_count: usize,
+    ) -> Mock<'_> {
         // block alpha-sepolia 171544
         self.mock_server.mock(|when, then| {
             when.method("GET")
@@ -225,8 +244,7 @@ impl GatewayMock {
                 },
                 "timestamp": timestamp,
                 "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "transactions": [
-                    {
+                "transactions": (0..transaction_count).map(|_| json!({
                         "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
                         "version": "0x1",
                         "max_fee": "0x0",
@@ -250,10 +268,8 @@ impl GatewayMock {
                             "0x1"
                         ],
                         "type": "INVOKE_FUNCTION"
-                    },
-                ],
-                "transaction_receipts": [
-                    {
+                    })).collect::<Vec<_>>(),
+                "transaction_receipts": (0..transaction_count).map(|index| if index < executed_count { json!({
                         "execution_status": "SUCCEEDED",
                         "transaction_index": 3,
                         "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
@@ -269,10 +285,8 @@ impl GatewayMock {
                             "n_memory_holes": 0
                         },
                         "actual_fee": "0x0"
-                    },
-                ],
-                "transaction_state_diffs": [
-                    {
+                    }) } else { Value::Null }).collect::<Vec<_>>(),
+                "transaction_state_diffs": (0..transaction_count).map(|index| if index < executed_count { json!({
                         "storage_diffs": {
                             "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d": [
                                 {
@@ -302,8 +316,7 @@ impl GatewayMock {
                         "old_declared_contracts": [],
                         "declared_classes": [],
                         "replaced_classes": []
-                    }
-                ],
+                    }) } else { Value::Null }).collect::<Vec<_>>(),
             }));
         })
     }

--- a/madara/crates/client/sync/src/tests/gateway_mock.rs
+++ b/madara/crates/client/sync/src/tests/gateway_mock.rs
@@ -228,8 +228,26 @@ impl GatewayMock {
         executed_count: usize,
         hash_offset: usize,
     ) -> Mock<'_> {
-        let transaction_hashes = (0..transaction_count)
-            .map(|index| {
+        self.mock_block_pending_with_hash_offsets(
+            block_number,
+            timestamp,
+            executed_count,
+            vec![hash_offset; transaction_count],
+        )
+    }
+
+    pub fn mock_block_pending_with_hash_offsets(
+        &self,
+        block_number: u64,
+        timestamp: usize,
+        executed_count: usize,
+        hash_offsets: Vec<usize>,
+    ) -> Mock<'_> {
+        let transaction_count = hash_offsets.len();
+        let transaction_hashes = hash_offsets
+            .into_iter()
+            .enumerate()
+            .map(|(index, hash_offset)| {
                 if hash_offset == 0 && index == 0 {
                     "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1".to_owned()
                 } else {

--- a/madara/crates/client/sync/src/tests/gateway_mock.rs
+++ b/madara/crates/client/sync/src/tests/gateway_mock.rs
@@ -217,6 +217,27 @@ impl GatewayMock {
         transaction_count: usize,
         executed_count: usize,
     ) -> Mock<'_> {
+        self.mock_block_pending_custom(block_number, timestamp, transaction_count, executed_count, 0)
+    }
+
+    pub fn mock_block_pending_custom(
+        &self,
+        block_number: u64,
+        timestamp: usize,
+        transaction_count: usize,
+        executed_count: usize,
+        hash_offset: usize,
+    ) -> Mock<'_> {
+        let transaction_hashes = (0..transaction_count)
+            .map(|index| {
+                if hash_offset == 0 && index == 0 {
+                    "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1".to_owned()
+                } else {
+                    format!("0x{:x}", hash_offset + index + 1)
+                }
+            })
+            .collect::<Vec<_>>();
+
         // block alpha-sepolia 171544
         self.mock_server.mock(|when, then| {
             when.method("GET")
@@ -244,8 +265,8 @@ impl GatewayMock {
                 },
                 "timestamp": timestamp,
                 "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "transactions": (0..transaction_count).map(|_| json!({
-                        "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
+                "transactions": transaction_hashes.iter().map(|transaction_hash| json!({
+                        "transaction_hash": transaction_hash,
                         "version": "0x1",
                         "max_fee": "0x0",
                         "signature": [
@@ -271,8 +292,8 @@ impl GatewayMock {
                     })).collect::<Vec<_>>(),
                 "transaction_receipts": (0..transaction_count).map(|index| if index < executed_count { json!({
                         "execution_status": "SUCCEEDED",
-                        "transaction_index": 3,
-                        "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
+                        "transaction_index": index,
+                        "transaction_hash": transaction_hashes[index],
                         "l2_to_l1_messages": [],
                         "events": [],
                         "execution_resources": {

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -230,6 +230,12 @@ async fn test_pending_block_reorg_disabled(mut ctx: TestContext) {
     assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
 
     grown_block_mock.delete();
+    let mut candidate_replaced_block_mock =
+        ctx.gateway_mock.mock_block_pending_with_hash_offsets(2, 1000000000000, 2, vec![0, 0, 100]);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    candidate_replaced_block_mock.delete();
     let mut shrunk_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_count(2, 1000000000000, 2);
     assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
     assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -27,6 +27,27 @@ struct TestContext {
     gateway_mock: GatewayMock,
 }
 
+async fn poll_preconfirmed(
+    gateway_mock: &GatewayMock,
+    importer: &Arc<BlockImporter>,
+    backend: &Arc<MadaraBackend>,
+    disable_reorg_preconfirmed: bool,
+) -> bool {
+    let mut sync = crate::gateway::blocks::gateway_preconfirmed_block_sync(
+        gateway_mock.client(),
+        importer.clone(),
+        backend.clone(),
+        disable_reorg_preconfirmed,
+    );
+    sync.run().await.unwrap().is_some()
+}
+
+fn preconfirmed_state(backend: &Arc<MadaraBackend>) -> (u64, usize, usize) {
+    let mut block = backend.block_view_on_preconfirmed().unwrap();
+    block.refresh_with_candidates();
+    (block.header().block_timestamp.0, block.num_executed_transactions(), block.candidate_transactions().len())
+}
+
 #[fixture]
 fn ctx(gateway_mock: GatewayMock) -> TestContext {
     let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
@@ -174,6 +195,54 @@ async fn test_pending_block_update(mut ctx: TestContext) {
 
     assert!(ctx.backend.has_preconfirmed_block());
     assert_eq!(ctx.backend.block_view_on_preconfirmed().unwrap().header().block_timestamp.0, 1999999999999);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_pending_block_reorg_disabled(mut ctx: TestContext) {
+    ctx.gateway_mock.mock_block(0, felt!("0x10"), felt!("0x0"));
+    ctx.gateway_mock.mock_block(1, felt!("0x11"), felt!("0x10"));
+    ctx.gateway_mock.mock_header_latest(1, felt!("0x11"));
+    let mut pending_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_counts(2, 1000000000000, 2, 1);
+
+    let mut sync = crate::gateway::forward_sync(
+        ctx.backend.clone(),
+        ctx.importer.clone(),
+        ctx.gateway_mock.client(),
+        SyncControllerConfig::default().service_state_sender(ctx.service_state_sender),
+        ForwardSyncConfig::default().disable_reorg_preconfirmed(true),
+    );
+
+    let task = AbortOnDrop::spawn(async move { sync.run(ServiceContext::default()).await.unwrap() });
+
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Starting);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Idle);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::SyncingTo { target: 1 });
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Idle);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::UpdatedPreconfirmedBlock);
+
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 1, 1));
+    drop(task);
+
+    pending_block_mock.delete();
+    let mut grown_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_counts(2, 1000000000000, 3, 2);
+    assert!(poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    grown_block_mock.delete();
+    let mut shrunk_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_count(2, 1000000000000, 2);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    shrunk_block_mock.delete();
+    let mut empty_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_count(2, 1000000000000, 0);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    empty_block_mock.delete();
+    ctx.gateway_mock.mock_block_pending_with_ts_and_counts(2, 1999999999999, 3, 2);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
 }
 
 #[rstest]

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -235,6 +235,11 @@ async fn test_pending_block_reorg_disabled(mut ctx: TestContext) {
     assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
 
     shrunk_block_mock.delete();
+    let mut replaced_block_mock = ctx.gateway_mock.mock_block_pending_custom(2, 1000000000000, 3, 2, 100);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    replaced_block_mock.delete();
     let mut empty_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_count(2, 1000000000000, 0);
     assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
     assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));

--- a/madara/node/src/cli/l2.rs
+++ b/madara/node/src/cli/l2.rs
@@ -89,6 +89,12 @@ pub struct L2SyncParams {
     /// operators who want to manually handle chain divergences.
     #[clap(env = "MADARA_DISABLE_REORG", long, default_value_t = false)]
     pub disable_reorg: bool,
+
+    /// Disable replacement of an already-synced preconfirmed block when the upstream block shrinks,
+    /// changes header, or changes its existing transaction prefix. Forward-only updates remain enabled.
+    #[serde(default)]
+    #[clap(env = "MADARA_DISABLE_REORG_PRECONFIRMED", long, default_value_t = false)]
+    pub disable_reorg_preconfirmed: bool,
 }
 
 impl L2SyncParams {

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -371,6 +371,14 @@ mod tests {
     }
 
     #[test]
+    fn full_node_can_disable_preconfirmed_reorgs_independently() {
+        let run_cmd = RunCmd::parse_from(["madara", "--full", "--network", "sepolia", "--disable-reorg-preconfirmed"]);
+
+        assert!(run_cmd.l2_sync_params.disable_reorg_preconfirmed);
+        assert!(!run_cmd.l2_sync_params.disable_reorg);
+    }
+
+    #[test]
     fn sequencer_runs_and_saves_mempool_by_default() {
         let run_cmd = RunCmd::parse_from(["madara", "--sequencer", "--preset", "devnet"]);
 

--- a/madara/node/src/service/l2.rs
+++ b/madara/node/src/service/l2.rs
@@ -125,7 +125,8 @@ impl Service for SyncService {
                         .snap_sync(this.params.snap_sync)
                         .keep_pre_v0_13_2_hashes(this.params.keep_pre_v0_13_2_hashes())
                         .enable_bouncer_config_sync(this.params.bouncer_config_sync_enable)
-                        .disable_reorg(this.params.disable_reorg),
+                        .disable_reorg(this.params.disable_reorg)
+                        .disable_reorg_preconfirmed(this.params.disable_reorg_preconfirmed),
                 )
                 .run(ctx.clone())
                 .await?;
@@ -162,7 +163,8 @@ impl Service for SyncService {
                     .snap_sync(this.params.snap_sync)
                     .keep_pre_v0_13_2_hashes(this.params.keep_pre_v0_13_2_hashes())
                     .enable_bouncer_config_sync(this.params.bouncer_config_sync_enable)
-                    .disable_reorg(this.params.disable_reorg),
+                    .disable_reorg(this.params.disable_reorg)
+                    .disable_reorg_preconfirmed(this.params.disable_reorg_preconfirmed),
             )
             .run(ctx)
             .await


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Testing
- [ ] Other (please describe):

## What is the current behavior?

`MADARA_DISABLE_REORG` only applies to confirmed-block parent-hash divergence. An already-synced preconfirmed block is still replaced when its header changes, its executed transaction count shrinks, or its transaction prefix diverges.
\n
## What is the new behavior?

- Adds the independent `MADARA_DISABLE_REORG_PRECONFIRMED` environment variable and `--disable-reorg-preconfirmed` CLI option.
- When enabled, preserves the local preconfirmed block if the upstream header changes or any previously-synced executed/candidate transaction is removed or replaced.
- Continues to accept forward-only updates, including candidate-to-executed progress and appended transactions.
- Defaults to `false`, leaving existing behavior unchanged unless explicitly enabled.

## Does this introduce a breaking change?

No.

## Other information

Validation:

- `cargo test -p mc-sync --lib` (34 passed, 1 ignored)
- `cargo test -p madara -F mp-utils/testing full_node_can_disable_preconfirmed_reorgs_independently`
- `cargo check -p madara --bin madara`
- `cargo fmt --all -- --check`

