### PR TITLE
feat(sync): restore preconfirmed reorg protection

### DIFF
--- a/configs/args/config.json
+++ b/configs/args/config.json
@@ -63,7 +63,8 @@
     "stop_on_sync": false,
     "backup_every_n_blocks": null,
     "bouncer_config_sync_enable": false,
-    "disable_reorg": false
+    "disable_reorg": false,
+    "disable_reorg_preconfirmed": false
   },
   "l1_sync_params": {
     "l1_sync_disabled": true,

--- a/madara/crates/client/sync/src/gateway/blocks.rs
+++ b/madara/crates/client/sync/src/gateway/blocks.rs
@@ -464,6 +464,7 @@ pub fn gateway_preconfirmed_block_sync(
     client: Arc<GatewayProvider>,
     _importer: Arc<BlockImporter>,
     backend: Arc<MadaraBackend>,
+    disable_reorg_preconfirmed: bool,
 ) -> ThrottledRepeatedFuture<()> {
     ThrottledRepeatedFuture::new(
         move |_| {
@@ -517,19 +518,43 @@ pub fn gateway_preconfirmed_block_sync(
                         return Ok(None);
                     }
 
-                    // True if this gateway block should be considered as a new pre-confirmed block entirely.
-                    let new_preconfirmed = in_backend.header() != &header
-                        || in_backend.num_executed_transactions() > n_executed
+                    let local_executed = in_backend.num_executed_transactions();
+                    let executed_prefix_changed = local_executed > n_executed
                         ||
                         // Compare hashes
                         // TODO: should we compute these hashes? probably not?
                         Iterator::ne(
                             in_backend.borrow_content().executed_transactions().map(|tx| tx.transaction.receipt.transaction_hash()),
-                            block.transactions[..n_executed].iter().map(|tx| tx.transaction_hash()),
+                            block.transactions[..local_executed].iter().map(|tx| tx.transaction_hash()),
+                        );
+                    let local_candidates = in_backend.candidate_transactions();
+                    let local_transaction_count = local_executed + local_candidates.len();
+                    let candidate_prefix_changed = local_transaction_count > block.transactions.len()
+                        || Iterator::ne(
+                            local_candidates.iter().map(|tx| &tx.hash),
+                            block.transactions[local_executed..local_transaction_count]
+                                .iter()
+                                .map(|tx| tx.transaction_hash()),
                         );
 
+                    // True if this gateway block should be considered as a new pre-confirmed block entirely.
+                    let new_preconfirmed = in_backend.header() != &header || executed_prefix_changed;
+                    let preconfirmed_reorg = new_preconfirmed || candidate_prefix_changed;
+
+                    if disable_reorg_preconfirmed && preconfirmed_reorg {
+                        tracing::debug!(
+                            block_number,
+                            local_executed,
+                            local_candidates = local_candidates.len(),
+                            upstream_executed = n_executed,
+                            upstream_candidates = block.transactions.len().saturating_sub(n_executed),
+                            "Ignoring upstream preconfirmed block replacement because preconfirmed reorgs are disabled"
+                        );
+                        return Ok(None);
+                    }
+
                     if !new_preconfirmed {
-                        common_prefix = Some(in_backend.num_executed_transactions());
+                        common_prefix = Some(local_executed);
                     }
 
                     // Whether there was no change at all (no need to update the backend)

--- a/madara/crates/client/sync/src/gateway/mod.rs
+++ b/madara/crates/client/sync/src/gateway/mod.rs
@@ -28,6 +28,7 @@ pub struct ForwardSyncConfig {
     pub keep_pre_v0_13_2_hashes: bool,
     pub enable_bouncer_config_sync: bool,
     pub disable_reorg: bool,
+    pub disable_reorg_preconfirmed: bool,
 }
 
 impl Default for ForwardSyncConfig {
@@ -44,6 +45,7 @@ impl Default for ForwardSyncConfig {
             keep_pre_v0_13_2_hashes: false,
             enable_bouncer_config_sync: false,
             disable_reorg: false,
+            disable_reorg_preconfirmed: false,
         }
     }
 }
@@ -65,6 +67,9 @@ impl ForwardSyncConfig {
     pub fn disable_reorg(self, val: bool) -> Self {
         Self { disable_reorg: val, ..self }
     }
+    pub fn disable_reorg_preconfirmed(self, val: bool) -> Self {
+        Self { disable_reorg_preconfirmed: val, ..self }
+    }
 }
 
 pub type GatewaySync = SyncController<GatewayForwardSync>;
@@ -77,7 +82,12 @@ pub fn forward_sync(
 ) -> GatewaySync {
     let probe = Arc::new(GatewayLatestProbe::new(client.clone()));
     let probe = ThrottledRepeatedFuture::new(move |val| probe.clone().probe(val), Duration::from_secs(1));
-    let get_pending_block = gateway_preconfirmed_block_sync(client.clone(), importer.clone(), backend.clone());
+    let get_pending_block = gateway_preconfirmed_block_sync(
+        client.clone(),
+        importer.clone(),
+        backend.clone(),
+        config.disable_reorg_preconfirmed,
+    );
     SyncController::new(
         backend.clone(),
         GatewayForwardSync::new(backend, importer, client, config),

--- a/madara/crates/client/sync/src/tests/gateway_mock.rs
+++ b/madara/crates/client/sync/src/tests/gateway_mock.rs
@@ -198,6 +198,48 @@ impl GatewayMock {
 
     /// Ts is timestamp. We use that to differentiate pending blocks in the tests.
     pub fn mock_block_pending_with_ts(&self, block_number: u64, timestamp: usize) -> Mock<'_> {
+        self.mock_block_pending_with_ts_and_count(block_number, timestamp, 1)
+    }
+
+    pub fn mock_block_pending_with_ts_and_count(
+        &self,
+        block_number: u64,
+        timestamp: usize,
+        transaction_count: usize,
+    ) -> Mock<'_> {
+        self.mock_block_pending_with_ts_and_counts(block_number, timestamp, transaction_count, transaction_count)
+    }
+
+    pub fn mock_block_pending_with_ts_and_counts(
+        &self,
+        block_number: u64,
+        timestamp: usize,
+        transaction_count: usize,
+        executed_count: usize,
+    ) -> Mock<'_> {
+        let transaction_hashes = (0..transaction_count)
+            .map(|index| {
+                if index == 0 {
+                    Felt::from_hex_unchecked("0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1")
+                } else {
+                    Felt::from(index + 1)
+                }
+            })
+            .collect::<Vec<_>>();
+        self.mock_block_pending_with_hashes(block_number, timestamp, &transaction_hashes, executed_count)
+    }
+
+    pub fn mock_block_pending_with_hashes(
+        &self,
+        block_number: u64,
+        timestamp: usize,
+        transaction_hashes: &[Felt],
+        executed_count: usize,
+    ) -> Mock<'_> {
+        assert!(executed_count <= transaction_hashes.len());
+        let transaction_hashes = transaction_hashes.iter().map(|hash| format!("{hash:#x}")).collect::<Vec<_>>();
+        let transaction_count = transaction_hashes.len();
+
         // block alpha-sepolia 171544
         self.mock_server.mock(|when, then| {
             when.method("GET")
@@ -225,9 +267,8 @@ impl GatewayMock {
                 },
                 "timestamp": timestamp,
                 "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-                "transactions": [
-                    {
-                        "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
+                "transactions": transaction_hashes.iter().map(|transaction_hash| json!({
+                        "transaction_hash": transaction_hash,
                         "version": "0x1",
                         "max_fee": "0x0",
                         "signature": [
@@ -250,13 +291,11 @@ impl GatewayMock {
                             "0x1"
                         ],
                         "type": "INVOKE_FUNCTION"
-                    },
-                ],
-                "transaction_receipts": [
-                    {
+                    })).collect::<Vec<_>>(),
+                "transaction_receipts": (0..transaction_count).map(|index| if index < executed_count { json!({
                         "execution_status": "SUCCEEDED",
-                        "transaction_index": 3,
-                        "transaction_hash": "0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1",
+                        "transaction_index": index,
+                        "transaction_hash": transaction_hashes[index],
                         "l2_to_l1_messages": [],
                         "events": [],
                         "execution_resources": {
@@ -269,10 +308,8 @@ impl GatewayMock {
                             "n_memory_holes": 0
                         },
                         "actual_fee": "0x0"
-                    },
-                ],
-                "transaction_state_diffs": [
-                    {
+                    }) } else { Value::Null }).collect::<Vec<_>>(),
+                "transaction_state_diffs": (0..transaction_count).map(|index| if index < executed_count { json!({
                         "storage_diffs": {
                             "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d": [
                                 {
@@ -302,8 +339,7 @@ impl GatewayMock {
                         "old_declared_contracts": [],
                         "declared_classes": [],
                         "replaced_classes": []
-                    }
-                ],
+                    }) } else { Value::Null }).collect::<Vec<_>>(),
             }));
         })
     }

--- a/madara/crates/client/sync/src/tests/pipeline.rs
+++ b/madara/crates/client/sync/src/tests/pipeline.rs
@@ -27,6 +27,35 @@ struct TestContext {
     gateway_mock: GatewayMock,
 }
 
+async fn poll_preconfirmed(
+    gateway_mock: &GatewayMock,
+    importer: &Arc<BlockImporter>,
+    backend: &Arc<MadaraBackend>,
+    disable_reorg_preconfirmed: bool,
+) -> bool {
+    let mut sync = crate::gateway::blocks::gateway_preconfirmed_block_sync(
+        gateway_mock.client(),
+        importer.clone(),
+        backend.clone(),
+        disable_reorg_preconfirmed,
+    );
+    sync.run().await.unwrap().is_some()
+}
+
+fn preconfirmed_state(backend: &Arc<MadaraBackend>) -> (u64, usize, usize) {
+    let mut block = backend.block_view_on_preconfirmed().unwrap();
+    block.refresh_with_candidates();
+    (block.header().block_timestamp.0, block.num_executed_transactions(), block.candidate_transactions().len())
+}
+
+fn preconfirmed_transaction_hashes(backend: &Arc<MadaraBackend>) -> (Vec<Felt>, Vec<Felt>) {
+    let mut block = backend.block_view_on_preconfirmed().unwrap();
+    block.refresh_with_candidates();
+    let executed = block.get_executed_transactions(..).into_iter().map(|tx| *tx.receipt.transaction_hash()).collect();
+    let candidates = block.candidate_transactions().iter().map(|tx| tx.hash).collect();
+    (executed, candidates)
+}
+
 #[fixture]
 fn ctx(gateway_mock: GatewayMock) -> TestContext {
     let backend = MadaraBackend::open_for_testing(Arc::new(ChainConfig::madara_test()));
@@ -174,6 +203,107 @@ async fn test_pending_block_update(mut ctx: TestContext) {
 
     assert!(ctx.backend.has_preconfirmed_block());
     assert_eq!(ctx.backend.block_view_on_preconfirmed().unwrap().header().block_timestamp.0, 1999999999999);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_pending_block_reorg_disabled(mut ctx: TestContext) {
+    ctx.gateway_mock.mock_block(0, felt!("0x10"), felt!("0x0"));
+    ctx.gateway_mock.mock_block(1, felt!("0x11"), felt!("0x10"));
+    let mut latest_mock = ctx.gateway_mock.mock_header_latest(1, felt!("0x11"));
+    let mut pending_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_counts(2, 1000000000000, 2, 1);
+
+    let mut sync = crate::gateway::forward_sync(
+        ctx.backend.clone(),
+        ctx.importer.clone(),
+        ctx.gateway_mock.client(),
+        SyncControllerConfig::default().service_state_sender(ctx.service_state_sender),
+        ForwardSyncConfig::default().disable_reorg_preconfirmed(true),
+    );
+
+    let task = AbortOnDrop::spawn(async move { sync.run(ServiceContext::default()).await.unwrap() });
+
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Starting);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Idle);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::SyncingTo { target: 1 });
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::Idle);
+    assert_eq!(ctx.service_state_recv.recv().await.unwrap(), ServiceEvent::UpdatedPreconfirmedBlock);
+
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 1, 1));
+    drop(task);
+
+    pending_block_mock.delete();
+    let mut grown_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_counts(2, 1000000000000, 3, 2);
+    assert!(poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    grown_block_mock.delete();
+    let hashes =
+        [felt!("0x6a5a493cf33919e58aa4c75777bffdef97c0e39cac968896d7bee8cc67905a1"), felt!("0x2"), felt!("0x67")];
+    let mut candidate_replaced_block_mock =
+        ctx.gateway_mock.mock_block_pending_with_hashes(2, 1000000000000, &hashes, 2);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    candidate_replaced_block_mock.delete();
+    let mut shrunk_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_count(2, 1000000000000, 2);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    shrunk_block_mock.delete();
+    let hashes = [felt!("0x65"), felt!("0x66"), felt!("0x67")];
+    let mut replaced_block_mock = ctx.gateway_mock.mock_block_pending_with_hashes(2, 1000000000000, &hashes, 2);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    replaced_block_mock.delete();
+    let mut empty_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_count(2, 1000000000000, 0);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    empty_block_mock.delete();
+    let mut header_replaced_block_mock = ctx.gateway_mock.mock_block_pending_with_ts_and_counts(2, 1999999999999, 3, 2);
+    assert!(!poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, true).await);
+    assert_eq!(preconfirmed_state(&ctx.backend), (1000000000000, 2, 1));
+
+    header_replaced_block_mock.delete();
+    latest_mock.delete();
+    ctx.gateway_mock.mock_block(2, felt!("0x12"), felt!("0x11"));
+    ctx.gateway_mock.mock_header_latest(2, felt!("0x12"));
+    ctx.gateway_mock.mock_block_pending_with_ts(3, 2000000000000);
+
+    let mut sync = crate::gateway::forward_sync(
+        ctx.backend.clone(),
+        ctx.importer,
+        ctx.gateway_mock.client(),
+        SyncControllerConfig::default().stop_on_sync(true),
+        ForwardSyncConfig::default().disable_reorg_preconfirmed(true),
+    );
+    sync.run(ServiceContext::default()).await.unwrap();
+
+    assert_eq!(ctx.backend.latest_confirmed_block_n(), Some(2));
+    assert_eq!(ctx.backend.block_view_on_preconfirmed().unwrap().header().block_number, 3);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_pending_block_reorg_allowed_by_default(ctx: TestContext) {
+    let hashes = [felt!("0x1"), felt!("0x2")];
+    let mut pending_block_mock = ctx.gateway_mock.mock_block_pending_with_hashes(0, 1000000000000, &hashes, 1);
+    assert!(poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, false).await);
+    assert_eq!(preconfirmed_transaction_hashes(&ctx.backend), (vec![felt!("0x1")], vec![felt!("0x2")]));
+
+    pending_block_mock.delete();
+    let hashes = [felt!("0x1"), felt!("0x2"), felt!("0x3")];
+    let mut grown_block_mock = ctx.gateway_mock.mock_block_pending_with_hashes(0, 1000000000000, &hashes, 2);
+    assert!(poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, false).await);
+    assert_eq!(preconfirmed_transaction_hashes(&ctx.backend), (vec![felt!("0x1"), felt!("0x2")], vec![felt!("0x3")]));
+
+    grown_block_mock.delete();
+    let hashes = [felt!("0x1"), felt!("0x2"), felt!("0x4")];
+    ctx.gateway_mock.mock_block_pending_with_hashes(0, 1000000000000, &hashes, 2);
+    assert!(poll_preconfirmed(&ctx.gateway_mock, &ctx.importer, &ctx.backend, false).await);
+    assert_eq!(preconfirmed_transaction_hashes(&ctx.backend), (vec![felt!("0x1"), felt!("0x2")], vec![felt!("0x4")]));
 }
 
 #[rstest]

