### PR TITLE
fix(db): honor fsync in RocksDB write options

### DIFF
--- a/madara/crates/client/db/src/rocksdb/options.rs
+++ b/madara/crates/client/db/src/rocksdb/options.rs
@@ -162,9 +162,7 @@ impl DbWriteMode {
             opts.disable_wal(true);
         }
 
-        if !self.fsync {
-            opts.set_sync(false);
-        }
+        opts.set_sync(self.fsync);
 
         opts
     }


### PR DESCRIPTION
`DbWriteMode { wal: true, fsync: true }` currently leaves RocksDB synchronous writes disabled. This patch passes the configured value to `set_sync`, enabling synchronous WAL writes when WAL is enabled and preserving the default disabled-sync behavior.

Addresses #1257. **This PR remains an incomplete draft and is not ready to merge.**

The [review comment](https://github.com/madara-alliance/madara/pull/1258#discussion_r3997065825) is correct: the setter change also makes WAL disabled plus fsync enabled fail at write time. The patch must reject that configuration before database use. The underlying bug is still present in reviewed upstream revision `802086d2085788a279c2a6dd8e24dfd1408c7765`, so the issue and draft remain open.

Remaining work:

- Validate the write mode at the shared database configuration/open boundary, covering CLI and direct callers. Reject fsync when WAL is disabled before opening or writing the database.
- Correct the formatter/documentation describing the invalid combination as a fast mode. Do not silently downgrade requested durability.
- Add actual RocksDB coverage for the three supported modes and early rejection of the invalid mode.

Validation of the current PR head `a0b1d029cc2cf9433cd5ea8ff99ec85105ad5f9c`:

- The original source-level stand-in reproduced the missing setter call. Its previous “all four combinations pass” wording described setter values only; it did not establish valid database behavior and is withdrawn.
- `rustfmt --check` and `git diff --check` passed during the original patch preparation; this documentation update does not represent a new test run.
- Full `mc-db` tests and a real RocksDB integration test were not run for this PR head. The separate game fork contains a WAL-sync test, but that is not coverage landed in this PR; it expects the invalid write to fail rather than preventing invalid configuration.
- No crash or power-loss validation has been performed for this PR. A graceful close/reopen test would not establish those guarantees.