--- a/madara/node/src/cli/l2.rs
+++ b/madara/node/src/cli/l2.rs
@@ -89,6 +89,13 @@ pub struct L2SyncParams {
     /// operators who want to manually handle chain divergences.
     #[clap(env = "MADARA_DISABLE_REORG", long, default_value_t = false)]
     pub disable_reorg: bool,
+
+    /// Disable replacement of an already-synced preconfirmed block when the upstream block shrinks,
+    /// changes header, or changes its existing transaction prefix. Forward-only updates remain enabled,
+    /// and confirmed-block imports still replace the preserved preconfirmed view.
+    #[serde(default)]
+    #[clap(env = "MADARA_DISABLE_REORG_PRECONFIRMED", long, default_value_t = false)]
+    pub disable_reorg_preconfirmed: bool,
 }
 
 impl L2SyncParams {

--- a/madara/node/src/cli/mod.rs
+++ b/madara/node/src/cli/mod.rs
@@ -371,6 +371,14 @@ mod tests {
     }
 
     #[test]
+    fn full_node_can_disable_preconfirmed_reorgs_independently() {
+        let run_cmd = RunCmd::parse_from(["madara", "--full", "--network", "sepolia", "--disable-reorg-preconfirmed"]);
+
+        assert!(run_cmd.l2_sync_params.disable_reorg_preconfirmed);
+        assert!(!run_cmd.l2_sync_params.disable_reorg);
+    }
+
+    #[test]
     fn sequencer_runs_and_saves_mempool_by_default() {
         let run_cmd = RunCmd::parse_from(["madara", "--sequencer", "--preset", "devnet"]);
 

--- a/madara/node/src/service/l2.rs
+++ b/madara/node/src/service/l2.rs
@@ -125,7 +125,8 @@ impl Service for SyncService {
                         .snap_sync(this.params.snap_sync)
                         .keep_pre_v0_13_2_hashes(this.params.keep_pre_v0_13_2_hashes())
                         .enable_bouncer_config_sync(this.params.bouncer_config_sync_enable)
-                        .disable_reorg(this.params.disable_reorg),
+                        .disable_reorg(this.params.disable_reorg)
+                        .disable_reorg_preconfirmed(this.params.disable_reorg_preconfirmed),
                 )
                 .run(ctx.clone())
                 .await?;
@@ -162,7 +163,8 @@ impl Service for SyncService {
                     .snap_sync(this.params.snap_sync)
                     .keep_pre_v0_13_2_hashes(this.params.keep_pre_v0_13_2_hashes())
                     .enable_bouncer_config_sync(this.params.bouncer_config_sync_enable)
-                    .disable_reorg(this.params.disable_reorg),
+                    .disable_reorg(this.params.disable_reorg)
+                    .disable_reorg_preconfirmed(this.params.disable_reorg_preconfirmed),
             )
             .run(ctx)
             .await


### PR DESCRIPTION
## Context

PR #1251 was accidentally merged and immediately reverted by #1253. This PR restores the feature from the current `main` branch. The original review history remains available on #1251.

## Review feedback carried forward

- Added default-off forward-growth and candidate-replacement coverage with exact executed/candidate hash assertions ([original thread](https://github.com/madara-alliance/madara/pull/1251#discussion_r3955852867)).
- Documented and tested that confirmed-block import replaces the preserved preconfirmed view and advances normally ([original thread](https://github.com/madara-alliance/madara/pull/1251#discussion_r3955852876)).
- Simplified the pending-block fixture to one explicit transaction-hash helper while retaining the count-based convenience wrappers ([original thread](https://github.com/madara-alliance/madara/pull/1251#discussion_r3955852881)).

## Behavior

- Adds the independent `MADARA_DISABLE_REORG_PRECONFIRMED` environment variable and `--disable-reorg-preconfirmed` CLI option.
- When enabled, preserves the local preconfirmed block if the upstream header changes or any previously synced executed/candidate transaction is removed or replaced.
- Continues to accept forward-only updates, including candidate-to-executed progress and appended transactions.
- Confirmed blocks always take precedence over a preserved preconfirmed view.
- Defaults to `false`, leaving existing behavior unchanged unless explicitly enabled.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Full compilation and test validation delegated to CI.
